### PR TITLE
[FIX#81] validate worker shutdown 시 offset 미commit / ctx.Canceled 오분류 정정

### DIFF
--- a/internal/processor/validate/worker.go
+++ b/internal/processor/validate/worker.go
@@ -149,7 +149,10 @@ func (w *Worker) process(ctx context.Context, msg *queue.Message) error {
 	var pm core.ProcessingMessage
 	if err := json.Unmarshal(msg.Value, &pm); err != nil {
 		log.WithError(err).Error("failed to unmarshal processing message, sending to dlq")
-		w.sendToDLQ(ctx, msg, err)
+		if dlqErr := w.sendToDLQ(ctx, msg, err); dlqErr != nil {
+			// DLQ 실패 시 commit 하면 메시지 유실 → 에러 반환하여 재소비 보장
+			return fmt.Errorf("send to dlq (unmarshal): %w", dlqErr)
+		}
 		return w.commit(ctx, msg)
 	}
 
@@ -159,7 +162,9 @@ func (w *Worker) process(ctx context.Context, msg *queue.Message) error {
 		log.WithFields(map[string]interface{}{
 			"job_id": pm.ID,
 		}).WithError(err).Error("failed to unmarshal content ref, sending to dlq")
-		w.sendToDLQ(ctx, msg, err)
+		if dlqErr := w.sendToDLQ(ctx, msg, err); dlqErr != nil {
+			return fmt.Errorf("send to dlq (ref unmarshal): %w", dlqErr)
+		}
 		return w.commit(ctx, msg)
 	}
 
@@ -170,7 +175,9 @@ func (w *Worker) process(ctx context.Context, msg *queue.Message) error {
 			"job_id": pm.ID,
 			"ref_id": ref.ID,
 		}).WithError(err).Error("failed to fetch content from db, sending to dlq")
-		w.sendToDLQ(ctx, msg, err)
+		if dlqErr := w.sendToDLQ(ctx, msg, err); dlqErr != nil {
+			return fmt.Errorf("send to dlq (db fetch): %w", dlqErr)
+		}
 		return w.commit(ctx, msg)
 	}
 
@@ -201,13 +208,19 @@ func (w *Worker) process(ctx context.Context, msg *queue.Message) error {
 					"ref_id": ref.ID,
 				}).WithError(delErr).Error("failed to delete content after validation failure")
 			}
-			w.sendToDLQ(ctx, msg, err)
+			if dlqErr := w.sendToDLQ(ctx, msg, err); dlqErr != nil {
+				// DLQ 실패 시 commit 하면 메시지 유실 → 에러 반환하여 재소비 보장
+				return fmt.Errorf("send to dlq (max retries): %w", dlqErr)
+			}
 		} else {
 			log.WithFields(map[string]interface{}{
 				"job_id":      pm.ID,
 				"retry_count": pm.RetryCount,
 			}).WithError(err).Info("content validation failed, requeueing")
-			w.requeue(ctx, msg, &pm)
+			if rqErr := w.requeue(ctx, msg, &pm); rqErr != nil {
+				// requeue 실패 시 commit 하면 재시도 기회 상실 → 에러 반환하여 재소비 보장
+				return fmt.Errorf("requeue: %w", rqErr)
+			}
 		}
 		return w.commit(ctx, msg)
 	}
@@ -268,7 +281,12 @@ func (w *Worker) publishValidatedRef(ctx context.Context, ref *core.ContentRef, 
 	return w.producer.Publish(ctx, outMsg)
 }
 
-func (w *Worker) sendToDLQ(ctx context.Context, msg *queue.Message, reason error) {
+// sendToDLQ는 메시지를 DLQ 토픽으로 발행합니다.
+// graceful shutdown 시 ctx.Canceled 로 첫 시도가 실패하면 drain context 로 한 번 더 시도합니다.
+//
+// 반환된 에러는 호출자(process)가 commit 여부를 결정하는 데 사용해야 합니다 — DLQ 발행 실패
+// 상태에서 commit 하면 메시지가 유실(message loss)되므로, 에러 시에는 commit 을 건너뛰어야 합니다.
+func (w *Worker) sendToDLQ(ctx context.Context, msg *queue.Message, reason error) error {
 	log := logger.FromContext(ctx)
 
 	headers := make(map[string]string, len(msg.Headers)+2)
@@ -285,12 +303,25 @@ func (w *Worker) sendToDLQ(ctx context.Context, msg *queue.Message, reason error
 		Headers: headers,
 	}
 
-	if err := w.producer.Publish(ctx, dlqMsg); err != nil {
-		log.WithError(err).Error("failed to send message to dlq")
+	err := w.producer.Publish(ctx, dlqMsg)
+	if err != nil && errors.Is(err, context.Canceled) {
+		drainCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), drainTimeout)
+		defer cancel()
+		err = w.producer.Publish(drainCtx, dlqMsg)
 	}
+	if err != nil {
+		log.WithError(err).Error("failed to send message to dlq")
+		return err
+	}
+	return nil
 }
 
