### PR TITLE
[FIX#64]: LoadRedis 환경변수 유효성 검사 추가

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -218,7 +218,7 @@ func DefaultRedisConfig() RedisConfig {
 }
 
 // LoadRedis는 .env 파일을 로드한 후 OS 환경변수로 RedisConfig를 구성합니다.
-// 환경변수 값이 설정되어 있지만 파싱에 실패하면 에러를 반환합니다.
+// 환경변수 값이 설정되어 있지만 파싱에 실패하거나 범위를 벗어나면 에러를 반환합니다.
 func LoadRedis(envFiles ...string) (RedisConfig, error) {
 	if len(envFiles) == 0 {
 		envFiles = []string{".env"}
@@ -237,6 +237,9 @@ func LoadRedis(envFiles ...string) (RedisConfig, error) {
 		if err != nil {
 			return RedisConfig{}, fmt.Errorf("parse REDIS_PORT %q: %w", v, err)
 		}
+		if p < 1 || p > 65535 {
+			return RedisConfig{}, fmt.Errorf("invalid REDIS_PORT %d: must be between 1 and 65535", p)
+		}
 		cfg.Port = p
 	}
 	if v := os.Getenv("REDIS_PASSWORD"); v != "" {
@@ -247,12 +250,18 @@ func LoadRedis(envFiles ...string) (RedisConfig, error) {
 		if err != nil {
 			return RedisConfig{}, fmt.Errorf("parse REDIS_DB %q: %w", v, err)
 		}
+		if n < 0 {
+			return RedisConfig{}, fmt.Errorf("invalid REDIS_DB %d: must be 0 or greater", n)
+		}
 		cfg.DB = n
 	}
 	if v := os.Getenv("REDIS_DIAL_TIMEOUT"); v != "" {
 		d, err := time.ParseDuration(v)
 		if err != nil {
 			return RedisConfig{}, fmt.Errorf("parse REDIS_DIAL_TIMEOUT %q: %w", v, err)
+		}
+		if d <= 0 {
+			return RedisConfig{}, fmt.Errorf("invalid REDIS_DIAL_TIMEOUT %q: must be positive", v)
 		}
 		cfg.DialTimeout = d
 	}
@@ -261,6 +270,9 @@ func LoadRedis(envFiles ...string) (RedisConfig, error) {
 		if err != nil {
 			return RedisConfig{}, fmt.Errorf("parse REDIS_READ_TIMEOUT %q: %w", v, err)
 		}
+		if d <= 0 {
+			return RedisConfig{}, fmt.Errorf("invalid REDIS_READ_TIMEOUT %q: must be positive", v)
+		}
 		cfg.ReadTimeout = d
 	}
 	if v := os.Getenv("REDIS_WRITE_TIMEOUT"); v != "" {
@@ -268,12 +280,18 @@ func LoadRedis(envFiles ...string) (RedisConfig, error) {
 		if err != nil {
 			return RedisConfig{}, fmt.Errorf("parse REDIS_WRITE_TIMEOUT %q: %w", v, err)
 		}
+		if d <= 0 {
+			return RedisConfig{}, fmt.Errorf("invalid REDIS_WRITE_TIMEOUT %q: must be positive", v)
+		}
 		cfg.WriteTimeout = d
 	}
 	if v := os.Getenv("REDIS_POOL_SIZE"); v != "" {
 		n, err := strconv.Atoi(v)
 		if err != nil {
 			return RedisConfig{}, fmt.Errorf("parse REDIS_POOL_SIZE %q: %w", v, err)
+		}
+		if n < 1 {
+			return RedisConfig{}, fmt.Errorf("invalid REDIS_POOL_SIZE %d: must be 1 or greater", n)
 		}
 		cfg.PoolSize = n
 	}

--- a/test/pkg/config/config_test.go
+++ b/test/pkg/config/config_test.go
@@ -124,3 +124,168 @@ func unsetEnvVars(t *testing.T) {
 		t.Setenv(v, "")
 	}
 }
+
+// unsetRedisEnvVars는 테스트 격리를 위해 REDIS_* 환경변수를 초기화합니다.
+func unsetRedisEnvVars(t *testing.T) {
+	t.Helper()
+	vars := []string{
+		"REDIS_HOST", "REDIS_PORT", "REDIS_PASSWORD",
+		"REDIS_DB", "REDIS_DIAL_TIMEOUT", "REDIS_READ_TIMEOUT",
+		"REDIS_WRITE_TIMEOUT", "REDIS_POOL_SIZE",
+	}
+	for _, v := range vars {
+		t.Setenv(v, "")
+	}
+}
+
+func TestLoadRedis_DefaultValues(t *testing.T) {
+	unsetRedisEnvVars(t)
+
+	cfg, err := config.LoadRedis("/tmp/nonexistent-env-file.env")
+	if err != nil {
+		t.Fatalf("기본값 로드 실패: %v", err)
+	}
+
+	def := config.DefaultRedisConfig()
+	if cfg.Host != def.Host {
+		t.Errorf("Host: got %q, want %q", cfg.Host, def.Host)
+	}
+	if cfg.Port != def.Port {
+		t.Errorf("Port: got %d, want %d", cfg.Port, def.Port)
+	}
+	if cfg.DB != def.DB {
+		t.Errorf("DB: got %d, want %d", cfg.DB, def.DB)
+	}
+	if cfg.PoolSize != def.PoolSize {
+		t.Errorf("PoolSize: got %d, want %d", cfg.PoolSize, def.PoolSize)
+	}
+	if cfg.DialTimeout != def.DialTimeout {
+		t.Errorf("DialTimeout: got %v, want %v", cfg.DialTimeout, def.DialTimeout)
+	}
+}
+
+func TestLoadRedis_EnvOverride(t *testing.T) {
+	unsetRedisEnvVars(t)
+	t.Setenv("REDIS_HOST", "redis.example.com")
+	t.Setenv("REDIS_PORT", "6380")
+	t.Setenv("REDIS_DB", "2")
+	t.Setenv("REDIS_POOL_SIZE", "20")
+	t.Setenv("REDIS_DIAL_TIMEOUT", "10s")
+
+	cfg, err := config.LoadRedis("/tmp/nonexistent-env-file.env")
+	if err != nil {
+		t.Fatalf("환경변수 로드 실패: %v", err)
+	}
+
+	if cfg.Host != "redis.example.com" {
+		t.Errorf("Host: got %q, want %q", cfg.Host, "redis.example.com")
+	}
+	if cfg.Port != 6380 {
+		t.Errorf("Port: got %d, want 6380", cfg.Port)
+	}
+	if cfg.DB != 2 {
+		t.Errorf("DB: got %d, want 2", cfg.DB)
+	}
+	if cfg.PoolSize != 20 {
+		t.Errorf("PoolSize: got %d, want 20", cfg.PoolSize)
+	}
+	if cfg.DialTimeout != 10*time.Second {
+		t.Errorf("DialTimeout: got %v, want 10s", cfg.DialTimeout)
+	}
+}
+
+func TestLoadRedis_InvalidPort(t *testing.T) {
+	tests := []struct {
+		name  string
+		value string
+	}{
+		{"not a number", "not-a-number"},
+		{"port zero", "0"},
+		{"port too large", "70000"},
+		{"negative port", "-1"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			unsetRedisEnvVars(t)
+			t.Setenv("REDIS_PORT", tt.value)
+
+			_, err := config.LoadRedis("/tmp/nonexistent-env-file.env")
+			if err == nil {
+				t.Fatalf("REDIS_PORT=%q: 에러가 반환되어야 합니다", tt.value)
+			}
+		})
+	}
+}
+
+func TestLoadRedis_InvalidDB(t *testing.T) {
+	tests := []struct {
+		name  string
+		value string
+	}{
+		{"not a number", "not-a-number"},
+		{"negative db index", "-1"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			unsetRedisEnvVars(t)
+			t.Setenv("REDIS_DB", tt.value)
+
+			_, err := config.LoadRedis("/tmp/nonexistent-env-file.env")
+			if err == nil {
+				t.Fatalf("REDIS_DB=%q: 에러가 반환되어야 합니다", tt.value)
+			}
+		})
+	}
+}
+
+func TestLoadRedis_InvalidPoolSize(t *testing.T) {
+	tests := []struct {
+		name  string
+		value string
+	}{
+		{"not a number", "not-a-number"},
+		{"zero", "0"},
+		{"negative", "-5"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			unsetRedisEnvVars(t)
+			t.Setenv("REDIS_POOL_SIZE", tt.value)
+
+			_, err := config.LoadRedis("/tmp/nonexistent-env-file.env")
+			if err == nil {
+				t.Fatalf("REDIS_POOL_SIZE=%q: 에러가 반환되어야 합니다", tt.value)
+			}
+		})
+	}
+}
+
+func TestLoadRedis_InvalidTimeouts(t *testing.T) {
+	timeoutEnvVars := []string{
+		"REDIS_DIAL_TIMEOUT",
+		"REDIS_READ_TIMEOUT",
+		"REDIS_WRITE_TIMEOUT",
+	}
+	invalidValues := []struct {
+		name  string
+		value string
+	}{
+		{"not a duration", "not-a-duration"},
+		{"zero", "0s"},
+		{"negative", "-1s"},
+	}
+
+	for _, envVar := range timeoutEnvVars {
+		for _, tt := range invalidValues {
+			t.Run(envVar+"/"+tt.name, func(t *testing.T) {
+				unsetRedisEnvVars(t)
+				t.Setenv(envVar, tt.value)
+
+				_, err := config.LoadRedis("/tmp/nonexistent-env-file.env")
+				if err == nil {
+					t.Fatalf("%s=%q: 에러가 반환되어야 합니다", envVar, tt.value)
+				}
+			})
+		}
+	}
+}


### PR DESCRIPTION
## 연관 이슈
- #64

<br>

## 구현 내용
- `pkg/config/config.go` — `LoadRedis` 함수에 파싱 후 범위 검증 로직 추가
  - `REDIS_PORT`: 1 이상 65535 이하
  - `REDIS_DB`: 0 이상
  - `REDIS_DIAL_TIMEOUT` / `REDIS_READ_TIMEOUT` / `REDIS_WRITE_TIMEOUT`: 양수
  - `REDIS_POOL_SIZE`: 1 이상
- `test/pkg/config/config_test.go` — `LoadRedis` 관련 테스트 추가 (21개 케이스)
  - `TestLoadRedis_DefaultValues`, `TestLoadRedis_EnvOverride`
  - `TestLoadRedis_InvalidPort`, `TestLoadRedis_InvalidDB`, `TestLoadRedis_InvalidPoolSize`, `TestLoadRedis_InvalidTimeouts`

<br>

## TODO
- 없음

<br>

## 논의 사항
- 없음

<br>