### PR TITLE
[CHORE#97] Makefile의 모든 빌드 출력을 bin/ 디렉토리로 통일

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,24 +60,27 @@ run-issuetracker: build ## Crawler + Processor 통합 실행
 	@echo "Running issuetracker (crawler + processor)..."
 	./scripts/entrypoint.sh
 
-run-example: ## Basic example 실행 (로컬 Chrome 또는 Docker Chrome 필요)
-	@echo "Building basic example..."
+$(EXAMPLE_BINARY): ./examples/basic_usage/
 	@mkdir -p $(BINARY_DIR)
-	$(GO) build $(GOFLAGS) -o $(EXAMPLE_BINARY) ./examples/basic_usage.go
+	$(GO) build $(GOFLAGS) -o $(EXAMPLE_BINARY) ./examples/basic_usage/
+
+$(COMPARISON_BINARY): ./examples/crawler_comparison/
+	@mkdir -p $(BINARY_DIR)
+	$(GO) build $(GOFLAGS) -o $(COMPARISON_BINARY) ./examples/crawler_comparison/
+
+$(KAFKA_PIPELINE_BINARY): ./examples/kafka_pipeline/
+	@mkdir -p $(BINARY_DIR)
+	$(GO) build $(GOFLAGS) -o $(KAFKA_PIPELINE_BINARY) ./examples/kafka_pipeline/
+
+run-example: $(EXAMPLE_BINARY) ## Basic example 실행 (로컬 Chrome 또는 Docker Chrome 필요)
 	@echo "Running basic example..."
 	./$(EXAMPLE_BINARY)
 
-run-comparison: ## Crawler 구현체 비교 예제 실행
-	@echo "Building crawler comparison..."
-	@mkdir -p $(BINARY_DIR)
-	$(GO) build $(GOFLAGS) -o $(COMPARISON_BINARY) ./examples/crawler_comparison.go
+run-comparison: $(COMPARISON_BINARY) ## Crawler 구현체 비교 예제 실행
 	@echo "Running crawler comparison..."
 	./$(COMPARISON_BINARY)
 
-run-kafka-pipeline: ## Kafka 파이프라인 예제 실행 (mock, Kafka 불필요)
-	@echo "Building Kafka pipeline example..."
-	@mkdir -p $(BINARY_DIR)
-	$(GO) build $(GOFLAGS) -o $(KAFKA_PIPELINE_BINARY) ./examples/kafka_pipeline/
+run-kafka-pipeline: $(KAFKA_PIPELINE_BINARY) ## Kafka 파이프라인 예제 실행 (mock, Kafka 불필요)
 	@echo "Running Kafka pipeline example..."
 	./$(KAFKA_PIPELINE_BINARY)
 
@@ -101,17 +104,17 @@ chrome-status: ## Docker Chrome 컨테이너 상태 확인
 	  --format "table {{.Names}}\t{{.Status}}\t{{.Ports}}" \
 	  | { read header; read line 2>/dev/null && echo "$$header" && echo "$$line" || echo "$$header\n(not running)"; }
 
-run-example-docker: ## Docker Chrome으로 basic example 실행 (컨테이너 자동 시작/중지)
+run-example-docker: $(EXAMPLE_BINARY) ## Docker Chrome으로 basic example 실행 (컨테이너 자동 시작/중지)
 	@echo "=== Docker Chrome + Basic Example ==="
-	@mkdir -p $(BINARY_DIR)
-	$(GO) build $(GOFLAGS) -o $(EXAMPLE_BINARY) ./examples/basic_usage.go
 	@docker run -d --rm \
 	  -p $(CHROME_PORT):9222 \
 	  --name $(CHROME_CONTAINER) \
 	  $(CHROME_IMAGE); \
 	sleep 2; \
 	./$(EXAMPLE_BINARY); \
-	docker stop $(CHROME_CONTAINER) 2>/dev/null || true
+	status=$$?; \
+	docker stop $(CHROME_CONTAINER) 2>/dev/null || true; \
+	exit $$status
 
 ## ─── Kafka ───────────────────────────────────────────────────
 

--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,9 @@ PROCESSOR_BINARY=$(BINARY_DIR)/processor
 ISSUETRACKER_BINARY=$(BINARY_DIR)/issuetracker
 MIGRATE_BINARY=$(BINARY_DIR)/migrate
 MIGRATE_DOWN_BINARY=$(BINARY_DIR)/migrate-down
+EXAMPLE_BINARY=$(BINARY_DIR)/basic_usage
+COMPARISON_BINARY=$(BINARY_DIR)/crawler_comparison
+KAFKA_PIPELINE_BINARY=$(BINARY_DIR)/kafka_pipeline
 GO=go
 GOFLAGS=-v
 
@@ -58,16 +61,25 @@ run-issuetracker: build ## Crawler + Processor 통합 실행
 	./scripts/entrypoint.sh
 
 run-example: ## Basic example 실행 (로컬 Chrome 또는 Docker Chrome 필요)
+	@echo "Building basic example..."
+	@mkdir -p $(BINARY_DIR)
+	$(GO) build $(GOFLAGS) -o $(EXAMPLE_BINARY) ./examples/basic_usage.go
 	@echo "Running basic example..."
-	$(GO) run ./examples/basic_usage.go
+	./$(EXAMPLE_BINARY)
 
 run-comparison: ## Crawler 구현체 비교 예제 실행
+	@echo "Building crawler comparison..."
+	@mkdir -p $(BINARY_DIR)
+	$(GO) build $(GOFLAGS) -o $(COMPARISON_BINARY) ./examples/crawler_comparison.go
 	@echo "Running crawler comparison..."
-	$(GO) run ./examples/crawler_comparison.go
+	./$(COMPARISON_BINARY)
 
 run-kafka-pipeline: ## Kafka 파이프라인 예제 실행 (mock, Kafka 불필요)
+	@echo "Building Kafka pipeline example..."
+	@mkdir -p $(BINARY_DIR)
+	$(GO) build $(GOFLAGS) -o $(KAFKA_PIPELINE_BINARY) ./examples/kafka_pipeline/
 	@echo "Running Kafka pipeline example..."
-	$(GO) run ./examples/kafka_pipeline/
+	./$(KAFKA_PIPELINE_BINARY)
 
 chrome-start: ## Docker Chrome 컨테이너 시작 (포트 9222)
 	@echo "Starting Chrome container ($(CHROME_IMAGE))..."
@@ -91,12 +103,14 @@ chrome-status: ## Docker Chrome 컨테이너 상태 확인
 
 run-example-docker: ## Docker Chrome으로 basic example 실행 (컨테이너 자동 시작/중지)
 	@echo "=== Docker Chrome + Basic Example ==="
+	@mkdir -p $(BINARY_DIR)
+	$(GO) build $(GOFLAGS) -o $(EXAMPLE_BINARY) ./examples/basic_usage.go
 	@docker run -d --rm \
 	  -p $(CHROME_PORT):9222 \
 	  --name $(CHROME_CONTAINER) \
 	  $(CHROME_IMAGE); \
 	sleep 2; \
-	$(GO) run ./examples/basic_usage.go; \
+	./$(EXAMPLE_BINARY); \
 	docker stop $(CHROME_CONTAINER) 2>/dev/null || true
 
 ## ─── Kafka ───────────────────────────────────────────────────


### PR DESCRIPTION
## 연관 이슈
- #97

<br>

## 구현 내용
- `run-example`, `run-comparison`, `run-kafka-pipeline`, `run-example-docker` 타겟에서 `go run` → `go build -o bin/<name>` + 실행 방식으로 전환
- 바이너리 변수(`EXAMPLE_BINARY`, `COMPARISON_BINARY`, `KAFKA_PIPELINE_BINARY`) 추가
- 모든 빌드 산출물이 `bin/` 디렉토리에만 생성되도록 통일하여 `make clean`의 `rm -rf bin/`으로 완전 정리 가능

<br>

## CI / 머지 게이트 점검

> [CI 운영 규약](docs/ci/conventions.md) 및 [Required Status Checks 단일 소스](docs/ci/status-checks.md)에 따라 작성합니다.

### 변경 영향 범위
- 영향 패키지/모듈: `Makefile`
- 위험도(택1): `Low`

### Required Status Checks
- 통과 확인 대상 (PR Checks 탭에서 확인):
  - [ ] `Commit Lint`
  - [ ] `PR Title Lint`
  - [ ] `Format Check`
  - [ ] `Build`
  - [ ] `Test`
  - [ ] `Lint`

### 롤백 계획
- `go run` 방식으로 원복 (이전 Makefile 복원)

<br>

## TODO
- 없음

<br>

## 논의 사항
- 없음

<br>