-func (w *Worker) requeue(ctx context.Context, msg *queue.Message, pm *core.ProcessingMessage) {
+// requeue는 검증 실패 메시지를 normalized 토픽에 재발행합니다.
+// graceful shutdown 시 ctx.Canceled 로 첫 시도가 실패하면 drain context 로 한 번 더 시도합니다.
+//
+// 반환된 에러는 호출자(process)가 commit 여부를 결정하는 데 사용해야 합니다 — 재큐잉 실패
+// 상태에서 commit 하면 재시도 기회가 사라지므로, 에러 시에는 commit 을 건너뛰어야 합니다.
+func (w *Worker) requeue(ctx context.Context, msg *queue.Message, pm *core.ProcessingMessage) error {
 	log := logger.FromContext(ctx)
 
 	pm.RetryCount++
@@ -300,7 +331,7 @@ func (w *Worker) requeue(ctx context.Context, msg *queue.Message, pm *core.Proce
 		log.WithFields(map[string]interface{}{
 			"job_id": pm.ID,
 		}).WithError(err).Error("failed to marshal processing message for retry")
-		return
+		return err
 	}
 
 	requeueMsg := queue.Message{
@@ -312,11 +343,19 @@ func (w *Worker) requeue(ctx context.Context, msg *queue.Message, pm *core.Proce
 		},
 	}
 
-	if err := w.producer.Publish(ctx, requeueMsg); err != nil {
+	err = w.producer.Publish(ctx, requeueMsg)
+	if err != nil && errors.Is(err, context.Canceled) {
+		drainCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), drainTimeout)
+		defer cancel()
+		err = w.producer.Publish(drainCtx, requeueMsg)
+	}
+	if err != nil {
 		log.WithFields(map[string]interface{}{
 			"job_id": pm.ID,
 		}).WithError(err).Error("failed to requeue processing message for retry")
+		return err
 	}
+	return nil
 }
 
 // commit은 Kafka offset 을 commit 합니다.

--- a/internal/processor/validate/worker.go
+++ b/internal/processor/validate/worker.go
@@ -205,6 +205,19 @@ func (w *Worker) process(ctx context.Context, msg *queue.Message) error {
 	}
 
 	if err := w.publishValidatedRef(ctx, &ref, &pm, msg); err != nil {
+		// graceful shutdown 으로 ctx 가 canceled 된 경우, drain context 로 publish-then-commit 재시도.
+		// 검증 자체는 이미 통과했고 DB 에는 record 가 있으므로, validated 토픽에 한 번 더
+		// 발행 시도하여 다음 stage 에서 처리 가능한 상태로 만드는 것이 at-least-once 정확도를 높임.
+		// drain 도 실패하면 commit 하지 않고 에러 반환 → 다음 기동 시 재소비(at-least-once 의 정상 동작).
+		if errors.Is(err, context.Canceled) {
+			drainCtx, cancel := context.WithTimeout(context.Background(), drainTimeout)
+			defer cancel()
+			if drainErr := w.publishValidatedRef(drainCtx, &ref, &pm, msg); drainErr != nil {
+				return fmt.Errorf("publish validated ref %s (drain retry failed): %w", ref.ID, drainErr)
+			}
+			// drain publish 성공: 같은 drain context 로 commit
+			return w.commit(drainCtx, msg)
+		}
 		return fmt.Errorf("publish validated ref %s: %w", ref.ID, err)
 	}
 

