### PR TITLE
[REFAC#78]: Rate Limiter Wait() debug 로그 강화

### DIFF
--- a/internal/crawler/core/rate_limiter.go
+++ b/internal/crawler/core/rate_limiter.go
@@ -37,27 +37,34 @@ func NewRateLimiter(requestsPerHour, burst int) RateLimiter {
 // token이 없으면 token이 생성될 때까지 대기합니다.
 func (r *TokenBucketRateLimiter) Wait(ctx context.Context) error {
 	log := logger.FromContext(ctx)
-	waitStarted := false
+	waitCount := 0
 
 	for {
 		if r.Allow() {
-			if waitStarted {
-				log.Debug("rate limit wait completed")
+			if waitCount > 0 {
+				log.WithField("wait_count", waitCount).Debug("rate limit wait completed")
 			}
 			return nil
 		}
 
-		// 다음 token이 생성될 때까지 대기
 		sleepDuration := r.timeToNextToken()
+		waitCount++
 
-		if !waitStarted {
-			log.WithField("wait_ms", sleepDuration.Milliseconds()).
-				Debug("rate limit reached, waiting for token")
-			waitStarted = true
+		if waitCount == 1 {
+			log.WithFields(map[string]interface{}{
+				"wait_ms": sleepDuration.Milliseconds(),
+				"rate":    r.rate,
+				"burst":   r.burst,
+			}).Debug("rate limit reached, waiting for token")
 		}
 
 		select {
 		case <-ctx.Done():
+			log.WithFields(map[string]interface{}{
+				"wait_count": waitCount,
+				"rate":       r.rate,
+				"burst":      r.burst,
+			}).Debug("rate limit wait cancelled by context")
 			return ctx.Err()
 		case <-time.After(sleepDuration):
 			// continue to check again

--- a/internal/crawler/core/rate_limiter.go
+++ b/internal/crawler/core/rate_limiter.go
@@ -60,12 +60,14 @@ func (r *TokenBucketRateLimiter) Wait(ctx context.Context) error {
 
 		select {
 		case <-ctx.Done():
+			ctxErr := ctx.Err()
 			log.WithFields(map[string]interface{}{
 				"wait_count": waitCount,
 				"rate":       r.rate,
 				"burst":      r.burst,
-			}).Debug("rate limit wait cancelled by context")
-			return ctx.Err()
+				"ctx_err":    ctxErr,
+			}).Debug("rate limit wait context done")
+			return ctxErr
 		case <-time.After(sleepDuration):
 			// continue to check again
 		}

--- a/test/internal/crawler_core/rate_limiter_test.go
+++ b/test/internal/crawler_core/rate_limiter_test.go
@@ -16,12 +16,10 @@ import (
 
 // debugContext는 debug 레벨 logger를 buf에 기록하는 context를 반환합니다.
 func debugContext(buf *bytes.Buffer) context.Context {
-	log := logger.New(logger.Config{
-		Level:      logger.LevelDebug,
-		Output:     buf,
-		TimeFormat: time.RFC3339,
-	})
-	return log.ToContext(context.Background())
+	cfg := logger.DefaultConfig()
+	cfg.Level = logger.LevelDebug
+	cfg.Output = buf
+	return logger.New(cfg).ToContext(context.Background())
 }
 
 // lastLog는 buf에서 마지막 JSON 로그 라인을 파싱해 반환합니다.
@@ -195,7 +193,10 @@ func TestRateLimiter_Wait_LogsContextCancelled(t *testing.T) {
 
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
-	ctx = logger.New(logger.Config{Level: logger.LevelDebug, Output: &buf}).ToContext(ctx)
+	logCfg := logger.DefaultConfig()
+	logCfg.Level = logger.LevelDebug
+	logCfg.Output = &buf
+	ctx = logger.New(logCfg).ToContext(ctx)
 
 	err := limiter.Wait(ctx)
 	require.ErrorIs(t, err, context.Canceled)

--- a/test/internal/crawler_core/rate_limiter_test.go
+++ b/test/internal/crawler_core/rate_limiter_test.go
@@ -17,8 +17,9 @@ import (
 // debugContext는 debug 레벨 logger를 buf에 기록하는 context를 반환합니다.
 func debugContext(buf *bytes.Buffer) context.Context {
 	log := logger.New(logger.Config{
-		Level:  logger.LevelDebug,
-		Output: buf,
+		Level:      logger.LevelDebug,
+		Output:     buf,
+		TimeFormat: time.RFC3339,
 	})
 	return log.ToContext(context.Background())
 }

--- a/test/internal/crawler_core/rate_limiter_test.go
+++ b/test/internal/crawler_core/rate_limiter_test.go
@@ -2,14 +2,49 @@ package core_test
 
 import (
 	core "issuetracker/internal/crawler/core"
+	"issuetracker/pkg/logger"
 
+	"bytes"
 	"context"
+	"encoding/json"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+// debugContext는 debug 레벨 logger를 buf에 기록하는 context를 반환합니다.
+func debugContext(buf *bytes.Buffer) context.Context {
+	log := logger.New(logger.Config{
+		Level:  logger.LevelDebug,
+		Output: buf,
+	})
+	return log.ToContext(context.Background())
+}
+
+// lastLog는 buf에서 마지막 JSON 로그 라인을 파싱해 반환합니다.
+func lastLog(t *testing.T, buf *bytes.Buffer) map[string]interface{} {
+	t.Helper()
+	lines := bytes.Split(bytes.TrimRight(buf.Bytes(), "\n"), []byte("\n"))
+	var out map[string]interface{}
+	require.NoError(t, json.Unmarshal(lines[len(lines)-1], &out))
+	return out
+}
+
+// findLog는 buf에서 message가 일치하는 첫 번째 로그를 반환합니다.
+func findLog(buf *bytes.Buffer, message string) map[string]interface{} {
+	for _, line := range bytes.Split(bytes.TrimRight(buf.Bytes(), "\n"), []byte("\n")) {
+		var entry map[string]interface{}
+		if err := json.Unmarshal(line, &entry); err != nil {
+			continue
+		}
+		if entry["message"] == message {
+			return entry
+		}
+	}
+	return nil
+}
 
 func TestNewRateLimiter(t *testing.T) {
 	limiter := core.NewRateLimiter(3600, 10)
@@ -32,7 +67,6 @@ func TestRateLimiter_Allow_Refill(t *testing.T) {
 	// 시간당 3600 요청 = 초당 1 요청
 	limiter := core.NewRateLimiter(3600, 1)
 
-	// 첫 번째 요청 허용
 	assert.True(t, limiter.Allow())
 
 	// 즉시 두 번째 요청은 거부
@@ -41,7 +75,6 @@ func TestRateLimiter_Allow_Refill(t *testing.T) {
 	// 1초 대기 후 refill
 	time.Sleep(1100 * time.Millisecond)
 
-	// 이제 허용되어야 함
 	assert.True(t, limiter.Allow())
 }
 
@@ -50,29 +83,22 @@ func TestRateLimiter_Wait_Success(t *testing.T) {
 	ctx := context.Background()
 
 	// 처음 2개는 즉시 허용
-	err := limiter.Wait(ctx)
-	require.NoError(t, err)
-
-	err = limiter.Wait(ctx)
-	require.NoError(t, err)
+	require.NoError(t, limiter.Wait(ctx))
+	require.NoError(t, limiter.Wait(ctx))
 
 	// 세 번째는 대기 필요
 	start := time.Now()
-	err = limiter.Wait(ctx)
+	require.NoError(t, limiter.Wait(ctx))
 	elapsed := time.Since(start)
 
-	require.NoError(t, err)
-	// 최소 0.5초 이상 대기해야 함 (1초의 여유를 둠)
+	// 최소 0.5초 이상 대기해야 함
 	assert.Greater(t, elapsed, 500*time.Millisecond)
 }
 
 func TestRateLimiter_Wait_ContextCanceled(t *testing.T) {
 	limiter := core.NewRateLimiter(10, 1) // 낮은 rate로 설정
+	limiter.Allow()                        // 토큰 소진
 
-	// Token 소진
-	limiter.Allow()
-
-	// Context cancel
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 
@@ -82,11 +108,8 @@ func TestRateLimiter_Wait_ContextCanceled(t *testing.T) {
 
 func TestRateLimiter_Wait_ContextTimeout(t *testing.T) {
 	limiter := core.NewRateLimiter(10, 1) // 낮은 rate로 설정
+	limiter.Allow()                        // 토큰 소진
 
-	// Token 소진
-	limiter.Allow()
-
-	// 짧은 timeout 설정
 	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
 	defer cancel()
 
@@ -113,7 +136,6 @@ func TestRateLimiter_ConcurrentRequests(t *testing.T) {
 		}()
 	}
 
-	// 모든 고루틴 완료 대기
 	for i := 0; i < 20; i++ {
 		<-done
 	}
@@ -130,4 +152,57 @@ func TestTokenBucketRateLimiter_String(t *testing.T) {
 	assert.Contains(t, str, "RateLimiter")
 	assert.Contains(t, str, "rate=1.00/s")
 	assert.Contains(t, str, "burst=10")
+}
+
+func TestRateLimiter_Wait_LogsWaitStart(t *testing.T) {
+	var buf bytes.Buffer
+	ctx := debugContext(&buf)
+
+	limiter := core.NewRateLimiter(3600, 1)
+	require.NoError(t, limiter.Wait(ctx)) // 첫 번째 — 즉시 통과
+	buf.Reset()
+
+	require.NoError(t, limiter.Wait(ctx)) // 두 번째 — 대기 발생
+
+	entry := findLog(&buf, "rate limit reached, waiting for token")
+	require.NotNil(t, entry, "rate limit reached 로그가 있어야 합니다")
+	assert.Contains(t, entry, "wait_ms")
+	assert.Contains(t, entry, "rate")
+	assert.Contains(t, entry, "burst")
+}
+
+func TestRateLimiter_Wait_LogsWaitCompleted(t *testing.T) {
+	var buf bytes.Buffer
+	ctx := debugContext(&buf)
+
+	limiter := core.NewRateLimiter(3600, 1)
+	require.NoError(t, limiter.Wait(ctx)) // 첫 번째 — 즉시 통과
+	buf.Reset()
+
+	require.NoError(t, limiter.Wait(ctx)) // 두 번째 — 대기 후 완료
+
+	entry := findLog(&buf, "rate limit wait completed")
+	require.NotNil(t, entry, "rate limit wait completed 로그가 있어야 합니다")
+	assert.Contains(t, entry, "wait_count")
+}
+
+func TestRateLimiter_Wait_LogsContextCancelled(t *testing.T) {
+	var buf bytes.Buffer
+
+	limiter := core.NewRateLimiter(10, 1)
+	limiter.Allow() // 토큰 소진
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	ctx = logger.New(logger.Config{Level: logger.LevelDebug, Output: &buf}).ToContext(ctx)
+
+	err := limiter.Wait(ctx)
+	require.ErrorIs(t, err, context.Canceled)
+
+	entry := lastLog(t, &buf)
+	assert.Equal(t, "debug", entry["level"])
+	assert.Equal(t, "rate limit wait cancelled by context", entry["message"])
+	assert.Contains(t, entry, "wait_count")
+	assert.Contains(t, entry, "rate")
+	assert.Contains(t, entry, "burst")
 }

--- a/test/internal/crawler_core/rate_limiter_test.go
+++ b/test/internal/crawler_core/rate_limiter_test.go
@@ -97,7 +97,7 @@ func TestRateLimiter_Wait_Success(t *testing.T) {
 
 func TestRateLimiter_Wait_ContextCanceled(t *testing.T) {
 	limiter := core.NewRateLimiter(10, 1) // 낮은 rate로 설정
-	limiter.Allow()                        // 토큰 소진
+	limiter.Allow()                       // 토큰 소진
 
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
@@ -108,7 +108,7 @@ func TestRateLimiter_Wait_ContextCanceled(t *testing.T) {
 
 func TestRateLimiter_Wait_ContextTimeout(t *testing.T) {
 	limiter := core.NewRateLimiter(10, 1) // 낮은 rate로 설정
-	limiter.Allow()                        // 토큰 소진
+	limiter.Allow()                       // 토큰 소진
 
 	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
 	defer cancel()


### PR DESCRIPTION
## 연관 이슈
- #78

<br>

## 구현 내용
- `internal/crawler/core/rate_limiter.go`: `Wait()` debug 로그 강화
  - 대기 시작 시 `wait_ms`, `rate`, `burst` 필드 추가
  - 대기 완료 시 `wait_count` 필드 추가
  - context 취소 시 `wait_count`, `rate`, `burst` 필드 추가
  - `waitStarted bool` 플래그를 `waitCount int` 카운터로 교체
- `test/internal/crawler_core/rate_limiter_test.go`: Wait() 로그 검증 테스트 3종 추가
  - `debugContext`, `lastLog`, `findLog` 헬퍼 추가
  - `TestRateLimiter_Wait_LogsWaitStart`: 대기 시작 로그 필드 검증
  - `TestRateLimiter_Wait_LogsWaitCompleted`: 대기 완료 로그 필드 검증
  - `TestRateLimiter_Wait_LogsContextCancelled`: context 취소 로그 필드 검증

<br>

## TODO
- 없음

<br>

## 논의 사항
- `Allow()` · `refill()`은 context를 받지 않으므로 로그 추가 없음
  - `Wait(ctx)`의 ctx는 취소/타임아웃 제어 + 로거 추출의 이중 역할
  - `Allow()`는 단순 토큰 체크로 ctx가 불필요하여 로그 생략

<br>