### PR TITLE
[FEAT#76]: LOG_LEVEL 환경변수로 로깅 레벨 런타임 제어

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -30,6 +30,10 @@ REDIS_POOL_SIZE=10
 # Kafka 연결 설정 (pkg/queue/config.go 기본값: localhost:9092)
 # KAFKA_BROKERS=localhost:9092
 
+# 로깅 설정
+LOG_LEVEL=info
+LOG_PRETTY=false
+
 # Scheduler 크롤 주기 설정
 SCHEDULER_FEED_INTERVAL=20m
 SCHEDULER_CATEGORY_INTERVAL=2h

--- a/cmd/crawler/main.go
+++ b/cmd/crawler/main.go
@@ -27,10 +27,10 @@ func main() {
 	if err != nil {
 		panic("failed to load log config: " + err.Error())
 	}
-	log := logger.New(logger.Config{
-		Level:  logger.Level(logCfg.Level),
-		Pretty: logCfg.Pretty,
-	})
+	loggerCfg := logger.DefaultConfig()
+	loggerCfg.Level = logger.Level(logCfg.Level)
+	loggerCfg.Pretty = logCfg.Pretty
+	log := logger.New(loggerCfg)
 
 	log.Info("starting IssueTracker crawler")
 

--- a/cmd/crawler/main.go
+++ b/cmd/crawler/main.go
@@ -23,10 +23,14 @@ import (
 )
 
 func main() {
-	logConfig := logger.DefaultConfig()
-	logConfig.Level = logger.LevelInfo
-	logConfig.Pretty = false
-	log := logger.New(logConfig)
+	logCfg, err := config.LoadLog()
+	if err != nil {
+		panic("failed to load log config: " + err.Error())
+	}
+	log := logger.New(logger.Config{
+		Level:  logger.Level(logCfg.Level),
+		Pretty: logCfg.Pretty,
+	})
 
 	log.Info("starting IssueTracker crawler")
 

--- a/cmd/crawler/main.go
+++ b/cmd/crawler/main.go
@@ -23,14 +23,16 @@ import (
 )
 
 func main() {
+	log := logger.New(logger.DefaultConfig())
+
 	logCfg, err := config.LoadLog()
 	if err != nil {
-		panic("failed to load log config: " + err.Error())
+		log.WithError(err).Fatal("failed to load log config")
 	}
 	loggerCfg := logger.DefaultConfig()
 	loggerCfg.Level = logger.Level(logCfg.Level)
 	loggerCfg.Pretty = logCfg.Pretty
-	log := logger.New(loggerCfg)
+	log = logger.New(loggerCfg)
 
 	log.Info("starting IssueTracker crawler")
 

--- a/cmd/issuetracker/main.go
+++ b/cmd/issuetracker/main.go
@@ -29,10 +29,10 @@ func main() {
 	if err != nil {
 		panic("failed to load log config: " + err.Error())
 	}
-	log := logger.New(logger.Config{
-		Level:  logger.Level(logCfg.Level),
-		Pretty: logCfg.Pretty,
-	})
+	loggerCfg := logger.DefaultConfig()
+	loggerCfg.Level = logger.Level(logCfg.Level)
+	loggerCfg.Pretty = logCfg.Pretty
+	log := logger.New(loggerCfg)
 
 	log.Info("starting IssueTracker")
 

--- a/cmd/issuetracker/main.go
+++ b/cmd/issuetracker/main.go
@@ -25,14 +25,16 @@ import (
 const validateWorkerCount = 8
 
 func main() {
+	log := logger.New(logger.DefaultConfig())
+
 	logCfg, err := config.LoadLog()
 	if err != nil {
-		panic("failed to load log config: " + err.Error())
+		log.WithError(err).Fatal("failed to load log config")
 	}
 	loggerCfg := logger.DefaultConfig()
 	loggerCfg.Level = logger.Level(logCfg.Level)
 	loggerCfg.Pretty = logCfg.Pretty
-	log := logger.New(loggerCfg)
+	log = logger.New(loggerCfg)
 
 	log.Info("starting IssueTracker")
 

--- a/cmd/issuetracker/main.go
+++ b/cmd/issuetracker/main.go
@@ -25,10 +25,14 @@ import (
 const validateWorkerCount = 8
 
 func main() {
-	logConfig := logger.DefaultConfig()
-	logConfig.Level = logger.LevelInfo
-	logConfig.Pretty = false
-	log := logger.New(logConfig)
+	logCfg, err := config.LoadLog()
+	if err != nil {
+		panic("failed to load log config: " + err.Error())
+	}
+	log := logger.New(logger.Config{
+		Level:  logger.Level(logCfg.Level),
+		Pretty: logCfg.Pretty,
+	})
 
 	log.Info("starting IssueTracker")
 

--- a/cmd/processor/main.go
+++ b/cmd/processor/main.go
@@ -20,10 +20,14 @@ import (
 const validateWorkerCount = 8
 
 func main() {
-	logConfig := logger.DefaultConfig()
-	logConfig.Level = logger.LevelInfo
-	logConfig.Pretty = false
-	log := logger.New(logConfig)
+	logCfg, err := config.LoadLog()
+	if err != nil {
+		panic("failed to load log config: " + err.Error())
+	}
+	log := logger.New(logger.Config{
+		Level:  logger.Level(logCfg.Level),
+		Pretty: logCfg.Pretty,
+	})
 
 	log.Info("starting IssueTracker processor")
 

--- a/cmd/processor/main.go
+++ b/cmd/processor/main.go
@@ -24,10 +24,10 @@ func main() {
 	if err != nil {
 		panic("failed to load log config: " + err.Error())
 	}
-	log := logger.New(logger.Config{
-		Level:  logger.Level(logCfg.Level),
-		Pretty: logCfg.Pretty,
-	})
+	loggerCfg := logger.DefaultConfig()
+	loggerCfg.Level = logger.Level(logCfg.Level)
+	loggerCfg.Pretty = logCfg.Pretty
+	log := logger.New(loggerCfg)
 
 	log.Info("starting IssueTracker processor")
 

--- a/cmd/processor/main.go
+++ b/cmd/processor/main.go
@@ -20,14 +20,16 @@ import (
 const validateWorkerCount = 8
 
 func main() {
+	log := logger.New(logger.DefaultConfig())
+
 	logCfg, err := config.LoadLog()
 	if err != nil {
-		panic("failed to load log config: " + err.Error())
+		log.WithError(err).Fatal("failed to load log config")
 	}
 	loggerCfg := logger.DefaultConfig()
 	loggerCfg.Level = logger.Level(logCfg.Level)
 	loggerCfg.Pretty = logCfg.Pretty
-	log := logger.New(loggerCfg)
+	log = logger.New(loggerCfg)
 
 	log.Info("starting IssueTracker processor")
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -33,7 +33,7 @@ func LoadLog(envFiles ...string) (LogConfig, error) {
 		envFiles = []string{".env"}
 	}
 	if err := godotenv.Load(envFiles...); err != nil && !errors.Is(err, os.ErrNotExist) {
-		return LogConfig{}, fmt.Errorf("failed to load env file %q: %w", envFiles[0], err)
+		return LogConfig{}, fmt.Errorf("failed to load env files %v: %w", envFiles, err)
 	}
 
 	cfg := DefaultLogConfig()
@@ -108,7 +108,7 @@ func LoadValidate(envFiles ...string) (ValidateConfig, error) {
 		envFiles = []string{".env"}
 	}
 	if err := godotenv.Load(envFiles...); err != nil && !errors.Is(err, os.ErrNotExist) {
-		return ValidateConfig{}, fmt.Errorf("failed to load env file %q: %w", envFiles[0], err)
+		return ValidateConfig{}, fmt.Errorf("failed to load env files %v: %w", envFiles, err)
 	}
 
 	cfg := DefaultValidateConfig()
@@ -182,7 +182,7 @@ func LoadClassifier(envFiles ...string) (ClassifierConfig, error) {
 		envFiles = []string{".env"}
 	}
 	if err := godotenv.Load(envFiles...); err != nil && !errors.Is(err, os.ErrNotExist) {
-		return ClassifierConfig{}, fmt.Errorf("failed to load env file %q: %w", envFiles[0], err)
+		return ClassifierConfig{}, fmt.Errorf("failed to load env files %v: %w", envFiles, err)
 	}
 
 	cfg := DefaultClassifierConfig()
@@ -269,7 +269,7 @@ func LoadRedis(envFiles ...string) (RedisConfig, error) {
 		envFiles = []string{".env"}
 	}
 	if err := godotenv.Load(envFiles...); err != nil && !errors.Is(err, os.ErrNotExist) {
-		return RedisConfig{}, fmt.Errorf("failed to load env file %q: %w", envFiles[0], err)
+		return RedisConfig{}, fmt.Errorf("failed to load env files %v: %w", envFiles, err)
 	}
 
 	cfg := DefaultRedisConfig()
@@ -431,7 +431,7 @@ func LoadScheduler(envFiles ...string) (SchedulerConfig, error) {
 		envFiles = []string{".env"}
 	}
 	if err := godotenv.Load(envFiles...); err != nil && !errors.Is(err, os.ErrNotExist) {
-		return SchedulerConfig{}, fmt.Errorf("failed to load env file %q: %w", envFiles[0], err)
+		return SchedulerConfig{}, fmt.Errorf("failed to load env files %v: %w", envFiles, err)
 	}
 
 	cfg := DefaultSchedulerConfig()

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -12,6 +12,51 @@ import (
 	"github.com/joho/godotenv"
 )
 
+// LogConfig는 로거 설정을 나타냅니다.
+type LogConfig struct {
+	Level  string // LOG_LEVEL: debug | info | warn | error (default: info)
+	Pretty bool   // LOG_PRETTY: true | false (default: false)
+}
+
+// DefaultLogConfig는 기본 LogConfig를 반환합니다.
+func DefaultLogConfig() LogConfig {
+	return LogConfig{
+		Level:  "info",
+		Pretty: false,
+	}
+}
+
+// LoadLog는 .env 파일을 로드한 후 OS 환경변수로 LogConfig를 구성합니다.
+// 지원 환경변수: LOG_LEVEL (debug|info|warn|error), LOG_PRETTY (true|false)
+func LoadLog(envFiles ...string) (LogConfig, error) {
+	if len(envFiles) == 0 {
+		envFiles = []string{".env"}
+	}
+	if err := godotenv.Load(envFiles...); err != nil && !errors.Is(err, os.ErrNotExist) {
+		return LogConfig{}, fmt.Errorf("failed to load env file %q: %w", envFiles[0], err)
+	}
+
+	cfg := DefaultLogConfig()
+
+	if v := os.Getenv("LOG_LEVEL"); v != "" {
+		switch v {
+		case "debug", "info", "warn", "error":
+			cfg.Level = v
+		default:
+			return LogConfig{}, fmt.Errorf("invalid LOG_LEVEL %q: must be one of debug, info, warn, error", v)
+		}
+	}
+	if v := os.Getenv("LOG_PRETTY"); v != "" {
+		b, err := strconv.ParseBool(v)
+		if err != nil {
+			return LogConfig{}, fmt.Errorf("parse LOG_PRETTY %q: %w", v, err)
+		}
+		cfg.Pretty = b
+	}
+
+	return cfg, nil
+}
+
 // ValidateConfig는 Content 검증 단계의 임계값 설정을 나타냅니다.
 // 뉴스/커뮤니티 소스 타입별로 독립적으로 조정할 수 있습니다.
 type ValidateConfig struct {

--- a/test/pkg/config/config_test.go
+++ b/test/pkg/config/config_test.go
@@ -112,6 +112,106 @@ func TestLoad_MissingEnvFileIsIgnored(t *testing.T) {
 	}
 }
 
+// unsetLogEnvVars는 테스트 격리를 위해 LOG_* 환경변수를 초기화합니다.
+func unsetLogEnvVars(t *testing.T) {
+	t.Helper()
+	t.Setenv("LOG_LEVEL", "")
+	t.Setenv("LOG_PRETTY", "")
+}
+
+func TestLoadLog_DefaultValues(t *testing.T) {
+	unsetLogEnvVars(t)
+
+	cfg, err := config.LoadLog("/tmp/nonexistent-env-file.env")
+	if err != nil {
+		t.Fatalf("기본값 로드 실패: %v", err)
+	}
+
+	def := config.DefaultLogConfig()
+	if cfg.Level != def.Level {
+		t.Errorf("Level: got %q, want %q", cfg.Level, def.Level)
+	}
+	if cfg.Pretty != def.Pretty {
+		t.Errorf("Pretty: got %v, want %v", cfg.Pretty, def.Pretty)
+	}
+}
+
+func TestLoadLog_EnvOverride(t *testing.T) {
+	tests := []struct {
+		name       string
+		level      string
+		pretty     string
+		wantLevel  string
+		wantPretty bool
+	}{
+		{"debug level", "debug", "false", "debug", false},
+		{"warn level", "warn", "false", "warn", false},
+		{"error level", "error", "false", "error", false},
+		{"pretty true", "info", "true", "info", true},
+		{"pretty false", "info", "false", "info", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			unsetLogEnvVars(t)
+			t.Setenv("LOG_LEVEL", tt.level)
+			t.Setenv("LOG_PRETTY", tt.pretty)
+
+			cfg, err := config.LoadLog("/tmp/nonexistent-env-file.env")
+			if err != nil {
+				t.Fatalf("환경변수 로드 실패: %v", err)
+			}
+			if cfg.Level != tt.wantLevel {
+				t.Errorf("Level: got %q, want %q", cfg.Level, tt.wantLevel)
+			}
+			if cfg.Pretty != tt.wantPretty {
+				t.Errorf("Pretty: got %v, want %v", cfg.Pretty, tt.wantPretty)
+			}
+		})
+	}
+}
+
+func TestLoadLog_InvalidLevel(t *testing.T) {
+	tests := []struct {
+		name  string
+		value string
+	}{
+		{"uppercase", "INFO"},
+		{"mixed case", "Debug"},
+		{"unknown level", "verbose"},
+		{"empty-like typo", "infoo"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			unsetLogEnvVars(t)
+			t.Setenv("LOG_LEVEL", tt.value)
+
+			_, err := config.LoadLog("/tmp/nonexistent-env-file.env")
+			if err == nil {
+				t.Fatalf("LOG_LEVEL=%q: 에러가 반환되어야 합니다", tt.value)
+			}
+		})
+	}
+}
+
+func TestLoadLog_InvalidPretty(t *testing.T) {
+	unsetLogEnvVars(t)
+	t.Setenv("LOG_PRETTY", "not-a-bool")
+
+	_, err := config.LoadLog("/tmp/nonexistent-env-file.env")
+	if err == nil {
+		t.Fatal("잘못된 LOG_PRETTY 값에 대해 에러가 반환되어야 합니다")
+	}
+}
+
+func TestLoadLog_MissingEnvFileIsIgnored(t *testing.T) {
+	unsetLogEnvVars(t)
+
+	_, err := config.LoadLog("/tmp/does-not-exist.env")
+	if err != nil {
+		t.Fatalf("존재하지 않는 .env 파일은 에러를 반환하면 안 됩니다: %v", err)
+	}
+}
+
 // unsetEnvVars는 테스트 격리를 위해 POSTGRES_* 환경변수를 초기화합니다.
 func unsetEnvVars(t *testing.T) {
 	t.Helper()


### PR DESCRIPTION
## 연관 이슈
- #76

<br>

## 구현 내용
- `pkg/config/config.go`: `LogConfig` 구조체 및 `LoadLog()` 함수 추가
  - `LOG_LEVEL` 환경변수 지원 (debug | info | warn | error, 기본값: info)
  - `LOG_PRETTY` 환경변수 지원 (true | false, 기본값: false)
  - 유효하지 않은 `LOG_LEVEL` 값은 에러 반환
- `cmd/crawler/main.go`, `cmd/processor/main.go`, `cmd/issuetracker/main.go`: 하드코딩된 `LevelInfo` 제거, `config.LoadLog()`로 대체
- `.env.example`: `LOG_LEVEL=info`, `LOG_PRETTY=false` 기본값 추가

<br>

## TODO
- #78 Rate Limiter debug 로그 추가 (본 이슈 선행 완료 후 진행)

<br>

## 논의 사항
- 없음

<br>