### PR TITLE
[CHORE#87]: Harness PR Trigger 및 status check 연동 검증

### DIFF
--- a/docs/harness/verification-log.md
+++ b/docs/harness/verification-log.md
@@ -1,0 +1,20 @@
+# Harness 연동 검증 로그
+
+이슈 [#87](https://github.com/EinSofINTEREST/IssueTracker/issues/87) 후속 검증 결과를 누적 기록합니다.
+
+## 검증 항목 정의
+
+| 항목 | 합격 기준 |
+|------|-----------|
+| PR Trigger 발사 | main 대상 PR 생성 시 Harness 파이프라인 실행 시작 |
+| `harness-ci-build` status 전송 | PR Checks 탭에 context 노출 + pending → success/failure 전이 |
+| `harness-approval` status 전송 | 승인/거부/타임아웃 시 각각 success/failure 전이 |
+| Ruleset 매칭 | 등록 후 PR이 status 미통과 시 머지 차단 |
+
+## 실행 기록
+
+> 검증을 진행하며 한 행씩 추가합니다.
+
+| 일자 | PR | 시나리오 | 결과 | 비고 |
+|------|----|---------|------|------|
+| _pending_ | #(임시 PR) | 최초 트리거 / status 전송 | _대기_ | 본 PR 머지 후 갱신 |


### PR DESCRIPTION
## 연관 이슈
- #87

<br>

## 구현 내용
- \`docs/harness/verification-log.md\` 신설 (검증 결과 누적 기록 스텁)

본 PR의 주 목적은 **파일 변경이 아닌 트리거 발사** 입니다. main 대상 PR 이벤트가 발생하면 Harness PR Trigger가 동작하고, build 스테이지의 \`sendGitStatus\` 블록을 통해 \`harness-ci-build\` context가 본 PR Checks 탭으로 전송되어야 합니다.

<br>

## Harness Engineering 점검 (필수)

### 변경 영향 범위
- 영향 파이프라인/스테이지 식별자: Sample_Harness_Governance / build, approval
- 변경 범위: N/A (검증용 PR)
- 위험도: Low

### Approval / 조건 실행
- Approval 게이트 포함 여부: No (검증용으로 build 스테이지 트리거 확인이 1차 목표)
- JEXL 조건 실행 사용 여부: No

### Failure Strategy
- 적용 전략: N/A
- Ignore Failure 사용 여부: 미사용
- 적용 범위: N/A

### 검증 / 롤백
- Required status check 이름: \`Format Check\` (현행), \`harness-ci-build\` (검증 대상)
- 롤백 계획: 단일 문서 추가이므로 revert PR로 원복 가능

<br>

## 검증 절차
1. 본 PR 생성 시 Harness webhook 수신 → 파이프라인 실행 시작 확인
2. PR Checks 탭에서 \`harness-ci-build\` context 표시 확인
3. 결과를 \`docs/harness/verification-log.md\` 표에 갱신 (성공 시 후속 커밋)
4. status 전송 OK 확인 후 Ruleset \`Main branch merge gate\` 의 \`required_status_checks\` 에 추가

<br>

## TODO
- 트리거 결과 기록 후 verification-log.md 갱신 커밋
- Ruleset 갱신은 별도 \`gh api PUT\` 으로 진행

<br>

## 논의 사항
- 본 PR은 트리거가 발사되지 않으면 Checks 탭이 비어 있을 수 있음. 이 경우 OAuth Connector scope 점검 또는 Trigger target branch 필터 재확인 필요