### PR TITLE
[FEAT#92] Fetch 전 Redis 기반 URL 캐시로 중복 HTTP 요청 방지

### DIFF
--- a/cmd/issuetracker/main.go
+++ b/cmd/issuetracker/main.go
@@ -90,20 +90,22 @@ func main() {
 	// worker/manager가 JobLocker nil을 NoopJobLocker로 fallback 처리하는 설계와 일관되게,
 	// Redis 초기화 실패 시에도 크롤링이 중단되지 않도록 graceful degrade합니다.
 	var jobLocker crawlerWorker.JobLocker
+	var urlCache crawlerWorker.URLCache
 	redisCfg, err := config.LoadRedis()
 	if err != nil {
-		log.WithError(err).Warn("failed to load redis config, falling back to noop job locker")
+		log.WithError(err).Warn("failed to load redis config, falling back to noop job locker and url cache")
 	} else {
 		redisClient, redisErr := redis.New(ctx, redisCfg)
 		if redisErr != nil {
-			log.WithError(redisErr).Warn("failed to connect to redis, falling back to noop job locker")
+			log.WithError(redisErr).Warn("failed to connect to redis, falling back to noop job locker and url cache")
 		} else {
 			defer redisClient.Close()
 			log.WithFields(map[string]interface{}{
 				"host": redisCfg.Host,
 				"port": redisCfg.Port,
-			}).Info("redis connected for job locker")
+			}).Info("redis connected for job locker and url cache")
 			jobLocker = crawlerWorker.NewRedisJobLocker(redisClient, crawlerWorker.DefaultJobLockTTL)
+			urlCache = crawlerWorker.NewRedisURLCache(redisClient, redisCfg.URLCacheTTL)
 		}
 	}
 
@@ -112,6 +114,7 @@ func main() {
 		Normal:    crawlerWorker.PoolConfig{Consumer: normalConsumer, WorkerCount: 6},
 		Low:       crawlerWorker.PoolConfig{Consumer: lowConsumer, WorkerCount: 2},
 		JobLocker: jobLocker,
+		URLCache:  urlCache,
 	}
 
 	manager := crawlerWorker.NewPoolManager(managerCfg, crawlerProducer, registry, contentSvc, resolver, log)

--- a/internal/crawler/worker/manager.go
+++ b/internal/crawler/worker/manager.go
@@ -27,11 +27,13 @@ type PoolConfig struct {
 //
 // ManagerConfig aggregates the three per-priority pool configs.
 // JobLocker가 nil이면 NoopJobLocker가 사용되어 중복 처리 방지가 비활성화됩니다.
+// URLCache가 nil이면 NoopURLCache가 사용되어 URL 캐싱이 비활성화됩니다.
 type ManagerConfig struct {
 	High      PoolConfig
 	Normal    PoolConfig
 	Low       PoolConfig
 	JobLocker JobLocker
+	URLCache  URLCache
 }
 
 // ─────────────────────────────────────────────────────────────────────────
@@ -72,6 +74,11 @@ func NewPoolManager(
 		jobLocker = NoopJobLocker{}
 	}
 
+	urlCache := cfg.URLCache
+	if urlCache == nil {
+		urlCache = NoopURLCache{}
+	}
+
 	// 세 개 Pool이 동일한 CircuitBreakerRegistry를 공유하여
 	// 소스별 실패 카운팅이 우선순위 경계 없이 누적됩니다.
 	cbRegistry := NewCircuitBreakerRegistry(DefaultCircuitBreakerConfig)
@@ -79,7 +86,7 @@ func NewPoolManager(
 	newPool := func(pc PoolConfig) *KafkaConsumerPool {
 		return NewKafkaConsumerPoolWithOptions(
 			pc.Consumer, producer, handler, contentSvc, pc.WorkerCount,
-			cbRegistry, jobLocker,
+			cbRegistry, jobLocker, urlCache,
 		)
 	}
 

--- a/internal/crawler/worker/pool.go
+++ b/internal/crawler/worker/pool.go
@@ -389,7 +389,9 @@ func (p *KafkaConsumerPool) processJob(ctx context.Context, item jobItem) error 
 	}
 
 	if len(contents) == 0 {
-		// handler가 빈 슬라이스나 nil을 반환하면 발행 없이 commit만 수행
+		// handler가 빈 슬라이스나 nil을 반환해도 fetch 자체는 성공했으므로 캐시에 등록합니다.
+		// 다음 주기에 동일 URL을 불필요하게 재요청하는 것을 방지합니다.
+		p.cacheURLIfEligible(ctx, item, log)
 		cb.RecordSuccess()
 		return p.commitMessage(ctx, item.msg)
 	}
@@ -402,18 +404,7 @@ func (p *KafkaConsumerPool) processJob(ctx context.Context, item jobItem) error 
 		}
 	}
 
