### PR TITLE
[FIX#73]: CNN RSS 핸들러 제거 및 HTML 카테고리 기반 크롤링 전환

### DIFF
--- a/internal/crawler/domain/news/us/cnn/config.go
+++ b/internal/crawler/domain/news/us/cnn/config.go
@@ -1,9 +1,8 @@
 // Package cnn implements a crawler for CNN (www.cnn.com).
 //
 // Package cnn은 CNN 뉴스 크롤러를 구현합니다.
-// Primary strategy: RSS feed (for article lists).
-// Secondary strategy: HTML scraping via goquery (for full article content).
-// Fallback strategy: headless browser via chromedp.
+// Primary strategy: HTML scraping via goquery (for category lists and full article content).
+// Fallback strategy: headless browser via chromedp (for JavaScript-rendered pages).
 package cnn
 
 import (

--- a/internal/crawler/domain/news/us/cnn/config.go
+++ b/internal/crawler/domain/news/us/cnn/config.go
@@ -15,9 +15,6 @@ type CNNConfig struct {
 	// BaseURL은 CNN 메인 URL입니다.
 	BaseURL string
 
-	// FeedURLs는 카테고리명 → RSS 피드 URL 매핑입니다.
-	FeedURLs map[string]string
-
 	// CategoryURLs는 카테고리명 → HTML 목록 페이지 URL 매핑입니다.
 	CategoryURLs map[string]string
 
@@ -45,16 +42,6 @@ func DefaultCNNConfig() CNNConfig {
 
 	return CNNConfig{
 		BaseURL: "https://www.cnn.com",
-		FeedURLs: map[string]string{
-			"top":           "https://rss.cnn.com/rss/cnn_topstories.rss",
-			"us":            "https://rss.cnn.com/rss/cnn_us.rss",
-			"world":         "https://rss.cnn.com/rss/cnn_world.rss",
-			"politics":      "https://rss.cnn.com/rss/cnn_allpolitics.rss",
-			"business":      "https://rss.cnn.com/rss/money_latest.rss",
-			"tech":          "https://rss.cnn.com/rss/cnn_tech.rss",
-			"health":        "https://rss.cnn.com/rss/cnn_health.rss",
-			"entertainment": "https://rss.cnn.com/rss/showbiz_video.rss",
-		},
 		CategoryURLs: map[string]string{
 			"us":            "https://edition.cnn.com/us",
 			"world":         "https://edition.cnn.com/world",

--- a/internal/crawler/domain/news/us/cnn/config.go
+++ b/internal/crawler/domain/news/us/cnn/config.go
@@ -43,6 +43,7 @@ func DefaultCNNConfig() CNNConfig {
 	return CNNConfig{
 		BaseURL: "https://www.cnn.com",
 		CategoryURLs: map[string]string{
+			"top":           "https://edition.cnn.com",
 			"us":            "https://edition.cnn.com/us",
 			"world":         "https://edition.cnn.com/world",
 			"politics":      "https://edition.cnn.com/politics",

--- a/internal/crawler/domain/news/us/registry.go
+++ b/internal/crawler/domain/news/us/registry.go
@@ -43,17 +43,14 @@ func registerCNN(registry *handler.Registry, config core.Config, repo storage.Ne
 	}
 
 	// goquery fetcher (주 전략: 카테고리 목록 + 기사 본문 수집)
-	gqSource := cnnCfg.CrawlerConfig.SourceInfo
-	gqSource.Name = "cnn-goquery"
-	gqCrawler := goquery.NewGoqueryCrawler("cnn-goquery", gqSource, config)
+	// SourceInfo.Name은 논리 소스명("cnn")을 유지하여 DB/Kafka 소스 식별자 일관성 보장
+	gqCrawler := goquery.NewGoqueryCrawler("cnn-goquery", cnnCfg.CrawlerConfig.SourceInfo, config)
 	gqFetcher := fetcher.NewGoqueryFetcher(gqCrawler)
 
 	// chromedp fetcher (폴백: JavaScript 렌더링 필요 시)
-	cdpSource := cnnCfg.CrawlerConfig.SourceInfo
-	cdpSource.Name = "cnn-browser"
 	cdpCrawler := cdp.NewChromedpCrawlerWithOptions(
 		"cnn-browser",
-		cdpSource,
+		cnnCfg.CrawlerConfig.SourceInfo,
 		config,
 		cdp.DefaultRemoteOptions(),
 	)

--- a/internal/crawler/domain/news/us/registry.go
+++ b/internal/crawler/domain/news/us/registry.go
@@ -29,8 +29,8 @@ func Register(registry *handler.Registry, config core.Config, repo storage.NewsA
 }
 
 // registerCNN은 CNN 뉴스 핸들러를 조립하고 등록합니다.
-// 체인: RSS(주) → GoQuery(HTML 폴백) → Browser(최종 폴백)
-// RSS는 기사 목록 수집에 사용되고, GoQuery/Browser는 전체 기사 본문 수집에 사용됩니다.
+// 체인: GoQuery(주) → Browser(폴백)
+// CNN RSS 피드가 지원 중단되어 HTML 기반 크롤링을 기본 전략으로 사용합니다.
 func registerCNN(registry *handler.Registry, config core.Config, repo storage.NewsArticleRepository, publisher news.JobPublisher, log *logger.Logger) {
 	cnnCfg := cnn.DefaultCNNConfig()
 	cnnCfg.CrawlerConfig = config
@@ -42,17 +42,13 @@ func registerCNN(registry *handler.Registry, config core.Config, repo storage.Ne
 		Language: "en",
 	}
 
-	// RSS fetcher (주 전략: 기사 목록)
-	rssSource := cnnCfg.CrawlerConfig.SourceInfo
-	rssFetcher := fetcher.NewRSSFetcher(rssSource, log)
-
-	// goquery fetcher (기사 본문 수집)
+	// goquery fetcher (주 전략: 카테고리 목록 + 기사 본문 수집)
 	gqSource := cnnCfg.CrawlerConfig.SourceInfo
 	gqSource.Name = "cnn-goquery"
 	gqCrawler := goquery.NewGoqueryCrawler("cnn-goquery", gqSource, config)
 	gqFetcher := fetcher.NewGoqueryFetcher(gqCrawler)
 
-	// chromedp fetcher (최종 폴백: JavaScript 렌더링 필요 시)
+	// chromedp fetcher (폴백: JavaScript 렌더링 필요 시)
 	cdpSource := cnnCfg.CrawlerConfig.SourceInfo
 	cdpSource.Name = "cnn-browser"
 	cdpCrawler := cdp.NewChromedpCrawlerWithOptions(
@@ -67,10 +63,9 @@ func registerCNN(registry *handler.Registry, config core.Config, repo storage.Ne
 	parser := cnn.NewCNNParser(cnnCfg)
 	crawler := cnn.NewCNNCrawler(cnnCfg, gqFetcher, parser, log)
 
-	// 체인 조립: RSS → GoQuery → Browser
-	// CNN은 RSS로 목록을 수집하고, GoQuery로 전체 기사를 파싱합니다.
+	// 체인 조립: GoQuery → Browser (RSS 제외)
 	// lazy loading 감지 시 GoQuery에서 Browser로 자동 위임합니다.
-	chain := news.BuildChain(rssFetcher, gqFetcher, brFetcher, log,
+	chain := news.BuildChain(nil, gqFetcher, brFetcher, log,
 		"data-lazy-src",
 		"lazyload",
 		"data-lazy",

--- a/internal/scheduler/entries.go
+++ b/internal/scheduler/entries.go
@@ -22,18 +22,18 @@ func DefaultEntries(cfg config.SchedulerConfig) []ScheduleEntry {
 	return entries
 }
 
-// cnnEntries는 CNN RSS 피드 기반 스케줄 항목을 반환합니다.
-// CNN은 RSS 피드를 제공하므로 TargetTypeFeed + FeedInterval을 사용합니다.
+// cnnEntries는 CNN 카테고리 페이지 기반 스케줄 항목을 반환합니다.
+// CNN RSS 피드가 지원 중단되어 HTML 카테고리 페이지를 직접 크롤링합니다.
 func cnnEntries(cfg config.SchedulerConfig) []ScheduleEntry {
 	cnnCfg := cnn.DefaultCNNConfig()
-	entries := make([]ScheduleEntry, 0, len(cnnCfg.FeedURLs))
+	entries := make([]ScheduleEntry, 0, len(cnnCfg.CategoryURLs))
 
-	for _, url := range cnnCfg.FeedURLs {
+	for _, url := range cnnCfg.CategoryURLs {
 		entries = append(entries, ScheduleEntry{
 			CrawlerName: "cnn",
 			URL:         url,
-			TargetType:  core.TargetTypeFeed,
-			Interval:    cfg.FeedInterval,
+			TargetType:  core.TargetTypeCategory,
+			Interval:    cfg.CategoryInterval,
 			Priority:    core.PriorityNormal,
 			Timeout:     cfg.JobTimeout,
 		})

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -408,7 +408,6 @@ func Load(envFiles ...string) (DBConfig, error) {
 // SchedulerConfig는 Job Scheduler의 크롤 주기 설정을 나타냅니다.
 // 소스 타입별로 독립적으로 조정할 수 있습니다.
 type SchedulerConfig struct {
-	FeedInterval     time.Duration // RSS 피드 폴링 주기 — SCHEDULER_FEED_INTERVAL (default: 20m)
 	CategoryInterval time.Duration // 카테고리 목록 폴링 주기 — SCHEDULER_CATEGORY_INTERVAL (default: 2h)
 	JobTimeout       time.Duration // 개별 Job 최대 실행 시간 — SCHEDULER_JOB_TIMEOUT (default: 30s)
 	MaxRetries       int           // Job 최대 재시도 횟수 — SCHEDULER_MAX_RETRIES (default: 3)
@@ -417,7 +416,6 @@ type SchedulerConfig struct {
 // DefaultSchedulerConfig는 기본 SchedulerConfig를 반환합니다.
 func DefaultSchedulerConfig() SchedulerConfig {
 	return SchedulerConfig{
-		FeedInterval:     20 * time.Minute,
 		CategoryInterval: 2 * time.Hour,
 		JobTimeout:       30 * time.Second,
 		MaxRetries:       3,
@@ -459,7 +457,6 @@ func LoadScheduler(envFiles ...string) (SchedulerConfig, error) {
 	}
 
 	for _, op := range []error{
-		parseDuration("SCHEDULER_FEED_INTERVAL", &cfg.FeedInterval),
 		parseDuration("SCHEDULER_CATEGORY_INTERVAL", &cfg.CategoryInterval),
 		parseDuration("SCHEDULER_JOB_TIMEOUT", &cfg.JobTimeout),
 		parseInt("SCHEDULER_MAX_RETRIES", &cfg.MaxRetries),


### PR DESCRIPTION
## 연관 이슈
- #73

<br>

## 구현 내용
- CNN RSS 피드 지원 중단에 따라 RSS 핸들러를 체인에서 제거
- 크롤러 체인을 `RSS → GoQuery → Browser` 3단계에서 `GoQuery → Browser` 2단계로 변경
- 스케줄러 엔트리를 `TargetTypeFeed`(RSS) 기반에서 `TargetTypeCategory`(HTML) 기반으로 전환
- `CNNConfig`에서 `FeedURLs` 필드 및 RSS URL 8개 완전 제거

<br>

## CI / 머지 게이트 점검

> [CI 운영 규약](docs/ci/conventions.md) 및 [Required Status Checks 단일 소스](docs/ci/status-checks.md)에 따라 작성합니다.

### 변경 영향 범위
- 영향 패키지/모듈: `internal/crawler/domain/news/us/cnn`, `internal/crawler/domain/news/us`, `internal/scheduler`
- 위험도(택1): `Medium`

### Required Status Checks
- 통과 확인 대상 (PR Checks 탭에서 확인):
  - [ ] `Commit Lint`
  - [ ] `PR Title Lint`
  - [ ] `Format Check`
  - [ ] `Build`
  - [ ] `Test`
  - [ ] `Lint`

### 롤백 계획
- `FeedURLs` 복원 및 `registerCNN`에서 RSS fetcher 재등록으로 즉시 원복 가능

<br>

## TODO
- CNN GoQuery 셀렉터(`config.go`)가 현재 CNN HTML 구조와 일치하는지 실제 수집 테스트 필요
- #73 네트워크 경로 차단 이슈가 해소되었는지 병행 확인

<br>

## 논의 사항
- RSS 핸들러 코드 자체(`RSSFetchHandler`, `fetcher/rss.go`)는 다른 소스에서 사용 중이므로 삭제하지 않음
- 향후 CNN이 RSS를 재개하면 `BuildChain`의 첫 번째 인자만 복원하면 됨

<br>