### PR TITLE
[REFAC#40]: classifier 클라이언트 연결 주소 환경 변수화

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -19,3 +19,7 @@ POSTGRES_CONN_TIMEOUT=5s
 
 # Kafka 연결 설정 (pkg/queue/config.go 기본값: localhost:9092)
 # KAFKA_BROKERS=localhost:9092
+
+# Classifier 서비스 연결 설정
+CLASSIFIER_HTTP_ADDR=http://localhost:8000
+CLASSIFIER_GRPC_ADDR=localhost:50051

--- a/internal/classifier/grpc/client.go
+++ b/internal/classifier/grpc/client.go
@@ -10,7 +10,6 @@ package grpc
 import (
 	"context"
 	"fmt"
-	"os"
 	"time"
 
 	"google.golang.org/grpc"
@@ -38,15 +37,11 @@ type Config struct {
 	Timeout time.Duration // 요청별 타임아웃
 }
 
-// DefaultConfig는 환경변수(CLASSIFIER_GRPC_ADDR)를 읽어 설정을 반환합니다.
-// 환경변수가 없으면 로컬 개발 기본값(localhost:50051)을 사용합니다.
+// DefaultConfig는 로컬 개발 환경 기본 설정을 반환합니다.
+// 환경변수 기반 설정은 pkg/config.LoadClassifier()를 사용하세요.
 func DefaultConfig() Config {
-	target := os.Getenv("CLASSIFIER_GRPC_ADDR")
-	if target == "" {
-		target = defaultTarget
-	}
 	return Config{
-		Target:  target,
+		Target:  defaultTarget,
 		Timeout: defaultTimeout,
 	}
 }

--- a/internal/classifier/grpc/client.go
+++ b/internal/classifier/grpc/client.go
@@ -10,6 +10,7 @@ package grpc
 import (
 	"context"
 	"fmt"
+	"os"
 	"time"
 
 	"google.golang.org/grpc"
@@ -37,10 +38,15 @@ type Config struct {
 	Timeout time.Duration // 요청별 타임아웃
 }
 
-// DefaultConfig는 로컬 개발 환경 기본 설정을 반환합니다.
+// DefaultConfig는 환경변수(CLASSIFIER_GRPC_ADDR)를 읽어 설정을 반환합니다.
+// 환경변수가 없으면 로컬 개발 기본값(localhost:50051)을 사용합니다.
 func DefaultConfig() Config {
+	target := os.Getenv("CLASSIFIER_GRPC_ADDR")
+	if target == "" {
+		target = defaultTarget
+	}
 	return Config{
-		Target:  defaultTarget,
+		Target:  target,
 		Timeout: defaultTimeout,
 	}
 }

--- a/internal/classifier/http/client.go
+++ b/internal/classifier/http/client.go
@@ -16,6 +16,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"os"
 	"time"
 
 	"issuetracker/internal/classifier"
@@ -39,10 +40,15 @@ type Config struct {
 	Timeout time.Duration
 }
 
-// DefaultConfig는 로컬 개발 환경 기본 설정을 반환합니다.
+// DefaultConfig는 환경변수(CLASSIFIER_HTTP_ADDR)를 읽어 설정을 반환합니다.
+// 환경변수가 없으면 로컬 개발 기본값(http://localhost:8000)을 사용합니다.
 func DefaultConfig() Config {
+	baseURL := os.Getenv("CLASSIFIER_HTTP_ADDR")
+	if baseURL == "" {
+		baseURL = defaultBaseURL
+	}
 	return Config{
-		BaseURL: defaultBaseURL,
+		BaseURL: baseURL,
 		Timeout: defaultTimeout,
 	}
 }

--- a/internal/classifier/http/client.go
+++ b/internal/classifier/http/client.go
@@ -16,7 +16,6 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"os"
 	"time"
 
 	"issuetracker/internal/classifier"
@@ -40,15 +39,11 @@ type Config struct {
 	Timeout time.Duration
 }
 
-// DefaultConfig는 환경변수(CLASSIFIER_HTTP_ADDR)를 읽어 설정을 반환합니다.
-// 환경변수가 없으면 로컬 개발 기본값(http://localhost:8000)을 사용합니다.
+// DefaultConfig는 로컬 개발 환경 기본 설정을 반환합니다.
+// 환경변수 기반 설정은 pkg/config.LoadClassifier()를 사용하세요.
 func DefaultConfig() Config {
-	baseURL := os.Getenv("CLASSIFIER_HTTP_ADDR")
-	if baseURL == "" {
-		baseURL = defaultBaseURL
-	}
 	return Config{
-		BaseURL: baseURL,
+		BaseURL: defaultBaseURL,
 		Timeout: defaultTimeout,
 	}
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -12,6 +12,43 @@ import (
 	"github.com/joho/godotenv"
 )
 
+// ClassifierConfig는 Classifier 서비스 연결 설정을 나타냅니다.
+// 모든 필드는 환경변수(LoadClassifier 참조)로 덮어쓸 수 있습니다.
+type ClassifierConfig struct {
+	HTTPAddr string // HTTP 서버 주소 (예: "http://localhost:8000")
+	GRPCAddr string // gRPC 서버 주소 (예: "localhost:50051")
+}
+
+// DefaultClassifierConfig는 로컬 개발 환경용 기본 ClassifierConfig를 반환합니다.
+func DefaultClassifierConfig() ClassifierConfig {
+	return ClassifierConfig{
+		HTTPAddr: "http://localhost:8000",
+		GRPCAddr: "localhost:50051",
+	}
+}
+
+// LoadClassifier는 .env 파일을 로드한 후 OS 환경변수로 ClassifierConfig를 구성합니다.
+// 지원 환경변수: CLASSIFIER_HTTP_ADDR, CLASSIFIER_GRPC_ADDR
+func LoadClassifier(envFiles ...string) (ClassifierConfig, error) {
+	if len(envFiles) == 0 {
+		envFiles = []string{".env"}
+	}
+	if err := godotenv.Load(envFiles...); err != nil && !errors.Is(err, os.ErrNotExist) {
+		return ClassifierConfig{}, fmt.Errorf("env 파일 로드 실패: %w", err)
+	}
+
+	cfg := DefaultClassifierConfig()
+
+	if v := os.Getenv("CLASSIFIER_HTTP_ADDR"); v != "" {
+		cfg.HTTPAddr = v
+	}
+	if v := os.Getenv("CLASSIFIER_GRPC_ADDR"); v != "" {
+		cfg.GRPCAddr = v
+	}
+
+	return cfg, nil
+}
+
 // DBConfig는 PostgreSQL 연결 설정을 나타냅니다.
 // 모든 필드는 환경변수(Load 참조)로 덮어쓸 수 있습니다.
 type DBConfig struct {


### PR DESCRIPTION
## 연관 이슈
- #40

<br>

## 구현 내용
- `pkg/config`: `ClassifierConfig` 구조체 및 `LoadClassifier()` 함수 추가 (`CLASSIFIER_HTTP_ADDR`, `CLASSIFIER_GRPC_ADDR` 환경변수 지원)
- `internal/classifier/http/client.go`: `DefaultConfig()`에서 `CLASSIFIER_HTTP_ADDR` 환경변수 읽도록 변경 (미설정 시 `http://localhost:8000` 폴백)
- `internal/classifier/grpc/client.go`: `DefaultConfig()`에서 `CLASSIFIER_GRPC_ADDR` 환경변수 읽도록 변경 (미설정 시 `localhost:50051` 폴백)
- `.env.example`: Classifier 연결 주소 환경변수 항목 추가 및 문서화

<br>

## TODO
- 

<br>

## 논의 사항
- 

<br>