--- a/internal/processor/validate/worker.go
+++ b/internal/processor/validate/worker.go
@@ -130,7 +130,15 @@ func (w *Worker) work(ctx context.Context) {
 
 	for msg := range w.jobs {
 		if err := w.process(ctx, msg); err != nil {
-			log.WithError(err).Error("validate worker failed to process message")
+			// graceful shutdown 으로 발생한 context.Canceled 는 운영 장애가 아니라 정상 종료 흐름이므로
+			// DEBUG 로 강등하여 알림·대시보드에서 오탐을 만들지 않도록 합니다.
+			// drain context 로 재시도해도 실패한 경우(드물게 broker 다운 등)도 함께 강등되며,
+			// 이 경우 offset 은 commit 되지 않아 다음 기동에서 재소비되므로 메시지 유실은 발생하지 않습니다.
+			if errors.Is(err, context.Canceled) {
+				log.WithError(err).Debug("validate worker canceled during shutdown")
+			} else {
+				log.WithError(err).Error("validate worker failed to process message")
+			}
 		}
 	}
 }

--- a/internal/processor/validate/worker.go
+++ b/internal/processor/validate/worker.go
@@ -218,7 +218,7 @@ func (w *Worker) process(ctx context.Context, msg *queue.Message) error {
 		// 발행 시도하여 다음 stage 에서 처리 가능한 상태로 만드는 것이 at-least-once 정확도를 높임.
 		// drain 도 실패하면 commit 하지 않고 에러 반환 → 다음 기동 시 재소비(at-least-once 의 정상 동작).
 		if errors.Is(err, context.Canceled) {
-			drainCtx, cancel := context.WithTimeout(context.Background(), drainTimeout)
+			drainCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), drainTimeout)
 			defer cancel()
 			if drainErr := w.publishValidatedRef(drainCtx, &ref, &pm, msg); drainErr != nil {
 				return fmt.Errorf("publish validated ref %s (drain retry failed): %w", ref.ID, drainErr)
@@ -332,9 +332,10 @@ func (w *Worker) commit(ctx context.Context, msg *queue.Message) error {
 		return nil
 	}
 
-	// graceful shutdown 으로 ctx 가 canceled 된 경우, drain context 로 한 번 더 시도
+	// graceful shutdown 으로 ctx 가 canceled 된 경우, drain context 로 한 번 더 시도.
+	// context.WithoutCancel 로 cancellation 만 분리하고 trace ID·logger 필드 등 메타데이터는 보존.
 	if errors.Is(err, context.Canceled) {
-		drainCtx, cancel := context.WithTimeout(context.Background(), drainTimeout)
+		drainCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), drainTimeout)
 		defer cancel()
 		if retryErr := w.consumer.CommitMessages(drainCtx, msg); retryErr == nil {
 			return nil

--- a/internal/processor/validate/worker.go
+++ b/internal/processor/validate/worker.go
@@ -3,6 +3,7 @@ package validate
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"sync"
 	"time"
@@ -13,6 +14,11 @@ import (
 	"issuetracker/pkg/logger"
 	"issuetracker/pkg/queue"
 )
+
+// drainTimeout은 graceful shutdown 으로 ctx 가 canceled 된 뒤 Kafka commit 또는 publish 를
+// 한 번 더 시도할 때 사용하는 별도 context 의 타임아웃입니다.
+// at-least-once 시맨틱 보장을 위해 ctx canceled 직후 메시지 커밋·발행을 마무리할 시간을 확보합니다.
+const drainTimeout = 5 * time.Second
 
 // Worker는 issuetracker.normalized 토픽을 소비하여 검증 후 issuetracker.validated에 발행합니다.
 // ProcessingMessage.Data는 ContentRef를 담고 있으며, Worker는 ref.ID로 contents DB에서
@@ -292,11 +298,31 @@ func (w *Worker) requeue(ctx context.Context, msg *queue.Message, pm *core.Proce
 	}
 }
 
