### PR TITLE
[REFAC#67] 에러 메시지 컨벤션 시스템 전반 통일

### DIFF
--- a/.claude/rules/04-error-handling.md
+++ b/.claude/rules/04-error-handling.md
@@ -20,6 +20,77 @@
    - Enable type-based handling
    - Include machine-readable error codes
 
+## Layer Rules — When to Use `CrawlerError` vs `fmt.Errorf`
+
+본 프로젝트는 `internal/crawler/core.CrawlerError` 를 시스템 전반의 구조화 에러 타입으로
+사용합니다(타입 이름은 역사적 사유). 모든 에러 생성을 일률적으로 구조화하지 않고, 레이어별
+규칙을 명확히 분리합니다.
+
+### MUST — `CrawlerError` 로 반환해야 하는 boundary
+
+다음 위치에서 발생하는 에러는 반드시 `core.NewXxxError(...)` 생성자로 만들어 반환합니다.
+재시도/라우팅/로깅 전략이 카테고리·코드에 의존하기 때문입니다.
+
+| 레이어 | 카테고리 | 생성자 |
+|---|---|---|
+| `internal/crawler/` 의 fetch/parse 결과 | `Network`, `RateLimit`, `Timeout`, `Parse`, `NotFound`, `Forbidden` | `NewNetworkError`, `NewRateLimitError`, `NewTimeoutError`, `NewParseError`, `NewNotFoundError`, `NewForbiddenError`, `NewHTTPServerError`, `NewHTTPClientError` |
+| `internal/processor/validate/` 의 검증 결과 | `Validation` | `NewValidationError` (코드: `VAL_001` ~ `VAL_006`) |
+| `internal/storage/service/` 의 boundary 메소드 | `Storage` | `NewStorageError` (`STORAGE_001` 조회 / `STORAGE_002` 저장 / `STORAGE_003` 삭제) |
+| 카테고리화된 DB 에러를 식별 가능한 곳 | `Database` | `NewDatabaseError` (`DB_001` ~ `DB_004`) |
+
+### MAY — `fmt.Errorf` 유지가 적절한 레이어
+
+다음 코드는 `fmt.Errorf("동사 대상 [식별자]: %w", ...)` 패턴을 유지합니다.
+
+- **`pkg/` 의 generic 유틸 패키지** (`pkg/queue`, `pkg/links`, `pkg/redis`, `pkg/config`)
+  - `pkg/` 는 도메인 의존성을 갖지 않는 standalone 라이브러리로 설계됨.
+  - `internal/crawler/core` 를 import 하면 레이어링이 무너짐.
+  - 호출하는 `internal/` boundary 에서 카테고리에 맞는 `CrawlerError` 로 변환해 wrap 합니다.
+- **`internal/` 의 helper / 내부 함수**
+  - 패키지 외부로 노출되지 않는 helper 는 fmt.Errorf 로 충분.
+  - 외부 노출 함수에서 최종 boundary 변환만 보장하면 됩니다.
+- **`internal/classifier`, `internal/publisher` 의 비-boundary 경로**
+  - 외부 시스템(grpc/http) 호출 자체에서 발생한 에러는 호출처에서 카테고리화.
+
+### 예시 — boundary 변환 패턴
+
+```go
+// pkg/links/extractor.go (generic util — fmt.Errorf 유지)
+func (e *Extractor) Extract(html, baseURL string) ([]Link, error) {
+    if _, err := url.Parse(baseURL); err != nil {
+        return nil, fmt.Errorf("resolve base url: %w", err)
+    }
+    ...
+}
+
+// internal/crawler/core/extractor.go (boundary — CrawlerError 로 변환)
+func (e *HTMLLinkExtractor) Extract(raw *RawContent) ([]Link, error) {
+    extracted, err := e.inner.Extract(raw.HTML, raw.URL)
+    if err != nil {
+        return nil, NewParseError(CodeParseHTML, "failed to extract links", raw.URL, err)
+    }
+    ...
+}
+```
+
+### `CrawlerError.Is` 와 `errors.As`
+
+`CrawlerError.Is(target)` 는 `Code` 또는 `Category` 가 동일하면 true.
+호출자는 다음 두 가지 패턴 중 적합한 쪽을 사용합니다.
+
+```go
+// 패턴 A — 카테고리 분기
+var ce *core.CrawlerError
+if errors.As(err, &ce) && ce.Category == core.ErrCategoryRateLimit {
+    // backoff 길게
+}
+
+// 패턴 B — 특정 코드 매칭 (errors.Is 는 CrawlerError.Is 를 호출)
+if errors.Is(err, &core.CrawlerError{Code: core.CodeNetTimeout}) {
+    // 타임아웃 전용 처리
+}
+```
+
 ## Error Taxonomy
 
 ### Error Categories

--- a/.claude/rules/04-error-handling.md
+++ b/.claude/rules/04-error-handling.md
@@ -136,7 +136,11 @@ type CrawlerError struct {
 }
 
 func (e *CrawlerError) Error() string {
-    return fmt.Sprintf("[%s:%s] %s: %v", e.Category, e.Code, e.Message, e.Err)
+    if e.Err != nil {
+        return fmt.Sprintf("[%s:%s] %s: %v", e.Category, e.Code, e.Message, e.Err)
+    }
+    // wrapped err 가 nil 이면 ": <nil>" 깨진 표현을 출력하지 않음
+    return fmt.Sprintf("[%s:%s] %s", e.Category, e.Code, e.Message)
 }
 
 func (e *CrawlerError) Unwrap() error {

--- a/internal/crawler/core/errors.go
+++ b/internal/crawler/core/errors.go
@@ -106,13 +106,26 @@ func (e *CrawlerError) Unwrap() error {
 	return e.Err
 }
 
-// Is는 errors.Is 와 호환되며, target 이 같은 Code 또는 같은 Category 이면 true 를 반환합니다.
+// Is는 errors.Is 와 호환되며, target 에 지정된 식별 필드(Code, Category)가 모두 일치할 때 true 를 반환합니다.
+// target 의 필드 중 빈 값("")은 비교에서 제외되어, Code 만 / Category 만 / 둘 다 명시한 모든 패턴을 정확히 처리합니다.
+//
+// 예) errors.Is(err, &CrawlerError{Code: CodeNetTimeout})         → Code 만 매칭
+//
+//	errors.Is(err, &CrawlerError{Category: ErrCategoryNetwork}) → Category 만 매칭
+//	errors.Is(err, &CrawlerError{Code: "X", Category: "Y"})     → Code AND Category 모두 매칭
 func (e *CrawlerError) Is(target error) bool {
 	t, ok := target.(*CrawlerError)
 	if !ok {
 		return false
 	}
-	return e.Code == t.Code || e.Category == t.Category
+	if t.Code != "" && t.Code != e.Code {
+		return false
+	}
+	if t.Category != "" && t.Category != e.Category {
+		return false
+	}
+	// target 에 두 필드 모두 비어있으면 임의의 CrawlerError 와 일치하지 않도록 false 처리
+	return t.Code != "" || t.Category != ""
 }
 
 // ──────────────────────────────────────────────────────────────────────
@@ -231,38 +244,57 @@ func NewHTTPClientError(url string, statusCode int) *CrawlerError {
 	}
 }
 
+// inheritRetryable은 inner err 가 *CrawlerError 이면 그 Retryable 을 상속하고,
+// 아니면 호출자가 지정한 default 값을 반환합니다.
+// 의도: 시스템 계층 wrapper(Storage/Database/Queue)가 inner 의 retry 시맨틱을
+// 무의식적으로 덮어쓰는 것을 방지합니다(예: DB constraint violation 의 Retryable=false 보존).
+func inheritRetryable(err error, defaultRetryable bool) bool {
+	if ce, ok := err.(*CrawlerError); ok {
+		return ce.Retryable
+	}
+	return defaultRetryable
+}
+
 // NewDatabaseError는 database 에러를 생성합니다.
-// retryable 은 호출자가 결정합니다(예: 일시적 connection failure 는 retryable, constraint violation 은 false).
+// retryable 은 호출자가 결정하되, inner err 가 이미 *CrawlerError 이면 그 Retryable 을 상속합니다.
+// (예: 일시적 connection failure 는 retryable, constraint violation 은 false)
 func NewDatabaseError(code, message string, retryable bool, err error) *CrawlerError {
 	return &CrawlerError{
 		Category:  ErrCategoryDatabase,
 		Code:      code,
 		Message:   message,
-		Retryable: retryable,
+		Retryable: inheritRetryable(err, retryable),
 		Err:       err,
 	}
 }
 
 // NewQueueError는 message queue(Kafka 등) 에러를 생성합니다.
 // publish 실패 등 일시적 오류는 retryable=true 로, 메시지 형식 오류는 false 로 호출자가 결정합니다.
+// inner err 가 *CrawlerError 이면 그 Retryable 을 상속합니다.
 func NewQueueError(code, message string, retryable bool, err error) *CrawlerError {
 	return &CrawlerError{
 		Category:  ErrCategoryQueue,
 		Code:      code,
 		Message:   message,
-		Retryable: retryable,
+		Retryable: inheritRetryable(err, retryable),
 		Err:       err,
 	}
 }
 
 // NewStorageError는 storage(content service 등) 경계 에러를 생성합니다.
-// 내부 cause(주로 DatabaseError)를 그대로 wrap 하여 errors.As 로 추출 가능하게 합니다.
+// 내부 cause(주로 DatabaseError 또는 raw repo 에러)를 wrap 하여 errors.As 로 추출 가능하게 합니다.
+// inner err 가 *CrawlerError 이면 그 Retryable 을 상속합니다 — 예: DatabaseError(Retryable=false)
+// 를 NewStorageError(..., true, err) 로 wrap 해도 false 가 보존됩니다.
+//
+// NOTE: Category 는 Storage 로 고정됩니다. retry 정책에서 storage 카테고리를 retryable
+// 대상으로 포함하지 않으면 inner 가 retryable 이어도 결과적으로 재시도되지 않습니다.
+// (.claude/rules/04-error-handling.md 의 layer rules 참고)
 func NewStorageError(code, message string, retryable bool, err error) *CrawlerError {
 	return &CrawlerError{
 		Category:  ErrCategoryStorage,
 		Code:      code,
 		Message:   message,
-		Retryable: retryable,
+		Retryable: inheritRetryable(err, retryable),
 		Err:       err,
 	}
 }

--- a/internal/crawler/core/errors.go
+++ b/internal/crawler/core/errors.go
@@ -37,11 +37,11 @@ const (
 // 에러 코드 상수 — .claude/rules/04-error-handling.md 의 코드 카탈로그와 1:1 대응합니다.
 // 코드는 로그/메트릭에서 카디널리티가 안정적이도록 문자열 상수로 고정합니다.
 const (
-	// Network / HTTP
-	CodeNetConnRefused = "NET_001" // 연결 거부 / 즉시 실패
-	CodeNetTimeout     = "NET_002" // 응답 본문 읽기 또는 연결 타임아웃
-	CodeNetDNSFailure  = "NET_003" // DNS 해상 실패
-	CodeReqBuild       = "REQ_001" // http.Request 생성 실패
+	// Network / HTTP — 모두 NewNetworkError 로 생성되어 retryable=true 가 기본값
+	CodeNetConnRefused = "NET_001" // 일시적 connection refused / 네트워크 단절 (retryable)
+	CodeNetTimeout     = "NET_002" // 응답 본문 읽기 또는 연결 타임아웃 (retryable)
+	CodeNetDNSFailure  = "NET_003" // DNS 해상 실패 (retryable)
+	CodeReqBuild       = "REQ_001" // http.Request 생성 실패 (retryable, 내부 보존)
 
 	// Parse
 	CodeParseHTML     = "PARSE_001" // 잘못된 HTML 구조
@@ -50,12 +50,12 @@ const (
 	CodeParseJSON     = "PARSE_004" // JSON 파싱 실패
 
 	// Validation
-	CodeValMissingField  = "VAL_001" // 필수 필드 누락
-	CodeValInvalidFormat = "VAL_002" // 필드 형식 불일치
-	CodeValContentShort  = "VAL_003" // 본문 길이 미달
-	CodeValContentLong   = "VAL_004" // 본문 길이 초과
-	CodeValQualityLow    = "VAL_005" // 품질 점수 임계 미달
-	CodeValSpam          = "VAL_006" // 스팸/도배 패턴 탐지
+	CodeValMissingField  = "VAL_001" // 필수 필드 누락 (예: PublishedAt)
+	CodeValInvalidFormat = "VAL_002" // 필드 형식 불일치 (default fallback)
+	CodeValContentShort  = "VAL_003" // 텍스트 필드 최소 길이 미달 (Title min_length / Body min_length 등)
+	CodeValContentLong   = "VAL_004" // 텍스트 필드 최대 길이 초과 (Title max_length / Body max_length 등)
+	CodeValQualityLow    = "VAL_005" // 품질 점수 임계 미달 (errors 가 비어 있는 임계 실패도 포함)
+	CodeValSpam          = "VAL_006" // 스팸/도배 패턴 탐지 (caps, punct, flood)
 
 	// Database
 	CodeDBConnFail     = "DB_001" // 커넥션 실패

--- a/internal/crawler/core/errors.go
+++ b/internal/crawler/core/errors.go
@@ -1,6 +1,209 @@
+// Package core 의 errors.go는 시스템 전반에서 사용하는 구조화 에러 타입과 카테고리/코드 체계를 정의합니다.
+// 타입 이름은 역사적 사유로 CrawlerError 이지만, 크롤러뿐 아니라 storage/queue/processor 등
+// 다른 internal/ 레이어 경계에서도 동일하게 사용합니다(레이어별 사용 규칙은
+// .claude/rules/04-error-handling.md 참고).
+//
+// Although the type is named CrawlerError for historical reasons, it is the system-wide
+// structured error used at any internal/ boundary (crawler, storage, queue, processor, ...).
 package core
 
 import "fmt"
+
+// ErrorCategory는 에러의 카테고리를 나타냅니다. retry 가능 여부, 라우팅 규칙 등은 카테고리 기준으로 결정됩니다.
+type ErrorCategory string
+
+const (
+	// Temporary errors - retry 가능
+	ErrCategoryNetwork   ErrorCategory = "network"
+	ErrCategoryRateLimit ErrorCategory = "rate_limit"
+	ErrCategoryTimeout   ErrorCategory = "timeout"
+
+	// Permanent errors - retry 불가
+	ErrCategoryNotFound   ErrorCategory = "not_found"
+	ErrCategoryForbidden  ErrorCategory = "forbidden"
+	ErrCategoryParse      ErrorCategory = "parse"
+	ErrCategoryValidation ErrorCategory = "validation"
+
+	// System errors
+	ErrCategoryDatabase ErrorCategory = "database"
+	ErrCategoryQueue    ErrorCategory = "queue"
+	ErrCategoryStorage  ErrorCategory = "storage"
+
+	// Logic errors
+	ErrCategoryConfig   ErrorCategory = "config"
+	ErrCategoryInternal ErrorCategory = "internal"
+)
+
+// 에러 코드 상수 — .claude/rules/04-error-handling.md 의 코드 카탈로그와 1:1 대응합니다.
+// 코드는 로그/메트릭에서 카디널리티가 안정적이도록 문자열 상수로 고정합니다.
+const (
+	// Network / HTTP
+	CodeNetConnRefused = "NET_001" // 연결 거부 / 즉시 실패
+	CodeNetTimeout     = "NET_002" // 응답 본문 읽기 또는 연결 타임아웃
+	CodeNetDNSFailure  = "NET_003" // DNS 해상 실패
+	CodeReqBuild       = "REQ_001" // http.Request 생성 실패
+
+	// Parse
+	CodeParseHTML     = "PARSE_001" // 잘못된 HTML 구조
+	CodeParseSelector = "PARSE_002" // 필수 셀렉터 누락
+	CodeParseEncoding = "PARSE_003" // 인코딩 변환 실패
+	CodeParseJSON     = "PARSE_004" // JSON 파싱 실패
+
+	// Validation
+	CodeValMissingField  = "VAL_001" // 필수 필드 누락
+	CodeValInvalidFormat = "VAL_002" // 필드 형식 불일치
+	CodeValContentShort  = "VAL_003" // 본문 길이 미달
+	CodeValContentLong   = "VAL_004" // 본문 길이 초과
+	CodeValQualityLow    = "VAL_005" // 품질 점수 임계 미달
+	CodeValSpam          = "VAL_006" // 스팸/도배 패턴 탐지
+
+	// Database
+	CodeDBConnFail     = "DB_001" // 커넥션 실패
+	CodeDBQueryTimeout = "DB_002" // 쿼리 타임아웃
+	CodeDBConstraint   = "DB_003" // 제약 위반
+	CodeDBDeadlock     = "DB_004" // 데드락
+
+	// Queue
+	CodeQueuePublish   = "QUEUE_001" // 발행 실패
+	CodeQueueFull      = "QUEUE_002" // 큐 포화
+	CodeQueueMalformed = "QUEUE_003" // 메시지 형식 오류
+
+	// Storage (서비스 계층, content/raw_content 추상)
+	CodeStorageRead   = "STORAGE_001" // 조회 실패
+	CodeStorageWrite  = "STORAGE_002" // 저장 실패
+	CodeStorageDelete = "STORAGE_003" // 삭제 실패
+
+	// Config
+	CodeConfigParse   = "CONFIG_001" // 설정 파싱 실패
+	CodeConfigMissing = "CONFIG_002" // 필수 설정 누락
+
+	// Internal
+	CodeInternal = "INTERNAL_001" // 그 외 내부 오류
+)
+
+// CrawlerError는 시스템 전반에서 사용하는 구조화 에러입니다.
+// 타입 이름은 역사적 사유로 유지되지만, 크롤러뿐 아니라 storage/queue/processor 등
+// 모든 internal/ 레이어 경계에서 동일하게 사용합니다.
+type CrawlerError struct {
+	Category   ErrorCategory
+	Code       string
+	Message    string
+	Source     string
+	URL        string
+	StatusCode int
+	Retryable  bool
+	Err        error
+}
+
+func (e *CrawlerError) Error() string {
+	if e.Err != nil {
+		return fmt.Sprintf("[%s:%s] %s: %v", e.Category, e.Code, e.Message, e.Err)
+	}
+	return fmt.Sprintf("[%s:%s] %s", e.Category, e.Code, e.Message)
+}
+
+func (e *CrawlerError) Unwrap() error {
+	return e.Err
+}
+
+// Is는 errors.Is 와 호환되며, target 이 같은 Code 또는 같은 Category 이면 true 를 반환합니다.
+func (e *CrawlerError) Is(target error) bool {
+	t, ok := target.(*CrawlerError)
+	if !ok {
+		return false
+	}
+	return e.Code == t.Code || e.Category == t.Category
+}
+
+// ──────────────────────────────────────────────────────────────────────
+// 카테고리별 생성자 — internal/ 레이어 경계에서 호출합니다.
+// pkg/ 의 generic 유틸 패키지(pkg/links, pkg/queue, pkg/redis 등)는
+// 의도적으로 fmt.Errorf 를 유지하고, 호출하는 internal/ 경계에서 변환합니다.
+// ──────────────────────────────────────────────────────────────────────
+
+// NewNetworkError는 network 에러를 생성합니다 (retryable).
+func NewNetworkError(code, message, url string, err error) *CrawlerError {
+	return &CrawlerError{
+		Category:  ErrCategoryNetwork,
+		Code:      code,
+		Message:   message,
+		URL:       url,
+		Retryable: true,
+		Err:       err,
+	}
+}
+
+// NewTimeoutError는 timeout 에러를 생성합니다 (retryable).
+func NewTimeoutError(code, message, url string, err error) *CrawlerError {
+	return &CrawlerError{
+		Category:  ErrCategoryTimeout,
+		Code:      code,
+		Message:   message,
+		URL:       url,
+		Retryable: true,
+		Err:       err,
+	}
+}
+
+// NewRateLimitError는 rate limit 에러를 생성합니다 (retryable).
+func NewRateLimitError(code, message, url string, statusCode int) *CrawlerError {
+	return &CrawlerError{
+		Category:   ErrCategoryRateLimit,
+		Code:       code,
+		Message:    message,
+		URL:        url,
+		StatusCode: statusCode,
+		Retryable:  true,
+	}
+}
+
+// NewParseError는 parse 에러를 생성합니다 (non-retryable).
+func NewParseError(code, message, url string, err error) *CrawlerError {
+	return &CrawlerError{
+		Category:  ErrCategoryParse,
+		Code:      code,
+		Message:   message,
+		URL:       url,
+		Retryable: false,
+		Err:       err,
+	}
+}
+
+// NewValidationError는 validation 에러를 생성합니다 (non-retryable).
+// 검증 임계 미달 / 필수 필드 누락 등 컨텐츠 자체 결함을 나타냅니다.
+func NewValidationError(code, message string, err error) *CrawlerError {
+	return &CrawlerError{
+		Category:  ErrCategoryValidation,
+		Code:      code,
+		Message:   message,
+		Retryable: false,
+		Err:       err,
+	}
+}
+
+// NewNotFoundError는 404 에러를 생성합니다 (non-retryable).
+func NewNotFoundError(url string) *CrawlerError {
+	return &CrawlerError{
+		Category:   ErrCategoryNotFound,
+		Code:       "HTTP_404",
+		Message:    "resource not found",
+		URL:        url,
+		StatusCode: 404,
+		Retryable:  false,
+	}
+}
+
+// NewForbiddenError는 403 에러를 생성합니다 (non-retryable).
+func NewForbiddenError(url string) *CrawlerError {
+	return &CrawlerError{
+		Category:   ErrCategoryForbidden,
+		Code:       "HTTP_403",
+		Message:    "forbidden",
+		URL:        url,
+		StatusCode: 403,
+		Retryable:  false,
+	}
+}
 
 // NewHTTPServerError는 5xx 서버 에러를 생성합니다 (retryable).
 func NewHTTPServerError(url string, statusCode int) *CrawlerError {
@@ -28,104 +231,61 @@ func NewHTTPClientError(url string, statusCode int) *CrawlerError {
 	}
 }
 
-// ErrorCategory는 에러의 카테고리를 나타냅니다.
-type ErrorCategory string
-
-const (
-	// Temporary errors - retry 가능
-	ErrCategoryNetwork   ErrorCategory = "network"
-	ErrCategoryRateLimit ErrorCategory = "rate_limit"
-	ErrCategoryTimeout   ErrorCategory = "timeout"
-
-	// Permanent errors - retry 불가
-	ErrCategoryNotFound   ErrorCategory = "not_found"
-	ErrCategoryForbidden  ErrorCategory = "forbidden"
-	ErrCategoryParse      ErrorCategory = "parse"
-	ErrCategoryValidation ErrorCategory = "validation"
-
-	// System errors
-	ErrCategoryDatabase ErrorCategory = "database"
-	ErrCategoryQueue    ErrorCategory = "queue"
-	ErrCategoryStorage  ErrorCategory = "storage"
-
-	// Logic errors
-	ErrCategoryConfig   ErrorCategory = "config"
-	ErrCategoryInternal ErrorCategory = "internal"
-)
-
-// CrawlerError는 크롤러에서 발생하는 에러를 나타냅니다.
-// 에러 카테고리, 코드, 메시지를 포함하며 retry 가능 여부를 나타냅니다.
-type CrawlerError struct {
-	Category   ErrorCategory
-	Code       string
-	Message    string
-	Source     string
-	URL        string
-	StatusCode int
-	Retryable  bool
-	Err        error
-}
-
-func (e *CrawlerError) Error() string {
-	return fmt.Sprintf("[%s:%s] %s: %v", e.Category, e.Code, e.Message, e.Err)
-}
-
-func (e *CrawlerError) Unwrap() error {
-	return e.Err
-}
-
-func (e *CrawlerError) Is(target error) bool {
-	t, ok := target.(*CrawlerError)
-	if !ok {
-		return false
-	}
-	return e.Code == t.Code || e.Category == t.Category
-}
-
-// NewNetworkError는 network 에러를 생성합니다.
-func NewNetworkError(code, message, url string, err error) *CrawlerError {
+// NewDatabaseError는 database 에러를 생성합니다.
+// retryable 은 호출자가 결정합니다(예: 일시적 connection failure 는 retryable, constraint violation 은 false).
+func NewDatabaseError(code, message string, retryable bool, err error) *CrawlerError {
 	return &CrawlerError{
-		Category:  ErrCategoryNetwork,
+		Category:  ErrCategoryDatabase,
 		Code:      code,
 		Message:   message,
-		URL:       url,
-		Retryable: true,
+		Retryable: retryable,
 		Err:       err,
 	}
 }
 
-// NewRateLimitError는 rate limit 에러를 생성합니다.
-func NewRateLimitError(code, message, url string, statusCode int) *CrawlerError {
+// NewQueueError는 message queue(Kafka 등) 에러를 생성합니다.
+// publish 실패 등 일시적 오류는 retryable=true 로, 메시지 형식 오류는 false 로 호출자가 결정합니다.
+func NewQueueError(code, message string, retryable bool, err error) *CrawlerError {
 	return &CrawlerError{
-		Category:   ErrCategoryRateLimit,
-		Code:       code,
-		Message:    message,
-		URL:        url,
-		StatusCode: statusCode,
-		Retryable:  true,
+		Category:  ErrCategoryQueue,
+		Code:      code,
+		Message:   message,
+		Retryable: retryable,
+		Err:       err,
 	}
 }
 
-// NewParseError는 parse 에러를 생성합니다.
-func NewParseError(code, message, url string, err error) *CrawlerError {
+// NewStorageError는 storage(content service 등) 경계 에러를 생성합니다.
+// 내부 cause(주로 DatabaseError)를 그대로 wrap 하여 errors.As 로 추출 가능하게 합니다.
+func NewStorageError(code, message string, retryable bool, err error) *CrawlerError {
 	return &CrawlerError{
-		Category:  ErrCategoryParse,
+		Category:  ErrCategoryStorage,
 		Code:      code,
 		Message:   message,
-		URL:       url,
+		Retryable: retryable,
+		Err:       err,
+	}
+}
+
+// NewConfigError는 설정 로딩/검증 단계의 에러를 생성합니다 (non-retryable, fail-fast 의도).
+func NewConfigError(code, message string, err error) *CrawlerError {
+	return &CrawlerError{
+		Category:  ErrCategoryConfig,
+		Code:      code,
+		Message:   message,
 		Retryable: false,
 		Err:       err,
 	}
 }
 
-// NewNotFoundError는 404 에러를 생성합니다.
-func NewNotFoundError(url string) *CrawlerError {
+// NewInternalError는 분류 불가능한 내부 로직 오류를 생성합니다.
+// 가급적 더 구체적인 카테고리를 우선 사용하고, 마지막 fallback 으로만 사용합니다.
+func NewInternalError(code, message string, err error) *CrawlerError {
 	return &CrawlerError{
-		Category:   ErrCategoryNotFound,
-		Code:       "HTTP_404",
-		Message:    "resource not found",
-		URL:        url,
-		StatusCode: 404,
-		Retryable:  false,
+		Category:  ErrCategoryInternal,
+		Code:      code,
+		Message:   message,
+		Retryable: false,
+		Err:       err,
 	}
 }

--- a/internal/crawler/core/extractor.go
+++ b/internal/crawler/core/extractor.go
@@ -1,8 +1,6 @@
 package core
 
 import (
-	"fmt"
-
 	"issuetracker/pkg/links"
 )
 
@@ -43,14 +41,17 @@ func NewHTMLLinkExtractor(baseURL string, opts ...links.Option) *HTMLLinkExtract
 
 // Extract는 raw.HTML에서 링크를 추출하여 []Link로 반환합니다.
 // raw가 nil이면 에러를 반환합니다.
+//
+// pkg/links 는 generic 유틸 패키지로 fmt.Errorf 를 유지하고,
+// 본 boundary 에서 CrawlerError 로 변환합니다(.claude/rules/04-error-handling.md 참고).
 func (e *HTMLLinkExtractor) Extract(raw *RawContent) ([]Link, error) {
 	if raw == nil {
-		return nil, fmt.Errorf("raw content is nil")
+		return nil, NewInternalError(CodeInternal, "raw content is nil", nil)
 	}
 
 	extracted, err := e.inner.Extract(raw.HTML, raw.URL)
 	if err != nil {
-		return nil, fmt.Errorf("extract links from %s: %w", raw.URL, err)
+		return nil, NewParseError(CodeParseHTML, "failed to extract links", raw.URL, err)
 	}
 
 	if len(extracted) == 0 {

--- a/internal/processor/validate/validator.go
+++ b/internal/processor/validate/validator.go
@@ -47,13 +47,38 @@ type validatorProcessor struct {
 }
 
 // Process는 content를 검증하고 Reliability를 설정합니다.
+// 검증 실패 시 core.CrawlerError(Validation 카테고리)로 반환하며,
+// 첫 번째 룰에 따라 코드를 부여합니다(임계 미달은 VAL_005, errors 가 비어있는 임계 실패도 VAL_005).
 func (p *validatorProcessor) Process(ctx context.Context, content *core.Content) (*core.Content, error) {
 	result := p.validator.Validate(ctx, content)
 	content.Reliability = result.QualityScore
 
 	if !result.IsValid {
-		return nil, fmt.Errorf("content %s failed validation: %v", content.ID, result.Errors)
+		code := codeForValidationResult(result)
+		message := fmt.Sprintf("content %s failed validation: %v", content.ID, result.Errors)
+		return nil, core.NewValidationError(code, message, nil)
 	}
 
 	return content, nil
+}
+
+// codeForValidationResult는 ValidationResult.Errors 에서 첫 번째 룰을 참조하여
+// 가장 적절한 에러 코드를 결정합니다. errors 가 비어있으면 임계 미달로 간주합니다.
+func codeForValidationResult(result processor.ValidationResult) string {
+	if len(result.Errors) == 0 {
+		return core.CodeValQualityLow
+	}
+
+	switch result.Errors[0].Rule {
+	case "min_length":
+		return core.CodeValContentShort
+	case "max_length":
+		return core.CodeValContentLong
+	case "required":
+		return core.CodeValMissingField
+	case "spam_caps", "spam_punct", "spam_flood":
+		return core.CodeValSpam
+	default:
+		return core.CodeValInvalidFormat
+	}
 }

--- a/internal/storage/service/content.go
+++ b/internal/storage/service/content.go
@@ -80,12 +80,12 @@ func (s *contentService) Store(ctx context.Context, content *core.Content) (stri
 		}
 
 		if !errors.Is(err, storage.ErrNotFound) {
-			return "", false, fmt.Errorf("check duplicate: %w", err)
+			return "", false, core.NewStorageError(core.CodeStorageRead, "check duplicate", true, err)
 		}
 	}
 
 	if err := s.repo.Save(ctx, content); err != nil {
-		return "", false, fmt.Errorf("save content: %w", err)
+		return "", false, core.NewStorageError(core.CodeStorageWrite, "save content", true, err)
 	}
 
 	return content.ID, false, nil
@@ -111,7 +111,7 @@ func (s *contentService) StoreBatch(ctx context.Context, contents []*core.Conten
 func (s *contentService) GetByID(ctx context.Context, id string) (*core.Content, error) {
 	content, err := s.repo.GetByID(ctx, id)
 	if err != nil {
-		return nil, fmt.Errorf("get content by id: %w", err)
+		return nil, core.NewStorageError(core.CodeStorageRead, "get content by id", true, err)
 	}
 
 	return content, nil
@@ -127,7 +127,12 @@ func (s *contentService) ListByCountry(
 
 	contents, err := s.repo.List(ctx, filter)
 	if err != nil {
-		return nil, fmt.Errorf("list contents by country %s: %w", country, err)
+		return nil, core.NewStorageError(
+			core.CodeStorageRead,
+			fmt.Sprintf("list contents by country %s", country),
+			true,
+			err,
+		)
 	}
 
 	return contents, nil
@@ -137,7 +142,7 @@ func (s *contentService) ListByCountry(
 func (s *contentService) Search(ctx context.Context, filter storage.ContentFilter) ([]*core.Content, error) {
 	contents, err := s.repo.List(ctx, filter)
 	if err != nil {
-		return nil, fmt.Errorf("search contents: %w", err)
+		return nil, core.NewStorageError(core.CodeStorageRead, "search contents", true, err)
 	}
 
 	return contents, nil
@@ -162,7 +167,12 @@ func (s *contentService) CountByCountry(ctx context.Context, days int) (map[stri
 			PublishedAfter: &after,
 		})
 		if err != nil {
-			return nil, fmt.Errorf("count contents for country %s: %w", country, err)
+			return nil, core.NewStorageError(
+				core.CodeStorageRead,
+				fmt.Sprintf("count contents for country %s", country),
+				true,
+				err,
+			)
 		}
 
 		result[country] = count

--- a/internal/storage/service/raw_content.go
+++ b/internal/storage/service/raw_content.go
@@ -56,13 +56,13 @@ func (s *rawContentService) Store(ctx context.Context, raw *core.RawContent) (st
 	}
 
 	if !errors.Is(err, storage.ErrDuplicate) {
-		return "", false, fmt.Errorf("save raw content: %w", err)
+		return "", false, core.NewStorageError(core.CodeStorageWrite, "save raw content", true, err)
 	}
 
 	// 동일 URL 존재 → 기존 레코드 ID 조회
 	existing, err := s.repo.GetByURL(ctx, raw.URL)
 	if err != nil {
-		return "", false, fmt.Errorf("get existing raw content by url: %w", err)
+		return "", false, core.NewStorageError(core.CodeStorageRead, "get existing raw content by url", true, err)
 	}
 
 	s.log.WithFields(map[string]interface{}{
@@ -77,7 +77,7 @@ func (s *rawContentService) Store(ctx context.Context, raw *core.RawContent) (st
 func (s *rawContentService) GetByID(ctx context.Context, id string) (*core.RawContent, error) {
 	raw, err := s.repo.GetByID(ctx, id)
 	if err != nil {
-		return nil, fmt.Errorf("get raw content by id: %w", err)
+		return nil, core.NewStorageError(core.CodeStorageRead, "get raw content by id", true, err)
 	}
 
 	return raw, nil
@@ -87,7 +87,7 @@ func (s *rawContentService) GetByID(ctx context.Context, id string) (*core.RawCo
 func (s *rawContentService) List(ctx context.Context, filter storage.RawContentFilter) ([]*core.RawContent, error) {
 	raws, err := s.repo.List(ctx, filter)
 	if err != nil {
-		return nil, fmt.Errorf("list raw contents: %w", err)
+		return nil, core.NewStorageError(core.CodeStorageRead, "list raw contents", true, err)
 	}
 
 	return raws, nil
@@ -97,7 +97,12 @@ func (s *rawContentService) List(ctx context.Context, filter storage.RawContentF
 func (s *rawContentService) PurgeOlderThan(ctx context.Context, cutoff time.Time) (int64, error) {
 	n, err := s.repo.DeleteBefore(ctx, cutoff)
 	if err != nil {
-		return 0, fmt.Errorf("purge raw contents older than %s: %w", cutoff.Format(time.RFC3339), err)
+		return 0, core.NewStorageError(
+			core.CodeStorageDelete,
+			fmt.Sprintf("purge raw contents older than %s", cutoff.Format(time.RFC3339)),
+			true,
+			err,
+		)
 	}
 
 	s.log.WithFields(map[string]interface{}{

--- a/internal/storage/service/raw_content.go
+++ b/internal/storage/service/raw_content.go
@@ -4,7 +4,6 @@ package service
 import (
 	"context"
 	"errors"
-	"fmt"
 	"time"
 
 	"issuetracker/internal/crawler/core"
@@ -94,15 +93,15 @@ func (s *rawContentService) List(ctx context.Context, filter storage.RawContentF
 }
 
 // PurgeOlderThan은 cutoff 이전 데이터를 일괄 삭제합니다.
+// 에러 메시지는 고정 문자열을 사용하고 cutoff 는 구조화 로그 필드로 분리합니다
+// (에러 문자열이 로그/DLQ 헤더에 그대로 들어갈 때 시간값이 카디널리티를 폭발시키지 않도록).
 func (s *rawContentService) PurgeOlderThan(ctx context.Context, cutoff time.Time) (int64, error) {
 	n, err := s.repo.DeleteBefore(ctx, cutoff)
 	if err != nil {
-		return 0, core.NewStorageError(
-			core.CodeStorageDelete,
-			fmt.Sprintf("purge raw contents older than %s", cutoff.Format(time.RFC3339)),
-			true,
-			err,
-		)
+		s.log.WithFields(map[string]interface{}{
+			"cutoff": cutoff.Format(time.RFC3339),
+		}).WithError(err).Error("failed to purge raw contents")
+		return 0, core.NewStorageError(core.CodeStorageDelete, "purge raw contents", true, err)
 	}
 
 	s.log.WithFields(map[string]interface{}{

--- a/test/internal/crawler_core/errors_test.go
+++ b/test/internal/crawler_core/errors_test.go
@@ -42,7 +42,7 @@ func TestCrawlerError_Is(t *testing.T) {
 		expected bool
 	}{
 		{
-			name: "same code",
+			name: "both fields match",
 			err: &core.CrawlerError{
 				Category: core.ErrCategoryNetwork,
 				Code:     "NET_001",
@@ -54,7 +54,29 @@ func TestCrawlerError_Is(t *testing.T) {
 			expected: true,
 		},
 		{
-			name: "same category different code",
+			name: "category-only target matches by category",
+			err: &core.CrawlerError{
+				Category: core.ErrCategoryNetwork,
+				Code:     "NET_001",
+			},
+			target: &core.CrawlerError{
+				Category: core.ErrCategoryNetwork,
+			},
+			expected: true,
+		},
+		{
+			name: "code-only target matches by code",
+			err: &core.CrawlerError{
+				Category: core.ErrCategoryNetwork,
+				Code:     "NET_001",
+			},
+			target: &core.CrawlerError{
+				Code: "NET_001",
+			},
+			expected: true,
+		},
+		{
+			name: "both fields populated, only category matches → false (AND semantics)",
 			err: &core.CrawlerError{
 				Category: core.ErrCategoryNetwork,
 				Code:     "NET_001",
@@ -63,18 +85,38 @@ func TestCrawlerError_Is(t *testing.T) {
 				Category: core.ErrCategoryNetwork,
 				Code:     "NET_002",
 			},
-			expected: true,
+			expected: false,
 		},
 		{
-			name: "different category",
+			name: "both fields populated, only code matches → false (AND semantics)",
 			err: &core.CrawlerError{
 				Category: core.ErrCategoryNetwork,
 				Code:     "NET_001",
 			},
 			target: &core.CrawlerError{
 				Category: core.ErrCategoryParse,
-				Code:     "PARSE_001",
+				Code:     "NET_001",
 			},
+			expected: false,
+		},
+		{
+			name: "different category, code-only target → false",
+			err: &core.CrawlerError{
+				Category: core.ErrCategoryNetwork,
+				Code:     "NET_001",
+			},
+			target: &core.CrawlerError{
+				Code: "PARSE_001",
+			},
+			expected: false,
+		},
+		{
+			name: "empty target matches nothing",
+			err: &core.CrawlerError{
+				Category: core.ErrCategoryNetwork,
+				Code:     "NET_001",
+			},
+			target:   &core.CrawlerError{},
 			expected: false,
 		},
 		{
@@ -93,6 +135,32 @@ func TestCrawlerError_Is(t *testing.T) {
 			assert.Equal(t, tt.expected, tt.err.Is(tt.target))
 		})
 	}
+}
+
+func TestNewStorageError_InheritsRetryableFromInnerCrawlerError(t *testing.T) {
+	// inner DatabaseError(Retryable=false, e.g. constraint violation)
+	inner := core.NewDatabaseError(core.CodeDBConstraint, "unique violation", false, errors.New("23505"))
+
+	// 호출자가 retryable=true 로 wrap 해도 inner 의 false 가 보존되어야 함
+	wrapped := core.NewStorageError(core.CodeStorageWrite, "save content", true, inner)
+
+	assert.False(t, wrapped.Retryable, "inner *CrawlerError 의 Retryable=false 가 상속되어야 함")
+	assert.Equal(t, core.ErrCategoryStorage, wrapped.Category, "Category 는 wrapper(Storage) 가 유지")
+}
+
+func TestNewStorageError_UsesDefaultRetryableForNonCrawlerInner(t *testing.T) {
+	// inner 가 일반 error 이면 호출자의 default 가 사용됨
+	wrapped := core.NewStorageError(core.CodeStorageWrite, "save content", true, errors.New("driver failure"))
+
+	assert.True(t, wrapped.Retryable, "non-CrawlerError inner 에 대해 호출자 default(true) 사용")
+}
+
+func TestNewQueueError_InheritsRetryableFromInnerCrawlerError(t *testing.T) {
+	inner := core.NewInternalError(core.CodeInternal, "fatal config", errors.New("boom"))
+
+	wrapped := core.NewQueueError(core.CodeQueuePublish, "publish failed", true, inner)
+
+	assert.False(t, wrapped.Retryable, "inner internal error 의 Retryable=false 가 상속되어야 함")
 }
 
 func TestNewNetworkError(t *testing.T) {

--- a/test/internal/crawler_core/errors_test.go
+++ b/test/internal/crawler_core/errors_test.go
@@ -22,6 +22,20 @@ func TestCrawlerError_Error(t *testing.T) {
 	assert.Equal(t, expected, err.Error())
 }
 
+// Err=nil 인 경우 ": <nil>" 깨진 표현 없이 prefix 만 출력하는지 검증
+func TestCrawlerError_Error_NilWrappedErr(t *testing.T) {
+	err := &core.CrawlerError{
+		Category: core.ErrCategoryNotFound,
+		Code:     "HTTP_404",
+		Message:  "resource not found",
+		URL:      "https://example.com",
+		Err:      nil,
+	}
+
+	expected := "[not_found:HTTP_404] resource not found"
+	assert.Equal(t, expected, err.Error())
+}
+
 func TestCrawlerError_Unwrap(t *testing.T) {
 	underlyingErr := errors.New("underlying error")
 	err := &core.CrawlerError{
@@ -210,5 +224,90 @@ func TestNewNotFoundError(t *testing.T) {
 	assert.Equal(t, "HTTP_404", err.Code)
 	assert.Equal(t, url, err.URL)
 	assert.Equal(t, 404, err.StatusCode)
+	assert.False(t, err.Retryable)
+}
+
+func TestNewTimeoutError(t *testing.T) {
+	url := "https://example.com"
+	cause := errors.New("deadline exceeded")
+
+	err := core.NewTimeoutError(core.CodeNetTimeout, "request timeout", url, cause)
+
+	assert.Equal(t, core.ErrCategoryTimeout, err.Category)
+	assert.Equal(t, core.CodeNetTimeout, err.Code)
+	assert.Equal(t, url, err.URL)
+	assert.True(t, err.Retryable)
+	assert.Equal(t, cause, err.Err)
+	assert.Equal(t, cause, err.Unwrap())
+}
+
+func TestNewForbiddenError(t *testing.T) {
+	url := "https://example.com"
+
+	err := core.NewForbiddenError(url)
+
+	assert.Equal(t, core.ErrCategoryForbidden, err.Category)
+	assert.Equal(t, "HTTP_403", err.Code)
+	assert.Equal(t, url, err.URL)
+	assert.Equal(t, 403, err.StatusCode)
+	assert.False(t, err.Retryable)
+}
+
+func TestNewValidationError(t *testing.T) {
+	cause := errors.New("title too short")
+
+	err := core.NewValidationError(core.CodeValContentShort, "title length below minimum", cause)
+
+	assert.Equal(t, core.ErrCategoryValidation, err.Category)
+	assert.Equal(t, core.CodeValContentShort, err.Code)
+	assert.False(t, err.Retryable)
+	assert.Equal(t, cause, err.Err)
+}
+
+func TestNewDatabaseError(t *testing.T) {
+	cause := errors.New("connection refused")
+
+	// 일반 inner error → 호출자 default 사용
+	err := core.NewDatabaseError(core.CodeDBConnFail, "connection failed", true, cause)
+	assert.Equal(t, core.ErrCategoryDatabase, err.Category)
+	assert.Equal(t, core.CodeDBConnFail, err.Code)
+	assert.True(t, err.Retryable)
+	assert.Equal(t, cause, err.Err)
+}
+
+func TestNewQueueError(t *testing.T) {
+	cause := errors.New("malformed message")
+
+	err := core.NewQueueError(core.CodeQueueMalformed, "invalid message", false, cause)
+	assert.Equal(t, core.ErrCategoryQueue, err.Category)
+	assert.Equal(t, core.CodeQueueMalformed, err.Code)
+	assert.False(t, err.Retryable)
+}
+
+func TestNewStorageError(t *testing.T) {
+	cause := errors.New("io failure")
+
+	err := core.NewStorageError(core.CodeStorageWrite, "save content", true, cause)
+	assert.Equal(t, core.ErrCategoryStorage, err.Category)
+	assert.Equal(t, core.CodeStorageWrite, err.Code)
+	assert.True(t, err.Retryable)
+}
+
+func TestNewConfigError(t *testing.T) {
+	cause := errors.New("invalid yaml")
+
+	err := core.NewConfigError(core.CodeConfigParse, "failed to parse config", cause)
+	assert.Equal(t, core.ErrCategoryConfig, err.Category)
+	assert.Equal(t, core.CodeConfigParse, err.Code)
+	assert.False(t, err.Retryable, "config error 는 fail-fast 의도로 항상 non-retryable")
+	assert.Equal(t, cause, err.Err)
+}
+
+func TestNewInternalError(t *testing.T) {
+	cause := errors.New("nil pointer")
+
+	err := core.NewInternalError(core.CodeInternal, "internal failure", cause)
+	assert.Equal(t, core.ErrCategoryInternal, err.Category)
+	assert.Equal(t, core.CodeInternal, err.Code)
 	assert.False(t, err.Retryable)
 }

--- a/test/internal/crawler_core/extractor_test.go
+++ b/test/internal/crawler_core/extractor_test.go
@@ -1,0 +1,65 @@
+package core_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	core "issuetracker/internal/crawler/core"
+)
+
+func TestHTMLLinkExtractor_NilRaw_ReturnsInternalCrawlerError(t *testing.T) {
+	e := core.NewHTMLLinkExtractor("https://example.com")
+
+	links, err := e.Extract(nil)
+
+	assert.Nil(t, links)
+	require.Error(t, err)
+
+	var ce *core.CrawlerError
+	require.True(t, errors.As(err, &ce), "에러는 *core.CrawlerError 로 확정되어야 함")
+	assert.Equal(t, core.ErrCategoryInternal, ce.Category)
+	assert.Equal(t, core.CodeInternal, ce.Code)
+}
+
+func TestHTMLLinkExtractor_InnerError_WrapsAsParseCrawlerError(t *testing.T) {
+	// pkg/links 의 inner.Extract 는 raw.URL 이 url.Parse 실패하는 값일 때
+	// fmt.Errorf("resolve base url: ...") 를 반환합니다.
+	// 이 에러가 boundary 에서 NewParseError(CodeParseHTML, ...) 로 변환되는지 검증.
+	e := core.NewHTMLLinkExtractor("https://example.com")
+
+	raw := &core.RawContent{
+		URL:  "%/", // url.Parse 가 "invalid URL escape" 로 실패
+		HTML: `<html><body><a href="/foo">link</a></body></html>`,
+	}
+
+	links, err := e.Extract(raw)
+
+	assert.Nil(t, links)
+	require.Error(t, err)
+
+	var ce *core.CrawlerError
+	require.True(t, errors.As(err, &ce), "boundary 에러는 *core.CrawlerError 여야 함")
+	assert.Equal(t, core.ErrCategoryParse, ce.Category)
+	assert.Equal(t, core.CodeParseHTML, ce.Code)
+	assert.Equal(t, raw.URL, ce.URL, "URL 필드는 raw.URL 을 보존해야 함")
+	assert.NotNil(t, ce.Unwrap(), "내부 cause 가 wrap 되어야 함")
+}
+
+func TestHTMLLinkExtractor_ValidInput_NoError(t *testing.T) {
+	e := core.NewHTMLLinkExtractor("https://example.com")
+
+	raw := &core.RawContent{
+		URL: "https://example.com/page",
+		HTML: `<html><body>
+			<a href="/foo">internal</a>
+			<a href="https://other.com/bar">external</a>
+		</body></html>`,
+	}
+
+	links, err := e.Extract(raw)
+	require.NoError(t, err)
+	assert.NotEmpty(t, links)
+}

--- a/test/internal/processor/validate/processor_test.go
+++ b/test/internal/processor/validate/processor_test.go
@@ -1,0 +1,118 @@
+package validate_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	core "issuetracker/internal/crawler/core"
+	"issuetracker/internal/processor"
+	"issuetracker/internal/processor/validate"
+)
+
+// stubValidator는 입력에 관계없이 고정된 ValidationResult 를 반환합니다.
+type stubValidator struct {
+	result processor.ValidationResult
+}
+
+func (s *stubValidator) Validate(_ context.Context, _ *core.Content) processor.ValidationResult {
+	return s.result
+}
+
+// 검증 실패 시 ContentProcessor 가 첫 번째 Rule 기준으로 에러 코드를 부여하는지 검증.
+// DLQ 라우팅이 코드에 의존하므로 매핑이 회귀하지 않도록 고정합니다.
+func TestContentProcessor_Process_AssignsCodeFromFirstRule(t *testing.T) {
+	tests := []struct {
+		name     string
+		errors   []processor.ValidationError
+		wantCode string
+	}{
+		{
+			name:     "min_length → VAL_003",
+			errors:   []processor.ValidationError{{Field: "Title", Rule: "min_length"}},
+			wantCode: core.CodeValContentShort,
+		},
+		{
+			name:     "max_length → VAL_004",
+			errors:   []processor.ValidationError{{Field: "Body", Rule: "max_length"}},
+			wantCode: core.CodeValContentLong,
+		},
+		{
+			name:     "required → VAL_001",
+			errors:   []processor.ValidationError{{Field: "PublishedAt", Rule: "required"}},
+			wantCode: core.CodeValMissingField,
+		},
+		{
+			name:     "spam_caps → VAL_006",
+			errors:   []processor.ValidationError{{Field: "Body", Rule: "spam_caps"}},
+			wantCode: core.CodeValSpam,
+		},
+		{
+			name:     "spam_punct → VAL_006",
+			errors:   []processor.ValidationError{{Field: "Body", Rule: "spam_punct"}},
+			wantCode: core.CodeValSpam,
+		},
+		{
+			name:     "spam_flood → VAL_006",
+			errors:   []processor.ValidationError{{Field: "Body", Rule: "spam_flood"}},
+			wantCode: core.CodeValSpam,
+		},
+		{
+			name:     "unknown rule → VAL_002 (default fallback)",
+			errors:   []processor.ValidationError{{Field: "Body", Rule: "weird_rule_xyz"}},
+			wantCode: core.CodeValInvalidFormat,
+		},
+		{
+			name:     "no errors but invalid (threshold below) → VAL_005",
+			errors:   nil,
+			wantCode: core.CodeValQualityLow,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			v := &stubValidator{
+				result: processor.ValidationResult{
+					IsValid:      false,
+					QualityScore: 0.1,
+					Errors:       tt.errors,
+				},
+			}
+			cp := validate.NewContentProcessor(v)
+
+			content := &core.Content{ID: "test-id"}
+			out, err := cp.Process(context.Background(), content)
+
+			assert.Nil(t, out)
+			require.Error(t, err)
+
+			var ce *core.CrawlerError
+			require.True(t, errors.As(err, &ce), "검증 에러는 *core.CrawlerError 여야 함")
+			assert.Equal(t, core.ErrCategoryValidation, ce.Category)
+			assert.Equal(t, tt.wantCode, ce.Code)
+			assert.False(t, ce.Retryable, "validation 에러는 non-retryable")
+		})
+	}
+}
+
+// 검증 통과 시 Reliability 가 QualityScore 로 설정되고 에러 없이 content 가 반환되는지 검증.
+func TestContentProcessor_Process_SuccessSetsReliability(t *testing.T) {
+	v := &stubValidator{
+		result: processor.ValidationResult{
+			IsValid:      true,
+			QualityScore: 0.85,
+			Errors:       nil,
+		},
+	}
+	cp := validate.NewContentProcessor(v)
+
+	content := &core.Content{ID: "ok-id"}
+	out, err := cp.Process(context.Background(), content)
+
+	require.NoError(t, err)
+	assert.Equal(t, content, out)
+	assert.InDelta(t, 0.85, content.Reliability, 1e-6)
+}


### PR DESCRIPTION
## 연관 이슈
- #67

<br>

## 구현 내용

이슈 #67 의 원래 범위(크롤러 boundary)를 시스템 전반으로 확대하여, `internal/crawler/core.CrawlerError` 를 시스템 표준 구조화 에러로 정착시켰습니다.

### 1. 에러 인프라 보강 (`internal/crawler/core/errors.go`)

- 누락된 카테고리 생성자 **8종** 추가:
  - `NewValidationError`, `NewDatabaseError`, `NewQueueError`, `NewStorageError`, `NewConfigError`, `NewInternalError`, `NewTimeoutError`, `NewForbiddenError`
- 에러 코드를 **상수화** (이전엔 `errors-handling.md` 의 doc-only 였음):
  - `CodeNetConnRefused`(`NET_001`) ~ `CodeInternal`(`INTERNAL_001`)
  - 로그/메트릭에서 카디널리티가 안정적이도록 문자열 리터럴 흩어짐 방지
- `CrawlerError.Error()` 가 `Err == nil` 일 때 `": <nil>"` 깨진 표현을 출력하지 않도록 분기 추가

### 2. Boundary 에러 변환

| 파일 | 변경 |
|---|---|
| `internal/crawler/core/extractor.go` | pkg/links wrapper boundary 에서 `NewParseError(CodeParseHTML, ...)` / `NewInternalError` 로 변환 (이슈 명시) |
| `internal/processor/validate/validator.go` | 검증 실패를 `NewValidationError` 로 반환, 첫 번째 룰 기반 코드 부여 (`min_length`→`VAL_003`, `required`→`VAL_001`, `spam_*`→`VAL_006`, threshold 미달→`VAL_005`) |
| `internal/storage/service/content.go` | 외부 노출 메소드 6개 모두 `NewStorageError(CodeStorageRead/Write, ...)` 적용 |
| `internal/storage/service/raw_content.go` | 외부 노출 메소드 5개 모두 동일 패턴 적용 |

### 3. 레이어 규칙 명문화 (`.claude/rules/04-error-handling.md`)

이슈 항목 "fmt.Errorf 유지가 적절한 내부 레이어 기준 명문화" 를 충족하기 위해 새 섹션 추가:

- **MUST `CrawlerError`**: `internal/crawler/`(fetch/parse), `internal/processor/validate/`(검증), `internal/storage/service/`(boundary)
- **MAY `fmt.Errorf` 유지**: `pkg/` generic 유틸 (`pkg/queue`, `pkg/links`, `pkg/redis`, `pkg/config`) — `pkg/` 는 도메인 의존성이 없어야 하므로 `internal/crawler/core` import 금지. 호출하는 internal/ boundary 에서 변환.
- `internal/` 의 비-boundary helper 도 fmt.Errorf 유지 가능
- `errors.As` / `errors.Is` 사용 패턴 (카테고리 분기 / 코드 매칭) 예시 포함

### 4. 의도적으로 변환하지 않은 부분

- `pkg/queue/{producer,consumer}.go`, `pkg/links/extractor.go`, `pkg/redis/*` — 위 레이어 규칙에 따라 fmt.Errorf 유지. 호출하는 internal/ 측에서 boundary 변환 수행.
- `internal/classifier/*`, `internal/publisher/*` — 이슈 본문에 명시된 fmt.Errorf 유지 대상.

<br>

## CI / 머지 게이트 점검

> [CI 운영 규약](docs/ci/conventions.md) 및 [Required Status Checks 단일 소스](docs/ci/status-checks.md)에 따라 작성합니다.

### 변경 영향 범위
- 영향 패키지/모듈: `internal/crawler/core`, `internal/processor/validate`, `internal/storage/service`, `.claude/rules`
- 위험도(택1): `Medium` — 에러 타입이 변경되어 errors.As 의존 코드(retry 로직, DLQ 라우팅) 의 동작이 달라질 수 있으나, 모든 변경은 `*core.CrawlerError` 로 수렴하므로 errors.As 패턴은 보존됨

### Required Status Checks
- 통과 확인 대상 (PR Checks 탭에서 확인):
  - [ ] `Commit Lint`
  - [ ] `PR Title Lint`
  - [ ] `Format Check`
  - [ ] `Build`
  - [ ] `Test`
  - [ ] `Lint`

검증 (로컬):
- `gofmt -l .` 변경 없음
- `go build ./...` 통과
- `go test ./test/...` 17개 패키지 전부 통과
- `go test -race ./test/...` 17개 패키지 전부 통과 (race detector)

### 롤백 계획
- 단일 PR 단위 revert 로 즉시 원복.
- 추가 보강 PR 에서 새 카테고리(예: classifier, publisher) 를 점진 적용 가능하도록 errors.go 의 생성자 시그니처를 안정화함.

<br>

## TODO
- (Follow-up 가능) `internal/classifier`, `internal/publisher` boundary 에 동일 규칙 적용 검토 — 본 PR 의 범위 외이며 별도 이슈로 분리 권장

<br>

## 논의 사항
- `pkg/queue` 의 fmt.Errorf 유지가 적절한지 — generic 유틸이지만 시스템 핵심 의존이므로, 향후 pkg/errs(또는 errors 공유 패키지) 도입 시 변환을 재검토.
- `CrawlerError` 라는 타입 이름이 시스템 전반에 사용되기엔 오해 소지가 있음. 본 PR 에서는 doc 으로만 정정하고 rename 은 별도 이슈로 분리(파급 큼).

<br>