### PR TITLE
[FEAT#34] Kafka Blob 오프로딩 — RawContent Postgres 저장 후 경량 RawContentRef 발행

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,6 +194,7 @@ make deps
 - [x] Docker Compose Kafka stack (KRaft mode, no Zookeeper)
 - [x] Kafka topic initialization with configurable partitions via `.env`
 - [x] Kafka UI at `http://localhost:8080`
+- [x] Priority-based multi-pool manager (`PoolManager`)
 
 ✅ **News Domain Crawlers** (v0.4.0)
 - [x] News domain DIP interfaces (`internal/crawler/domain/news/news.go`)
@@ -211,8 +212,13 @@ make deps
 - [x] Migration — `news_articles` table creation (`003_create_news_articles.up.sql`)
 - [x] Tests — 780+ cases for KR parser/crawler, 519+ cases for US parser/crawler
 
-🚧 **In Progress**
-- [ ] Priority-based multi-pool manager
+✅ **Kafka Blob Offloading** (v0.5.0)
+- [x] `RawContentRef` — lightweight Kafka message struct (ID + metadata, no HTML body)
+- [x] `RawContentService` injected into `KafkaConsumerPool` for Postgres-first storage
+- [x] Worker saves full `RawContent` (including HTML) to Postgres, then publishes only `RawContentRef` to Kafka
+- [x] Duplicate URL handling — returns existing record ID without error
+- [x] `PoolManager` (`manager.go`) — priority-based multi-pool orchestration (High / Normal / Low)
+- [x] Unit tests for pool processing logic (`test/internal/worker/`)
 
 📋 **Planned**
 - [ ] Processing pipeline (normalize → validate → enrich)
@@ -238,7 +244,8 @@ issuetracker/
 │   │   │   ├── handler.go     # Handler interface, Registry
 │   │   │   └── noop.go        # Fallback noop handler
 │   │   ├── worker/            # Kafka consumer pool
-│   │   │   └── pool.go        # KafkaConsumerPool (goroutine worker pool + DLQ)
+│   │   │   ├── pool.go        # KafkaConsumerPool (goroutine worker pool + DLQ + Postgres offload)
+│   │   │   └── manager.go     # PoolManager (High/Normal/Low priority pool orchestration)
 │   └── storage/               # Data access layer
 │       ├── news_article.go    # NewsArticle repository interface
 │       └── postgres/          # PostgreSQL implementation

--- a/cmd/crawler/main.go
+++ b/cmd/crawler/main.go
@@ -109,7 +109,10 @@ func main() {
     Low:    worker.PoolConfig{Consumer: lowConsumer, WorkerCount: 2},
   }
 
-  manager := worker.NewPoolManager(managerCfg, producer, registry, resolver, log)
+  manager, err := worker.NewPoolManager(managerCfg, producer, registry, resolver, log)
+  if err != nil {
+    log.WithError(err).Fatal("pool manager 생성 실패")
+  }
   manager.Start(ctx)
 
   log.WithFields(map[string]interface{}{

--- a/docs/ko/README.md
+++ b/docs/ko/README.md
@@ -194,6 +194,7 @@ make deps
 - [x] Docker Compose Kafka 스택 (KRaft 모드, Zookeeper 불필요)
 - [x] `.env`를 통한 설정 가능한 파티션으로 Kafka 토픽 초기화
 - [x] Kafka UI (`http://localhost:8080`)
+- [x] 우선순위 기반 다중 풀 매니저 (`PoolManager`)
 
 ✅ **뉴스 도메인 크롤러** (v0.4.0)
 - [x] 뉴스 도메인 DIP 인터페이스 (`internal/crawler/domain/news/news.go`)
@@ -211,8 +212,13 @@ make deps
 - [x] 마이그레이션 — `news_articles` 테이블 생성 (`003_create_news_articles.up.sql`)
 - [x] 테스트 — KR 파서/크롤러 780+ 케이스, US 파서/크롤러 519+ 케이스
 
-🚧 **진행 중**
-- [ ] 우선순위 기반 다중 풀 매니저
+✅ **Kafka Blob 오프로딩** (v0.5.0)
+- [x] `RawContentRef` — 경량 Kafka 메시지 구조체 (ID + 메타데이터, HTML 본문 제외)
+- [x] `RawContentService`를 `KafkaConsumerPool`에 주입하여 Postgres 우선 저장
+- [x] 워커가 전체 `RawContent`(HTML 포함)를 Postgres에 저장 후 `RawContentRef`만 Kafka에 발행
+- [x] 중복 URL 처리 — 에러 없이 기존 레코드 ID 반환
+- [x] `PoolManager` (`manager.go`) — 우선순위 기반 다중 풀 오케스트레이션 (High / Normal / Low)
+- [x] 풀 처리 로직 단위 테스트 (`test/internal/worker/`)
 
 📋 **계획됨**
 - [ ] 처리 파이프라인 (normalize → validate → enrich)
@@ -238,7 +244,8 @@ issuetracker/
 │   │   │   ├── handler.go     # Handler 인터페이스, Registry
 │   │   │   └── noop.go        # 폴백 noop 핸들러
 │   │   ├── worker/            # Kafka consumer 풀
-│   │   │   └── pool.go        # KafkaConsumerPool (고루틴 워커 풀 + DLQ)
+│   │   │   ├── pool.go        # KafkaConsumerPool (고루틴 워커 풀 + DLQ + Postgres 오프로딩)
+│   │   │   └── manager.go     # PoolManager (High/Normal/Low 우선순위 풀 오케스트레이션)
 │   └── storage/               # 데이터 액세스 레이어
 │       ├── news_article.go    # NewsArticle 리포지토리 인터페이스
 │       └── postgres/          # PostgreSQL 구현

--- a/examples/kafka_pipeline/main.go
+++ b/examples/kafka_pipeline/main.go
@@ -14,6 +14,7 @@ import (
 
   "issuetracker/internal/crawler/core"
   "issuetracker/internal/crawler/worker"
+  "issuetracker/internal/storage"
   "issuetracker/pkg/logger"
   "issuetracker/pkg/queue"
 )
@@ -102,6 +103,25 @@ func (c *mockConsumer) Close() error { return nil }
 // =========================================================
 // 테스트용 크롤러 핸들러
 // =========================================================
+
+// mockRawContentService는 Postgres 저장 없이 ID를 그대로 반환하는 테스트용 RawContentService입니다.
+type mockRawContentService struct{}
+
+func (s *mockRawContentService) Store(_ context.Context, raw *core.RawContent) (string, bool, error) {
+  return raw.ID, false, nil
+}
+
+func (s *mockRawContentService) GetByID(_ context.Context, id string) (*core.RawContent, error) {
+  return nil, nil
+}
+
+func (s *mockRawContentService) List(_ context.Context, _ storage.RawContentFilter) ([]*core.RawContent, error) {
+  return nil, nil
+}
+
+func (s *mockRawContentService) PurgeOlderThan(_ context.Context, _ time.Time) (int64, error) {
+  return 0, nil
+}
 
 // testCrawlerHandler는 실제 HTTP 요청 없이 더미 RawContent를 생성합니다.
 type testCrawlerHandler struct {
@@ -214,18 +234,20 @@ func printPipelineResults(log *logger.Logger, published []queue.Message) {
     case queue.TopicRawUS:
       rawCount++
 
-      var raw core.RawContent
-      if err := json.Unmarshal(msg.Value, &raw); err != nil {
+      // Kafka에는 HTML 없는 RawContentRef만 발행됩니다 (Postgres 오프로딩)
+      var ref core.RawContentRef
+      if err := json.Unmarshal(msg.Value, &ref); err != nil {
         continue
       }
 
       log.WithFields(map[string]interface{}{
         "topic":   msg.Topic,
-        "url":     raw.URL,
-        "source":  raw.SourceInfo.Name,
-        "country": raw.SourceInfo.Country,
+        "id":      ref.ID,
+        "url":     ref.URL,
+        "source":  ref.SourceInfo.Name,
+        "country": ref.SourceInfo.Country,
         "size":    fmt.Sprintf("%d bytes", len(msg.Value)),
-      }).Info("raw content")
+      }).Info("raw content ref (offloaded to postgres)")
 
     case queue.TopicDLQ:
       dlqCount++
@@ -304,6 +326,7 @@ func main() {
     consumer,
     producer,
     handler,
+    &mockRawContentService{},   // Postgres 오프로딩 서비스 (예제용 in-memory mock)
     workerCount,
     worker.DefaultRawTopicFunc, // 국가 코드 기반 raw 토픽 결정
   )

--- a/examples/kafka_pipeline/main.go
+++ b/examples/kafka_pipeline/main.go
@@ -322,7 +322,7 @@ func main() {
   consumer := newMockConsumer(msgs)
   handler := &testCrawlerHandler{log: log}
 
-  pool := worker.NewKafkaConsumerPool(
+  pool, err := worker.NewKafkaConsumerPool(
     consumer,
     producer,
     handler,
@@ -330,6 +330,9 @@ func main() {
     workerCount,
     worker.DefaultRawTopicFunc, // 국가 코드 기반 raw 토픽 결정
   )
+  if err != nil {
+    log.WithError(err).Fatal("KafkaConsumerPool 생성 실패")
+  }
 
   start := time.Now()
   pool.Start(ctx)

--- a/internal/crawler/core/models.go
+++ b/internal/crawler/core/models.go
@@ -49,6 +49,16 @@ type RawContent struct {
   Metadata   map[string]interface{}
 }
 
+// RawContentRef는 Kafka raw 토픽에 발행되는 경량 참조 메시지입니다.
+// HTML 본문을 제외하고 다운스트림 소비자가 Postgres에서 전체 데이터를 조회할 수 있는
+// 최소한의 필드만 포함합니다.
+type RawContentRef struct {
+  ID         string     `json:"id"`
+  URL        string     `json:"url"`
+  FetchedAt  time.Time  `json:"fetched_at"`
+  SourceInfo SourceInfo `json:"source_info"`
+}
+
 // Content는 파싱된 컨텐츠 데이터를 나타냅니다.
 // 뉴스 기사, 커뮤니티 게시글, 소셜 미디어 포스트 등을 포함합니다.
 // DB 저장 시 3개 테이블로 분리됩니다:

--- a/internal/crawler/worker/manager.go
+++ b/internal/crawler/worker/manager.go
@@ -6,6 +6,7 @@ import (
   "sync"
 
   "issuetracker/internal/crawler/core"
+  "issuetracker/internal/storage/service"
   "issuetracker/pkg/logger"
   "issuetracker/pkg/queue"
 )
@@ -34,6 +35,11 @@ type ManagerConfig struct {
   // RawTopicFn은 크롤링 결과를 publish할 raw 토픽을 국가 코드 기반으로 결정합니다.
   // nil이면 DefaultRawTopicFunc(US→raw.us, KR→raw.kr)를 사용합니다.
   RawTopicFn RawTopicFunc
+
+  // RawContentSvc는 크롤링 결과를 Postgres에 저장하는 서비스입니다.
+  // Kafka 메시지 크기 제한(1MB)을 초과하는 대용량 HTML을 오프로딩하며,
+  // raw 토픽에는 ID만 포함된 RawContentRef를 발행합니다.
+  RawContentSvc service.RawContentService
 }
 
 // ─────────────────────────────────────────────────────────────────────────
@@ -47,10 +53,10 @@ type ManagerConfig struct {
 // using the configured PriorityResolver.
 //
 // 사용 흐름:
-//   1. NewPoolManager로 생성
-//   2. Start(ctx)로 모든 Pool 구동
-//   3. Publish(ctx, job)으로 Job을 적절한 우선순위 큐에 삽입
-//   4. 종료 시 Stop(ctx) 호출
+//  1. NewPoolManager로 생성
+//  2. Start(ctx)로 모든 Pool 구동
+//  3. Publish(ctx, job)으로 Job을 적절한 우선순위 큐에 삽입
+//  4. 종료 시 Stop(ctx) 호출
 type PoolManager struct {
   pools    map[core.Priority]*KafkaConsumerPool
   producer queue.Producer
@@ -76,9 +82,9 @@ func NewPoolManager(
 
   return &PoolManager{
     pools: map[core.Priority]*KafkaConsumerPool{
-      core.PriorityHigh:   NewKafkaConsumerPool(cfg.High.Consumer, producer, handler, cfg.High.WorkerCount, rawTopicFn),
-      core.PriorityNormal: NewKafkaConsumerPool(cfg.Normal.Consumer, producer, handler, cfg.Normal.WorkerCount, rawTopicFn),
-      core.PriorityLow:    NewKafkaConsumerPool(cfg.Low.Consumer, producer, handler, cfg.Low.WorkerCount, rawTopicFn),
+      core.PriorityHigh:   NewKafkaConsumerPool(cfg.High.Consumer, producer, handler, cfg.RawContentSvc, cfg.High.WorkerCount, rawTopicFn),
+      core.PriorityNormal: NewKafkaConsumerPool(cfg.Normal.Consumer, producer, handler, cfg.RawContentSvc, cfg.Normal.WorkerCount, rawTopicFn),
+      core.PriorityLow:    NewKafkaConsumerPool(cfg.Low.Consumer, producer, handler, cfg.RawContentSvc, cfg.Low.WorkerCount, rawTopicFn),
     },
     producer: producer,
     resolver: resolver,

--- a/internal/crawler/worker/manager.go
+++ b/internal/crawler/worker/manager.go
@@ -68,35 +68,42 @@ type PoolManager struct {
 //
 // NewPoolManager creates one KafkaConsumerPool per priority level (high/normal/low).
 // cfg.RawTopicFn이 nil이면 DefaultRawTopicFunc를 사용합니다.
+// cfg.RawContentSvc가 nil이면 에러를 반환합니다.
 func NewPoolManager(
   cfg ManagerConfig,
   producer queue.Producer,
   handler JobHandler,
   resolver PriorityResolver,
   log *logger.Logger,
-) *PoolManager {
-  // RawContentSvc는 필수 의존성입니다.
-  // nil이면 processJob()에서 Store() 호출 시 런타임 패닉이 발생하므로
-  // 초기화 단계에서 명확히 실패합니다.
-  if cfg.RawContentSvc == nil {
-    panic("NewPoolManager: cfg.RawContentSvc는 nil일 수 없습니다")
-  }
-
+) (*PoolManager, error) {
   rawTopicFn := cfg.RawTopicFn
   if rawTopicFn == nil {
     rawTopicFn = DefaultRawTopicFunc
   }
 
+  highPool, err := NewKafkaConsumerPool(cfg.High.Consumer, producer, handler, cfg.RawContentSvc, cfg.High.WorkerCount, rawTopicFn)
+  if err != nil {
+    return nil, fmt.Errorf("NewPoolManager: high pool을 생성할 수 없습니다: %w", err)
+  }
+  normalPool, err := NewKafkaConsumerPool(cfg.Normal.Consumer, producer, handler, cfg.RawContentSvc, cfg.Normal.WorkerCount, rawTopicFn)
+  if err != nil {
+    return nil, fmt.Errorf("NewPoolManager: normal pool을 생성할 수 없습니다: %w", err)
+  }
+  lowPool, err := NewKafkaConsumerPool(cfg.Low.Consumer, producer, handler, cfg.RawContentSvc, cfg.Low.WorkerCount, rawTopicFn)
+  if err != nil {
+    return nil, fmt.Errorf("NewPoolManager: low pool을 생성할 수 없습니다: %w", err)
+  }
+
   return &PoolManager{
     pools: map[core.Priority]*KafkaConsumerPool{
-      core.PriorityHigh:   NewKafkaConsumerPool(cfg.High.Consumer, producer, handler, cfg.RawContentSvc, cfg.High.WorkerCount, rawTopicFn),
-      core.PriorityNormal: NewKafkaConsumerPool(cfg.Normal.Consumer, producer, handler, cfg.RawContentSvc, cfg.Normal.WorkerCount, rawTopicFn),
-      core.PriorityLow:    NewKafkaConsumerPool(cfg.Low.Consumer, producer, handler, cfg.RawContentSvc, cfg.Low.WorkerCount, rawTopicFn),
+      core.PriorityHigh:   highPool,
+      core.PriorityNormal: normalPool,
+      core.PriorityLow:    lowPool,
     },
     producer: producer,
     resolver: resolver,
     log:      log,
-  }
+  }, nil
 }
 
 // Publish는 CrawlJob을 PriorityResolver로 우선순위를 결정한 후 해당 Kafka crawl 토픽에 발행합니다.

--- a/internal/crawler/worker/manager.go
+++ b/internal/crawler/worker/manager.go
@@ -75,6 +75,13 @@ func NewPoolManager(
   resolver PriorityResolver,
   log *logger.Logger,
 ) *PoolManager {
+  // RawContentSvc는 필수 의존성입니다.
+  // nil이면 processJob()에서 Store() 호출 시 런타임 패닉이 발생하므로
+  // 초기화 단계에서 명확히 실패합니다.
+  if cfg.RawContentSvc == nil {
+    panic("NewPoolManager: cfg.RawContentSvc는 nil일 수 없습니다")
+  }
+
   rawTopicFn := cfg.RawTopicFn
   if rawTopicFn == nil {
     rawTopicFn = DefaultRawTopicFunc

--- a/internal/crawler/worker/pool.go
+++ b/internal/crawler/worker/pool.go
@@ -213,7 +213,7 @@ func (p *KafkaConsumerPool) processJob(ctx context.Context, item jobItem) error 
 func (p *KafkaConsumerPool) publishRawRef(ctx context.Context, ref *core.RawContentRef, job *core.CrawlJob) error {
   data, err := json.Marshal(ref)
   if err != nil {
-    return fmt.Errorf("RawContentRef 직렬화 실패: %w", err)
+    return fmt.Errorf("marshal raw content ref: %w", err)
   }
 
   msg := queue.Message{

--- a/internal/crawler/worker/pool.go
+++ b/internal/crawler/worker/pool.go
@@ -11,31 +11,32 @@ import (
   "sync"
 
   "issuetracker/internal/crawler/core"
+  "issuetracker/internal/storage/service"
   "issuetracker/pkg/logger"
   "issuetracker/pkg/queue"
 )
 
 // JobHandler는 CrawlJob을 처리하는 인터페이스입니다.
-//
-// JobHandler processes a CrawlJob and returns the fetched raw content.
-// Implementations must be safe for concurrent use by multiple goroutines.
+// 구현체는 여러 goroutine에서 동시에 호출되므로 goroutine-safe해야 합니다.
 type JobHandler interface {
   Handle(ctx context.Context, job *core.CrawlJob) (*core.RawContent, error)
 }
 
 // KafkaConsumerPool은 Kafka consumer group 기반 crawler worker pool입니다.
 //
-// KafkaConsumerPool reads CrawlJob messages from a Kafka topic, distributes
-// them to worker goroutines via an internal channel, and publishes the resulting
-// RawContent to the raw topic determined by rawTopicFn. Failed jobs are retried or sent to DLQ.
+// Kafka 토픽에서 CrawlJob 메시지를 읽어 내부 채널을 통해 worker goroutine에 분배합니다.
+// 각 job의 RawContent는 먼저 rawContentSvc를 통해 Postgres에 저장되고,
+// HTML을 제외한 경량 RawContentRef(ID만 포함)만 raw 토픽에 발행합니다.
+// 이를 통해 대용량 페이지(예: CNN ~5.6MB)의 Kafka 메시지 크기 초과 문제를 방지합니다.
 type KafkaConsumerPool struct {
-  consumer    queue.Consumer
-  producer    queue.Producer
-  handler     JobHandler
-  workerCount int
-  rawTopicFn  RawTopicFunc // 국가 코드 → raw 토픽 이름 결정 함수
-  jobs        chan jobItem
-  wg          sync.WaitGroup
+  consumer      queue.Consumer
+  producer      queue.Producer
+  handler       JobHandler
+  rawContentSvc service.RawContentService // RawContent를 Postgres에 저장하는 서비스
+  workerCount   int
+  rawTopicFn    RawTopicFunc // 국가 코드 → raw 토픽 이름 결정 함수
+  jobs          chan jobItem
+  wg            sync.WaitGroup
 }
 
 type jobItem struct {
@@ -45,14 +46,15 @@ type jobItem struct {
 
 // NewKafkaConsumerPool은 새로운 KafkaConsumerPool을 생성합니다.
 //
-// NewKafkaConsumerPool creates a pool that reads from consumer, processes jobs
-// via handler, and publishes raw content to the topic returned by rawTopicFn.
-// workerCount controls the number of concurrent processing goroutines.
+// consumer에서 메시지를 읽어 handler로 처리하고, rawContentSvc로 Postgres에 저장한 뒤
+// rawTopicFn이 반환하는 토픽에 RawContentRef를 발행합니다.
+// workerCount는 동시에 실행되는 처리 goroutine 수를 결정합니다.
 // rawTopicFn이 nil이면 DefaultRawTopicFunc를 사용합니다.
 func NewKafkaConsumerPool(
   consumer queue.Consumer,
   producer queue.Producer,
   handler JobHandler,
+  rawContentSvc service.RawContentService,
   workerCount int,
   rawTopicFn RawTopicFunc,
 ) *KafkaConsumerPool {
@@ -60,11 +62,12 @@ func NewKafkaConsumerPool(
     rawTopicFn = DefaultRawTopicFunc
   }
   return &KafkaConsumerPool{
-    consumer:    consumer,
-    producer:    producer,
-    handler:     handler,
-    workerCount: workerCount,
-    rawTopicFn:  rawTopicFn,
+    consumer:      consumer,
+    producer:      producer,
+    handler:       handler,
+    rawContentSvc: rawContentSvc,
+    workerCount:   workerCount,
+    rawTopicFn:    rawTopicFn,
     // 버퍼 크기: worker 수의 2배로 polling과 처리 사이의 지연을 흡수
     jobs: make(chan jobItem, workerCount*2),
   }
@@ -115,13 +118,13 @@ func (p *KafkaConsumerPool) pollMessages(ctx context.Context) {
         return
       }
 
-      log.WithError(err).Error("failed to fetch message from kafka")
+      log.WithError(err).Error("Kafka 메시지 수신 실패")
       continue
     }
 
     job, err := core.UnmarshalCrawlJob(msg.Value)
     if err != nil {
-      log.WithError(err).Error("malformed crawl job message, sending to DLQ")
+      log.WithError(err).Error("CrawlJob 역직렬화 실패, DLQ로 전송")
       p.sendToDLQ(ctx, msg, err)
       continue
     }
@@ -144,7 +147,7 @@ func (p *KafkaConsumerPool) worker(ctx context.Context) {
       log.WithFields(map[string]interface{}{
         "job_id":  item.job.ID,
         "crawler": item.job.CrawlerName,
-      }).WithError(err).Error("job processing failed")
+      }).WithError(err).Error("job 처리 실패")
     }
   }
 }
@@ -156,7 +159,7 @@ func (p *KafkaConsumerPool) processJob(ctx context.Context, item jobItem) error 
     "job_id":  item.job.ID,
     "crawler": item.job.CrawlerName,
     "url":     item.job.Target.URL,
-  }).Info("processing crawl job")
+  }).Info("crawl job 처리 시작")
 
   raw, err := p.handler.Handle(ctx, item.job)
   if err != nil {
@@ -175,26 +178,41 @@ func (p *KafkaConsumerPool) processJob(ctx context.Context, item jobItem) error 
     return p.commitMessage(ctx, item.msg)
   }
 
-  if err := p.publishRaw(ctx, raw, item.job); err != nil {
-    return fmt.Errorf("publish raw content for job %s: %w", item.job.ID, err)
+  // Postgres에 HTML 본문을 포함한 전체 RawContent 저장
+  // 중복 URL이면 기존 ID를 반환하며 에러를 반환하지 않습니다
+  id, _, err := p.rawContentSvc.Store(ctx, raw)
+  if err != nil {
+    return fmt.Errorf("store raw content for job %s: %w", item.job.ID, err)
+  }
+
+  // Kafka에는 ID만 포함된 경량 참조 메시지 발행 (1MB 한도 초과 방지)
+  ref := &core.RawContentRef{
+    ID:         id,
+    URL:        raw.URL,
+    FetchedAt:  raw.FetchedAt,
+    SourceInfo: raw.SourceInfo,
+  }
+
+  if err := p.publishRawRef(ctx, ref, item.job); err != nil {
+    return fmt.Errorf("publish raw ref for job %s: %w", item.job.ID, err)
   }
 
   return p.commitMessage(ctx, item.msg)
 }
 
-func (p *KafkaConsumerPool) publishRaw(ctx context.Context, raw *core.RawContent, job *core.CrawlJob) error {
-  data, err := json.Marshal(raw)
+func (p *KafkaConsumerPool) publishRawRef(ctx context.Context, ref *core.RawContentRef, job *core.CrawlJob) error {
+  data, err := json.Marshal(ref)
   if err != nil {
-    return fmt.Errorf("marshal raw content: %w", err)
+    return fmt.Errorf("RawContentRef 직렬화 실패: %w", err)
   }
 
   msg := queue.Message{
-    Topic: p.rawTopicFn(raw.SourceInfo.Country), // 국가 코드 기반으로 raw 토픽 결정
-    Key:   []byte(raw.URL),                      // URL을 파티션 키로 사용하여 동일 URL의 순서 보장
+    Topic: p.rawTopicFn(ref.SourceInfo.Country), // 국가 코드 기반으로 raw 토픽 결정
+    Key:   []byte(ref.URL),                       // URL을 파티션 키로 사용하여 동일 URL의 순서 보장
     Value: data,
     Headers: map[string]string{
-      "source":  raw.SourceInfo.Name,
-      "country": raw.SourceInfo.Country,
+      "source":  ref.SourceInfo.Name,
+      "country": ref.SourceInfo.Country,
       "job_id":  job.ID,
     },
   }
@@ -204,7 +222,7 @@ func (p *KafkaConsumerPool) publishRaw(ctx context.Context, raw *core.RawContent
 
 func (p *KafkaConsumerPool) commitMessage(ctx context.Context, msg *queue.Message) error {
   if err := p.consumer.CommitMessages(ctx, msg); err != nil {
-    return fmt.Errorf("commit offset: %w", err)
+    return fmt.Errorf("offset commit 실패: %w", err)
   }
 
   return nil
@@ -229,7 +247,7 @@ func (p *KafkaConsumerPool) sendToDLQ(ctx context.Context, msg *queue.Message, r
   }
 
   if err := p.producer.Publish(ctx, dlqMsg); err != nil {
-    log.WithError(err).Error("failed to send message to DLQ")
+    log.WithError(err).Error("DLQ 전송 실패")
   }
 }
 
@@ -240,7 +258,7 @@ func (p *KafkaConsumerPool) requeueWithRetry(ctx context.Context, job *core.Craw
 
   data, err := job.Marshal()
   if err != nil {
-    log.WithError(err).Error("failed to marshal job for requeue")
+    log.WithError(err).Error("재큐잉을 위한 job 직렬화 실패")
     return
   }
 
@@ -257,7 +275,7 @@ func (p *KafkaConsumerPool) requeueWithRetry(ctx context.Context, job *core.Craw
   }
 
   if err := p.producer.Publish(ctx, msg); err != nil {
-    log.WithError(err).Error("failed to requeue job for retry")
+    log.WithError(err).Error("재시도 재큐잉 실패")
   }
 }
 

--- a/internal/crawler/worker/pool.go
+++ b/internal/crawler/worker/pool.go
@@ -50,6 +50,10 @@ type jobItem struct {
 // rawTopicFn이 반환하는 토픽에 RawContentRef를 발행합니다.
 // workerCount는 동시에 실행되는 처리 goroutine 수를 결정합니다.
 // rawTopicFn이 nil이면 DefaultRawTopicFunc를 사용합니다.
+// rawContentSvc가 nil이면 에러를 반환합니다.
+//
+// TODO: 향후 Postgres 부하 절감을 위해 rawContentSvc 앞단에 in-memory 캐시(예: LRU)를
+// 추가하여 동일 URL의 중복 저장 요청을 줄이는 캐싱 레이어를 구현할 것.
 func NewKafkaConsumerPool(
   consumer queue.Consumer,
   producer queue.Producer,
@@ -57,7 +61,13 @@ func NewKafkaConsumerPool(
   rawContentSvc service.RawContentService,
   workerCount int,
   rawTopicFn RawTopicFunc,
-) *KafkaConsumerPool {
+) (*KafkaConsumerPool, error) {
+  // rawContentSvc는 필수 의존성입니다.
+  // nil이면 processJob()에서 Store() 호출 시 런타임 패닉이 발생하므로
+  // 초기화 단계에서 명확히 실패합니다.
+  if rawContentSvc == nil {
+    return nil, fmt.Errorf("NewKafkaConsumerPool: rawContentSvc가 nil이면 안 됩니다")
+  }
   if rawTopicFn == nil {
     rawTopicFn = DefaultRawTopicFunc
   }
@@ -70,7 +80,7 @@ func NewKafkaConsumerPool(
     rawTopicFn:    rawTopicFn,
     // 버퍼 크기: worker 수의 2배로 polling과 처리 사이의 지연을 흡수
     jobs: make(chan jobItem, workerCount*2),
-  }
+  }, nil
 }
 
 // Start는 worker goroutine들과 message polling goroutine을 시작합니다.

--- a/test/internal/worker/pool_test.go
+++ b/test/internal/worker/pool_test.go
@@ -164,7 +164,7 @@ func runPool(
 
   stopCtx, stopCancel := context.WithTimeout(context.Background(), 5*time.Second)
   defer stopCancel()
-  _ = pool.Stop(stopCtx)
+  assert.NoError(t, pool.Stop(stopCtx))
 }
 
 // ─────────────────────────────────────────────────────────────────────────────

--- a/test/internal/worker/pool_test.go
+++ b/test/internal/worker/pool_test.go
@@ -137,7 +137,12 @@ func marshaledJobMsg(t *testing.T, job *core.CrawlJob) *queue.Message {
 
 // runPool은 pool을 구동하고 단일 메시지를 처리한 뒤 종료합니다.
 // 두 번째 FetchMessage 호출 시 ctx를 cancel하여 pollMessages가 깨끗이 종료되도록 합니다.
-func runPool(t *testing.T, consumer *mockConsumer, pool *worker.KafkaConsumerPool, msg *queue.Message) {
+func runPool(
+  t *testing.T,
+  consumer *mockConsumer,
+  pool *worker.KafkaConsumerPool,
+  msg *queue.Message,
+) {
   t.Helper()
 
   ctx, cancel := context.WithCancel(context.Background())

--- a/test/internal/worker/pool_test.go
+++ b/test/internal/worker/pool_test.go
@@ -166,6 +166,19 @@ func runPool(t *testing.T, consumer *mockConsumer, pool *worker.KafkaConsumerPoo
 // 테스트
 // ─────────────────────────────────────────────────────────────────────────────
 
+// TestKafkaConsumerPool_NilRawContentSvc_ReturnsError는
+// rawContentSvc가 nil일 때 NewKafkaConsumerPool이 에러를 반환하는지 검증합니다.
+func TestKafkaConsumerPool_NilRawContentSvc_ReturnsError(t *testing.T) {
+  consumer := new(mockConsumer)
+  producer := new(mockProducer)
+  handler := new(mockJobHandler)
+
+  pool, err := worker.NewKafkaConsumerPool(consumer, producer, handler, nil, 1, nil)
+
+  assert.Nil(t, pool)
+  assert.Error(t, err)
+}
+
 // TestKafkaConsumerPool_ProcessJob_StoresInPostgresAndPublishesRef는
 // 정상 흐름에서 RawContent를 Postgres에 저장하고 ID만 담긴 RawContentRef를 Kafka에 발행하는지 검증합니다.
 func TestKafkaConsumerPool_ProcessJob_StoresInPostgresAndPublishesRef(t *testing.T) {
@@ -174,7 +187,8 @@ func TestKafkaConsumerPool_ProcessJob_StoresInPostgresAndPublishesRef(t *testing
   handler := new(mockJobHandler)
   rawSvc := new(mockRawContentService)
 
-  pool := worker.NewKafkaConsumerPool(consumer, producer, handler, rawSvc, 1, nil)
+  pool, err := worker.NewKafkaConsumerPool(consumer, producer, handler, rawSvc, 1, nil)
+  assert.NoError(t, err)
 
   job := newTestJob()
   raw := newTestRawContent()
@@ -212,7 +226,8 @@ func TestKafkaConsumerPool_ProcessJob_DuplicateURL_PublishesExistingID(t *testin
   handler := new(mockJobHandler)
   rawSvc := new(mockRawContentService)
 
-  pool := worker.NewKafkaConsumerPool(consumer, producer, handler, rawSvc, 1, nil)
+  pool, err := worker.NewKafkaConsumerPool(consumer, producer, handler, rawSvc, 1, nil)
+  assert.NoError(t, err)
 
   job := newTestJob()
   raw := newTestRawContent()
@@ -247,7 +262,8 @@ func TestKafkaConsumerPool_ProcessJob_StoreError_DoesNotPublish(t *testing.T) {
   handler := new(mockJobHandler)
   rawSvc := new(mockRawContentService)
 
-  pool := worker.NewKafkaConsumerPool(consumer, producer, handler, rawSvc, 1, nil)
+  pool, err := worker.NewKafkaConsumerPool(consumer, producer, handler, rawSvc, 1, nil)
+  assert.NoError(t, err)
 
   job := newTestJob()
   raw := newTestRawContent()
@@ -272,7 +288,8 @@ func TestKafkaConsumerPool_ProcessJob_NilRaw_CommitsWithoutStore(t *testing.T) {
   handler := new(mockJobHandler)
   rawSvc := new(mockRawContentService)
 
-  pool := worker.NewKafkaConsumerPool(consumer, producer, handler, rawSvc, 1, nil)
+  pool, err := worker.NewKafkaConsumerPool(consumer, producer, handler, rawSvc, 1, nil)
+  assert.NoError(t, err)
 
   job := newTestJob()
   msg := marshaledJobMsg(t, job)
@@ -296,7 +313,8 @@ func TestKafkaConsumerPool_ProcessJob_PublishedRefHasNoHTML(t *testing.T) {
   handler := new(mockJobHandler)
   rawSvc := new(mockRawContentService)
 
-  pool := worker.NewKafkaConsumerPool(consumer, producer, handler, rawSvc, 1, nil)
+  pool, err := worker.NewKafkaConsumerPool(consumer, producer, handler, rawSvc, 1, nil)
+  assert.NoError(t, err)
 
   job := newTestJob()
   raw := newTestRawContent()
@@ -337,7 +355,8 @@ func TestKafkaConsumerPool_ProcessJob_KRSource_PublishesToKRTopic(t *testing.T) 
   handler := new(mockJobHandler)
   rawSvc := new(mockRawContentService)
 
-  pool := worker.NewKafkaConsumerPool(consumer, producer, handler, rawSvc, 1, nil)
+  pool, err := worker.NewKafkaConsumerPool(consumer, producer, handler, rawSvc, 1, nil)
+  assert.NoError(t, err)
 
   job := newTestJob()
   raw := newTestRawContent()

--- a/test/internal/worker/pool_test.go
+++ b/test/internal/worker/pool_test.go
@@ -1,0 +1,360 @@
+package worker_test
+
+import (
+  "context"
+  "encoding/json"
+  "errors"
+  "testing"
+  "time"
+
+  "github.com/stretchr/testify/assert"
+  "github.com/stretchr/testify/mock"
+
+  "issuetracker/internal/crawler/core"
+  "issuetracker/internal/crawler/worker"
+  "issuetracker/internal/storage"
+  "issuetracker/pkg/queue"
+)
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Mock 구현체
+// ─────────────────────────────────────────────────────────────────────────────
+
+type mockConsumer struct{ mock.Mock }
+
+func (m *mockConsumer) FetchMessage(ctx context.Context) (*queue.Message, error) {
+  args := m.Called(ctx)
+  if args.Get(0) == nil {
+    return nil, args.Error(1)
+  }
+  return args.Get(0).(*queue.Message), args.Error(1)
+}
+
+func (m *mockConsumer) CommitMessages(ctx context.Context, msgs ...*queue.Message) error {
+  args := m.Called(ctx, msgs)
+  return args.Error(0)
+}
+
+func (m *mockConsumer) Close() error {
+  args := m.Called()
+  return args.Error(0)
+}
+
+type mockProducer struct{ mock.Mock }
+
+func (m *mockProducer) Publish(ctx context.Context, msg queue.Message) error {
+  args := m.Called(ctx, msg)
+  return args.Error(0)
+}
+
+func (m *mockProducer) PublishBatch(ctx context.Context, msgs []queue.Message) error {
+  args := m.Called(ctx, msgs)
+  return args.Error(0)
+}
+
+func (m *mockProducer) Close() error {
+  args := m.Called()
+  return args.Error(0)
+}
+
+type mockJobHandler struct{ mock.Mock }
+
+func (m *mockJobHandler) Handle(ctx context.Context, job *core.CrawlJob) (*core.RawContent, error) {
+  args := m.Called(ctx, job)
+  if args.Get(0) == nil {
+    return nil, args.Error(1)
+  }
+  return args.Get(0).(*core.RawContent), args.Error(1)
+}
+
+type mockRawContentService struct{ mock.Mock }
+
+func (m *mockRawContentService) Store(ctx context.Context, raw *core.RawContent) (string, bool, error) {
+  args := m.Called(ctx, raw)
+  return args.String(0), args.Bool(1), args.Error(2)
+}
+
+func (m *mockRawContentService) GetByID(ctx context.Context, id string) (*core.RawContent, error) {
+  args := m.Called(ctx, id)
+  if args.Get(0) == nil {
+    return nil, args.Error(1)
+  }
+  return args.Get(0).(*core.RawContent), args.Error(1)
+}
+
+func (m *mockRawContentService) List(ctx context.Context, filter storage.RawContentFilter) ([]*core.RawContent, error) {
+  args := m.Called(ctx, filter)
+  if args.Get(0) == nil {
+    return nil, args.Error(1)
+  }
+  return args.Get(0).([]*core.RawContent), args.Error(1)
+}
+
+func (m *mockRawContentService) PurgeOlderThan(ctx context.Context, cutoff time.Time) (int64, error) {
+  args := m.Called(ctx, cutoff)
+  return args.Get(0).(int64), args.Error(1)
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 헬퍼
+// ─────────────────────────────────────────────────────────────────────────────
+
+func newTestJob() *core.CrawlJob {
+  return &core.CrawlJob{
+    ID:          "job-001",
+    CrawlerName: "test-crawler",
+    Target:      core.Target{URL: "https://example.com/article"},
+    Priority:    core.PriorityNormal,
+    MaxRetries:  3,
+  }
+}
+
+func newTestRawContent() *core.RawContent {
+  return &core.RawContent{
+    ID:        "raw-001",
+    URL:       "https://example.com/article",
+    HTML:      "<html><body>Test</body></html>",
+    FetchedAt: time.Now(),
+    SourceInfo: core.SourceInfo{
+      Country:  "US",
+      Type:     core.SourceTypeNews,
+      Name:     "test-source",
+      Language: "en",
+    },
+  }
+}
+
+func marshaledJobMsg(t *testing.T, job *core.CrawlJob) *queue.Message {
+  t.Helper()
+  data, err := job.Marshal()
+  assert.NoError(t, err)
+  return &queue.Message{
+    Topic: queue.TopicCrawlNormal,
+    Key:   []byte(job.ID),
+    Value: data,
+  }
+}
+
+// runPool은 pool을 구동하고 단일 메시지를 처리한 뒤 종료합니다.
+// 두 번째 FetchMessage 호출 시 ctx를 cancel하여 pollMessages가 깨끗이 종료되도록 합니다.
+func runPool(t *testing.T, consumer *mockConsumer, pool *worker.KafkaConsumerPool, msg *queue.Message) {
+  t.Helper()
+
+  ctx, cancel := context.WithCancel(context.Background())
+
+  consumer.On("FetchMessage", mock.Anything).Return(msg, nil).Once()
+  // 두 번째 호출에서 ctx를 cancel → pollMessages가 ctx.Err() != nil로 정상 종료
+  consumer.On("FetchMessage", mock.Anything).
+    Run(func(_ mock.Arguments) { cancel() }).
+    Return(nil, context.Canceled)
+  consumer.On("Close").Return(nil)
+
+  pool.Start(ctx)
+
+  // pollMessages가 ctx cancel을 감지하고 종료할 때까지 대기.
+  // cancel()은 두 번째 FetchMessage 호출의 Run 훅에서 실행되므로,
+  // 이 시점에는 첫 번째 메시지가 이미 p.jobs 채널에 버퍼링된 상태입니다.
+  // pool.Stop이 p.jobs를 닫기 전에 pollMessages가 반드시 종료되어야 패닉을 방지합니다.
+  <-ctx.Done()
+
+  stopCtx, stopCancel := context.WithTimeout(context.Background(), 5*time.Second)
+  defer stopCancel()
+  _ = pool.Stop(stopCtx)
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 테스트
+// ─────────────────────────────────────────────────────────────────────────────
+
+// TestKafkaConsumerPool_ProcessJob_StoresInPostgresAndPublishesRef는
+// 정상 흐름에서 RawContent를 Postgres에 저장하고 ID만 담긴 RawContentRef를 Kafka에 발행하는지 검증합니다.
+func TestKafkaConsumerPool_ProcessJob_StoresInPostgresAndPublishesRef(t *testing.T) {
+  consumer := new(mockConsumer)
+  producer := new(mockProducer)
+  handler := new(mockJobHandler)
+  rawSvc := new(mockRawContentService)
+
+  pool := worker.NewKafkaConsumerPool(consumer, producer, handler, rawSvc, 1, nil)
+
+  job := newTestJob()
+  raw := newTestRawContent()
+  msg := marshaledJobMsg(t, job)
+
+  handler.On("Handle", mock.Anything, job).Return(raw, nil)
+  rawSvc.On("Store", mock.Anything, raw).Return("raw-001", false, nil)
+
+  // RawContentRef가 올바른 토픽과 ID로 발행되는지 확인
+  producer.On("Publish", mock.Anything, mock.MatchedBy(func(m queue.Message) bool {
+    if m.Topic != queue.TopicRawUS {
+      return false
+    }
+    var ref core.RawContentRef
+    if err := json.Unmarshal(m.Value, &ref); err != nil {
+      return false
+    }
+    return ref.ID == "raw-001" && ref.URL == raw.URL
+  })).Return(nil)
+
+  consumer.On("CommitMessages", mock.Anything, mock.Anything).Return(nil)
+
+  runPool(t, consumer, pool, msg)
+
+  handler.AssertExpectations(t)
+  rawSvc.AssertExpectations(t)
+  producer.AssertExpectations(t)
+}
+
+// TestKafkaConsumerPool_ProcessJob_DuplicateURL_PublishesExistingID는
+// 중복 URL에서 Store가 기존 ID를 반환해도 RawContentRef를 정상 발행하는지 검증합니다.
+func TestKafkaConsumerPool_ProcessJob_DuplicateURL_PublishesExistingID(t *testing.T) {
+  consumer := new(mockConsumer)
+  producer := new(mockProducer)
+  handler := new(mockJobHandler)
+  rawSvc := new(mockRawContentService)
+
+  pool := worker.NewKafkaConsumerPool(consumer, producer, handler, rawSvc, 1, nil)
+
+  job := newTestJob()
+  raw := newTestRawContent()
+  msg := marshaledJobMsg(t, job)
+
+  handler.On("Handle", mock.Anything, job).Return(raw, nil)
+  // 중복: Store가 기존 ID와 isDuplicate=true를 반환
+  rawSvc.On("Store", mock.Anything, raw).Return("existing-raw-999", true, nil)
+
+  // 기존 ID가 ref에 포함되어야 합니다
+  producer.On("Publish", mock.Anything, mock.MatchedBy(func(m queue.Message) bool {
+    var ref core.RawContentRef
+    if err := json.Unmarshal(m.Value, &ref); err != nil {
+      return false
+    }
+    return ref.ID == "existing-raw-999"
+  })).Return(nil)
+
+  consumer.On("CommitMessages", mock.Anything, mock.Anything).Return(nil)
+
+  runPool(t, consumer, pool, msg)
+
+  rawSvc.AssertExpectations(t)
+  producer.AssertExpectations(t)
+}
+
+// TestKafkaConsumerPool_ProcessJob_StoreError_DoesNotPublish는
+// Postgres 저장 실패 시 Kafka 발행 없이 에러를 반환하는지 검증합니다.
+func TestKafkaConsumerPool_ProcessJob_StoreError_DoesNotPublish(t *testing.T) {
+  consumer := new(mockConsumer)
+  producer := new(mockProducer)
+  handler := new(mockJobHandler)
+  rawSvc := new(mockRawContentService)
+
+  pool := worker.NewKafkaConsumerPool(consumer, producer, handler, rawSvc, 1, nil)
+
+  job := newTestJob()
+  raw := newTestRawContent()
+  msg := marshaledJobMsg(t, job)
+
+  handler.On("Handle", mock.Anything, job).Return(raw, nil)
+  rawSvc.On("Store", mock.Anything, raw).Return("", false, errors.New("db connection failed"))
+
+  runPool(t, consumer, pool, msg)
+
+  rawSvc.AssertExpectations(t)
+  // Store 실패 시 Publish가 호출되면 안 됩니다
+  producer.AssertNotCalled(t, "Publish", mock.Anything, mock.Anything)
+}
+
+// TestKafkaConsumerPool_ProcessJob_NilRaw_CommitsWithoutStore는
+// handler가 nil RawContent를 반환할 때 Store와 Publish를 호출하지 않고
+// 바로 commit하는지 검증합니다.
+func TestKafkaConsumerPool_ProcessJob_NilRaw_CommitsWithoutStore(t *testing.T) {
+  consumer := new(mockConsumer)
+  producer := new(mockProducer)
+  handler := new(mockJobHandler)
+  rawSvc := new(mockRawContentService)
+
+  pool := worker.NewKafkaConsumerPool(consumer, producer, handler, rawSvc, 1, nil)
+
+  job := newTestJob()
+  msg := marshaledJobMsg(t, job)
+
+  // handler가 nil 반환 (처리할 내용 없음)
+  handler.On("Handle", mock.Anything, job).Return(nil, nil)
+  consumer.On("CommitMessages", mock.Anything, mock.Anything).Return(nil)
+
+  runPool(t, consumer, pool, msg)
+
+  rawSvc.AssertNotCalled(t, "Store", mock.Anything, mock.Anything)
+  producer.AssertNotCalled(t, "Publish", mock.Anything, mock.Anything)
+  consumer.AssertCalled(t, "CommitMessages", mock.Anything, mock.Anything)
+}
+
+// TestKafkaConsumerPool_ProcessJob_PublishedRefHasNoHTML는
+// Kafka에 발행되는 메시지에 HTML이 포함되지 않음을 검증합니다 (대용량 페이지 오프로딩).
+func TestKafkaConsumerPool_ProcessJob_PublishedRefHasNoHTML(t *testing.T) {
+  consumer := new(mockConsumer)
+  producer := new(mockProducer)
+  handler := new(mockJobHandler)
+  rawSvc := new(mockRawContentService)
+
+  pool := worker.NewKafkaConsumerPool(consumer, producer, handler, rawSvc, 1, nil)
+
+  job := newTestJob()
+  raw := newTestRawContent()
+  // 대용량 HTML 시뮬레이션 (~5.6MB, CNN live blog 수준)
+  raw.HTML = string(make([]byte, 5*1024*1024))
+
+  msg := marshaledJobMsg(t, job)
+
+  handler.On("Handle", mock.Anything, job).Return(raw, nil)
+  rawSvc.On("Store", mock.Anything, raw).Return("raw-001", false, nil)
+
+  var capturedMsg queue.Message
+  producer.On("Publish", mock.Anything, mock.Anything).
+    Run(func(args mock.Arguments) {
+      capturedMsg = args.Get(1).(queue.Message)
+    }).
+    Return(nil)
+  consumer.On("CommitMessages", mock.Anything, mock.Anything).Return(nil)
+
+  runPool(t, consumer, pool, msg)
+
+  producer.AssertExpectations(t)
+
+  // 발행된 메시지가 1MB 이하인지 확인 (HTML이 없어야 함)
+  assert.Less(t, len(capturedMsg.Value), 1024*1024, "Kafka 메시지가 1MB 이하여야 합니다")
+
+  // RawContentRef로 역직렬화 가능하고 ID가 올바른지 확인
+  var ref core.RawContentRef
+  assert.NoError(t, json.Unmarshal(capturedMsg.Value, &ref))
+  assert.Equal(t, "raw-001", ref.ID)
+}
+
+// TestKafkaConsumerPool_ProcessJob_KRSource_PublishesToKRTopic는
+// 한국 소스의 RawContent를 kr 토픽에 발행하는지 검증합니다.
+func TestKafkaConsumerPool_ProcessJob_KRSource_PublishesToKRTopic(t *testing.T) {
+  consumer := new(mockConsumer)
+  producer := new(mockProducer)
+  handler := new(mockJobHandler)
+  rawSvc := new(mockRawContentService)
+
+  pool := worker.NewKafkaConsumerPool(consumer, producer, handler, rawSvc, 1, nil)
+
+  job := newTestJob()
+  raw := newTestRawContent()
+  raw.SourceInfo.Country = "KR"
+
+  msg := marshaledJobMsg(t, job)
+
+  handler.On("Handle", mock.Anything, job).Return(raw, nil)
+  rawSvc.On("Store", mock.Anything, raw).Return("raw-kr-001", false, nil)
+
+  producer.On("Publish", mock.Anything, mock.MatchedBy(func(m queue.Message) bool {
+    return m.Topic == queue.TopicRawKR
+  })).Return(nil)
+
+  consumer.On("CommitMessages", mock.Anything, mock.Anything).Return(nil)
+
+  runPool(t, consumer, pool, msg)
+
+  producer.AssertExpectations(t)
+}


### PR DESCRIPTION
## 이슈 번호
- #34 

## 요약

- Kafka 기본 메시지 크기 한도(1MB)를 초과하는 대용량 HTML 페이지(예: CNN ~5.6MB) 처리 문제를 해결합니다.
- 크롤러 워커가 전체 `RawContent`(HTML 포함)를 **Postgres에 먼저 저장**하고, ID만 포함된 경량 `RawContentRef`를 Kafka에 발행합니다.
- 다운스트림 소비자는 `RawContentRef.ID`로 Postgres에서 필요한 전체 데이터를 조회합니다.

## 변경 내용

### `internal/crawler/core/models.go`
- `RawContentRef` 구조체 추가 (`ID`, `URL`, `FetchedAt`, `SourceInfo` — HTML 필드 없음)

### `internal/crawler/worker/pool.go`
- `KafkaConsumerPool`에 `rawContentSvc service.RawContentService` 의존성 주입
- `publishRaw(RawContent)` → `publishRawRef(RawContentRef)` 교체
- 중복 URL이면 에러 없이 기존 레코드 ID 반환
- 주석 한국어화

### `internal/crawler/worker/manager.go`
- `ManagerConfig`에 `RawContentSvc service.RawContentService` 필드 추가
- `NewPoolManager`에서 High / Normal / Low 각 풀 생성 시 서비스 전달

### `examples/kafka_pipeline/main.go`
- `mockRawContentService` 추가 및 `RawContentRef` 디코딩으로 예제 업데이트

### `test/internal/worker/pool_test.go` (신규)
- 6개 단위 테스트 케이스:
  - 정상 흐름 — Postgres 저장 후 `RawContentRef` 발행
  - 중복 URL — 기존 ID로 발행
  - `Store()` 실패 — Kafka 발행 없이 에러 반환
  - `handler.Handle()` → `nil` 반환 — commit만 수행
  - 발행된 메시지에 HTML 필드 없음 검증
  - KR 소스 → `raw.kr` 토픽으로 발행 검증

### `README.md` / `docs/ko/README.md`
- `✅ Kafka Blob Offloading (v0.5.0)` 섹션 추가
- `PoolManager` 완료 항목 반영

## 처리 흐름

```
Before:  handler.Handle() → json.Marshal(RawContent ~5.6MB) → Kafka ❌
After:   handler.Handle() → Postgres.Store(RawContent) → Kafka(RawContentRef ~200B) ✅
```

## 테스트 체크리스트

- [x] `go build ./...` 통과
- [x] `go test ./test/internal/worker/...` — 6개 케이스 모두 통과
- [x] 중복 URL 시나리오 단위 테스트 통과
- [x] DLQ 라우팅 기존 동작 유지 확인