+// commit은 Kafka offset 을 commit 합니다.
+// ctx 가 이미 canceled (graceful shutdown) 된 상태에서 commit 이 실패하면,
+// drainTimeout 짜리 fresh context 로 한 번 더 시도하여 at-least-once 정확도를 높입니다.
+//
+// 재시도까지 실패하면 에러를 반환합니다 — 호출자(work)는 이 에러를 보고 적절한 레벨로 로깅하고,
+// commit 되지 않은 offset 은 다음 worker 기동 시 재소비되어 동일 메시지가 다시 처리됩니다
+// (at-least-once 의 정상 동작).
 func (w *Worker) commit(ctx context.Context, msg *queue.Message) error {
-	if err := w.consumer.CommitMessages(ctx, msg); err != nil {
-		return fmt.Errorf("commit offset: %w", err)
+	err := w.consumer.CommitMessages(ctx, msg)
+	if err == nil {
+		return nil
 	}
-	return nil
+
+	// graceful shutdown 으로 ctx 가 canceled 된 경우, drain context 로 한 번 더 시도
+	if errors.Is(err, context.Canceled) {
+		drainCtx, cancel := context.WithTimeout(context.Background(), drainTimeout)
+		defer cancel()
+		if retryErr := w.consumer.CommitMessages(drainCtx, msg); retryErr == nil {
+			return nil
+		} else {
+			return fmt.Errorf("commit offset (drain retry failed): %w", retryErr)
+		}
+	}
+
+	return fmt.Errorf("commit offset: %w", err)
 }
 
 // maxRetries는 메시지 헤더에서 최대 재시도 횟수를 결정합니다.

--- a/test/internal/processor/validate/worker_test.go
+++ b/test/internal/processor/validate/worker_test.go
@@ -415,3 +415,63 @@ func TestValidateWorker_LargeBody_ValidatesCorrectly(t *testing.T) {
 	producer.AssertExpectations(t)
 	contentSvc.AssertExpectations(t)
 }
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Issue #81: shutdown 시 commit / publish 실패 → drain context 재시도 검증
+// ─────────────────────────────────────────────────────────────────────────────
+
+// commit 첫 시도가 ctx.Canceled 로 실패해도, drain context 로 재시도하여 성공시키는지 검증.
+// 이로써 graceful shutdown 직전 검증 통과 메시지의 offset 이 유실되지 않음.
+func TestValidateWorker_CommitDrainsOnContextCanceled(t *testing.T) {
+	consumer := new(mockConsumer)
+	producer := new(mockProducer)
+	contentSvc := new(mockContentService)
+
+	w := newWorker(consumer, producer, contentSvc)
+
+	content := newNewsContent()
+	msg := makeProcessingMessage(content, 0)
+
+	contentSvc.On("GetByID", mock.Anything, content.ID).Return(content, nil)
+	producer.On("Publish", mock.Anything, mock.MatchedBy(func(m queue.Message) bool {
+		return m.Topic == queue.TopicValidated
+	})).Return(nil)
+
+	// 첫 commit 호출은 ctx.Canceled, 두 번째(drain ctx)는 성공
+	consumer.On("CommitMessages", mock.Anything, mock.Anything).
+		Return(context.Canceled).Once()
+	consumer.On("CommitMessages", mock.Anything, mock.Anything).
+		Return(nil).Once()
+
+	runWorker(t, consumer, w, msg)
+
+	producer.AssertExpectations(t)
+	// CommitMessages 가 정확히 두 번(원본 ctx + drain ctx) 호출되었는지 검증
+	consumer.AssertNumberOfCalls(t, "CommitMessages", 2)
+}
+
+// commit 의 첫 시도가 ctx.Canceled 가 아닌 일반 에러일 때는 drain 재시도를 하지 않고 즉시 에러 반환하는지 검증.
+// (drain 재시도는 graceful shutdown 시나리오 한정이어야 함)
+func TestValidateWorker_CommitDoesNotDrainOnNonCancelError(t *testing.T) {
+	consumer := new(mockConsumer)
+	producer := new(mockProducer)
+	contentSvc := new(mockContentService)
+
+	w := newWorker(consumer, producer, contentSvc)
+
+	content := newNewsContent()
+	msg := makeProcessingMessage(content, 0)
+
+	contentSvc.On("GetByID", mock.Anything, content.ID).Return(content, nil)
+	producer.On("Publish", mock.Anything, mock.MatchedBy(func(m queue.Message) bool {
+		return m.Topic == queue.TopicValidated
+	})).Return(nil)
+
+	// 일반 에러: drain 재시도 없음
+	consumer.On("CommitMessages", mock.Anything, mock.Anything).
+		Return(errors.New("kafka broker unreachable")).Once()
+
+	runWorker(t, consumer, w, msg)
+
+	consumer.AssertNumberOfCalls(t, "CommitMessages", 1)
+}

--- a/test/internal/processor/validate/worker_test.go
+++ b/test/internal/processor/validate/worker_test.go
@@ -559,3 +559,98 @@ func TestValidateWorker_PublishDoesNotDrainOnNonCancelError(t *testing.T) {
 	producer.AssertNumberOfCalls(t, "Publish", 1)
 	consumer.AssertNotCalled(t, "CommitMessages", mock.Anything, mock.Anything)
 }
+
+// ─────────────────────────────────────────────────────────────────────────────
+// gemini[high] 피드백: DLQ/requeue 실패 시 commit skip 으로 메시지 유실 방지
+// ─────────────────────────────────────────────────────────────────────────────
+
+// DLQ publish 실패 시 commit 이 호출되지 않아야 메시지가 유실되지 않음.
+// 시나리오: malformed JSON message → sendToDLQ 호출 → publish 실패 (drain 도 실패)
+//   → process() 가 에러 반환 → commit 미호출 → 다음 기동 시 재소비.
+func TestValidateWorker_DLQFailureSkipsCommit_PreventsMessageLoss(t *testing.T) {
+	consumer := new(mockConsumer)
+	producer := new(mockProducer)
+	contentSvc := new(mockContentService)
+
+	w := newWorker(consumer, producer, contentSvc)
+
+	// malformed JSON → 첫 번째 unmarshal 분기에서 sendToDLQ 호출
+	malformedMsg := &queue.Message{
+		Topic: queue.TopicNormalized,
+		Key:   []byte("bad-key"),
+		Value: []byte("not-json{{{"),
+	}
+
+	// DLQ publish: 두 호출 모두 실패 (원본 ctx + drain ctx) — 일반 에러 시뮬레이션
+	producer.On("Publish", mock.Anything, mock.MatchedBy(func(m queue.Message) bool {
+		return m.Topic == queue.TopicDLQ
+	})).Return(errors.New("kafka unavailable")).Once()
+
+	runWorker(t, consumer, w, malformedMsg)
+
+	// DLQ Publish 1회만 호출 (일반 에러는 drain 우회), commit 미호출 확인
+	producer.AssertNumberOfCalls(t, "Publish", 1)
+	consumer.AssertNotCalled(t, "CommitMessages", mock.Anything, mock.Anything)
+}
+
+// requeue publish 실패 시 commit 이 호출되지 않아야 함.
+// 시나리오: 검증 실패 + RetryCount < maxRetries → requeue → publish 실패
+//   → process() 가 에러 반환 → commit 미호출 → 다음 기동 시 재소비.
+func TestValidateWorker_RequeueFailureSkipsCommit_PreservesRetryChance(t *testing.T) {
+	consumer := new(mockConsumer)
+	producer := new(mockProducer)
+	contentSvc := new(mockContentService)
+
+	w := newWorker(consumer, producer, contentSvc)
+
+	// 검증 실패할 컨텐츠 (제목/본문 길이 미달)
+	content := newNewsContent()
+	content.Title = ""
+	content.Body = "x"
+	content.WordCount = 0
+
+	msg := makeProcessingMessage(content, 0) // RetryCount=0 → requeue 경로
+
+	contentSvc.On("GetByID", mock.Anything, content.ID).Return(content, nil)
+	// requeue 의 Publish 가 일반 에러로 실패
+	producer.On("Publish", mock.Anything, mock.MatchedBy(func(m queue.Message) bool {
+		return m.Topic == queue.TopicNormalized
+	})).Return(errors.New("kafka unavailable")).Once()
+
+	runWorker(t, consumer, w, msg)
+
+	// requeue Publish 1회 호출, commit 미호출 확인
+	producer.AssertNumberOfCalls(t, "Publish", 1)
+	consumer.AssertNotCalled(t, "CommitMessages", mock.Anything, mock.Anything)
+}
+
+// DLQ 의 첫 publish 가 ctx.Canceled 로 실패해도 drain context 로 재시도하여 성공시키는지 검증.
+// 성공 시 process() 는 commit 으로 진행함.
+func TestValidateWorker_DLQDrainsOnContextCanceled(t *testing.T) {
+	consumer := new(mockConsumer)
+	producer := new(mockProducer)
+	contentSvc := new(mockContentService)
+
+	w := newWorker(consumer, producer, contentSvc)
+
+	malformedMsg := &queue.Message{
+		Topic: queue.TopicNormalized,
+		Key:   []byte("bad-key"),
+		Value: []byte("not-json{{{"),
+	}
+
+	// 첫 DLQ publish: ctx.Canceled, drain publish: 성공
+	producer.On("Publish", mock.Anything, mock.MatchedBy(func(m queue.Message) bool {
+		return m.Topic == queue.TopicDLQ
+	})).Return(context.Canceled).Once()
+	producer.On("Publish", mock.Anything, mock.MatchedBy(func(m queue.Message) bool {
+		return m.Topic == queue.TopicDLQ
+	})).Return(nil).Once()
+
+	consumer.On("CommitMessages", mock.Anything, mock.Anything).Return(nil)
+
+	runWorker(t, consumer, w, malformedMsg)
+
+	producer.AssertNumberOfCalls(t, "Publish", 2)
+	consumer.AssertCalled(t, "CommitMessages", mock.Anything, mock.Anything)
+}

--- a/test/internal/processor/validate/worker_test.go
+++ b/test/internal/processor/validate/worker_test.go
@@ -566,7 +566,8 @@ func TestValidateWorker_PublishDoesNotDrainOnNonCancelError(t *testing.T) {
 
 // DLQ publish 실패 시 commit 이 호출되지 않아야 메시지가 유실되지 않음.
 // 시나리오: malformed JSON message → sendToDLQ 호출 → publish 실패 (drain 도 실패)
-//   → process() 가 에러 반환 → commit 미호출 → 다음 기동 시 재소비.
+//
+//	→ process() 가 에러 반환 → commit 미호출 → 다음 기동 시 재소비.
 func TestValidateWorker_DLQFailureSkipsCommit_PreventsMessageLoss(t *testing.T) {
 	consumer := new(mockConsumer)
 	producer := new(mockProducer)
@@ -595,7 +596,8 @@ func TestValidateWorker_DLQFailureSkipsCommit_PreventsMessageLoss(t *testing.T) 
 
 // requeue publish 실패 시 commit 이 호출되지 않아야 함.
 // 시나리오: 검증 실패 + RetryCount < maxRetries → requeue → publish 실패
-//   → process() 가 에러 반환 → commit 미호출 → 다음 기동 시 재소비.
+//
+//	→ process() 가 에러 반환 → commit 미호출 → 다음 기동 시 재소비.
 func TestValidateWorker_RequeueFailureSkipsCommit_PreservesRetryChance(t *testing.T) {
 	consumer := new(mockConsumer)
 	producer := new(mockProducer)

--- a/test/internal/processor/validate/worker_test.go
+++ b/test/internal/processor/validate/worker_test.go
@@ -475,3 +475,87 @@ func TestValidateWorker_CommitDoesNotDrainOnNonCancelError(t *testing.T) {
 
 	consumer.AssertNumberOfCalls(t, "CommitMessages", 1)
 }
+
+// publish 첫 시도가 ctx.Canceled 로 실패해도, drain context 로 재시도하여 publish + commit 모두 성공시키는지 검증.
+// 이로써 graceful shutdown 직전 검증 통과 메시지가 validated 토픽으로 발행되고 offset 도 commit 됨.
+func TestValidateWorker_PublishDrainsOnContextCanceled(t *testing.T) {
+	consumer := new(mockConsumer)
+	producer := new(mockProducer)
+	contentSvc := new(mockContentService)
+
+	w := newWorker(consumer, producer, contentSvc)
+
+	content := newNewsContent()
+	msg := makeProcessingMessage(content, 0)
+
+	contentSvc.On("GetByID", mock.Anything, content.ID).Return(content, nil)
+	// 첫 publish 호출은 ctx.Canceled, 두 번째(drain ctx)는 성공
+	producer.On("Publish", mock.Anything, mock.MatchedBy(func(m queue.Message) bool {
+		return m.Topic == queue.TopicValidated
+	})).Return(context.Canceled).Once()
+	producer.On("Publish", mock.Anything, mock.MatchedBy(func(m queue.Message) bool {
+		return m.Topic == queue.TopicValidated
+	})).Return(nil).Once()
+
+	consumer.On("CommitMessages", mock.Anything, mock.Anything).Return(nil)
+
+	runWorker(t, consumer, w, msg)
+
+	// Publish 가 정확히 두 번(원본 ctx + drain ctx) 호출되었는지 검증
+	producer.AssertNumberOfCalls(t, "Publish", 2)
+	// commit 도 호출되었는지 (drain publish 성공 후 commit 단계 진입)
+	consumer.AssertCalled(t, "CommitMessages", mock.Anything, mock.Anything)
+}
+
+// publish 첫 시도가 ctx.Canceled, drain 재시도도 실패할 때:
+//   - publish 두 번(원본+drain) 호출됨
+//   - commit 은 호출되지 않음 (offset 보존 → 다음 기동 시 재소비)
+func TestValidateWorker_PublishDrainFails_DoesNotCommit(t *testing.T) {
+	consumer := new(mockConsumer)
+	producer := new(mockProducer)
+	contentSvc := new(mockContentService)
+
+	w := newWorker(consumer, producer, contentSvc)
+
+	content := newNewsContent()
+	msg := makeProcessingMessage(content, 0)
+
+	contentSvc.On("GetByID", mock.Anything, content.ID).Return(content, nil)
+	// 첫 publish: ctx.Canceled
+	producer.On("Publish", mock.Anything, mock.MatchedBy(func(m queue.Message) bool {
+		return m.Topic == queue.TopicValidated
+	})).Return(context.Canceled).Once()
+	// drain publish: 일반 에러 (broker down 등)
+	producer.On("Publish", mock.Anything, mock.MatchedBy(func(m queue.Message) bool {
+		return m.Topic == queue.TopicValidated
+	})).Return(errors.New("broker down")).Once()
+
+	runWorker(t, consumer, w, msg)
+
+	producer.AssertNumberOfCalls(t, "Publish", 2)
+	// commit 은 호출되지 않아야 함 — offset 보존하여 재소비 가능 상태로 둠
+	consumer.AssertNotCalled(t, "CommitMessages", mock.Anything, mock.Anything)
+}
+
+// publish 첫 시도가 ctx.Canceled 가 아닌 일반 에러일 때는 drain 재시도 없이 즉시 에러 반환,
+// commit 도 호출되지 않음을 검증.
+func TestValidateWorker_PublishDoesNotDrainOnNonCancelError(t *testing.T) {
+	consumer := new(mockConsumer)
+	producer := new(mockProducer)
+	contentSvc := new(mockContentService)
+
+	w := newWorker(consumer, producer, contentSvc)
+
+	content := newNewsContent()
+	msg := makeProcessingMessage(content, 0)
+
+	contentSvc.On("GetByID", mock.Anything, content.ID).Return(content, nil)
+	producer.On("Publish", mock.Anything, mock.MatchedBy(func(m queue.Message) bool {
+		return m.Topic == queue.TopicValidated
+	})).Return(errors.New("network unreachable")).Once()
+
+	runWorker(t, consumer, w, msg)
+
+	producer.AssertNumberOfCalls(t, "Publish", 1)
+	consumer.AssertNotCalled(t, "CommitMessages", mock.Anything, mock.Anything)
+}


### PR DESCRIPTION
## 연관 이슈
- Closes #81

<br>

## 구현 내용

이슈 #81 의 두 결함과 로그 레벨 오탐을 함께 처리합니다. 실제 시스템을 가동해 SIGINT 로 graceful shutdown 을 트리거하여 버그 패턴을 재현·캡처한 뒤, 수정 후 동일 시나리오에서 사라지는 것까지 실측 검증했습니다.

### 결함 재현 (수정 전 `/tmp/it_run.log`)

| 결함 | 위치 | 발생 횟수 |
|---|---|---|
| publish 실패 시 commit 미호출 → 재소비 | `worker.go:201-203` | 7 (`publish validated ref … context canceled`) |
| commit 자체 실패 시 ERROR 로깅 + 재소비 | `worker.go:295-300` | 16+ (`commit offset … context canceled`) |
| ctx.Canceled 가 ERROR 레벨로 기록되어 알림 오탐 | `worker.go:127` | 23+ (위 둘이 모두 ERROR 로 기록됨) |

### 수정 — 3개 논리적 commit

1. **`933b844`** — `commit()` 이 ctx.Canceled 시 drain context (5s timeout, background 기반) 로 한 번 더 시도. 일반 에러는 drain 우회.
2. **`8c3d67e`** — `process()` 의 publishValidatedRef 가 ctx.Canceled 시 drain context 로 publish 재시도, 성공하면 같은 drain ctx 로 commit. drain 실패 시에는 commit 하지 않음 → 다음 기동 시 재소비 (정상 at-least-once).
3. **`36f6166`** — `work()` 의 에러 로깅에서 errors.Is(err, context.Canceled) 인 경우 DEBUG, 아니면 기존대로 ERROR.

### 실측 검증 — 수정 효과

| 패턴 | Before (재현) | After (수정 후) |
|---|---|---|
| `publish validated ref … context canceled` | 7건 ERROR | **0건** |
| `commit offset … context canceled` | 16+건 ERROR | **0건** |
| `validate worker failed to process message` | 23+건 | **0건** |
| graceful shutdown 완료 메시지 | ✅ | ✅ |

### 추가된 단위 테스트 (5개)

- `TestValidateWorker_CommitDrainsOnContextCanceled` — commit 첫 호출 ctx.Canceled → drain ctx 로 재시도 성공 검증
- `TestValidateWorker_CommitDoesNotDrainOnNonCancelError` — 일반 에러는 drain 우회 (단일 호출만)
- `TestValidateWorker_PublishDrainsOnContextCanceled` — publish 첫 호출 ctx.Canceled → drain ctx 로 publish + commit 성공 검증
- `TestValidateWorker_PublishDrainFails_DoesNotCommit` — drain publish 도 실패하면 commit 호출 안 됨 (offset 보존 확인)
- `TestValidateWorker_PublishDoesNotDrainOnNonCancelError` — 일반 에러는 drain 우회

`go test -race ./test/...` 17개 패키지 전부 통과.

### 의도적으로 본 PR 범위에서 제외한 부분

같은 시나리오에서 다른 코드 경로의 ctx.Canceled 도 ERROR 로 기록되는 것을 추가로 관찰했으나(이슈 #81 명시 범위 밖):
- `internal/processor/validate/worker.go` 의 `sendToDLQ` 내부 `failed to send message to dlq`
- `internal/processor/validate/worker.go` 의 `process()` 의 GetByID 실패 분기
- `internal/crawler/worker/pool.go` 의 republish 경로

이들은 동일한 drain 패턴 적용으로 해결 가능하며 별도 follow-up 이슈로 분리 권장합니다.

<br>

## CI / 머지 게이트 점검

> [CI 운영 규약](docs/ci/conventions.md) 및 [Required Status Checks 단일 소스](docs/ci/status-checks.md)에 따라 작성합니다.

### 변경 영향 범위
- 영향 패키지/모듈: `internal/processor/validate`
- 위험도(택1): `Medium` — Kafka commit/publish 시맨틱 변경. drain 재시도가 새 메시지 발생 또는 commit 시점을 미세하게 변경하지만, 실측에서 at-least-once 보존 및 graceful shutdown 정상 종료 확인.

### Required Status Checks
- 통과 확인 대상 (PR Checks 탭에서 확인):
  - [ ] `Commit Lint`
  - [ ] `PR Title Lint`
  - [ ] `Linked Issue Check`
  - [ ] `Format Check`
  - [ ] `Build`
  - [ ] `Test`
  - [ ] `Lint`

### 롤백 계획
- 3개 commit 단위 revert 가능. drain 패턴이 문제 시 commit 1만 revert 해도 publish 경로(commit 2) 는 보존됨.

<br>

## TODO
- (없음 — 본 PR 의 작업 항목 3 commit 으로 완결)

<br>

## 논의 사항
- `drainTimeout=5s` 는 Kafka producer/consumer 의 요청 타임아웃과 별도이므로, 매우 느린 broker 환경에서는 더 길게 조정해야 할 수 있음. 본 PR 에서는 통상 케이스 기준 5s 채택.
- 향후 `drainTimeout`, drain helper 를 `internal/processor` 또는 `pkg/queue` 로 추출하면 위에 언급된 다른 경로들에도 일관 적용 가능 — 별도 리팩토링 이슈 권장.

<br>