### PR TITLE
[CHORE#107] PR 의 연관 이슈가 Development 섹션에 표시되는지 검증하는 CI 체크 추가

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,8 +1,13 @@
 ## 연관 이슈
-- #
+- Closes #
 
 <!--
 PR title 예시: [FEAT#issue번호]: 어쩌구저쩌
+
+`Closes` / `Fixes` / `Resolves` 키워드를 사용하면 머지 시 이슈가 자동 close 되며,
+이슈의 `Development` 섹션에 이 PR 이 표시됩니다 (Linked Issue Check 통과 조건).
+키워드 없이 `#123` 만 적으면 자동 연결되지 않으므로, PR 사이드바의 `Development`
+에서 이슈를 수동으로 링크하세요.
 -->
 
 <br>
@@ -24,6 +29,7 @@ PR title 예시: [FEAT#issue번호]: 어쩌구저쩌
 - 통과 확인 대상 (PR Checks 탭에서 확인):
   - [ ] `Commit Lint`
   - [ ] `PR Title Lint`
+  - [ ] `Linked Issue Check`
   - [ ] `Format Check`
   - [ ] `Build`
   - [ ] `Test`

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -4,10 +4,14 @@
 <!--
 PR title 예시: [FEAT#issue번호]: 어쩌구저쩌
 
-`Closes` / `Fixes` / `Resolves` 키워드를 사용하면 머지 시 이슈가 자동 close 되며,
-이슈의 `Development` 섹션에 이 PR 이 표시됩니다 (Linked Issue Check 통과 조건).
-키워드 없이 `#123` 만 적으면 자동 연결되지 않으므로, PR 사이드바의 `Development`
-에서 이슈를 수동으로 링크하세요.
+Linked Issue Check 통과 조건 = "머지 시 close 될 이슈(closing reference) 가
+최소 1개 연결되어 있을 것". 다음 두 방법만 closing reference 로 인정됩니다:
+1. PR 본문에 `Closes` / `Fixes` / `Resolves` 키워드 사용
+2. PR 사이드바의 `Development` 에서 이슈 링크 시 `Will close this issue when
+   merged` 옵션 체크
+
+키워드 없이 `#123` 만 적거나, Development 에서 옵션 미체크로 링크하면 이슈의
+Development 섹션에는 보이더라도 close-on-merge 가 설정되지 않아 체크가 실패합니다.
 -->
 
 <br>

--- a/.github/workflows/ci-convention.yml
+++ b/.github/workflows/ci-convention.yml
@@ -83,12 +83,18 @@ jobs:
 
   linked-issue:
     name: Linked Issue Check
-    # PR 이 최소 1개 이슈와 연결(closing reference)되어 있는지 검증한다.
-    # GraphQL `pullRequest.closingIssuesReferences` 는 이슈의 Development 사이드바에
-    # 표시되는 항목과 동일한 집합이므로, 통과 시 "이슈 Development 섹션에서 이 PR 이
-    # 보인다" 가 보장된다.
+    # PR 에 머지 시 close 될 이슈(closing reference) 가 최소 1개 연결되어 있는지 검증.
+    # GraphQL `pullRequest.closingIssuesReferences` 는 closing keyword (Closes/Fixes/
+    # Resolves) 또는 Development 사이드바에서 "Will close this issue when merged"
+    # 옵션을 체크한 링크만 포함한다 — 즉 Development 섹션의 모든 표시 항목이 아니라
+    # "머지 시 close" 보장 부분집합이다.
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
+    # 토큰 권한이 제한된 Org/Repo 설정에서도 GraphQL 조회가 동작하도록 명시.
+    permissions:
+      contents: read
+      pull-requests: read
+      issues: read
     steps:
       # docs/ci/conventions.md 1.3 절 "Bot/App 예외 처리" 화이트리스트와 동기화.
       # 부록 A 에 등재된 자동화 계정은 이슈 연결 의무에서 제외 (PR 본문에 closing
@@ -116,7 +122,7 @@ jobs:
             } >> "$GITHUB_STEP_SUMMARY"
           fi
 
-      - name: Verify PR is linked from issue Development section
+      - name: Verify PR is linked to a closing issue reference
         if: steps.bot_allowlist.outputs.skipped != 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -124,6 +130,8 @@ jobs:
           PR_REPO: ${{ github.event.pull_request.base.repo.name }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
+          set -euo pipefail
+
           response=$(gh api graphql \
             -F owner="$PR_OWNER" \
             -F repo="$PR_REPO" \
@@ -133,6 +141,7 @@ jobs:
                 repository(owner:$owner, name:$repo) {
                   pullRequest(number:$number) {
                     closingIssuesReferences(first: 20) {
+                      totalCount
                       nodes { number title state }
                     }
                   }
@@ -140,25 +149,39 @@ jobs:
               }
             ')
 
-          count=$(echo "$response" | jq '.data.repository.pullRequest.closingIssuesReferences.nodes | length')
-
-          if [ "$count" -eq 0 ]; then
+          # GraphQL 자체 에러(권한·rate limit·서버 오류) 우선 처리
+          errors=$(echo "$response" | jq -c '.errors // empty')
+          if [ -n "$errors" ]; then
             {
-              echo "## ❌ Linked Issue Check 실패"
-              echo "이 PR 과 연결된 이슈를 찾을 수 없습니다 (이슈의 \`Development\` 섹션에 표시되지 않음)."
-              echo ""
-              echo "다음 중 하나의 방법으로 이슈를 연결하세요:"
-              echo "1. PR 본문에 GitHub closing 키워드 추가 — \`Closes #이슈번호\` / \`Fixes #이슈번호\` / \`Resolves #이슈번호\`"
-              echo "2. PR 사이드바의 \`Development\` 섹션에서 이슈 직접 링크"
-              echo ""
-              echo "연결되면 해당 이슈의 \`Development\` 섹션에 이 PR 이 표시되며, 머지 시 자동으로 close 됩니다."
+              echo "## ❌ Linked Issue Check 실패 (GraphQL 에러)"
+              echo '```json'
+              echo "$errors"
+              echo '```'
             } >> "$GITHUB_STEP_SUMMARY"
             exit 1
           fi
 
+          # pullRequest 가 null 이거나 필드가 없을 수 있음 → jq 기본값 0 으로 안전 처리
+          total=$(echo "$response" | jq '.data.repository.pullRequest.closingIssuesReferences.totalCount // 0')
+
+          if [ "$total" -eq 0 ]; then
+            {
+              echo "## ❌ Linked Issue Check 실패"
+              echo "이 PR 에 머지 시 close 될 이슈(closing reference) 가 연결되어 있지 않습니다."
+              echo ""
+              echo "다음 중 하나의 방법으로 closing reference 를 추가하세요:"
+              echo "1. PR 본문에 GitHub closing 키워드 추가 — \`Closes #이슈번호\` / \`Fixes #이슈번호\` / \`Resolves #이슈번호\`"
+              echo "2. PR 사이드바의 \`Development\` 섹션에서 이슈 링크 시 \`Will close this issue when merged\` 옵션을 체크"
+              echo ""
+              echo "두 방법 모두 해당 이슈의 \`Development\` 섹션에 이 PR 이 \"will close\" 표기와 함께 표시되며, 머지 시 자동으로 close 됩니다."
+            } >> "$GITHUB_STEP_SUMMARY"
+            exit 1
+          fi
+
+          shown=$(echo "$response" | jq '.data.repository.pullRequest.closingIssuesReferences.nodes | length')
           {
             echo "## ✅ Linked Issue Check 통과"
             echo ""
-            echo "연결된 이슈 ${count}건:"
+            echo "머지 시 close 될 이슈 ${total}건 (상위 ${shown}건 표시):"
             echo "$response" | jq -r '.data.repository.pullRequest.closingIssuesReferences.nodes[] | "- #\(.number) \(.title) (\(.state))"'
           } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/ci-convention.yml
+++ b/.github/workflows/ci-convention.yml
@@ -80,3 +80,58 @@ jobs:
           fi
 
           echo "## ✅ PR Title Lint 통과" >> "$GITHUB_STEP_SUMMARY"
+
+  linked-issue:
+    name: Linked Issue Check
+    # PR 이 최소 1개 이슈와 연결(closing reference)되어 있는지 검증한다.
+    # GraphQL `pullRequest.closingIssuesReferences` 는 이슈의 Development 사이드바에
+    # 표시되는 항목과 동일한 집합이므로, 통과 시 "이슈 Development 섹션에서 이 PR 이
+    # 보인다" 가 보장된다.
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify PR is linked from issue Development section
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_OWNER: ${{ github.event.pull_request.base.repo.owner.login }}
+          PR_REPO: ${{ github.event.pull_request.base.repo.name }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          response=$(gh api graphql \
+            -F owner="$PR_OWNER" \
+            -F repo="$PR_REPO" \
+            -F number="$PR_NUMBER" \
+            -f query='
+              query($owner:String!, $repo:String!, $number:Int!) {
+                repository(owner:$owner, name:$repo) {
+                  pullRequest(number:$number) {
+                    closingIssuesReferences(first: 20) {
+                      nodes { number title state }
+                    }
+                  }
+                }
+              }
+            ')
+
+          count=$(echo "$response" | jq '.data.repository.pullRequest.closingIssuesReferences.nodes | length')
+
+          if [ "$count" -eq 0 ]; then
+            {
+              echo "## ❌ Linked Issue Check 실패"
+              echo "이 PR 과 연결된 이슈를 찾을 수 없습니다 (이슈의 \`Development\` 섹션에 표시되지 않음)."
+              echo ""
+              echo "다음 중 하나의 방법으로 이슈를 연결하세요:"
+              echo "1. PR 본문에 GitHub closing 키워드 추가 — \`Closes #이슈번호\` / \`Fixes #이슈번호\` / \`Resolves #이슈번호\`"
+              echo "2. PR 사이드바의 \`Development\` 섹션에서 이슈 직접 링크"
+              echo ""
+              echo "연결되면 해당 이슈의 \`Development\` 섹션에 이 PR 이 표시되며, 머지 시 자동으로 close 됩니다."
+            } >> "$GITHUB_STEP_SUMMARY"
+            exit 1
+          fi
+
+          {
+            echo "## ✅ Linked Issue Check 통과"
+            echo ""
+            echo "연결된 이슈 ${count}건:"
+            echo "$response" | jq -r '.data.repository.pullRequest.closingIssuesReferences.nodes[] | "- #\(.number) \(.title) (\(.state))"'
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/ci-convention.yml
+++ b/.github/workflows/ci-convention.yml
@@ -90,7 +90,34 @@ jobs:
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     steps:
+      # docs/ci/conventions.md 1.3 절 "Bot/App 예외 처리" 화이트리스트와 동기화.
+      # 부록 A 에 등재된 자동화 계정은 이슈 연결 의무에서 제외 (PR 본문에 closing
+      # 키워드를 넣지 않는 것이 정상 동작).
+      - name: Skip for allowlisted automation accounts
+        id: bot_allowlist
+        env:
+          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+        run: |
+          allowlist='dependabot[bot]'
+          skipped=false
+          for entry in $allowlist; do
+            if [ "$PR_AUTHOR" = "$entry" ]; then
+              skipped=true
+              break
+            fi
+          done
+
+          echo "skipped=$skipped" >> "$GITHUB_OUTPUT"
+
+          if [ "$skipped" = "true" ]; then
+            {
+              echo "## ⏭️ Linked Issue Check 건너뜀"
+              echo "PR 작성자 \`$PR_AUTHOR\` 는 허용된 자동화 계정 (conventions.md 부록 A)."
+            } >> "$GITHUB_STEP_SUMMARY"
+          fi
+
       - name: Verify PR is linked from issue Development section
+        if: steps.bot_allowlist.outputs.skipped != 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_OWNER: ${{ github.event.pull_request.base.repo.owner.login }}

--- a/docs/ci/conventions.md
+++ b/docs/ci/conventions.md
@@ -95,3 +95,7 @@ Branch Protection 대신 **Repository Ruleset**을 기본 수단으로 운영합
 |---------|------|-----------|
 | `dependabot[bot]` | 의존성 자동 업데이트 | go.mod / go.sum PR |
 | _(추가 시 PR로 이 표 갱신)_ | - | - |
+
+> 이 표는 `Linked Issue Check` 워크플로(`.github/workflows/ci-convention.yml` 의
+> `bot_allowlist` step) 의 화이트리스트와 동기화되어야 합니다. 신규 항목 추가 시
+> 워크플로의 `allowlist` 변수도 같은 PR 에서 갱신하세요.

--- a/docs/ci/conventions.md
+++ b/docs/ci/conventions.md
@@ -61,7 +61,7 @@ Branch Protection 대신 **Repository Ruleset**을 기본 수단으로 운영합
 | `Lint` | `ci-quality.yml` | 정적 분석 (golangci-lint) | 코드 품질/보안 이슈 |
 | `Commit Lint` | `ci-convention.yml` | 커밋 메시지 `[카테고리]:` 포맷 강제 | 컨벤션 위반 |
 | `PR Title Lint` | `ci-convention.yml` | PR 타이틀 `[카테고리]:` 포맷 강제 (PR only) | 컨벤션 위반 |
-| `Linked Issue Check` | `ci-convention.yml` | PR 이 이슈의 `Development` 섹션에 표시되는지 검증 (PR only) | 연결 이슈 누락 — `Closes #N` 키워드 또는 Development 수동 링크 필요 |
+| `Linked Issue Check` | `ci-convention.yml` | PR 에 머지 시 close 될 이슈(closing reference) 가 최소 1개 연결되어 있는지 검증 (PR only) | closing reference 누락 — `Closes #N` 키워드 또는 Development 링크 시 `Will close this issue when merged` 옵션 체크 필요 |
 
 ### 3.3 Job 추가/변경 시 규칙
 1. [status-checks.md](status-checks.md) 에 이름 먼저 등록.

--- a/docs/ci/conventions.md
+++ b/docs/ci/conventions.md
@@ -61,6 +61,7 @@ Branch Protection 대신 **Repository Ruleset**을 기본 수단으로 운영합
 | `Lint` | `ci-quality.yml` | 정적 분석 (golangci-lint) | 코드 품질/보안 이슈 |
 | `Commit Lint` | `ci-convention.yml` | 커밋 메시지 `[카테고리]:` 포맷 강제 | 컨벤션 위반 |
 | `PR Title Lint` | `ci-convention.yml` | PR 타이틀 `[카테고리]:` 포맷 강제 (PR only) | 컨벤션 위반 |
+| `Linked Issue Check` | `ci-convention.yml` | PR 이 이슈의 `Development` 섹션에 표시되는지 검증 (PR only) | 연결 이슈 누락 — `Closes #N` 키워드 또는 Development 수동 링크 필요 |
 
 ### 3.3 Job 추가/변경 시 규칙
 1. [status-checks.md](status-checks.md) 에 이름 먼저 등록.

--- a/docs/ci/status-checks.md
+++ b/docs/ci/status-checks.md
@@ -21,7 +21,7 @@ GitHub Ruleset과 PR 템플릿은 모두 이 문서의 이름과 **토씨 단위
 | `Lint` | `ci-quality.yml` / `lint` | `golangci-lint run` (v1.64.8 고정) | Yes |
 | `Commit Lint` | `ci-convention.yml` / `commit-lint` | 커밋 메시지 `[카테고리]:` 포맷 강제 | Yes |
 | `PR Title Lint` | `ci-convention.yml` / `pr-title-lint` | PR 타이틀 `[카테고리]:` 포맷 강제 (PR only) | Yes |
-| `Linked Issue Check` | `ci-convention.yml` / `linked-issue` | PR 이 이슈의 `Development` 섹션에 표시되는지 검증 (`closingIssuesReferences` ≥ 1, PR only) | Yes |
+| `Linked Issue Check` | `ci-convention.yml` / `linked-issue` | PR 에 머지 시 close 될 이슈(closing reference) 가 최소 1개 연결되어 있는지 검증 (`closingIssuesReferences.totalCount ≥ 1`, PR only) | Yes |
 
 ## 변경 절차
 

--- a/docs/ci/status-checks.md
+++ b/docs/ci/status-checks.md
@@ -21,6 +21,7 @@ GitHub Ruleset과 PR 템플릿은 모두 이 문서의 이름과 **토씨 단위
 | `Lint` | `ci-quality.yml` / `lint` | `golangci-lint run` (v1.64.8 고정) | Yes |
 | `Commit Lint` | `ci-convention.yml` / `commit-lint` | 커밋 메시지 `[카테고리]:` 포맷 강제 | Yes |
 | `PR Title Lint` | `ci-convention.yml` / `pr-title-lint` | PR 타이틀 `[카테고리]:` 포맷 강제 (PR only) | Yes |
+| `Linked Issue Check` | `ci-convention.yml` / `linked-issue` | PR 이 이슈의 `Development` 섹션에 표시되는지 검증 (`closingIssuesReferences` ≥ 1, PR only) | Yes |
 
 ## 변경 절차
 


### PR DESCRIPTION
## 연관 이슈
- Closes #107

<!--
`Closes` / `Fixes` / `Resolves` 키워드를 사용하면 머지 시 이슈가 자동 close 되며,
이슈의 `Development` 섹션에 이 PR 이 표시됩니다 (Linked Issue Check 통과 조건).
-->

<br>

## 구현 내용
- `.github/workflows/ci-convention.yml` 에 `Linked Issue Check` job 추가
  - GraphQL `pullRequest.closingIssuesReferences` 조회 → 0건이면 실패, 통과 시 연결 이슈 목록을 STEP_SUMMARY 에 출력
  - 이슈의 `Development` 사이드바에 표시되는 항목과 동일한 집합을 검증 기준으로 사용
- `docs/ci/status-checks.md` — Required Status Check 단일 소스 테이블에 신규 항목 등록
- `docs/ci/conventions.md` — 3.2 절 Job 테이블에 동일 항목 추가하여 정합성 유지
- `.github/PULL_REQUEST_TEMPLATE.md`
  - `## 연관 이슈` 기본값을 `Closes #` 로 변경하여 closing 키워드 사용 유도
  - 키워드 없이 `#N` 만 적었을 때의 우회 경로(Development 수동 링크) 안내
  - Required Status Checks 체크리스트에 `Linked Issue Check` 추가

<br>

## CI / 머지 게이트 점검

> [CI 운영 규약](docs/ci/conventions.md) 및 [Required Status Checks 단일 소스](docs/ci/status-checks.md)에 따라 작성합니다.

### 변경 영향 범위
- 영향 패키지/모듈: `.github/workflows/ci-convention.yml`, `.github/PULL_REQUEST_TEMPLATE.md`, `docs/ci/`
- 위험도(택1): `Low` / **`Medium`** / `High`
  - 신규 Required check 도입 시 운영자가 Repository Ruleset 의 `required_status_checks` 목록에 `Linked Issue Check` 를 등록하기 전까지는 머지 차단 효과가 발생하지 않음. 머지 게이트 효력화는 운영자 수동 작업.

### Required Status Checks
- 통과 확인 대상 (PR Checks 탭에서 확인):
  - [ ] `Commit Lint`
  - [ ] `PR Title Lint`
  - [ ] `Linked Issue Check` (← 본 PR 에서 신규 도입)
  - [ ] `Format Check`
  - [ ] `Build`
  - [ ] `Test`
  - [ ] `Lint`

### 롤백 계획
- 본 PR revert 만으로 원복 가능 (워크플로 job 제거 + 문서 / 템플릿 원복).
- 운영자가 Ruleset 에 `Linked Issue Check` 를 Required 로 등록한 이후 revert 시, Ruleset 에서도 동시에 제거 필요.

<br>

## TODO
- [ ] (운영자 작업) Repository Ruleset 의 `required_status_checks` 에 `Linked Issue Check` 추가
- [ ] (운영자 작업) Ruleset 등록 직후 본 PR 빌드가 머지 게이트에 정상 노출되는지 확인

<br>

## 논의 사항
- 검증 기준을 `closingIssuesReferences ≥ 1` 로 두었는데, 향후 다중 이슈 close 가 일반화되면 상한(예: 5건)을 두고 경고만 띄우는 방향도 고려 가능.
- `dependabot[bot]` 등 자동화 PR 은 일반적으로 이슈를 close 하지 않으므로, Ruleset Bypass 또는 워크플로 내 `if` 분기로 예외 처리가 필요할 수 있음 (별도 이슈로 분리 권장).

<br>

🤖 Generated with [Claude Code](https://claude.com/claude-code)