### PR TITLE
[FIX]: HTTP 4xx/5xx 상태코드 에러 처리 및 Chain 위임 로직 개선

### DIFF
--- a/internal/crawler/domain/news/handler.go
+++ b/internal/crawler/domain/news/handler.go
@@ -2,6 +2,7 @@ package news
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 	"time"
@@ -157,6 +158,16 @@ func NewGoQueryFetchHandler(fetcher NewsFetcher, log *logger.Logger, lazyKeyword
 func (h *GoQueryFetchHandler) Handle(ctx context.Context, job *core.CrawlJob) (*core.RawContent, error) {
 	raw, err := h.fetcher.Fetch(ctx, job.Target)
 	if err != nil {
+		// URL 자체가 존재하지 않는 경우 다른 전략도 동일하게 실패하므로 즉시 반환
+		var crawlerErr *core.CrawlerError
+		if errors.As(err, &crawlerErr) && crawlerErr.Category == core.ErrCategoryNotFound {
+			h.log.WithFields(map[string]interface{}{
+				"handler": "goquery",
+				"url":     job.Target.URL,
+			}).WithError(err).Error("resource not found, aborting chain")
+			return nil, err
+		}
+
 		h.log.WithFields(map[string]interface{}{
 			"handler": "goquery",
 			"url":     job.Target.URL,

--- a/internal/crawler/implementation/chromedp/fetch.go
+++ b/internal/crawler/implementation/chromedp/fetch.go
@@ -3,8 +3,10 @@ package chromedp
 import (
 	"context"
 	"fmt"
+	"sync"
 	"time"
 
+	"github.com/chromedp/cdproto/network"
 	"github.com/chromedp/chromedp"
 
 	"issuetracker/internal/crawler/core"
@@ -34,8 +36,24 @@ func (c *ChromedpCrawler) Fetch(ctx context.Context, target core.Target) (*core.
 	tabCtx, timeoutCancel := context.WithTimeout(tabCtx, c.config.Timeout)
 	defer timeoutCancel()
 
-	// 렌더링 액션 구성
-	actions := c.buildFetchActions(target.URL)
+	// 메인 document의 HTTP 상태코드 캡처
+	var (
+		statusCode int64 = 200
+		statusMu   sync.Mutex
+	)
+	chromedp.ListenTarget(tabCtx, func(ev interface{}) {
+		if e, ok := ev.(*network.EventResponseReceived); ok {
+			if e.Type == network.ResourceTypeDocument {
+				statusMu.Lock()
+				statusCode = int64(e.Response.Status)
+				statusMu.Unlock()
+			}
+		}
+	})
+
+	// 렌더링 액션 구성 (network 이벤트 활성화 포함)
+	actions := []chromedp.Action{network.Enable()}
+	actions = append(actions, c.buildFetchActions(target.URL)...)
 
 	var html string
 	actions = append(actions, chromedp.OuterHTML("html", &html))
@@ -57,13 +75,47 @@ func (c *ChromedpCrawler) Fetch(ctx context.Context, target core.Target) (*core.
 
 	elapsed := time.Since(start)
 
+	statusMu.Lock()
+	capturedStatus := int(statusCode)
+	statusMu.Unlock()
+
+	// HTTP 상태코드 검사
+	if capturedStatus == 404 {
+		return nil, core.NewNotFoundError(target.URL)
+	}
+	if capturedStatus == 429 {
+		return nil, core.NewRateLimitError("HTTP_429", "rate limited", target.URL, capturedStatus)
+	}
+	if capturedStatus >= 500 {
+		return nil, &core.CrawlerError{
+			Category:   core.ErrCategoryNetwork,
+			Code:       fmt.Sprintf("HTTP_%d", capturedStatus),
+			Message:    "server error",
+			Source:     c.name,
+			URL:        target.URL,
+			StatusCode: capturedStatus,
+			Retryable:  true,
+		}
+	}
+	if capturedStatus >= 400 {
+		return nil, &core.CrawlerError{
+			Category:   core.ErrCategoryInternal,
+			Code:       fmt.Sprintf("HTTP_%d", capturedStatus),
+			Message:    "client error",
+			Source:     c.name,
+			URL:        target.URL,
+			StatusCode: capturedStatus,
+			Retryable:  false,
+		}
+	}
+
 	rawContent := &core.RawContent{
 		ID:         fmt.Sprintf("%s-%d", c.name, time.Now().UnixNano()),
 		SourceInfo: c.sourceInfo,
 		FetchedAt:  time.Now(),
 		URL:        target.URL,
 		HTML:       html,
-		StatusCode: 200,
+		StatusCode: capturedStatus,
 		Headers:    make(map[string]string),
 		Metadata:   target.Metadata,
 	}

--- a/internal/crawler/implementation/chromedp/fetch.go
+++ b/internal/crawler/implementation/chromedp/fetch.go
@@ -40,10 +40,11 @@ func (c *ChromedpCrawler) Fetch(ctx context.Context, target core.Target) (*core.
 	// 메인 네비게이션의 LoaderID를 추적하여 iframe/서브프레임 응답과 구분
 	// - 메인 프레임과 리다이렉트 체인은 동일한 LoaderID를 공유
 	// - iframe/서브프레임은 별도의 LoaderID를 가지므로 필터링됨
+	// - statusCode 초기값 0: 이벤트를 한 번도 수신하지 못한 경우와 명시적 구분
 	var (
-		statusCode     int64 = 200
-		statusMu       sync.Mutex
-		mainLoaderID   cdp.LoaderID
+		statusCode       int64
+		statusMu         sync.Mutex
+		mainLoaderID     cdp.LoaderID
 		loaderIDCaptured bool
 	)
 	chromedp.ListenTarget(tabCtx, func(ev interface{}) {
@@ -98,6 +99,12 @@ func (c *ChromedpCrawler) Fetch(ctx context.Context, target core.Target) (*core.
 	statusMu.Lock()
 	capturedStatus := int(statusCode)
 	statusMu.Unlock()
+
+	// 네비게이션이 중간에 취소되는 등의 이유로 응답 이벤트를 수신하지 못한 경우
+	if capturedStatus == 0 {
+		log.WithField("url", target.URL).Warn("no HTTP status code captured from navigation, treating as success")
+		capturedStatus = 200
+	}
 
 	// HTTP 상태코드 검사
 	if capturedStatus == 404 {

--- a/internal/crawler/implementation/chromedp/fetch.go
+++ b/internal/crawler/implementation/chromedp/fetch.go
@@ -6,6 +6,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/chromedp/cdproto/cdp"
 	"github.com/chromedp/cdproto/network"
 	"github.com/chromedp/chromedp"
 
@@ -36,16 +37,35 @@ func (c *ChromedpCrawler) Fetch(ctx context.Context, target core.Target) (*core.
 	tabCtx, timeoutCancel := context.WithTimeout(tabCtx, c.config.Timeout)
 	defer timeoutCancel()
 
-	// 메인 document의 HTTP 상태코드 캡처
+	// 메인 네비게이션의 LoaderID를 추적하여 iframe/서브프레임 응답과 구분
+	// - 메인 프레임과 리다이렉트 체인은 동일한 LoaderID를 공유
+	// - iframe/서브프레임은 별도의 LoaderID를 가지므로 필터링됨
 	var (
-		statusCode int64 = 200
-		statusMu   sync.Mutex
+		statusCode     int64 = 200
+		statusMu       sync.Mutex
+		mainLoaderID   cdp.LoaderID
+		loaderIDCaptured bool
 	)
 	chromedp.ListenTarget(tabCtx, func(ev interface{}) {
-		if e, ok := ev.(*network.EventResponseReceived); ok {
+		switch e := ev.(type) {
+		case *network.EventRequestWillBeSent:
+			// 첫 번째 Document 요청의 LoaderID를 메인 네비게이션으로 고정
 			if e.Type == network.ResourceTypeDocument {
 				statusMu.Lock()
-				statusCode = int64(e.Response.Status)
+				if !loaderIDCaptured {
+					mainLoaderID = e.LoaderID
+					loaderIDCaptured = true
+				}
+				statusMu.Unlock()
+			}
+		case *network.EventResponseReceived:
+			// 메인 네비게이션 LoaderID와 일치하는 Document 응답만 채택
+			// 리다이렉트 체인은 같은 LoaderID를 공유하므로 최종 상태코드가 올바르게 갱신됨
+			if e.Type == network.ResourceTypeDocument {
+				statusMu.Lock()
+				if loaderIDCaptured && e.LoaderID == mainLoaderID {
+					statusCode = int64(e.Response.Status)
+				}
 				statusMu.Unlock()
 			}
 		}

--- a/internal/crawler/implementation/goquery/fetch.go
+++ b/internal/crawler/implementation/goquery/fetch.go
@@ -46,6 +46,36 @@ func (c *GoqueryCrawler) Fetch(ctx context.Context, target core.Target) (*core.R
 	}
 	defer resp.Body.Close()
 
+	// HTTP 상태코드 검사: 4xx/5xx는 에러로 처리
+	if resp.StatusCode == http.StatusNotFound {
+		return nil, core.NewNotFoundError(target.URL)
+	}
+	if resp.StatusCode == http.StatusTooManyRequests {
+		return nil, core.NewRateLimitError("HTTP_429", "rate limited", target.URL, resp.StatusCode)
+	}
+	if resp.StatusCode >= 500 {
+		return nil, &core.CrawlerError{
+			Category:   core.ErrCategoryNetwork,
+			Code:       fmt.Sprintf("HTTP_%d", resp.StatusCode),
+			Message:    "server error",
+			Source:     c.name,
+			URL:        target.URL,
+			StatusCode: resp.StatusCode,
+			Retryable:  true,
+		}
+	}
+	if resp.StatusCode >= 400 {
+		return nil, &core.CrawlerError{
+			Category:   core.ErrCategoryInternal,
+			Code:       fmt.Sprintf("HTTP_%d", resp.StatusCode),
+			Message:    "client error",
+			Source:     c.name,
+			URL:        target.URL,
+			StatusCode: resp.StatusCode,
+			Retryable:  false,
+		}
+	}
+
 	// goquery Document 생성
 	doc, err := goquery.NewDocumentFromReader(resp.Body)
 	if err != nil {


### PR DESCRIPTION
## 연관 이슈
- #70

<br>

## 구현 내용
- `goquery/fetch.go`: `c.httpClient.Do()` 이후 `resp.StatusCode` 검사 추가
  - 404 → `NewNotFoundError` (non-retryable)
  - 429 → `NewRateLimitError` (retryable)
  - 5xx → `CrawlerError` / `ErrCategoryNetwork` (retryable)
  - 나머지 4xx → `CrawlerError` / `ErrCategoryInternal` (non-retryable)
- `chromedp/fetch.go`: `StatusCode: 200` 하드코딩 제거, `cdproto/network.EventResponseReceived` 이벤트로 실제 HTTP 상태코드 캡처 후 동일한 검사 로직 적용
- `news/handler.go`: `GoQueryFetchHandler`에서 `ErrCategoryNotFound` 에러 발생 시 browser 핸들러로 위임하지 않고 즉시 반환 처리

<br>

## TODO
- 404 응답이 이미 파이프라인에 유입된 데이터 정리 여부 검토 (이슈 원문 확인 사항)

<br>

## 논의 사항
- `ErrCategoryForbidden`(403)은 browser가 다른 헤더/fingerprint로 우회 가능성이 있어 현재 체인 위임을 유지함. 필요 시 추가 논의