### PR TITLE
[FEAT#96]: chromedp 크롤러 graceful timeout 구현

### DIFF
--- a/internal/crawler/implementation/chromedp/fetch.go
+++ b/internal/crawler/implementation/chromedp/fetch.go
@@ -2,6 +2,7 @@ package chromedp
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sync"
 	"time"
@@ -117,6 +118,8 @@ func (c *ChromedpCrawler) Fetch(ctx context.Context, target core.Target) (*core.
 		partialHTML, captureErr := captureOuterHTML(browserCtx)
 		if captureErr != nil {
 			// 부분 캡처 자체가 실패 → 빈 페이지/네트워크 불가와 동등한 완전 실패로 분류
+			// runErr(원인 timeout)와 captureErr(캡처 실패 사유 — target closed,
+			// context canceled, CDP 오류 등)를 모두 보존하여 디버깅 가능성 유지
 			return nil, &core.CrawlerError{
 				Category:  core.ErrCategoryTimeout,
 				Code:      "CDP_006",
@@ -124,12 +127,15 @@ func (c *ChromedpCrawler) Fetch(ctx context.Context, target core.Target) (*core.
 				Source:    c.name,
 				URL:       target.URL,
 				Retryable: true,
-				Err:       runErr,
+				Err:       errors.Join(runErr, captureErr),
 			}
 		}
 
 		// 부분 로드 DOM 유효성 검증 (최소 body + 길이 충족)
 		if !IsValidPartialDOM(partialHTML) {
+			// runErr(timeout) + DOM 검증 실패 사유(길이 정보 포함)를 함께 보존하여
+			// 에러 체인에서 "어떤 검증이 실패했는지"를 추적할 수 있도록 한다
+			validationErr := fmt.Errorf("partial DOM failed validation: length=%d", len(partialHTML))
 			return nil, &core.CrawlerError{
 				Category:  core.ErrCategoryTimeout,
 				Code:      "CDP_007",
@@ -137,7 +143,7 @@ func (c *ChromedpCrawler) Fetch(ctx context.Context, target core.Target) (*core.
 				Source:    c.name,
 				URL:       target.URL,
 				Retryable: true,
-				Err:       runErr,
+				Err:       errors.Join(runErr, validationErr),
 			}
 		}
 

--- a/internal/crawler/implementation/chromedp/fetch.go
+++ b/internal/crawler/implementation/chromedp/fetch.go
@@ -15,7 +15,13 @@ import (
 )
 
 // Fetch: 헤드리스 브라우저로 페이지를 렌더링하고 HTML 가져오기
-// JS 렌더링 완료 후의 DOM을 반환
+// JS 렌더링 완료 후의 DOM을 반환한다.
+//
+// timeout 처리:
+//   - 액션 실행은 runCtx(timeout 적용)로 수행하지만, 탭 자체는 browserCtx(timeout 미적용)로 유지
+//   - timeout 발생 시 browserCtx로 OuterHTML 재캡처를 시도하는 graceful fallback 적용
+//   - 캡처 결과가 IsValidPartialDOM 검증을 통과하면 partial_load 플래그와 함께 반환
+//   - 캡처 자체 실패/검증 실패 시에는 timeout 카테고리 에러로 분류
 func (c *ChromedpCrawler) Fetch(ctx context.Context, target core.Target) (*core.RawContent, error) {
 	log := logger.FromContext(ctx)
 
@@ -30,24 +36,29 @@ func (c *ChromedpCrawler) Fetch(ctx context.Context, target core.Target) (*core.
 	}
 
 	// 탭 생성 (요청별 격리)
-	tabCtx, cancel := chromedp.NewContext(c.allocCtx)
-	defer cancel()
+	// browserCtx는 timeout이 적용되지 않은 tab context로, graceful capture 시 재사용된다.
+	browserCtx, browserCancel := chromedp.NewContext(c.allocCtx)
+	defer browserCancel()
 
-	// Timeout 적용
-	tabCtx, timeoutCancel := context.WithTimeout(tabCtx, c.config.Timeout)
-	defer timeoutCancel()
+	// 액션 실행 전용 timeout context
+	// timeout 발생 시 runCtx만 cancel되고 browserCtx와 탭은 유효 상태로 유지되어
+	// 동일 탭에 OuterHTML 재명령을 발행할 수 있다.
+	runCtx, runCancel := context.WithTimeout(browserCtx, c.config.Timeout)
+	defer runCancel()
 
 	// 메인 네비게이션의 LoaderID를 추적하여 iframe/서브프레임 응답과 구분
 	// - 메인 프레임과 리다이렉트 체인은 동일한 LoaderID를 공유
 	// - iframe/서브프레임은 별도의 LoaderID를 가지므로 필터링됨
 	// - statusCode 초기값 0: 이벤트를 한 번도 수신하지 못한 경우와 명시적 구분
+	// - listener를 browserCtx에 등록하여 timeout 이후 graceful capture 단계에서도
+	//   추가로 도착하는 응답 이벤트를 수신할 수 있도록 한다.
 	var (
 		statusCode       int64
 		statusMu         sync.Mutex
 		mainLoaderID     cdp.LoaderID
 		loaderIDCaptured bool
 	)
-	chromedp.ListenTarget(tabCtx, func(ev interface{}) {
+	chromedp.ListenTarget(browserCtx, func(ev interface{}) {
 		switch e := ev.(type) {
 		case *network.EventRequestWillBeSent:
 			// 첫 번째 Document 요청의 LoaderID를 메인 네비게이션으로 고정
@@ -80,18 +91,62 @@ func (c *ChromedpCrawler) Fetch(ctx context.Context, target core.Target) (*core.
 	actions = append(actions, chromedp.OuterHTML("html", &html))
 
 	start := time.Now()
+	partialLoad := false
 
 	// 브라우저 실행
-	if err := chromedp.Run(tabCtx, actions...); err != nil {
-		return nil, &core.CrawlerError{
-			Category:  core.ErrCategoryNetwork,
-			Code:      "CDP_002",
-			Message:   "failed to render page",
-			Source:    c.name,
-			URL:       target.URL,
-			Retryable: true,
-			Err:       err,
+	if runErr := chromedp.Run(runCtx, actions...); runErr != nil {
+		// timeout 외 다른 에러는 즉시 실패 처리 (기존 CDP_002 동작 유지)
+		if !IsTimeoutError(runErr) {
+			return nil, &core.CrawlerError{
+				Category:  core.ErrCategoryNetwork,
+				Code:      "CDP_002",
+				Message:   "failed to render page",
+				Source:    c.name,
+				URL:       target.URL,
+				Retryable: true,
+				Err:       runErr,
+			}
 		}
+
+		// timeout 발생: 별도 context로 부분 DOM 캡처 시도
+		log.WithFields(map[string]interface{}{
+			"url":        target.URL,
+			"timeout_ms": c.config.Timeout.Milliseconds(),
+		}).Warn("page render timed out, attempting graceful capture")
+
+		partialHTML, captureErr := captureOuterHTML(browserCtx)
+		if captureErr != nil {
+			// 부분 캡처 자체가 실패 → 빈 페이지/네트워크 불가와 동등한 완전 실패로 분류
+			return nil, &core.CrawlerError{
+				Category:  core.ErrCategoryTimeout,
+				Code:      "CDP_006",
+				Message:   "render timeout and graceful capture failed",
+				Source:    c.name,
+				URL:       target.URL,
+				Retryable: true,
+				Err:       runErr,
+			}
+		}
+
+		// 부분 로드 DOM 유효성 검증 (최소 body + 길이 충족)
+		if !IsValidPartialDOM(partialHTML) {
+			return nil, &core.CrawlerError{
+				Category:  core.ErrCategoryTimeout,
+				Code:      "CDP_007",
+				Message:   "render timeout and partial DOM invalid",
+				Source:    c.name,
+				URL:       target.URL,
+				Retryable: true,
+				Err:       runErr,
+			}
+		}
+
+		html = partialHTML
+		partialLoad = true
+		log.WithFields(map[string]interface{}{
+			"url":  target.URL,
+			"size": len(html),
+		}).Info("graceful timeout capture succeeded")
 	}
 
 	elapsed := time.Since(start)
@@ -120,6 +175,12 @@ func (c *ChromedpCrawler) Fetch(ctx context.Context, target core.Target) (*core.
 		return nil, core.NewHTTPClientError(target.URL, capturedStatus)
 	}
 
+	// metadata: 부분 로드인 경우 호출자 원본을 보존하기 위해 복사 후 플래그 추가
+	metadata := target.Metadata
+	if partialLoad {
+		metadata = metadataWithPartialLoad(target.Metadata)
+	}
+
 	rawContent := &core.RawContent{
 		ID:         fmt.Sprintf("%s-%d", c.name, time.Now().UnixNano()),
 		SourceInfo: c.sourceInfo,
@@ -128,13 +189,14 @@ func (c *ChromedpCrawler) Fetch(ctx context.Context, target core.Target) (*core.
 		HTML:       html,
 		StatusCode: capturedStatus,
 		Headers:    make(map[string]string),
-		Metadata:   target.Metadata,
+		Metadata:   metadata,
 	}
 
 	log.WithFields(map[string]interface{}{
-		"url":         target.URL,
-		"size":        len(html),
-		"duration_ms": elapsed.Milliseconds(),
+		"url":          target.URL,
+		"size":         len(html),
+		"duration_ms":  elapsed.Milliseconds(),
+		"partial_load": partialLoad,
 	}).Info("page rendered successfully with chromedp")
 
 	return rawContent, nil

--- a/internal/crawler/implementation/chromedp/graceful_timeout.go
+++ b/internal/crawler/implementation/chromedp/graceful_timeout.go
@@ -38,11 +38,16 @@ func IsTimeoutError(err error) bool {
 // 최소 조건:
 //  1. minPartialDOMLength 이상의 길이 (빈 페이지/스켈레톤 페이지 배제)
 //  2. <body> 태그 존재 (DOM 구조의 최소 완전성 보장)
+//
+// 대소문자 처리: strings.ToLower(html)는 전체 HTML 복사본을 할당하므로
+// 대용량 페이지에서 불필요한 메모리 부하가 발생한다. HTML5는 소문자 태그를
+// 권장하고 일부 레거시 페이지가 대문자를 사용하는 점만 고려하면 충분하므로,
+// 두 케이스만 명시적으로 검사하여 zero-allocation 경로로 처리한다.
 func IsValidPartialDOM(html string) bool {
 	if len(html) < minPartialDOMLength {
 		return false
 	}
-	return strings.Contains(strings.ToLower(html), "<body")
+	return strings.Contains(html, "<body") || strings.Contains(html, "<BODY")
 }
 
 // captureOuterHTML: timeout 이후 별도 context로 OuterHTML 추출 시도

--- a/internal/crawler/implementation/chromedp/graceful_timeout.go
+++ b/internal/crawler/implementation/chromedp/graceful_timeout.go
@@ -1,0 +1,72 @@
+package chromedp
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"time"
+
+	"github.com/chromedp/chromedp"
+)
+
+// MetadataKeyPartialLoad: RawContent.Metadata에 부분 로드 여부를 표시하는 키
+// timeout 발생으로 graceful capture가 적용된 경우 true가 설정되어,
+// 다운스트림 파이프라인에서 데이터의 완전성 수준을 판단할 수 있다.
+const MetadataKeyPartialLoad = "partial_load"
+
+// gracefulCaptureTimeout: timeout 발생 시 부분 DOM 캡처에 허용하는 최대 시간
+// 너무 길면 전체 응답 시간이 늘어나고, 너무 짧으면 캡처 실패 빈도가 증가하므로
+// 실험적으로 3초가 적정 수준임을 가정한다 (chromedp OuterHTML 평균 < 1초).
+const gracefulCaptureTimeout = 3 * time.Second
+
+// minPartialDOMLength: 부분 로드 DOM으로 인정할 최소 HTML 길이 (바이트)
+// 빈 페이지(`<html><head></head><body></body></html>`)는 약 45바이트이므로
+// 이를 충분히 상회하는 값으로 설정하여 의미 있는 컨텐츠 존재를 보장한다.
+const minPartialDOMLength = 512
+
+// IsTimeoutError: 에러가 chromedp 작업의 timeout(deadline exceeded)인지 판별
+// chromedp.Run이 timeout으로 종료되면 context.DeadlineExceeded를 wrap하여 반환한다.
+// 사용자 취소(context.Canceled)는 별개로 취급하여 graceful capture를 시도하지 않는다.
+func IsTimeoutError(err error) bool {
+	if err == nil {
+		return false
+	}
+	return errors.Is(err, context.DeadlineExceeded)
+}
+
+// IsValidPartialDOM: 부분 로드된 HTML이 다운스트림 처리에 사용 가능한지 검증
+// 최소 조건:
+//  1. minPartialDOMLength 이상의 길이 (빈 페이지/스켈레톤 페이지 배제)
+//  2. <body> 태그 존재 (DOM 구조의 최소 완전성 보장)
+func IsValidPartialDOM(html string) bool {
+	if len(html) < minPartialDOMLength {
+		return false
+	}
+	return strings.Contains(strings.ToLower(html), "<body")
+}
+
+// captureOuterHTML: timeout 이후 별도 context로 OuterHTML 추출 시도
+// browserCtx는 timeout으로 cancel되지 않은 tab context여야 하며,
+// chromedp가 동일 탭에 새 명령을 발행할 수 있어야 한다.
+func captureOuterHTML(browserCtx context.Context) (string, error) {
+	rescueCtx, cancel := context.WithTimeout(browserCtx, gracefulCaptureTimeout)
+	defer cancel()
+
+	var html string
+	if err := chromedp.Run(rescueCtx, chromedp.OuterHTML("html", &html)); err != nil {
+		return "", err
+	}
+	return html, nil
+}
+
+// metadataWithPartialLoad: 원본 metadata를 복사하고 partial_load 플래그 설정
+// 호출자의 원본 map을 직접 변형하지 않아 부수효과를 방지한다.
+// src가 nil이어도 안전하게 새 map을 생성한다.
+func metadataWithPartialLoad(src map[string]interface{}) map[string]interface{} {
+	dst := make(map[string]interface{}, len(src)+1)
+	for k, v := range src {
+		dst[k] = v
+	}
+	dst[MetadataKeyPartialLoad] = true
+	return dst
+}

--- a/test/internal/chromedp/graceful_timeout_test.go
+++ b/test/internal/chromedp/graceful_timeout_test.go
@@ -1,0 +1,107 @@
+package chromedp_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	chromedpimpl "issuetracker/internal/crawler/implementation/chromedp"
+)
+
+// TestIsTimeoutError_NilError_ReturnsFalse: nil 에러는 timeout이 아님
+func TestIsTimeoutError_NilError_ReturnsFalse(t *testing.T) {
+	assert.False(t, chromedpimpl.IsTimeoutError(nil))
+}
+
+// TestIsTimeoutError_DeadlineExceeded_ReturnsTrue:
+// chromedp.Run이 timeout으로 종료되면 context.DeadlineExceeded를 wrap하여 반환하므로
+// errors.Is 매칭이 true를 반환해야 한다.
+func TestIsTimeoutError_DeadlineExceeded_ReturnsTrue(t *testing.T) {
+	assert.True(t, chromedpimpl.IsTimeoutError(context.DeadlineExceeded))
+}
+
+// TestIsTimeoutError_WrappedDeadlineExceeded_ReturnsTrue:
+// fmt.Errorf("%w") 로 wrap된 에러도 errors.Is로 식별 가능해야 한다.
+// chromedp 내부의 다양한 wrap 형태를 시뮬레이션한다.
+func TestIsTimeoutError_WrappedDeadlineExceeded_ReturnsTrue(t *testing.T) {
+	wrapped := fmt.Errorf("chromedp action failed: %w", context.DeadlineExceeded)
+	assert.True(t, chromedpimpl.IsTimeoutError(wrapped))
+}
+
+// TestIsTimeoutError_StringConcatNotWrapped_ReturnsFalse:
+// 문자열 결합으로 만든 에러(에러 chain 미보존)는 식별되지 않아야 한다.
+// errors.Is 의 정상 동작을 보장하는 sanity check.
+func TestIsTimeoutError_StringConcatNotWrapped_ReturnsFalse(t *testing.T) {
+	plain := errors.New("chromedp action failed: " + context.DeadlineExceeded.Error())
+	assert.False(t, chromedpimpl.IsTimeoutError(plain))
+}
+
+// TestIsTimeoutError_Canceled_ReturnsFalse:
+// 사용자 취소(context.Canceled)는 graceful capture 대상이 아니므로 false 반환해야 한다.
+func TestIsTimeoutError_Canceled_ReturnsFalse(t *testing.T) {
+	assert.False(t, chromedpimpl.IsTimeoutError(context.Canceled))
+}
+
+// TestIsTimeoutError_OtherError_ReturnsFalse: 기타 일반 에러는 false
+func TestIsTimeoutError_OtherError_ReturnsFalse(t *testing.T) {
+	assert.False(t, chromedpimpl.IsTimeoutError(errors.New("some other error")))
+}
+
+// TestIsValidPartialDOM_ValidHTML_ReturnsTrue:
+// 충분한 길이와 <body> 태그를 포함한 HTML은 유효한 부분 로드로 인정
+func TestIsValidPartialDOM_ValidHTML_ReturnsTrue(t *testing.T) {
+	html := "<html><head><title>Test</title></head><body>" +
+		strings.Repeat("<p>some real content here for length</p>", 20) +
+		"</body></html>"
+	assert.True(t, chromedpimpl.IsValidPartialDOM(html))
+}
+
+// TestIsValidPartialDOM_TooShort_ReturnsFalse:
+// 최소 길이 미만의 HTML은 의미 있는 컨텐츠가 없다고 판단하여 거부
+func TestIsValidPartialDOM_TooShort_ReturnsFalse(t *testing.T) {
+	html := "<html><body>tiny</body></html>"
+	assert.False(t, chromedpimpl.IsValidPartialDOM(html))
+}
+
+// TestIsValidPartialDOM_NoBody_ReturnsFalse:
+// <body> 태그가 없는 HTML은 DOM 구조가 불완전하다고 판단
+func TestIsValidPartialDOM_NoBody_ReturnsFalse(t *testing.T) {
+	// 길이는 충족하지만 body 태그 없음
+	html := "<html><head>" + strings.Repeat("<meta name='x' content='y'>", 50) + "</head></html>"
+	assert.False(t, chromedpimpl.IsValidPartialDOM(html))
+}
+
+// TestIsValidPartialDOM_BodyUpperCase_ReturnsTrue:
+// case-insensitive 매칭으로 대문자 BODY 태그도 인정
+func TestIsValidPartialDOM_BodyUpperCase_ReturnsTrue(t *testing.T) {
+	html := "<HTML><HEAD></HEAD><BODY " +
+		strings.Repeat("class='abcdef' ", 50) +
+		">content</BODY></HTML>"
+	assert.True(t, chromedpimpl.IsValidPartialDOM(html))
+}
+
+// TestIsValidPartialDOM_EmptyString_ReturnsFalse: 빈 문자열은 유효하지 않음
+func TestIsValidPartialDOM_EmptyString_ReturnsFalse(t *testing.T) {
+	assert.False(t, chromedpimpl.IsValidPartialDOM(""))
+}
+
+// TestIsValidPartialDOM_BodyWithAttributes_ReturnsTrue:
+// `<body class="...">` 형태의 attribute가 붙은 body 태그도 매칭되어야 함
+// (substring "<body" 검사이므로 자연스럽게 처리)
+func TestIsValidPartialDOM_BodyWithAttributes_ReturnsTrue(t *testing.T) {
+	html := "<html><head>" +
+		strings.Repeat("<link rel='stylesheet'>", 30) +
+		"</head><body class='dark-theme'>partial content</body></html>"
+	assert.True(t, chromedpimpl.IsValidPartialDOM(html))
+}
+
+// TestMetadataKeyPartialLoad_ConstantValue:
+// 다운스트림 소비자가 동일 키를 참조하므로 상수 값이 변경되지 않음을 보장한다.
+// 변경 시 다운스트림 호환성 영향이 발생하므로 명시적 회귀 테스트로 잠금.
+func TestMetadataKeyPartialLoad_ConstantValue(t *testing.T) {
+	assert.Equal(t, "partial_load", chromedpimpl.MetadataKeyPartialLoad)
+}


### PR DESCRIPTION
## 연관 이슈
- #96

<!--
PR title 예시: [FEAT#issue번호]: 어쩌구저쩌
-->

<br>

## 구현 내용
- `chromedp.Run` 의 timeout 발생 시 별도 context로 OuterHTML을 재캡처하는 graceful fallback 추가
- 액션 실행용 `runCtx` 와 탭 유지용 `browserCtx` 를 분리하여 timeout 이후에도 동일 탭에 명령 발행 가능
- 부분 로드 DOM 유효성 판정 헬퍼 `IsValidPartialDOM` 추가 — 최소 길이(512B) + `<body>` 태그 존재 검사
- `RawContent.Metadata` 에 `partial_load: true` 플래그 설정 (호출자 원본 map 보존을 위한 복사 적용)
- 캡처 실패 / 부분 DOM 검증 실패 / 일반 렌더 실패를 별도 에러 코드로 분류
  - `CDP_002` (network) — 비-timeout 일반 실패 (기존 동작 유지)
  - `CDP_006` (timeout) — timeout 후 graceful 캡처 자체 실패
  - `CDP_007` (timeout) — timeout 후 캡처 성공했으나 DOM 유효성 미충족
- network 이벤트 listener를 `browserCtx` 에 등록하여 timeout 이후 도착하는 응답 이벤트도 statusCode로 반영
- 단위 테스트 추가 (`test/internal/chromedp/graceful_timeout_test.go`)

<br>

## CI / 머지 게이트 점검

> [CI 운영 규약](docs/ci/conventions.md) 및 [Required Status Checks 단일 소스](docs/ci/status-checks.md)에 따라 작성합니다.

### 변경 영향 범위
- 영향 패키지/모듈: `internal/crawler/implementation/chromedp`, `test/internal/chromedp`
- 위험도(택1): `Low` / **`Medium`** / `High`
  - 기존 timeout 시 완전 실패 → 일부 partial_load 응답으로 다운스트림 데이터가 흘러갈 수 있음. 다운스트림 소비자가 `partial_load` 플래그를 인지/필터링하지 않으면 부분 데이터가 그대로 처리될 가능성이 있음.

### Required Status Checks
- 통과 확인 대상 (PR Checks 탭에서 확인):
  - [ ] `Commit Lint`
  - [ ] `PR Title Lint`
  - [ ] `Format Check`
  - [ ] `Build`
  - [ ] `Test`
  - [ ] `Lint`

### 롤백 계획
- 본 PR을 revert 시 chromedp 크롤러는 timeout 발생 시 `CDP_002` 에러를 반환하는 기존 동작으로 즉시 복원됩니다 (외부 인터페이스 변경 없음). 다운스트림은 신규 `partial_load` 메타데이터를 무시하면 그만이므로 데이터 호환성 영향 없음.

<br>

## TODO
- [x] graceful timeout 구현 (별도 context, OuterHTML 재캡처)
- [x] 부분 로드 DOM 유효성 판단 기준 (최소 길이 + body 존재)
- [x] `partial_load` 메타데이터 플래그
- [x] 완전 실패 / 부분 로드 / 일반 timeout 에러 분류
- [x] 단위 테스트 작성

<br>

## 논의 사항
- 다운스트림(예: validate / classifier)에서 `partial_load=true` 컨텐츠를 어떤 정책으로 다룰지에 대한 후속 논의가 필요합니다. (현재는 플래그만 전파)
- `gracefulCaptureTimeout` (3초), `minPartialDOMLength` (512B) 임계값은 운영 데이터 수집 후 튜닝이 필요할 수 있습니다.

<br>