### PR TITLE
[CHORE#42]: 로그 레벨 및 구조화 필드 가이드라인 추가 및 전체 파일 로그 컨벤션 적용

### DIFF
--- a/.claude/rules/04-error-handling.md
+++ b/.claude/rules/04-error-handling.md
@@ -192,11 +192,10 @@ func WithRetry(ctx context.Context, policy RetryPolicy, fn func() error) error {
 
         lastErr = err
         // Log retry attempt
-        log.Warn().
-            Err(err).
-            Int("attempt", attempt+1).
-            Int("max_attempts", policy.MaxAttempts).
-            Msg("retrying after error")
+        log.WithFields(map[string]interface{}{
+            "attempt":      attempt + 1,
+            "max_attempts": policy.MaxAttempts,
+        }).WithError(err).Warn("retrying after error")
     }
 
     return fmt.Errorf("max retries exceeded: %w", lastErr)

--- a/.claude/rules/04-error-handling.md
+++ b/.claude/rules/04-error-handling.md
@@ -245,57 +245,132 @@ Apply circuit breakers to:
 
 ### Structured Logging
 
-Use `github.com/rs/zerolog` for structured logging:
+Use `pkg/logger` (zerolog 기반 wrapper)로 구조화된 로깅을 수행합니다.
+로그 메시지는 **반드시 영어**로 작성합니다. (주석·문서는 한국어 허용, 로그 msg 문자열은 영어)
 
 ```go
-log.Info().
-    Str("crawler", "cnn").
-    Str("url", articleURL).
-    Int("status_code", resp.StatusCode).
-    Dur("duration", elapsed).
-    Msg("article fetched successfully")
+// Good — pkg/logger wrapper API
+log.WithFields(map[string]interface{}{
+    "crawler":     "cnn",
+    "url":         articleURL,
+    "status_code": resp.StatusCode,
+    "duration_ms": elapsed.Milliseconds(),
+}).Info("article fetched successfully")
 
-log.Error().
-    Err(err).
-    Str("crawler", "cnn").
-    Str("url", articleURL).
-    Str("error_code", "PARSE_001").
-    Msg("failed to parse article")
+log.WithFields(map[string]interface{}{
+    "crawler":    "cnn",
+    "url":        articleURL,
+    "error_code": "PARSE_001",
+}).WithError(err).Error("failed to parse article")
+
+// Bad — 로그 메시지에 한국어 사용 금지
+log.WithError(err).Error("기사 파싱 실패")
 ```
 
 ### Log Levels
 
-1. **DEBUG**: Detailed diagnostic information
-   - Request/response details
-   - Parsing steps
-   - Processing decisions
+레벨 선택 기준:
 
-2. **INFO**: General informational messages
-   - Successful operations
-   - Startup/shutdown
-   - Configuration loaded
-   - Job completed
+| Level | 사용 시점 | 예시 시나리오 |
+|-------|-----------|--------------|
+| **DEBUG** | 개발 또는 트러블슈팅 시에만 필요한 내부 상세 정보 | HTTP 요청 시작, 파싱 단계, 중복 감지, 재시도 결정 |
+| **INFO**  | 운영자가 프로덕션에서 확인하고 싶은 정상 동작 마일스톤 | Job 시작/완료, 서비스 연결 성공, Worker pool 기동, 정기 purge 완료 |
+| **WARN**  | 예상치 못했지만 gracefully 처리된 상황 — 시스템이 계속 동작 | 재시도 시도, fallback 프로토콜 전환, shutdown timeout |
+| **ERROR** | 작업 실패 — 주의가 필요하지만 다른 요청은 계속 처리 가능 | Job 처리 실패, 메시지 발행 실패, 파싱 실패 |
+| **FATAL** | 복구 불가능한 오류 — 프로세스 종료 필요 | 설정 파싱 실패, 기동 시 필수 DB 연결 불가 |
 
-3. **WARN**: Warning messages
-   - Retry attempts
-   - Degraded performance
-   - Deprecated usage
-   - Quality issues
+**빠른 판단 기준:**
+- 운영자가 알림을 받아야 하면: **ERROR** 또는 **FATAL**
+- 처리됐지만 운영자가 알아야 하면: **WARN**
+- 정상 동작 확인: **INFO**
+- 개발자 트레이싱 용: **DEBUG**
 
-4. **ERROR**: Error messages
-   - Failed operations
-   - Validation failures
-   - External service errors
-   - Data corruption
+```go
+// DEBUG — 운영 환경에서는 필터링됨
+log.WithField("url", url).Debug("starting HTTP GET request")
+log.WithField("attempt", attempt).Debug("error not retryable, skipping retry")
 
-5. **FATAL**: Critical errors requiring shutdown
-   - Configuration errors
-   - Fatal database errors
-   - Unrecoverable state
+// INFO — 정상 완료 마일스톤
+log.WithFields(map[string]interface{}{"job_id": id, "crawler": name}).Info("crawl job started")
+log.WithFields(map[string]interface{}{"deleted_count": n, "cutoff": t}).Info("raw content purge completed")
+
+// WARN — 예상 외 상황이지만 처리됨
+log.WithFields(map[string]interface{}{"attempt": a, "max_attempts": m, "delay_ms": d}).Warn("retrying after error")
+log.WithError(err).Warn("primary classifier failed, falling back to secondary protocol")
+
+// ERROR — 작업 실패
+log.WithFields(map[string]interface{}{"job_id": id, "crawler": name}).WithError(err).Error("job processing failed")
+log.WithError(err).Error("failed to send message to dlq")
+```
+
+### Field Naming Conventions
+
+모든 구조화 필드 키는 **snake_case**를 사용합니다. 아래 표에 정의된 표준 이름을 반드시 사용합니다.
+
+| Field Key        | Type     | 설명 |
+|-----------------|----------|------|
+| `crawler`       | string   | Crawler 이름 (예: `"cnn"`, `"naver"`) |
+| `source`        | string   | `SourceInfo.Name`과 동일한 소스 이름 |
+| `country`       | string   | ISO 3166-1 alpha-2 (예: `"US"`, `"KR"`) |
+| `url`           | string   | 처리 대상 URL |
+| `job_id`        | string   | CrawlJob UUID |
+| `request_id`    | string   | 인바운드 요청 추적 ID |
+| `error_code`    | string   | 에러 코드 상수 (예: `"NET_001"`, `"PARSE_001"`) |
+| `status_code`   | int      | HTTP 응답 상태 코드 |
+| `duration_ms`   | int64    | 경과 시간 (밀리초 단위) |
+| `attempt`       | int      | 현재 시도 횟수 (1-based) |
+| `max_attempts`  | int      | 최대 시도 횟수 |
+| `delay_ms`      | int64    | 재시도 backoff 대기 시간 (밀리초) |
+| `worker_count`  | int      | 워커 goroutine 수 |
+| `priority`      | int      | CrawlJob 우선순위 레벨 |
+| `topic`         | string   | Kafka 토픽 이름 |
+| `existing_id`   | string   | 중복 감지 시 기존 레코드 ID |
+| `content_hash`  | string   | 중복 감지용 SHA-256 콘텐츠 해시 |
+| `deleted_count` | int64    | 일괄 삭제된 레코드 수 |
+| `cutoff`        | string   | RFC3339 형식 purge 기준 시각 |
+| `host`          | string   | DB 호스트 |
+| `port`          | int      | DB 포트 |
+| `database`      | string   | DB 이름 |
+| `max_conns`     | int32    | 커넥션 풀 최대 크기 |
+
+**규칙:**
+- 임의의 키 이름 사용 금지 (예: `"db_name"` 대신 `"database"` 사용)
+- 시간 값은 반드시 밀리초 int64로, 키는 `duration_ms` 또는 `delay_ms`
+- 불리언 플래그는 긍정형 이름 사용 (예: `"retryable"`, `"is_duplicate"`)
+
+### Per-Component Required Fields
+
+컴포넌트별로 모든 로그 항목에 반드시 포함해야 하는 최소 필드입니다.
+
+**HTTP Client** (`internal/crawler/core/http_client.go`):
+- 모든 로그: `url`
+- 요청 완료 시: `status_code`, `duration_ms`
+- 에러 발생 시: `error_code`
+
+**Retry Logic** (`internal/crawler/core/retry.go`):
+- 재시도 시: `attempt`, `max_attempts`, `delay_ms`
+- 에러 포함: `.WithError(err)` 체이닝
+
+**Worker Pool** (`internal/crawler/worker/`):
+- Job 처리 로그: `job_id`, `crawler`
+- Job 시작/완료 로그: `job_id`, `crawler`, `url`
+- Pool 라이프사이클 로그: `priority`, `worker_count`
+- 메시지 발행 로그: `job_id`, `crawler`, `priority`, `topic`
+- DLQ/재큐잉 에러: `job_id`, `crawler`
+
+**Storage Service** (`internal/storage/service/`):
+- 중복 감지 로그: `existing_id`, `url` 또는 `content_hash`
+- 일괄 삭제 완료: `deleted_count`, `cutoff`
+
+**Database** (`internal/storage/postgres/`):
+- 연결 성공: `host`, `port`, `database`, `max_conns`
+
+**Classifier** (`internal/classifier/`):
+- fallback 전환 시: `.WithError(err)` 체이닝
 
 ### Log Context
 
-Always include relevant context:
+컴포넌트 초기화 시 scoped logger를 생성하여 반복 필드 중복을 방지합니다:
 
 ```go
 type LogContext struct {
@@ -308,30 +383,28 @@ type LogContext struct {
     JobID       string
 }
 
-// Use context to carry log fields
-func WithLogContext(ctx context.Context, lc LogContext) context.Context {
-    logger := log.With().
-        Str("request_id", lc.RequestID).
-        Str("crawler", lc.CrawlerName).
-        Str("source", lc.Source).
-        Str("country", lc.Country).
-        Logger()
-
-    return logger.WithContext(ctx)
+// pkg/logger를 사용하여 context에 필드 추가
+func buildLogger(ctx context.Context, lc LogContext) *logger.Logger {
+    return logger.FromContext(ctx).WithFields(map[string]interface{}{
+        "request_id": lc.RequestID,
+        "crawler":    lc.CrawlerName,
+        "source":     lc.Source,
+        "country":    lc.Country,
+    })
 }
 ```
 
 ### Log Storage
 
-1. **Console**: Development and debugging
-2. **File**: Structured JSON logs
-   - Rotate daily
-   - Compress old logs
-   - Retain for 30 days
-3. **Centralized**: Production logging
-   - Use Loki, Elasticsearch, or CloudWatch
-   - Enable full-text search
-   - Set up alerts on error patterns
+1. **Console**: 개발 및 디버깅 (Pretty mode)
+2. **File**: 구조화된 JSON 로그
+   - 일별 로테이션
+   - 오래된 로그 압축
+   - 30일 보존
+3. **Centralized**: 프로덕션 로깅
+   - Loki, Elasticsearch, 또는 CloudWatch 사용
+   - 전문 검색 활성화
+   - 에러 패턴 알림 설정
 
 ## Monitoring
 

--- a/.claude/rules/04-error-handling.md
+++ b/.claude/rules/04-error-handling.md
@@ -333,7 +333,8 @@ log.WithError(err).Error("failed to send message to dlq")
 | `max_conns`     | int32    | 커넥션 풀 최대 크기 |
 
 **규칙:**
-- 임의의 키 이름 사용 금지 (예: `"db_name"` 대신 `"database"` 사용)
+- 공통 표준 키 테이블에 정의된 키를 우선 사용하고, 표에 없는 컴포넌트 특화 키는 snake_case로 추가 가능 (예: `handler`, `feed_url`, `article_count`, `html_length`)
+- 이미 정의된 키와 의미가 중복되는 임의 키 생성 금지 (예: `"db_name"` 대신 `"database"` 사용)
 - 시간 값은 반드시 밀리초 int64로, 키는 `duration_ms` 또는 `delay_ms`
 - 불리언 플래그는 긍정형 이름 사용 (예: `"retryable"`, `"is_duplicate"`)
 

--- a/.claude/rules/04-error-handling.md
+++ b/.claude/rules/04-error-handling.md
@@ -382,14 +382,15 @@ type LogContext struct {
     JobID       string
 }
 
-// pkg/logger를 사용하여 context에 필드 추가
-func buildLogger(ctx context.Context, lc LogContext) *logger.Logger {
-    return logger.FromContext(ctx).WithFields(map[string]interface{}{
+// buildLogger는 scoped logger를 생성하여 context에 저장합니다.
+func buildLogger(ctx context.Context, lc LogContext) context.Context {
+    log := logger.FromContext(ctx).WithFields(map[string]interface{}{
         "request_id": lc.RequestID,
         "crawler":    lc.CrawlerName,
         "source":     lc.Source,
         "country":    lc.Country,
     })
+    return log.ToContext(ctx)
 }
 ```
 

--- a/cmd/crawler/main.go
+++ b/cmd/crawler/main.go
@@ -81,12 +81,12 @@ func main() {
 	// DB 연결 및 뉴스 기사 저장소 생성
 	dbCfg, err := config.Load()
 	if err != nil {
-		log.WithError(err).Fatal("DB 설정 로드 실패")
+		log.WithError(err).Fatal("failed to load db config")
 	}
 
 	pool, err := pgstore.NewPool(ctx, dbCfg, log)
 	if err != nil {
-		log.WithError(err).Fatal("DB 연결 실패")
+		log.WithError(err).Fatal("failed to connect to db")
 	}
 	defer pool.Close()
 

--- a/internal/crawler/domain/news/chain_handler.go
+++ b/internal/crawler/domain/news/chain_handler.go
@@ -54,7 +54,7 @@ func (h *ChainHandler) Handle(ctx context.Context, job *core.CrawlJob) (*core.Ra
 		"html_length": len(raw.HTML),
 		"has_parser":  h.Parser != nil,
 		"has_repo":    h.Repo != nil,
-	}).Debug("DB 저장 조건 확인")
+	}).Debug("checking db save conditions")
 
 	isArticle := job.Target.Type == core.TargetTypeArticle
 	canSave := raw.HTML != "" && h.Parser != nil && h.Repo != nil
@@ -68,7 +68,7 @@ func (h *ChainHandler) Handle(ctx context.Context, job *core.CrawlJob) (*core.Ra
 			"has_html":   raw.HTML != "",
 			"has_parser": h.Parser != nil,
 			"has_repo":   h.Repo != nil,
-		}).Warn("조건 불충족: saveArticle 건너뜀")
+		}).Warn("save conditions not met: skipping saveArticle")
 	} else {
 		// 정상적인 non-article 요청에서의 saveArticle 미실행은 debug 수준으로만 로깅
 		h.Log.WithFields(map[string]interface{}{
@@ -76,7 +76,7 @@ func (h *ChainHandler) Handle(ctx context.Context, job *core.CrawlJob) (*core.Ra
 			"has_html":   raw.HTML != "",
 			"has_parser": h.Parser != nil,
 			"has_repo":   h.Repo != nil,
-		}).Debug("조건 불충족(정상 흐름): non-article이므로 saveArticle 건너뜀")
+		}).Debug("non-article target: skipping saveArticle")
 	}
 
 	return raw, nil
@@ -85,11 +85,11 @@ func (h *ChainHandler) Handle(ctx context.Context, job *core.CrawlJob) (*core.Ra
 // saveArticle은 RawContent를 파싱하여 DB에 저장합니다.
 // 에러는 warn 로그로만 기록하며 호출자에게 전파하지 않습니다.
 func (h *ChainHandler) saveArticle(ctx context.Context, raw *core.RawContent) {
-	h.Log.WithField("url", raw.URL).Debug("기사 파싱 시작")
+	h.Log.WithField("url", raw.URL).Debug("parsing article")
 
 	article, err := h.Parser.ParseArticle(raw)
 	if err != nil {
-		h.Log.WithError(err).Warn("기사 파싱 실패, DB 저장 건너뜀")
+		h.Log.WithError(err).Warn("article parse failed, skipping db save")
 		return
 	}
 
@@ -97,16 +97,16 @@ func (h *ChainHandler) saveArticle(ctx context.Context, raw *core.RawContent) {
 		"title":  article.Title,
 		"author": article.Author,
 		"url":    article.URL,
-	}).Debug("기사 파싱 성공, DB 저장 시작")
+	}).Debug("article parsed successfully, saving to db")
 
 	record := ArticleToRecord(article, raw)
 
 	if err := h.Repo.Insert(ctx, record); err != nil {
-		h.Log.WithError(err).Warn("뉴스 기사 DB 저장 실패")
+		h.Log.WithError(err).Warn("failed to save news article to db")
 		return
 	}
 
-	h.Log.WithField("url", raw.URL).Debug("뉴스 기사 DB 저장 성공")
+	h.Log.WithField("url", raw.URL).Debug("news article saved to db")
 }
 
 // ArticleToRecord는 NewsArticle과 RawContent를 storage.NewsArticleRecord로 변환합니다.

--- a/internal/crawler/domain/news/fetcher/rss.go
+++ b/internal/crawler/domain/news/fetcher/rss.go
@@ -54,7 +54,7 @@ func (f *RSSFetcher) FetchFeed(ctx context.Context, feedURL string) ([]*news.New
 		"feed_url": feedURL,
 		"total":    len(feed.Items),
 		"parsed":   len(articles),
-	}).Info("rss 피드 fetch 완료")
+	}).Info("rss feed fetched successfully")
 
 	return articles, nil
 }

--- a/internal/crawler/domain/news/handler.go
+++ b/internal/crawler/domain/news/handler.go
@@ -74,15 +74,16 @@ func (h *RSSFetchHandler) Handle(ctx context.Context, job *core.CrawlJob) (*core
 		h.log.WithFields(map[string]interface{}{
 			"handler":  "rss",
 			"feed_url": feedURL,
-		}).WithError(err).Warn("rss fetch 실패, 다음 핸들러로 위임")
+		}).WithError(err).Warn("rss fetch failed, delegating to next handler")
 
 		return h.delegateToNext(ctx, job, err)
 	}
 
 	h.log.WithFields(map[string]interface{}{
 		"handler":       "rss",
+		"feed_url":      feedURL,
 		"article_count": len(articles),
-	}).Info("rss fetch 성공")
+	}).Info("rss feed fetched successfully")
 
 	return buildRSSRawContent(job, articles), nil
 }
@@ -159,7 +160,7 @@ func (h *GoQueryFetchHandler) Handle(ctx context.Context, job *core.CrawlJob) (*
 		h.log.WithFields(map[string]interface{}{
 			"handler": "goquery",
 			"url":     job.Target.URL,
-		}).WithError(err).Warn("goquery fetch 실패, 다음 핸들러로 위임")
+		}).WithError(err).Warn("goquery fetch failed, delegating to next handler")
 
 		return h.delegateToNext(ctx, job, err)
 	}
@@ -168,11 +169,14 @@ func (h *GoQueryFetchHandler) Handle(ctx context.Context, job *core.CrawlJob) (*
 		h.log.WithFields(map[string]interface{}{
 			"handler": "goquery",
 			"url":     job.Target.URL,
-		}).Warn("lazy loading 감지, browser로 위임")
+		}).Warn("lazy loading detected, delegating to browser handler")
 		return h.delegateToNext(ctx, job, fmt.Errorf("lazy loading content detected"))
 	}
 
-	h.log.WithField("handler", "goquery").Info("goquery fetch 성공")
+	h.log.WithFields(map[string]interface{}{
+		"handler": "goquery",
+		"url":     job.Target.URL,
+	}).Info("goquery fetch succeeded")
 	return raw, nil
 }
 
@@ -215,12 +219,15 @@ func (h *BrowserFetchHandler) Handle(ctx context.Context, job *core.CrawlJob) (*
 		h.log.WithFields(map[string]interface{}{
 			"handler": "browser",
 			"url":     job.Target.URL,
-		}).WithError(err).Error("browser fetch 실패, 체인 소진")
+		}).WithError(err).Error("browser fetch failed, all strategies exhausted")
 
 		return nil, err
 	}
 
-	h.log.WithField("handler", "browser").Info("browser fetch 성공")
+	h.log.WithFields(map[string]interface{}{
+		"handler": "browser",
+		"url":     job.Target.URL,
+	}).Info("browser fetch succeeded")
 	return raw, nil
 }
 

--- a/internal/crawler/domain/news/kr/daum/crawler.go
+++ b/internal/crawler/domain/news/kr/daum/crawler.go
@@ -54,13 +54,13 @@ func (c *DaumCrawler) Initialize(_ context.Context, config core.Config) error {
 
 // Start는 크롤러를 시작합니다.
 func (c *DaumCrawler) Start(ctx context.Context) error {
-	logger.FromContext(ctx).WithField("crawler", c.Name()).Info("daum 크롤러 시작")
+	logger.FromContext(ctx).WithField("crawler", c.Name()).Info("crawler started")
 	return nil
 }
 
 // Stop은 크롤러를 중지합니다.
 func (c *DaumCrawler) Stop(ctx context.Context) error {
-	logger.FromContext(ctx).WithField("crawler", c.Name()).Info("daum 크롤러 중지")
+	logger.FromContext(ctx).WithField("crawler", c.Name()).Info("crawler stopped")
 	return nil
 }
 

--- a/internal/crawler/domain/news/kr/naver/crawler.go
+++ b/internal/crawler/domain/news/kr/naver/crawler.go
@@ -54,13 +54,13 @@ func (c *NaverCrawler) Initialize(_ context.Context, config core.Config) error {
 
 // Start는 크롤러를 시작합니다.
 func (c *NaverCrawler) Start(ctx context.Context) error {
-	logger.FromContext(ctx).WithField("crawler", c.Name()).Info("naver 크롤러 시작")
+	logger.FromContext(ctx).WithField("crawler", c.Name()).Info("crawler started")
 	return nil
 }
 
 // Stop은 크롤러를 중지합니다.
 func (c *NaverCrawler) Stop(ctx context.Context) error {
-	logger.FromContext(ctx).WithField("crawler", c.Name()).Info("naver 크롤러 중지")
+	logger.FromContext(ctx).WithField("crawler", c.Name()).Info("crawler stopped")
 	return nil
 }
 

--- a/internal/crawler/domain/news/kr/registry.go
+++ b/internal/crawler/domain/news/kr/registry.go
@@ -74,7 +74,7 @@ func registerNaver(registry *handler.Registry, config core.Config, repo storage.
 
 	registry.Register("naver", news.NewChainHandler(crawler, chain, parser, repo, log))
 
-	log.WithField("crawler", "naver").Info("naver 뉴스 크롤러 등록 완료")
+	log.WithField("crawler", "naver").Info("naver news crawler registered")
 }
 
 // registerYonhap는 연합뉴스 핸들러를 조립하고 등록합니다.
@@ -105,7 +105,7 @@ func registerYonhap(registry *handler.Registry, config core.Config, repo storage
 
 	registry.Register("yonhap", news.NewChainHandler(crawler, chain, parser, repo, log))
 
-	log.WithField("crawler", "yonhap").Info("yonhap 뉴스 크롤러 등록 완료")
+	log.WithField("crawler", "yonhap").Info("yonhap news crawler registered")
 }
 
 // registerDaum는 다음 뉴스 핸들러를 조립하고 등록합니다.
@@ -153,5 +153,5 @@ func registerDaum(registry *handler.Registry, config core.Config, repo storage.N
 
 	registry.Register("daum", news.NewChainHandler(crawler, chain, parser, repo, log))
 
-	log.WithField("crawler", "daum").Info("daum 뉴스 크롤러 등록 완료")
+	log.WithField("crawler", "daum").Info("daum news crawler registered")
 }

--- a/internal/crawler/domain/news/kr/yonhap/crawler.go
+++ b/internal/crawler/domain/news/kr/yonhap/crawler.go
@@ -55,13 +55,13 @@ func (c *YonhapCrawler) Initialize(_ context.Context, config core.Config) error 
 
 // Start는 크롤러를 시작합니다.
 func (c *YonhapCrawler) Start(ctx context.Context) error {
-	logger.FromContext(ctx).WithField("crawler", c.Name()).Info("yonhap 크롤러 시작")
+	logger.FromContext(ctx).WithField("crawler", c.Name()).Info("crawler started")
 	return nil
 }
 
 // Stop은 크롤러를 중지합니다.
 func (c *YonhapCrawler) Stop(ctx context.Context) error {
-	logger.FromContext(ctx).WithField("crawler", c.Name()).Info("yonhap 크롤러 중지")
+	logger.FromContext(ctx).WithField("crawler", c.Name()).Info("crawler stopped")
 	return nil
 }
 

--- a/internal/crawler/domain/news/us/cnn/crawler.go
+++ b/internal/crawler/domain/news/us/cnn/crawler.go
@@ -55,13 +55,13 @@ func (c *CNNCrawler) Initialize(_ context.Context, config core.Config) error {
 
 // Start는 크롤러를 시작합니다.
 func (c *CNNCrawler) Start(ctx context.Context) error {
-	logger.FromContext(ctx).WithField("crawler", c.Name()).Info("cnn 크롤러 시작")
+	logger.FromContext(ctx).WithField("crawler", c.Name()).Info("crawler started")
 	return nil
 }
 
 // Stop은 크롤러를 중지합니다.
 func (c *CNNCrawler) Stop(ctx context.Context) error {
-	logger.FromContext(ctx).WithField("crawler", c.Name()).Info("cnn 크롤러 중지")
+	logger.FromContext(ctx).WithField("crawler", c.Name()).Info("crawler stopped")
 	return nil
 }
 

--- a/internal/crawler/domain/news/us/registry.go
+++ b/internal/crawler/domain/news/us/registry.go
@@ -77,5 +77,5 @@ func registerCNN(registry *handler.Registry, config core.Config, repo storage.Ne
 
 	registry.Register("cnn", news.NewChainHandler(crawler, chain, parser, repo, log))
 
-	log.WithField("crawler", "cnn").Info("cnn 뉴스 크롤러 등록 완료")
+	log.WithField("crawler", "cnn").Info("cnn news crawler registered")
 }

--- a/internal/crawler/implementation/chromedp/fetch.go
+++ b/internal/crawler/implementation/chromedp/fetch.go
@@ -69,9 +69,9 @@ func (c *ChromedpCrawler) Fetch(ctx context.Context, target core.Target) (*core.
 	}
 
 	log.WithFields(map[string]interface{}{
-		"url":      target.URL,
-		"size":     len(html),
-		"duration": elapsed.String(),
+		"url":         target.URL,
+		"size":        len(html),
+		"duration_ms": elapsed.Milliseconds(),
 	}).Info("page rendered successfully with chromedp")
 
 	return rawContent, nil

--- a/internal/crawler/worker/pool.go
+++ b/internal/crawler/worker/pool.go
@@ -118,13 +118,13 @@ func (p *KafkaConsumerPool) pollMessages(ctx context.Context) {
 				return
 			}
 
-			log.WithError(err).Error("Kafka 메시지 수신 실패")
+			log.WithError(err).Error("failed to receive kafka message")
 			continue
 		}
 
 		job, err := core.UnmarshalCrawlJob(msg.Value)
 		if err != nil {
-			log.WithError(err).Error("CrawlJob 역직렬화 실패, DLQ로 전송")
+			log.WithError(err).Error("failed to unmarshal crawl job, sending to dlq")
 			p.sendToDLQ(ctx, msg, err)
 			continue
 		}
@@ -147,7 +147,7 @@ func (p *KafkaConsumerPool) worker(ctx context.Context) {
 			log.WithFields(map[string]interface{}{
 				"job_id":  item.job.ID,
 				"crawler": item.job.CrawlerName,
-			}).WithError(err).Error("job 처리 실패")
+			}).WithError(err).Error("job processing failed")
 		}
 	}
 }
@@ -159,7 +159,7 @@ func (p *KafkaConsumerPool) processJob(ctx context.Context, item jobItem) error 
 		"job_id":  item.job.ID,
 		"crawler": item.job.CrawlerName,
 		"url":     item.job.Target.URL,
-	}).Info("crawl job 처리 시작")
+	}).Info("crawl job started")
 
 	raw, err := p.handler.Handle(ctx, item.job)
 	if err != nil {
@@ -203,7 +203,7 @@ func (p *KafkaConsumerPool) processJob(ctx context.Context, item jobItem) error 
 func (p *KafkaConsumerPool) publishRawRef(ctx context.Context, ref *core.RawContentRef, job *core.CrawlJob) error {
 	data, err := json.Marshal(ref)
 	if err != nil {
-		return fmt.Errorf("RawContentRef 직렬화 실패: %w", err)
+		return fmt.Errorf("marshal raw content ref: %w", err)
 	}
 
 	msg := queue.Message{
@@ -222,7 +222,7 @@ func (p *KafkaConsumerPool) publishRawRef(ctx context.Context, ref *core.RawCont
 
 func (p *KafkaConsumerPool) commitMessage(ctx context.Context, msg *queue.Message) error {
 	if err := p.consumer.CommitMessages(ctx, msg); err != nil {
-		return fmt.Errorf("offset commit 실패: %w", err)
+		return fmt.Errorf("commit offset: %w", err)
 	}
 
 	return nil
@@ -247,7 +247,7 @@ func (p *KafkaConsumerPool) sendToDLQ(ctx context.Context, msg *queue.Message, r
 	}
 
 	if err := p.producer.Publish(ctx, dlqMsg); err != nil {
-		log.WithError(err).Error("DLQ 전송 실패")
+		log.WithError(err).Error("failed to send message to dlq")
 	}
 }
 
@@ -258,7 +258,10 @@ func (p *KafkaConsumerPool) requeueWithRetry(ctx context.Context, job *core.Craw
 
 	data, err := job.Marshal()
 	if err != nil {
-		log.WithError(err).Error("재큐잉을 위한 job 직렬화 실패")
+		log.WithFields(map[string]interface{}{
+			"job_id":  job.ID,
+			"crawler": job.CrawlerName,
+		}).WithError(err).Error("failed to marshal job for retry")
 		return
 	}
 
@@ -275,7 +278,10 @@ func (p *KafkaConsumerPool) requeueWithRetry(ctx context.Context, job *core.Craw
 	}
 
 	if err := p.producer.Publish(ctx, msg); err != nil {
-		log.WithError(err).Error("재시도 재큐잉 실패")
+		log.WithFields(map[string]interface{}{
+			"job_id":  job.ID,
+			"crawler": job.CrawlerName,
+		}).WithError(err).Error("failed to requeue job for retry")
 	}
 }
 

--- a/internal/crawler/worker/pool.go
+++ b/internal/crawler/worker/pool.go
@@ -279,8 +279,10 @@ func (p *KafkaConsumerPool) requeueWithRetry(ctx context.Context, job *core.Craw
 
 	if err := p.producer.Publish(ctx, msg); err != nil {
 		log.WithFields(map[string]interface{}{
-			"job_id":  job.ID,
-			"crawler": job.CrawlerName,
+			"job_id":   job.ID,
+			"crawler":  job.CrawlerName,
+			"topic":    topic,
+			"priority": job.Priority,
 		}).WithError(err).Error("failed to requeue job for retry")
 	}
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -96,7 +96,7 @@ func Load(envFiles ...string) (DBConfig, error) {
 		envFiles = []string{".env"}
 	}
 	if err := godotenv.Load(envFiles...); err != nil && !errors.Is(err, os.ErrNotExist) {
-		return DBConfig{}, fmt.Errorf("load env file: %w", err)
+		return DBConfig{}, fmt.Errorf("failed to load env files %v: %w", envFiles, err)
 	}
 
 	cfg := DefaultDBConfig()

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -34,7 +34,7 @@ func LoadClassifier(envFiles ...string) (ClassifierConfig, error) {
 		envFiles = []string{".env"}
 	}
 	if err := godotenv.Load(envFiles...); err != nil && !errors.Is(err, os.ErrNotExist) {
-		return ClassifierConfig{}, fmt.Errorf("load env file: %w", err)
+		return ClassifierConfig{}, fmt.Errorf("failed to load env file %q: %w", envFiles[0], err)
 	}
 
 	cfg := DefaultClassifierConfig()

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -34,7 +34,7 @@ func LoadClassifier(envFiles ...string) (ClassifierConfig, error) {
 		envFiles = []string{".env"}
 	}
 	if err := godotenv.Load(envFiles...); err != nil && !errors.Is(err, os.ErrNotExist) {
-		return ClassifierConfig{}, fmt.Errorf("env 파일 로드 실패: %w", err)
+		return ClassifierConfig{}, fmt.Errorf("load env file: %w", err)
 	}
 
 	cfg := DefaultClassifierConfig()
@@ -96,7 +96,7 @@ func Load(envFiles ...string) (DBConfig, error) {
 		envFiles = []string{".env"}
 	}
 	if err := godotenv.Load(envFiles...); err != nil && !errors.Is(err, os.ErrNotExist) {
-		return DBConfig{}, fmt.Errorf("env 파일 로드 실패: %w", err)
+		return DBConfig{}, fmt.Errorf("load env file: %w", err)
 	}
 
 	cfg := DefaultDBConfig()
@@ -107,7 +107,7 @@ func Load(envFiles ...string) (DBConfig, error) {
 	if v := os.Getenv("POSTGRES_PORT"); v != "" {
 		p, err := strconv.Atoi(v)
 		if err != nil {
-			return DBConfig{}, fmt.Errorf("POSTGRES_PORT 파싱 실패 %q: %w", v, err)
+			return DBConfig{}, fmt.Errorf("parse POSTGRES_PORT %q: %w", v, err)
 		}
 		cfg.Port = p
 	}
@@ -126,21 +126,21 @@ func Load(envFiles ...string) (DBConfig, error) {
 	if v := os.Getenv("POSTGRES_MAX_CONNS"); v != "" {
 		n, err := strconv.ParseInt(v, 10, 32)
 		if err != nil {
-			return DBConfig{}, fmt.Errorf("POSTGRES_MAX_CONNS 파싱 실패 %q: %w", v, err)
+			return DBConfig{}, fmt.Errorf("parse POSTGRES_MAX_CONNS %q: %w", v, err)
 		}
 		cfg.MaxConns = int32(n)
 	}
 	if v := os.Getenv("POSTGRES_MIN_CONNS"); v != "" {
 		n, err := strconv.ParseInt(v, 10, 32)
 		if err != nil {
-			return DBConfig{}, fmt.Errorf("POSTGRES_MIN_CONNS 파싱 실패 %q: %w", v, err)
+			return DBConfig{}, fmt.Errorf("parse POSTGRES_MIN_CONNS %q: %w", v, err)
 		}
 		cfg.MinConns = int32(n)
 	}
 	if v := os.Getenv("POSTGRES_CONN_TIMEOUT"); v != "" {
 		d, err := time.ParseDuration(v)
 		if err != nil {
-			return DBConfig{}, fmt.Errorf("POSTGRES_CONN_TIMEOUT 파싱 실패 %q: %w", v, err)
+			return DBConfig{}, fmt.Errorf("parse POSTGRES_CONN_TIMEOUT %q: %w", v, err)
 		}
 		cfg.ConnTimeout = d
 	}


### PR DESCRIPTION
## 연관 이슈
- #42

<br>

## 구현 내용
- `.claude/rules/04-error-handling.md` 로깅 섹션 전면 개선
  - 로그 레벨별 사용 기준 및 시나리오 예시 테이블 추가 (DEBUG/INFO/WARN/ERROR/FATAL)
  - 표준 구조화 필드 키 네이밍 컨벤션 테이블 정의 (20개 필드)
  - 컴포넌트별 필수 필드 명세 추가 (HTTP Client, Retry, Worker Pool, Storage, DB, Classifier)
  - 로그 메시지 언어 정책 명시 (`msg` 문자열은 반드시 영어)
  - 예시 코드를 `pkg/logger` wrapper API 기준으로 통일
- 전체 Go 파일 로그 컨벤션 적용
  - 한국어 로그 메시지 → 영어로 변경 (14개 파일)
  - 비표준 필드키 수정: `"duration"` (string) → `"duration_ms"` (int64)
  - 누락된 필수 필드 추가 (`job_id`, `crawler` 등)
  - 한국어 `fmt.Errorf` 에러 문자열 → 영어로 변경 (`pkg/config/config.go`, `worker/pool.go`)

**변경 파일:**
- `.claude/rules/04-error-handling.md`
- `cmd/crawler/main.go`
- `internal/crawler/domain/news/chain_handler.go`
- `internal/crawler/domain/news/fetcher/rss.go`
- `internal/crawler/domain/news/handler.go`
- `internal/crawler/domain/news/kr/{daum,naver,yonhap}/crawler.go`
- `internal/crawler/domain/news/kr/registry.go`
- `internal/crawler/domain/news/us/cnn/crawler.go`
- `internal/crawler/domain/news/us/registry.go`
- `internal/crawler/implementation/chromedp/fetch.go`
- `internal/crawler/worker/pool.go`
- `pkg/config/config.go`

<br>

## TODO
- 향후 신규 파일 작성 시 정의된 컨벤션 준수 여부 코드 리뷰에서 확인

<br>

## 논의 사항
- 