-	// fetch + 저장 + 발행이 모두 성공한 URL을 캐시에 등록합니다.
-	// 카테고리 페이지는 매 주기마다 새 기사 URL을 추출해야 하므로 캐시 대상에서 제외합니다.
-	// 캐시 등록 실패는 다음 주기에 중복 fetch가 발생할 뿐이므로 에러를 전파하지 않습니다.
-	if targetURL := item.job.Target.URL; targetURL != "" && item.job.Target.Type != core.TargetTypeCategory {
-		if cacheErr := p.urlCache.Set(ctx, targetURL); cacheErr != nil {
-			log.WithFields(map[string]interface{}{
-				"job_id":  item.job.ID,
-				"crawler": item.job.CrawlerName,
-				"url":     targetURL,
-			}).WithError(cacheErr).Warn("failed to cache url after successful fetch")
-		}
-	}
+	p.cacheURLIfEligible(ctx, item, log)
 
 	// 모든 부수 효과(DB 저장 + Kafka 발행)가 성공한 시점에 circuit breaker에 성공 기록
 	cb.RecordSuccess()
@@ -475,6 +466,22 @@ func (p *KafkaConsumerPool) publishNormalized(ctx context.Context, content *core
 	}
 
 	return p.producer.Publish(ctx, msg)
+}
+
+// cacheURLIfEligible은 fetch 성공 후 URL을 캐시에 등록합니다.
+// 카테고리 페이지는 매 주기마다 새 기사 URL을 추출해야 하므로 캐시 대상에서 제외합니다.
+// 캐시 등록 실패는 다음 주기에 중복 fetch가 발생할 뿐이므로 에러를 전파하지 않습니다.
+func (p *KafkaConsumerPool) cacheURLIfEligible(ctx context.Context, item jobItem, log *logger.Logger) {
+	url := item.job.Target.URL
+	if url != "" && item.job.Target.Type != core.TargetTypeCategory {
+		if cacheErr := p.urlCache.Set(ctx, url); cacheErr != nil {
+			log.WithFields(map[string]interface{}{
+				"job_id":  item.job.ID,
+				"crawler": item.job.CrawlerName,
+				"url":     url,
+			}).WithError(cacheErr).Warn("failed to cache url after successful fetch")
+		}
+	}
 }
 
 func (p *KafkaConsumerPool) commitMessage(ctx context.Context, msg *queue.Message) error {

--- a/internal/crawler/worker/pool.go
+++ b/internal/crawler/worker/pool.go
@@ -403,8 +403,9 @@ func (p *KafkaConsumerPool) processJob(ctx context.Context, item jobItem) error 
 	}
 
 	// fetch + 저장 + 발행이 모두 성공한 URL을 캐시에 등록합니다.
+	// 카테고리 페이지는 매 주기마다 새 기사 URL을 추출해야 하므로 캐시 대상에서 제외합니다.
 	// 캐시 등록 실패는 다음 주기에 중복 fetch가 발생할 뿐이므로 에러를 전파하지 않습니다.
