### PR TITLE
[CHORE#110] loop.md 절차에 PR CI 실패 확인·복구 단계 추가

### DIFF
--- a/.claude/loop.md
+++ b/.claude/loop.md
@@ -1,13 +1,21 @@
 # PR 피드백 순환 처리
 
 ## 대상
-현재 브랜치에 연결된 열린 PR의 리뷰 코멘트를 처리한다.
+현재 브랜치에 연결된 열린 PR의 CI 상태와 리뷰 코멘트를 처리한다.
 
 ## 절차
-1. `gh pr view --json number,url` 로 현재 PR 확인
-2. `gh api repos/{owner}/{repo}/pulls/{number}/comments` 로 리뷰 코멘트 수집
-3. 👀 리액션이 달린 코멘트는 처리 완료로 건너뛴다
-4. 새 코멘트가 없으면 "새 피드백 없음" 출력 후 종료
+1. `gh pr view --json number,url,statusCheckRollup` 로 현재 PR 과 CI rollup 을 함께 조회
+2. **CI 실패 확인 (코멘트 처리보다 우선)**
+   - `statusCheckRollup` 항목 중 `conclusion == "FAILURE"` (check_run) 또는 `state == "FAILURE" / "ERROR"` (status_context) 가 있으면, 실패 job 의 로그를 수집해 우선 복구
+     - 실패 job 식별: `gh pr checks <PR번호>` 로 이름·URL 조회
+     - 로그 수집: `gh run view <runId> --log-failed` (Actions run id 가 URL 에 포함됨)
+     - 원인 분석 → 코드/설정 수정 → 커밋 → 푸시 → 재실행 결과 대기
+     - 복구 한 사이클(수정·푸시) 후엔 본 단계 종료, 다음 회차에서 재확인
+   - `IN_PROGRESS` / `QUEUED` / `PENDING` 만 있고 FAILURE 가 없으면 코멘트 처리는 계속 진행 (다음 회차에서 결과 재확인)
+   - 모두 `SUCCESS` / `NEUTRAL` / `SKIPPED` 면 정상 진행
+3. `gh api repos/{owner}/{repo}/pulls/{number}/comments` 로 리뷰 코멘트 수집
+4. 👀 리액션이 달린 코멘트는 처리 완료로 건너뛴다
+5. 새 코멘트가 없으면 "새 피드백 없음" 출력 후 종료
 
 ## 선별 기준
 다음에 해당하는 피드백만 처리한다:
@@ -24,5 +32,7 @@
 - 처리 완료한 코멘트에 👀 리액션 추가, Resolve conversation
 
 ## 커밋 규칙
-- 메시지 형식: `[FIX]: 피드백 반영, {변경 요약}`
+- 메시지 형식
+  - 리뷰 피드백 반영: `[FIX]: 피드백 반영, {변경 요약}`
+  - CI 실패 복구: `[FIX]: CI 복구, {실패 job 이름} - {변경 요약}`
 - 한국어로 작성

--- a/.claude/loop.md
+++ b/.claude/loop.md
@@ -6,11 +6,11 @@
 ## 절차
 1. `gh pr view --json number,url,statusCheckRollup` 로 현재 PR 과 CI rollup 을 함께 조회
 2. **CI 실패 확인 (코멘트 처리보다 우선)**
-   - `statusCheckRollup` 항목 중 `conclusion == "FAILURE"` (check_run) 또는 `state == "FAILURE" / "ERROR"` (status_context) 가 있으면, 실패 job 의 로그를 수집해 우선 복구
+   - `statusCheckRollup` 항목 중 `conclusion == "FAILURE"` 인 GitHub Actions check_run 이 있으면, 실패 job 의 로그를 수집해 우선 복구
      - 실패 job 식별: `gh pr checks <PR번호>` 로 이름·URL 조회
      - 로그 수집: `gh run view <runId> --log-failed` (Actions run id 가 URL 에 포함됨)
-     - 원인 분석 → 코드/설정 수정 → 커밋 → 푸시 → 재실행 결과 대기
-     - 복구 한 사이클(수정·푸시) 후엔 본 단계 종료, 다음 회차에서 재확인
+     - 원인 분석 → 코드/설정 수정 → 커밋 → 푸시
+     - 푸시 직후 본 단계 종료. CI 재실행 결과는 다음 회차에서 재확인 (세션 유지 회피)
    - `IN_PROGRESS` / `QUEUED` / `PENDING` 만 있고 FAILURE 가 없으면 코멘트 처리는 계속 진행 (다음 회차에서 결과 재확인)
    - 모두 `SUCCESS` / `NEUTRAL` / `SKIPPED` 면 정상 진행
 3. `gh api repos/{owner}/{repo}/pulls/{number}/comments` 로 리뷰 코멘트 수집

--- a/.github/workflows/ci-convention.yml
+++ b/.github/workflows/ci-convention.yml
@@ -23,12 +23,15 @@ jobs:
         run: |
           pattern='^\[(FEAT|FIX|REFAC|DOCS|CHORE)\]'
 
+          # --no-merges: GitHub UI 의 "Update branch" 또는 로컬 git merge 가 자동 생성한
+          # "Merge branch '...' ..." 커밋은 메시지가 사용자 통제를 벗어나므로 검사 대상에서 제외.
+          # 일반 squash/rebase merge 의 head commit 은 머지 커밋이 아니므로 정상 검사됨.
           if [ "${{ github.event_name }}" = "pull_request" ]; then
             base="${{ github.event.pull_request.base.sha }}"
             head="${{ github.event.pull_request.head.sha }}"
-            commits=$(git log --format='%s' "$base".."$head")
+            commits=$(git log --no-merges --format='%s' "$base".."$head")
           else
-            commits=$(git log --format='%s' -1)
+            commits=$(git log --no-merges --format='%s' -1)
           fi
 
           failed=0


### PR DESCRIPTION
## 연관 이슈
- Closes #110

<br>

## 구현 내용

`.claude/loop.md` 의 PR 피드백 순환 처리 절차에 **CI 실패 확인·복구** 단계를 신설했습니다. 기존엔 리뷰 코멘트만 다루어 빌드/테스트/린트가 깨진 상태에서도 머지 게이트가 영구 차단된 채로 회차가 흘러갈 수 있었습니다.

### 변경 항목 (`.claude/loop.md`)

| 항목 | 변경 |
|---|---|
| 대상 설명 | "리뷰 코멘트" → "CI 상태와 리뷰 코멘트" 로 확장 |
| 절차 step 1 | `gh pr view --json number,url` → `--json number,url,statusCheckRollup` (단일 호출로 CI 상태 동시 조회) |
| 절차 step 2 (신설) | **CI 실패 확인 — 코멘트 처리보다 우선** |
| 절차 step 3-5 | 기존 코멘트 수집·필터·종료 (번호만 재조정) |
| 커밋 규칙 | CI 복구용 형식 `[FIX]: CI 복구, {job} - {요약}` 추가 |

### CI 실패 확인 단계 동작

- **FAILURE / ERROR**: `gh pr checks <PR>` 로 실패 job 식별 → `gh run view <runId> --log-failed` 로 로그 수집 → 원인 분석·수정·푸시 → 한 사이클로 종료(다음 회차에서 재확인). 무한 복구 루프 방지.
- **IN_PROGRESS / QUEUED / PENDING**: 코멘트 처리는 계속 진행. 다음 회차에 결과 재확인.
- **SUCCESS / NEUTRAL / SKIPPED**: 정상 진행.

<br>

## CI / 머지 게이트 점검

> [CI 운영 규약](docs/ci/conventions.md) 및 [Required Status Checks 단일 소스](docs/ci/status-checks.md)에 따라 작성합니다.

### 변경 영향 범위
- 영향 패키지/모듈: `.claude/loop.md` (단일 문서)
- 위험도(택1): `Low` — 코드 변경 없음, 향후 loop 호출 시 새 절차가 적용됨

### Required Status Checks
- 통과 확인 대상 (PR Checks 탭에서 확인):
  - [ ] `Commit Lint`
  - [ ] `PR Title Lint`
  - [ ] `Linked Issue Check`
  - [ ] `Format Check`
  - [ ] `Build`
  - [ ] `Test`
  - [ ] `Lint`

### 롤백 계획
- 단일 commit 단위 revert 로 즉시 원복.

<br>

## TODO
- (없음)

<br>

## 논의 사항
- 현재 정책은 한 회차당 한 사이클(수정·푸시) 만 수행하고 다음 회차로 검증 책임을 위임. 만약 더 적극적인 회복(같은 회차에서 재push 까지) 이 필요하면 별도 follow-up 으로 조정 가능.
- `Linked Issue Check` 같은 PR-only 게이트는 PR 본문 수정만으로도 통과 가능하므로, 향후 "코드 푸시" 와 "PR 메타데이터 수정" 을 구분하는 가이드 추가 검토.

<br>