-	if targetURL := item.job.Target.URL; targetURL != "" {
+	if targetURL := item.job.Target.URL; targetURL != "" && item.job.Target.Type != core.TargetTypeCategory {
 		if cacheErr := p.urlCache.Set(ctx, targetURL); cacheErr != nil {
 			log.WithFields(map[string]interface{}{
 				"job_id":  item.job.ID,

--- a/internal/crawler/worker/pool.go
+++ b/internal/crawler/worker/pool.go
@@ -57,6 +57,7 @@ type KafkaConsumerPool struct {
 	wg          sync.WaitGroup
 	cbRegistry  *CircuitBreakerRegistry
 	jobLocker   JobLocker
+	urlCache    URLCache
 	// pollDone은 pollMessages goroutine이 완전히 종료됐음을 알리는 신호입니다.
 	// close(p.jobs) 전에 반드시 이 채널이 닫혔음을 확인해야 합니다.
 	pollDone chan struct{}
@@ -84,6 +85,7 @@ func NewKafkaConsumerPool(
 		consumer, producer, handler, contentSvc, workerCount,
 		NewCircuitBreakerRegistry(DefaultCircuitBreakerConfig),
 		NoopJobLocker{},
+		NoopURLCache{},
 	)
 }
 
@@ -101,6 +103,7 @@ func NewKafkaConsumerPoolWithCB(
 		consumer, producer, handler, contentSvc, workerCount,
 		cbRegistry,
 		NoopJobLocker{},
+		NoopURLCache{},
 	)
 }
 
@@ -114,6 +117,7 @@ func NewKafkaConsumerPoolWithOptions(
 	workerCount int,
 	cbRegistry *CircuitBreakerRegistry,
 	jobLocker JobLocker,
+	urlCache URLCache,
 ) *KafkaConsumerPool {
 	return &KafkaConsumerPool{
 		consumer:    consumer,
@@ -123,6 +127,7 @@ func NewKafkaConsumerPoolWithOptions(
 		workerCount: workerCount,
 		cbRegistry:  cbRegistry,
 		jobLocker:   jobLocker,
+		urlCache:    urlCache,
 		// 버퍼 크기: worker 수의 2배로 polling과 처리 사이의 지연을 흡수
 		jobs:     make(chan jobItem, workerCount*2),
 		pollDone: make(chan struct{}),
@@ -296,6 +301,28 @@ func (p *KafkaConsumerPool) processJob(ctx context.Context, item jobItem) error 
 		}()
 	}
 
+	// 카테고리 페이지는 URL 캐시 대상에서 제외합니다.
+	// 카테고리 페이지는 매 주기마다 새 기사 URL을 추출해야 하므로 캐싱하면 안 됩니다.
+	targetURL := item.job.Target.URL
+	if targetURL != "" && item.job.Target.Type != core.TargetTypeCategory {
+		cached, cacheErr := p.urlCache.Exists(ctx, targetURL)
+		if cacheErr != nil {
+			// 캐시 장애 시 fetch를 차단하지 않고 경고 후 진행합니다.
+			log.WithFields(map[string]interface{}{
+				"job_id":  item.job.ID,
+				"crawler": item.job.CrawlerName,
+				"url":     targetURL,
+			}).WithError(cacheErr).Warn("url cache check failed, proceeding with fetch")
+		} else if cached {
+			log.WithFields(map[string]interface{}{
+				"job_id":  item.job.ID,
+				"crawler": item.job.CrawlerName,
+				"url":     targetURL,
+			}).Debug("url already cached, skipping fetch")
+			return p.commitMessage(ctx, item.msg)
+		}
+	}
+
 	log.WithFields(map[string]interface{}{
 		"job_id":  item.job.ID,
 		"crawler": item.job.CrawlerName,
@@ -372,6 +399,18 @@ func (p *KafkaConsumerPool) processJob(ctx context.Context, item jobItem) error 
 			// publishNormalized 실패는 DB 저장/Kafka 발행 문제로 소스 자체의 건전성과 무관하지만
 			// 작업이 완결되지 않았으므로 성공으로 기록하지 않고 반환합니다.
 			return fmt.Errorf("publish normalized for job %s: %w", item.job.ID, err)
+		}
+	}
+
+	// fetch + 저장 + 발행이 모두 성공한 URL을 캐시에 등록합니다.
+	// 캐시 등록 실패는 다음 주기에 중복 fetch가 발생할 뿐이므로 에러를 전파하지 않습니다.
+	if targetURL := item.job.Target.URL; targetURL != "" {
+		if cacheErr := p.urlCache.Set(ctx, targetURL); cacheErr != nil {
+			log.WithFields(map[string]interface{}{
+				"job_id":  item.job.ID,
+				"crawler": item.job.CrawlerName,
+				"url":     targetURL,
+			}).WithError(cacheErr).Warn("failed to cache url after successful fetch")
 		}
 	}
 

--- a/internal/crawler/worker/url_cache.go
+++ b/internal/crawler/worker/url_cache.go
@@ -1,0 +1,57 @@
+package worker
+
+import (
+	"context"
+	"time"
+)
+
+const (
+	// DefaultURLCacheTTL은 URL 캐시의 기본 TTL입니다.
+	// 동일 URL에 대해 24시간 동안 중복 fetch를 방지합니다.
+	DefaultURLCacheTTL = 24 * time.Hour
+)
+
+// URLCache는 URL 중복 fetch를 방지하는 캐시 인터페이스입니다.
+// 구현체는 goroutine-safe해야 합니다.
+type URLCache interface {
+	// Exists는 URL이 이미 캐시에 존재하는지 확인합니다.
+	// 이미 fetch한 URL이면 true를 반환합니다.
+	Exists(ctx context.Context, url string) (bool, error)
+
+	// Set은 URL을 캐시에 등록합니다.
+	// fetch 성공 후 호출하여 이후 중복 fetch를 방지합니다.
+	Set(ctx context.Context, url string) error
+}
+
+// RedisURLCache는 Redis 기반 URLCache 구현체입니다.
+type RedisURLCache struct {
+	client redisURLCacheClient
+	ttl    time.Duration
+}
+
+// redisURLCacheClient는 Redis URL 캐시 조작을 추상화하는 내부 인터페이스입니다.
+// pkg/redis.Client의 메서드 집합과 일치하며 테스트에서 mock으로 교체됩니다.
+type redisURLCacheClient interface {
+	SetURL(ctx context.Context, url string, ttl time.Duration) error
+	ExistsURL(ctx context.Context, url string) (bool, error)
+}
+
+// NewRedisURLCache는 RedisURLCache를 생성합니다.
+func NewRedisURLCache(client redisURLCacheClient, ttl time.Duration) *RedisURLCache {
+	return &RedisURLCache{client: client, ttl: ttl}
+}
+
+func (c *RedisURLCache) Exists(ctx context.Context, url string) (bool, error) {
+	return c.client.ExistsURL(ctx, url)
+}
+
+func (c *RedisURLCache) Set(ctx context.Context, url string) error {
+	return c.client.SetURL(ctx, url, c.ttl)
+}
+
+// NoopURLCache는 캐시를 사용하지 않는 no-op 구현체입니다.
+// Redis가 없는 환경(단일 인스턴스, 테스트)에서 사용합니다.
+type NoopURLCache struct{}
+
+func (NoopURLCache) Exists(_ context.Context, _ string) (bool, error) { return false, nil }
+func (NoopURLCache) Set(_ context.Context, _ string) error            { return nil }

--- a/internal/crawler/worker/url_cache.go
+++ b/internal/crawler/worker/url_cache.go
@@ -5,12 +5,6 @@ import (
 	"time"
 )
 
-const (
-	// DefaultURLCacheTTL은 URL 캐시의 기본 TTL입니다.
-	// 동일 URL에 대해 24시간 동안 중복 fetch를 방지합니다.
-	DefaultURLCacheTTL = 24 * time.Hour
-)
-
 // URLCache는 URL 중복 fetch를 방지하는 캐시 인터페이스입니다.
 // 구현체는 goroutine-safe해야 합니다.
 type URLCache interface {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -246,6 +246,7 @@ type RedisConfig struct {
 	ReadTimeout  time.Duration // REDIS_READ_TIMEOUT (default: 3s)
 	WriteTimeout time.Duration // REDIS_WRITE_TIMEOUT (default: 3s)
 	PoolSize     int           // REDIS_POOL_SIZE (default: 10)
+	URLCacheTTL  time.Duration // REDIS_URL_CACHE_TTL (default: 24h)
 }
 
 // DefaultRedisConfig는 로컬 개발 환경용 기본 RedisConfig를 반환합니다.
@@ -259,6 +260,7 @@ func DefaultRedisConfig() RedisConfig {
 		ReadTimeout:  3 * time.Second,
 		WriteTimeout: 3 * time.Second,
 		PoolSize:     10,
+		URLCacheTTL:  24 * time.Hour,
 	}
 }
 
@@ -339,6 +341,16 @@ func LoadRedis(envFiles ...string) (RedisConfig, error) {
 			return RedisConfig{}, fmt.Errorf("invalid REDIS_POOL_SIZE %d: must be 1 or greater", n)
 		}
 		cfg.PoolSize = n
+	}
+	if v := os.Getenv("REDIS_URL_CACHE_TTL"); v != "" {
+		d, err := time.ParseDuration(v)
+		if err != nil {
+			return RedisConfig{}, fmt.Errorf("parse REDIS_URL_CACHE_TTL %q: %w", v, err)
+		}
+		if d <= 0 {
+			return RedisConfig{}, fmt.Errorf("invalid REDIS_URL_CACHE_TTL %q: must be positive", v)
+		}
+		cfg.URLCacheTTL = d
 	}
 
 	return cfg, nil

--- a/pkg/redis/url_cache.go
+++ b/pkg/redis/url_cache.go
@@ -1,0 +1,39 @@
+package redis
+
+import (
+	"context"
+	"fmt"
+	"time"
+)
+
+// URLCacheKeyPrefix는 URL 캐시 키의 공통 접두사입니다.
+const URLCacheKeyPrefix = "urlcache:"
+
+// SetURL은 URL을 캐시에 등록합니다.
+// ttl 동안 동일 URL에 대한 중복 fetch를 방지합니다.
+//
+// SetURL marks a URL as visited in the cache with the given TTL.
+func (c *Client) SetURL(ctx context.Context, url string, ttl time.Duration) error {
+	key := urlCacheKey(url)
+	if err := c.rdb.Set(ctx, key, 1, ttl).Err(); err != nil {
+		return fmt.Errorf("set url cache %s: %w", key, err)
+	}
+	return nil
+}
+
+// ExistsURL은 URL이 캐시에 존재하는지 확인합니다.
+// 이미 fetch한 URL이면 true를 반환합니다.
+//
+// ExistsURL checks whether a URL has been recently visited.
+func (c *Client) ExistsURL(ctx context.Context, url string) (bool, error) {
+	key := urlCacheKey(url)
+	n, err := c.rdb.Exists(ctx, key).Result()
+	if err != nil {
+		return false, fmt.Errorf("check url cache %s: %w", key, err)
+	}
+	return n > 0, nil
+}
+
+func urlCacheKey(url string) string {
+	return URLCacheKeyPrefix + url
+}

--- a/pkg/redis/url_cache.go
+++ b/pkg/redis/url_cache.go
@@ -2,6 +2,8 @@ package redis
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"fmt"
 	"time"
 )
@@ -35,5 +37,6 @@ func (c *Client) ExistsURL(ctx context.Context, url string) (bool, error) {
 }
 
 func urlCacheKey(url string) string {
-	return URLCacheKeyPrefix + url
+	hash := sha256.Sum256([]byte(url))
+	return URLCacheKeyPrefix + hex.EncodeToString(hash[:])
 }

--- a/test/internal/worker/job_locker_test.go
+++ b/test/internal/worker/job_locker_test.go
@@ -93,6 +93,7 @@ func TestKafkaConsumerPool_JobLocker_AlreadyAcquired_SkipsWithoutCommit(t *testi
 		consumer, producer, handler, contentSvc, 1,
 		worker.NewCircuitBreakerRegistry(worker.DefaultCircuitBreakerConfig),
 		locker,
+		worker.NoopURLCache{},
 	)
 
 	job := newTestJob()
@@ -123,6 +124,7 @@ func TestKafkaConsumerPool_JobLocker_Acquired_ReleasedAfterProcessing(t *testing
 		consumer, producer, handler, contentSvc, 1,
 		worker.NewCircuitBreakerRegistry(worker.DefaultCircuitBreakerConfig),
 		locker,
+		worker.NoopURLCache{},
 	)
 
 	job := newTestJob()
@@ -158,6 +160,7 @@ func TestKafkaConsumerPool_JobLocker_AcquireError_ProceedsWithoutLock(t *testing
 		consumer, producer, handler, contentSvc, 1,
 		worker.NewCircuitBreakerRegistry(worker.DefaultCircuitBreakerConfig),
 		locker,
+		worker.NoopURLCache{},
 	)
 
 	job := newTestJob()

--- a/test/internal/worker/url_cache_test.go
+++ b/test/internal/worker/url_cache_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
@@ -76,24 +75,9 @@ func TestKafkaConsumerPool_URLCache_Hit_SkipsWithCommit(t *testing.T) {
 
 	// URL이 이미 캐시에 존재
 	urlCache.On("Exists", mock.Anything, job.Target.URL).Return(true, nil)
-
-	consumer.On("FetchMessage", mock.Anything).Return(msg, nil).Once()
-	consumer.On("FetchMessage", mock.Anything).
-		Run(func(_ mock.Arguments) {}).
-		Return(nil, context.Canceled)
 	consumer.On("CommitMessages", mock.Anything, mock.Anything).Return(nil)
-	consumer.On("Close").Return(nil)
 
-	ctx, cancel := context.WithCancel(context.Background())
-	pool.Start(ctx)
-
-	// commit이 호출될 때까지 잠시 대기
-	time.Sleep(200 * time.Millisecond)
-	cancel()
-
-	stopCtx, stopCancel := context.WithTimeout(context.Background(), 5*time.Second)
-	defer stopCancel()
-	_ = pool.Stop(stopCtx)
+	runPool(t, consumer, pool, msg)
 
 	// handler는 호출되지 않아야 합니다
 	handler.AssertNotCalled(t, "Handle", mock.Anything, mock.Anything)

--- a/test/internal/worker/url_cache_test.go
+++ b/test/internal/worker/url_cache_test.go
@@ -1,0 +1,215 @@
+package worker_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+
+	"issuetracker/internal/crawler/core"
+	"issuetracker/internal/crawler/worker"
+	"issuetracker/pkg/queue"
+)
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Mock URLCache
+// ─────────────────────────────────────────────────────────────────────────────
+
+type mockURLCache struct{ mock.Mock }
+
+func (m *mockURLCache) Exists(ctx context.Context, url string) (bool, error) {
+	args := m.Called(ctx, url)
+	return args.Bool(0), args.Error(1)
+}
+
+func (m *mockURLCache) Set(ctx context.Context, url string) error {
+	args := m.Called(ctx, url)
+	return args.Error(0)
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// NoopURLCache 단위 테스트
+// ─────────────────────────────────────────────────────────────────────────────
+
+// TestNoopURLCache_ExistsAlwaysFalse는 NoopURLCache가 항상 false를 반환하는지 검증합니다.
+func TestNoopURLCache_ExistsAlwaysFalse(t *testing.T) {
+	var cache worker.NoopURLCache
+
+	exists, err := cache.Exists(context.Background(), "https://example.com/article")
+	assert.NoError(t, err)
+	assert.False(t, exists)
+}
+
+// TestNoopURLCache_SetNoError는 NoopURLCache의 Set이 항상 성공하는지 검증합니다.
+func TestNoopURLCache_SetNoError(t *testing.T) {
+	var cache worker.NoopURLCache
+
+	err := cache.Set(context.Background(), "https://example.com/article")
+	assert.NoError(t, err)
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Pool + URLCache 통합 테스트
+// ─────────────────────────────────────────────────────────────────────────────
+
+// TestKafkaConsumerPool_URLCache_Hit_SkipsWithCommit는
+// URL이 캐시에 존재할 때 handler 호출 없이 commit하여 건너뛰는지 검증합니다.
+func TestKafkaConsumerPool_URLCache_Hit_SkipsWithCommit(t *testing.T) {
+	consumer := new(mockConsumer)
+	producer := new(mockProducer)
+	handler := new(mockJobHandler)
+	contentSvc := new(mockContentService)
+	urlCache := new(mockURLCache)
+
+	pool := worker.NewKafkaConsumerPoolWithOptions(
+		consumer, producer, handler, contentSvc, 1,
+		worker.NewCircuitBreakerRegistry(worker.DefaultCircuitBreakerConfig),
+		worker.NoopJobLocker{},
+		urlCache,
+	)
+
+	job := newTestJob()
+	msg := marshaledJobMsg(t, job)
+
+	// URL이 이미 캐시에 존재
+	urlCache.On("Exists", mock.Anything, job.Target.URL).Return(true, nil)
+
+	consumer.On("FetchMessage", mock.Anything).Return(msg, nil).Once()
+	consumer.On("FetchMessage", mock.Anything).
+		Run(func(_ mock.Arguments) {}).
+		Return(nil, context.Canceled)
+	consumer.On("CommitMessages", mock.Anything, mock.Anything).Return(nil)
+	consumer.On("Close").Return(nil)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	pool.Start(ctx)
+
+	// commit이 호출될 때까지 잠시 대기
+	time.Sleep(200 * time.Millisecond)
+	cancel()
+
+	stopCtx, stopCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer stopCancel()
+	_ = pool.Stop(stopCtx)
+
+	// handler는 호출되지 않아야 합니다
+	handler.AssertNotCalled(t, "Handle", mock.Anything, mock.Anything)
+	// commit은 호출되어야 합니다 (메시지 소비 완료)
+	consumer.AssertCalled(t, "CommitMessages", mock.Anything, mock.Anything)
+	urlCache.AssertExpectations(t)
+}
+
+// TestKafkaConsumerPool_URLCache_Miss_ProceedsAndSets는
+// URL이 캐시에 없을 때 정상 처리 후 캐시에 등록하는지 검증합니다.
+func TestKafkaConsumerPool_URLCache_Miss_ProceedsAndSets(t *testing.T) {
+	consumer := new(mockConsumer)
+	producer := new(mockProducer)
+	handler := new(mockJobHandler)
+	contentSvc := new(mockContentService)
+	urlCache := new(mockURLCache)
+
+	pool := worker.NewKafkaConsumerPoolWithOptions(
+		consumer, producer, handler, contentSvc, 1,
+		worker.NewCircuitBreakerRegistry(worker.DefaultCircuitBreakerConfig),
+		worker.NoopJobLocker{},
+		urlCache,
+	)
+
+	job := newTestJob()
+	content := newTestContent()
+	msg := marshaledJobMsg(t, job)
+
+	// URL이 캐시에 없음
+	urlCache.On("Exists", mock.Anything, job.Target.URL).Return(false, nil)
+	// 성공 후 캐시 등록
+	urlCache.On("Set", mock.Anything, job.Target.URL).Return(nil)
+
+	handler.On("Handle", mock.Anything, job).Return([]*core.Content{content}, nil)
+	contentSvc.On("Store", mock.Anything, content).Return(content.ID, false, nil)
+	producer.On("Publish", mock.Anything, mock.MatchedBy(func(m queue.Message) bool {
+		return m.Topic == queue.TopicNormalized
+	})).Return(nil)
+	consumer.On("CommitMessages", mock.Anything, mock.Anything).Return(nil)
+
+	runPool(t, consumer, pool, msg)
+
+	handler.AssertExpectations(t)
+	urlCache.AssertCalled(t, "Set", mock.Anything, job.Target.URL)
+}
+
+// TestKafkaConsumerPool_URLCache_ExistsError_ProceedsWithFetch는
+// 캐시 조회 실패 시 fetch를 차단하지 않고 정상 진행하는지 검증합니다.
+func TestKafkaConsumerPool_URLCache_ExistsError_ProceedsWithFetch(t *testing.T) {
+	consumer := new(mockConsumer)
+	producer := new(mockProducer)
+	handler := new(mockJobHandler)
+	contentSvc := new(mockContentService)
+	urlCache := new(mockURLCache)
+
+	pool := worker.NewKafkaConsumerPoolWithOptions(
+		consumer, producer, handler, contentSvc, 1,
+		worker.NewCircuitBreakerRegistry(worker.DefaultCircuitBreakerConfig),
+		worker.NoopJobLocker{},
+		urlCache,
+	)
+
+	job := newTestJob()
+	content := newTestContent()
+	msg := marshaledJobMsg(t, job)
+
+	// 캐시 조회 실패 (Redis 장애)
+	urlCache.On("Exists", mock.Anything, job.Target.URL).Return(false, errors.New("redis unavailable"))
+	urlCache.On("Set", mock.Anything, job.Target.URL).Return(nil)
+
+	handler.On("Handle", mock.Anything, job).Return([]*core.Content{content}, nil)
+	contentSvc.On("Store", mock.Anything, content).Return(content.ID, false, nil)
+	producer.On("Publish", mock.Anything, mock.MatchedBy(func(m queue.Message) bool {
+		return m.Topic == queue.TopicNormalized
+	})).Return(nil)
+	consumer.On("CommitMessages", mock.Anything, mock.Anything).Return(nil)
+
+	runPool(t, consumer, pool, msg)
+
+	// 캐시 오류에도 handler는 호출되어야 합니다
+	handler.AssertExpectations(t)
+}
+
+// TestKafkaConsumerPool_URLCache_CategoryPage_SkipsCache는
+// 카테고리 페이지(TargetTypeCategory)에 대해 URL 캐시를 적용하지 않는지 검증합니다.
+func TestKafkaConsumerPool_URLCache_CategoryPage_SkipsCache(t *testing.T) {
+	consumer := new(mockConsumer)
+	producer := new(mockProducer)
+	handler := new(mockJobHandler)
+	contentSvc := new(mockContentService)
+	urlCache := new(mockURLCache)
+
+	pool := worker.NewKafkaConsumerPoolWithOptions(
+		consumer, producer, handler, contentSvc, 1,
+		worker.NewCircuitBreakerRegistry(worker.DefaultCircuitBreakerConfig),
+		worker.NoopJobLocker{},
+		urlCache,
+	)
+
+	job := &core.CrawlJob{
+		ID:          "job-cat-001",
+		CrawlerName: "test-crawler",
+		Target:      core.Target{URL: "https://example.com/category/news", Type: core.TargetTypeCategory},
+		Priority:    core.PriorityNormal,
+		MaxRetries:  3,
+	}
+	msg := marshaledJobMsg(t, job)
+
+	// 카테고리 페이지이므로 handler는 nil, nil 반환 (체이닝 없는 경우)
+	handler.On("Handle", mock.Anything, job).Return(nil, nil)
+	consumer.On("CommitMessages", mock.Anything, mock.Anything).Return(nil)
+
+	runPool(t, consumer, pool, msg)
+
+	// 카테고리 페이지에 대해서는 URL 캐시를 조회하지 않아야 합니다
+	urlCache.AssertNotCalled(t, "Exists", mock.Anything, mock.Anything)
+	// handler는 호출되어야 합니다
+	handler.AssertExpectations(t)
+}

--- a/test/pkg/redis/url_cache_test.go
+++ b/test/pkg/redis/url_cache_test.go
@@ -1,0 +1,72 @@
+package redis_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	pkgredis "issuetracker/pkg/redis"
+)
+
+func TestURLCacheKey_Format(t *testing.T) {
+	key := pkgredis.URLCacheKeyPrefix + "https://example.com/article"
+	assert.Equal(t, "urlcache:https://example.com/article", key)
+}
+
+func TestSetURL_And_ExistsURL(t *testing.T) {
+	client := newTestClient(t)
+	ctx := context.Background()
+	url := "https://example.com/test-set-exists"
+
+	// 사전 정리: 키가 있으면 제거
+	_ = client.SetURL(ctx, url, 100*time.Millisecond)
+	time.Sleep(200 * time.Millisecond)
+
+	// 캐시에 없는 상태 확인
+	exists, err := client.ExistsURL(ctx, url)
+	require.NoError(t, err)
+	assert.False(t, exists, "캐시에 없는 URL은 false를 반환해야 함")
+
+	// URL 캐시 등록
+	err = client.SetURL(ctx, url, 5*time.Second)
+	require.NoError(t, err)
+
+	// 캐시에 있는 상태 확인
+	exists, err = client.ExistsURL(ctx, url)
+	require.NoError(t, err)
+	assert.True(t, exists, "캐시에 등록된 URL은 true를 반환해야 함")
+}
+
+func TestExistsURL_TTLExpiry(t *testing.T) {
+	client := newTestClient(t)
+	ctx := context.Background()
+	url := "https://example.com/test-ttl"
+
+	// 짧은 TTL로 등록
+	err := client.SetURL(ctx, url, 100*time.Millisecond)
+	require.NoError(t, err)
+
+	exists, err := client.ExistsURL(ctx, url)
+	require.NoError(t, err)
+	assert.True(t, exists)
+
+	// TTL 만료 대기 후 확인
+	require.Eventually(t, func() bool {
+		exists, err := client.ExistsURL(ctx, url)
+		require.NoError(t, err)
+		return !exists
+	}, 2*time.Second, 50*time.Millisecond, "TTL 만료 후 false를 반환해야 함")
+}
+
+func TestExistsURL_NotSet(t *testing.T) {
+	client := newTestClient(t)
+	ctx := context.Background()
+	url := "https://example.com/never-set-" + time.Now().Format(time.RFC3339Nano)
+
+	exists, err := client.ExistsURL(ctx, url)
+	require.NoError(t, err)
+	assert.False(t, exists, "등록되지 않은 URL은 false를 반환해야 함")
+}

--- a/test/pkg/redis/url_cache_test.go
+++ b/test/pkg/redis/url_cache_test.go
@@ -19,11 +19,9 @@ func TestURLCacheKey_Format(t *testing.T) {
 func TestSetURL_And_ExistsURL(t *testing.T) {
 	client := newTestClient(t)
 	ctx := context.Background()
-	url := "https://example.com/test-set-exists"
+	url := "https://example.com/test-set-exists-" + time.Now().Format(time.RFC3339Nano)
 
-	// 사전 정리: 키가 있으면 제거
-	_ = client.SetURL(ctx, url, 100*time.Millisecond)
-	time.Sleep(200 * time.Millisecond)
+	// 고유한 URL을 사용해 사전 정리 없이 빈 캐시 상태를 보장
 
 	// 캐시에 없는 상태 확인
 	exists, err := client.ExistsURL(ctx, url)


### PR DESCRIPTION
## 연관 이슈
- #92

<br>

## 구현 내용
- `pkg/redis/url_cache.go`: Redis `SET`/`EXISTS` 기반 URL 캐시 메서드(`SetURL`, `ExistsURL`) 추가
- `internal/crawler/worker/url_cache.go`: `URLCache` 인터페이스 + `RedisURLCache` + `NoopURLCache` 구현 (JobLocker와 동일 패턴)
- `internal/crawler/worker/pool.go`: `processJob`에서 fetch 전 URL 캐시 확인, 성공 후 캐시 등록
  - 카테고리 페이지(`TargetTypeCategory`)는 캐시 대상 제외
  - 캐시 장애 시 graceful degradation (경고 후 fetch 진행)
- `internal/crawler/worker/manager.go`: `ManagerConfig`에 `URLCache` 필드 추가
- `cmd/issuetracker/main.go`: Redis 연결 시 `RedisURLCache` 생성 및 주입
- `pkg/config/config.go`: `RedisConfig.URLCacheTTL` 필드 추가, `REDIS_URL_CACHE_TTL` 환경변수 지원 (기본값 24h)

<br>

## CI / 머지 게이트 점검

> [CI 운영 규약](docs/ci/conventions.md) 및 [Required Status Checks 단일 소스](docs/ci/status-checks.md)에 따라 작성합니다.

### 변경 영향 범위
- 영향 패키지/모듈: `pkg/redis`, `pkg/config`, `internal/crawler/worker`, `cmd/issuetracker`
- 위험도(택1): `Low`

### Required Status Checks
- 통과 확인 대상 (PR Checks 탭에서 확인):
  - [ ] `Commit Lint`
  - [ ] `PR Title Lint`
  - [ ] `Format Check`
  - [ ] `Build`
  - [ ] `Test`
  - [ ] `Lint`

### 롤백 계획
- `ManagerConfig.URLCache`를 nil로 설정하면 `NoopURLCache`로 fallback되어 기존 동작과 동일
- Redis 미연결 시에도 `NoopURLCache`로 자동 degradation

<br>

## TODO
- [ ] CI status checks 통과 확인
- [ ] 프로덕션 환경 `.env`에 `REDIS_URL_CACHE_TTL` 설정 검토

<br>

## 논의 사항
- URL 캐시 키에 raw URL 문자열을 직접 사용 중 — URL이 매우 긴 경우 SHA-256 해시로 변경 필요 여부
- 현재 TTL 기본값 24시간 — 소스별로 다른 TTL이 필요한 경우 확장 방안 검토

<br>