### PR TITLE
[FEAT#41]: URL 정규화 — pkg/links Normalizer + 워커 풀 3 지점 적용

### DIFF
--- a/internal/crawler/worker/pool.go
+++ b/internal/crawler/worker/pool.go
@@ -9,6 +9,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"issuetracker/internal/crawler/core"
@@ -60,9 +61,10 @@ type KafkaConsumerPool struct {
 	jobLocker   JobLocker
 	urlCache    URLCache
 	// normalizer는 URL 정규화기입니다.
-	// nil 이면 정규화가 적용되지 않으며, 기존 동작이 유지됩니다.
-	// SetNormalizer 로 Start 호출 전에만 설정해야 합니다.
-	normalizer *links.Normalizer
+	// 미설정(nil) 이면 정규화가 적용되지 않으며, 기존 동작이 유지됩니다.
+	// atomic.Pointer 를 사용하여 polling/worker goroutine 의 동시 Load 와
+	// SetNormalizer 의 Store 사이에 race 가 발생하지 않도록 보장합니다.
+	normalizer atomic.Pointer[links.Normalizer]
 	// pollDone은 pollMessages goroutine이 완전히 종료됐음을 알리는 신호입니다.
 	// close(p.jobs) 전에 반드시 이 채널이 닫혔음을 확인해야 합니다.
 	pollDone chan struct{}
@@ -147,20 +149,21 @@ func NewKafkaConsumerPoolWithOptions(
 //  2. Content.CanonicalURL — publishNormalized 에서 Store 직전 (DB 중복 탐지)
 //  3. Kafka 파티션 키 — publishNormalized 에서 CanonicalURL 사용 (파티션 ordering)
 //
-// 동시성: Start 호출 전에만 설정해야 합니다.
-// Start 이후 호출은 polling/worker goroutine 과의 race를 유발할 수 있습니다.
+// 동시성: atomic.Pointer 기반 lock-free 설정/조회로 race-safe 합니다.
+// Start 이후 변경 시에도 worker goroutine 의 Load 와 race 가 발생하지 않습니다.
 func (p *KafkaConsumerPool) SetNormalizer(n *links.Normalizer) {
-	p.normalizer = n
+	p.normalizer.Store(n)
 }
 
 // normalizeURL은 normalizer가 설정된 경우 URL을 정규화하여 반환합니다.
 // normalizer 미설정 / 빈 URL / 정규화 실패 시 원본을 그대로 반환하여
 // 정규화 도입이 기존 fetch/저장 경로를 깨지 않도록 보장합니다.
 func (p *KafkaConsumerPool) normalizeURL(rawURL string) string {
-	if p.normalizer == nil || rawURL == "" {
+	n := p.normalizer.Load()
+	if n == nil || rawURL == "" {
 		return rawURL
 	}
-	normalized, err := p.normalizer.Normalize(rawURL)
+	normalized, err := n.Normalize(rawURL)
 	if err != nil || normalized == "" {
 		return rawURL
 	}

--- a/internal/crawler/worker/pool.go
+++ b/internal/crawler/worker/pool.go
@@ -455,17 +455,27 @@ func (p *KafkaConsumerPool) processJob(ctx context.Context, item jobItem) error 
 // 다운스트림 validator는 ref.ID로 DB에서 전체 데이터를 조회합니다.
 //
 // URL 정규화 (적용 지점 ②, ③):
-//   - CanonicalURL: content.URL 의 정규형으로 표준화 (DB 중복 탐지 정확도)
+//   - CanonicalURL: 파서가 채운 값(예: <link rel="canonical">)을 우선 정규화하고,
+//     비어있으면 content.URL 을 정규화하여 채움 (파서 결정 우선순위 보존)
 //   - Kafka 파티션 키: CanonicalURL 사용 (동일 기사가 동일 파티션으로 라우팅)
 //
-// normalizer 미설정 시 CanonicalURL = content.URL 로 fallback 되어 기존 동작 유지.
+// 주의: 현재 contents DB 의 unique 제약은 url 컬럼 (idx_contents_url) 이므로
+// CanonicalURL 정규화는 *DB 레벨* 중복 방지가 아닌 다운스트림 정규형 비교 및
+// 파티션 키 일관성에 기여합니다. DB 레벨 중복 방지는 별도 PR 에서 url 컬럼
+// 정규화 또는 unique 제약 변경으로 다뤄집니다.
+//
+// normalizer 미설정 시 normalizeURL 이 원본을 반환하여 기존 동작이 유지됩니다.
 func (p *KafkaConsumerPool) publishNormalized(ctx context.Context, content *core.Content, job *core.CrawlJob) error {
 	// 적용 지점 ②: CanonicalURL 정규화 (Store 직전)
-	// 파서는 일반적으로 CanonicalURL = content.URL 로 단순 복사하므로
-	// 본 boundary 에서 정규형을 강제하여 DB content unique 비교의 일관성을 확보합니다.
-	canonicalURL := p.normalizeURL(content.URL)
-	if canonicalURL != "" {
-		content.CanonicalURL = canonicalURL
+	// 우선순위: 파서가 채운 CanonicalURL > content.URL
+	// 파서가 <link rel="canonical"> 를 추출해 CanonicalURL 을 채운 경우 이를 보존하고,
+	// 비어있을 때만 content.URL 을 fallback 으로 사용합니다.
+	source := content.CanonicalURL
+	if source == "" {
+		source = content.URL
+	}
+	if normalized := p.normalizeURL(source); normalized != "" {
+		content.CanonicalURL = normalized
 	}
 
 	storedID, _, err := p.contentSvc.Store(ctx, content)

--- a/internal/crawler/worker/pool.go
+++ b/internal/crawler/worker/pool.go
@@ -13,6 +13,7 @@ import (
 
 	"issuetracker/internal/crawler/core"
 	"issuetracker/internal/storage/service"
+	"issuetracker/pkg/links"
 	"issuetracker/pkg/logger"
 	"issuetracker/pkg/queue"
 )
@@ -58,6 +59,10 @@ type KafkaConsumerPool struct {
 	cbRegistry  *CircuitBreakerRegistry
 	jobLocker   JobLocker
 	urlCache    URLCache
+	// normalizer는 URL 정규화기입니다.
+	// nil 이면 정규화가 적용되지 않으며, 기존 동작이 유지됩니다.
+	// SetNormalizer 로 Start 호출 전에만 설정해야 합니다.
+	normalizer *links.Normalizer
 	// pollDone은 pollMessages goroutine이 완전히 종료됐음을 알리는 신호입니다.
 	// close(p.jobs) 전에 반드시 이 채널이 닫혔음을 확인해야 합니다.
 	pollDone chan struct{}
@@ -132,6 +137,34 @@ func NewKafkaConsumerPoolWithOptions(
 		jobs:     make(chan jobItem, workerCount*2),
 		pollDone: make(chan struct{}),
 	}
+}
+
+// SetNormalizer는 URL 정규화기를 설정합니다.
+// nil 이거나 미호출 시 정규화는 적용되지 않으며, 기존 동작이 유지됩니다.
+//
+// 적용 지점:
+//  1. Target.URL — pollMessages 에서 unmarshal 직후 (URLCache·JobLocker 키 일관성)
+//  2. Content.CanonicalURL — publishNormalized 에서 Store 직전 (DB 중복 탐지)
+//  3. Kafka 파티션 키 — publishNormalized 에서 CanonicalURL 사용 (파티션 ordering)
+//
+// 동시성: Start 호출 전에만 설정해야 합니다.
+// Start 이후 호출은 polling/worker goroutine 과의 race를 유발할 수 있습니다.
+func (p *KafkaConsumerPool) SetNormalizer(n *links.Normalizer) {
+	p.normalizer = n
+}
+
+// normalizeURL은 normalizer가 설정된 경우 URL을 정규화하여 반환합니다.
+// normalizer 미설정 / 빈 URL / 정규화 실패 시 원본을 그대로 반환하여
+// 정규화 도입이 기존 fetch/저장 경로를 깨지 않도록 보장합니다.
+func (p *KafkaConsumerPool) normalizeURL(rawURL string) string {
+	if p.normalizer == nil || rawURL == "" {
+		return rawURL
+	}
+	normalized, err := p.normalizer.Normalize(rawURL)
+	if err != nil || normalized == "" {
+		return rawURL
+	}
+	return normalized
 }
 
 // Start는 worker goroutine들과 message polling goroutine을 시작합니다.
@@ -219,6 +252,12 @@ func (p *KafkaConsumerPool) pollMessages(ctx context.Context) {
 			}
 			continue
 		}
+
+		// 적용 지점 ①: Target.URL 정규화
+		// 다운스트림 모든 키(URLCache, JobLocker, Kafka 파티션)가 동일한 정규형을
+		// 사용하도록 가장 이른 시점에 한 번만 적용합니다.
+		// normalizer 미설정 시 원본이 반환되어 기존 동작이 유지됩니다.
+		job.Target.URL = p.normalizeURL(job.Target.URL)
 
 		select {
 		case p.jobs <- jobItem{msg: msg, job: job}:
@@ -414,7 +453,21 @@ func (p *KafkaConsumerPool) processJob(ctx context.Context, item jobItem) error 
 // publishNormalized는 Content를 contents DB에 저장한 뒤 ContentRef를
 // issuetracker.normalized 토픽에 ProcessingMessage로 발행합니다.
 // 다운스트림 validator는 ref.ID로 DB에서 전체 데이터를 조회합니다.
+//
+// URL 정규화 (적용 지점 ②, ③):
+//   - CanonicalURL: content.URL 의 정규형으로 표준화 (DB 중복 탐지 정확도)
+//   - Kafka 파티션 키: CanonicalURL 사용 (동일 기사가 동일 파티션으로 라우팅)
+//
+// normalizer 미설정 시 CanonicalURL = content.URL 로 fallback 되어 기존 동작 유지.
 func (p *KafkaConsumerPool) publishNormalized(ctx context.Context, content *core.Content, job *core.CrawlJob) error {
+	// 적용 지점 ②: CanonicalURL 정규화 (Store 직전)
+	// 파서는 일반적으로 CanonicalURL = content.URL 로 단순 복사하므로
+	// 본 boundary 에서 정규형을 강제하여 DB content unique 비교의 일관성을 확보합니다.
+	canonicalURL := p.normalizeURL(content.URL)
+	if canonicalURL != "" {
+		content.CanonicalURL = canonicalURL
+	}
+
 	storedID, _, err := p.contentSvc.Store(ctx, content)
 	if err != nil {
 		return fmt.Errorf("store content for job %s: %w", job.ID, err)
@@ -454,9 +507,18 @@ func (p *KafkaConsumerPool) publishNormalized(ctx context.Context, content *core
 		return fmt.Errorf("marshal processing message: %w", err)
 	}
 
+	// 적용 지점 ③: Kafka 파티션 키 — CanonicalURL 사용
+	// 동일 기사의 추적 파라미터/스킴 변형이 동일 파티션으로 라우팅되어
+	// ordering·CB·중복 처리 일관성이 보장됩니다.
+	// CanonicalURL 이 비어있으면 안전하게 content.URL 로 fallback 합니다.
+	partitionKey := content.CanonicalURL
+	if partitionKey == "" {
+		partitionKey = content.URL
+	}
+
 	msg := queue.Message{
 		Topic: queue.TopicNormalized,
-		Key:   []byte(content.URL),
+		Key:   []byte(partitionKey),
 		Value: pmBytes,
 		Headers: map[string]string{
 			"source":  content.SourceID,

--- a/pkg/links/normalizer.go
+++ b/pkg/links/normalizer.go
@@ -1,0 +1,221 @@
+package links
+
+import (
+	"fmt"
+	"net/url"
+	"strings"
+)
+
+// Normalizer는 URL 정규화를 수행합니다.
+// 추적 파라미터 제거, 프로토콜 정규화, trailing slash 제거 등을 통해
+// 동일 컨텐츠를 가리키는 URL이 항상 동일한 정규형을 갖도록 보장합니다.
+//
+// 사용 시점:
+//   - 중복 탐지 (URLCache, DB content unique constraint)
+//   - Kafka 파티션 키 일관성 (동일 기사가 동일 파티션으로 라우팅)
+//   - CanonicalURL 표준화 (다운스트림 비교)
+//
+// 기본 동작은 보수적이며 fetch 가능성을 깨지 않도록 설계되었습니다.
+// 자세한 옵션은 NewNormalizer 주석 참조.
+type Normalizer struct {
+	config normalizeConfig
+}
+
+// normalizeConfig는 Normalizer의 내부 설정을 보관합니다.
+// 외부에서 직접 변경할 수 없으며 NormalizeOption을 통해서만 구성됩니다.
+type normalizeConfig struct {
+	// hostAllowedParams는 호스트(소문자, www. 제거)별로
+	// 보존할 query 파라미터 키 집합을 매핑합니다.
+	// 비어있거나 호스트가 없으면 모든 query 파라미터를 제거합니다.
+	hostAllowedParams map[string]map[string]struct{}
+
+	forceHTTPS         bool
+	stripWWW           bool
+	stripTrailingSlash bool
+	stripFragment      bool
+}
+
+// NormalizeOption은 Normalizer의 동작을 변경하는 함수형 옵션입니다.
+type NormalizeOption func(*normalizeConfig)
+
+// WithAllowedParams는 특정 호스트에 대해 보존할 query 파라미터 이름을 등록합니다.
+// 호스트 매칭은 case-insensitive 이며 "www." 접두사는 자동으로 정규화됩니다.
+//
+// 예: 네이버 뉴스의 article_id, office_id는 컨텐츠 경로 분기에 필수이므로 보존:
+//
+//	WithAllowedParams("news.naver.com", "article_id", "office_id")
+//
+// 동일 호스트에 대해 여러 번 호출하면 파라미터 목록이 누적됩니다.
+func WithAllowedParams(host string, params ...string) NormalizeOption {
+	return func(c *normalizeConfig) {
+		if c.hostAllowedParams == nil {
+			c.hostAllowedParams = make(map[string]map[string]struct{})
+		}
+		key := normalizeHostKey(host)
+		set, ok := c.hostAllowedParams[key]
+		if !ok {
+			set = make(map[string]struct{}, len(params))
+			c.hostAllowedParams[key] = set
+		}
+		for _, p := range params {
+			set[p] = struct{}{}
+		}
+	}
+}
+
+// WithKeepHTTP는 http → https 강제 변환을 비활성화합니다.
+// http 전용 사이트(드물지만 존재)를 다룰 때 사용합니다.
+func WithKeepHTTP() NormalizeOption {
+	return func(c *normalizeConfig) { c.forceHTTPS = false }
+}
+
+// WithStripWWW는 호스트의 "www." 접두사 제거를 활성화합니다.
+// 기본값(off): 일부 호스트는 www 없이는 미해결되므로 fetch 안전을 위해 보수적.
+// 중복 탐지 강화 목적으로 활성화 가능.
+func WithStripWWW() NormalizeOption {
+	return func(c *normalizeConfig) { c.stripWWW = true }
+}
+
+// WithKeepTrailingSlash는 경로 끝 "/" 제거를 비활성화합니다.
+// 기본값(on): 안전. trailing slash로 컨텐츠가 달라지는 사이트에서 사용.
+func WithKeepTrailingSlash() NormalizeOption {
+	return func(c *normalizeConfig) { c.stripTrailingSlash = false }
+}
+
+// WithKeepFragment는 fragment("#...") 제거를 비활성화합니다.
+// 기본값(on): fragment는 클라이언트 사이드 처리로 서버 컨텐츠와 무관 — 보통 안전.
+func WithKeepFragment() NormalizeOption {
+	return func(c *normalizeConfig) { c.stripFragment = false }
+}
+
+// NewNormalizer는 새로운 Normalizer 인스턴스를 생성합니다.
+//
+// 기본 동작:
+//   - 모든 query 파라미터 제거 (per-host 화이트리스트 비어있음)
+//   - http → https 강제 변환 (forceHTTPS=true)
+//   - "www." 접두사 유지 (stripWWW=false, fetch 안전 우선)
+//   - 경로 끝 trailing slash 제거 (단, 루트 "/"는 유지)
+//   - fragment("#...") 제거
+//
+// 호출자는 WithAllowedParams 등으로 사이트별 예외를 등록할 수 있습니다.
+func NewNormalizer(opts ...NormalizeOption) *Normalizer {
+	cfg := normalizeConfig{
+		forceHTTPS:         true,
+		stripWWW:           false,
+		stripTrailingSlash: true,
+		stripFragment:      true,
+	}
+	for _, opt := range opts {
+		opt(&cfg)
+	}
+	return &Normalizer{config: cfg}
+}
+
+// Normalize는 URL을 정규화하여 반환합니다.
+//
+// 동작:
+//   - 빈 문자열 입력 → 빈 문자열 반환 (에러 없음)
+//   - 파싱 실패 → 에러 반환
+//   - host가 없는 상대 URL → 변경 없이 원본 반환 (정규화 대상 아님)
+//
+// 동일 컨텐츠를 가리키는 두 URL은 항상 동일한 정규형을 가져야 합니다.
+func (n *Normalizer) Normalize(rawURL string) (string, error) {
+	if rawURL == "" {
+		return "", nil
+	}
+
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return "", fmt.Errorf("parse url %q: %w", rawURL, err)
+	}
+
+	// 절대 URL이 아니면 정규화 대상이 아님 (host 없음)
+	if u.Host == "" {
+		return rawURL, nil
+	}
+
+	// scheme 정규화
+	if n.config.forceHTTPS && u.Scheme == "http" {
+		u.Scheme = "https"
+	}
+
+	// host 정규화: 소문자화 + 옵션에 따른 www. 제거
+	u.Host = strings.ToLower(u.Host)
+	if n.config.stripWWW {
+		u.Host = strings.TrimPrefix(u.Host, "www.")
+	}
+
+	// query 정규화: 화이트리스트에 없는 파라미터 제거 + 키 정렬
+	if u.RawQuery != "" {
+		u.RawQuery = n.filterQuery(u.Host, u.RawQuery)
+	}
+
+	// trailing slash 제거 (루트 경로 "/"는 보존)
+	if n.config.stripTrailingSlash && len(u.Path) > 1 && strings.HasSuffix(u.Path, "/") {
+		u.Path = strings.TrimRight(u.Path, "/")
+	}
+
+	// fragment 제거
+	if n.config.stripFragment {
+		u.Fragment = ""
+		u.RawFragment = ""
+	}
+
+	return u.String(), nil
+}
+
+// filterQuery는 호스트별 화이트리스트에 따라 query 파라미터를 필터링합니다.
+// url.Values.Encode 는 키 순으로 정렬된 결과를 반환하므로
+// 동일 컨텐츠는 항상 동일한 query 정규형을 갖습니다.
+func (n *Normalizer) filterQuery(host, rawQuery string) string {
+	allowed := n.allowedFor(host)
+	if len(allowed) == 0 {
+		// 화이트리스트 미등록 → 모든 파라미터 제거
+		return ""
+	}
+
+	values, err := url.ParseQuery(rawQuery)
+	if err != nil {
+		// 파싱 실패 시 안전하게 query 전체 제거
+		return ""
+	}
+
+	for k := range values {
+		if _, ok := allowed[k]; !ok {
+			values.Del(k)
+		}
+	}
+
+	if len(values) == 0 {
+		return ""
+	}
+	return values.Encode()
+}
+
+// allowedFor는 호스트에 대한 허용 파라미터 집합을 반환합니다.
+// 호스트는 normalizeHostKey로 정규화하여 매칭합니다.
+func (n *Normalizer) allowedFor(host string) map[string]struct{} {
+	if len(n.config.hostAllowedParams) == 0 {
+		return nil
+	}
+	return n.config.hostAllowedParams[normalizeHostKey(host)]
+}
+
+// normalizeHostKey는 호스트를 화이트리스트 매칭용 키로 정규화합니다.
+// 소문자화 + "www." 접두사 제거를 적용하여 등록자/검색자가
+// 동일 매칭을 얻도록 보장합니다.
+func normalizeHostKey(host string) string {
+	h := strings.ToLower(host)
+	return strings.TrimPrefix(h, "www.")
+}
+
+// defaultNormalizer는 NormalizeURL 패키지 헬퍼가 사용하는 기본 인스턴스입니다.
+// 화이트리스트가 비어있으므로 모든 query 파라미터가 제거됩니다.
+var defaultNormalizer = NewNormalizer()
+
+// NormalizeURL은 기본 옵션으로 URL을 정규화하는 패키지 레벨 헬퍼입니다.
+// 동일 옵션 조합으로 다회 호출 시에는 NewNormalizer 후 Normalize 호출이
+// 알로케이션 측면에서 효율적입니다.
+func NormalizeURL(rawURL string) (string, error) {
+	return defaultNormalizer.Normalize(rawURL)
+}

--- a/pkg/links/normalizer.go
+++ b/pkg/links/normalizer.go
@@ -40,6 +40,8 @@ type NormalizeOption func(*normalizeConfig)
 
 // WithAllowedParams는 특정 호스트에 대해 보존할 query 파라미터 이름을 등록합니다.
 // 호스트 매칭은 case-insensitive 이며 "www." 접두사는 자동으로 정규화됩니다.
+// 파라미터 키 매칭도 case-insensitive — 등록 시·필터링 시 모두 소문자로 정규화하여
+// `Article_ID` / `article_id` / `ARTICLE_ID` 가 동일하게 처리됩니다.
 //
 // 예: 네이버 뉴스의 article_id, office_id는 컨텐츠 경로 분기에 필수이므로 보존:
 //
@@ -58,7 +60,7 @@ func WithAllowedParams(host string, params ...string) NormalizeOption {
 			c.hostAllowedParams[key] = set
 		}
 		for _, p := range params {
-			set[p] = struct{}{}
+			set[normalizeParamKey(p)] = struct{}{}
 		}
 	}
 }
@@ -140,14 +142,23 @@ func (n *Normalizer) Normalize(rawURL string) (string, error) {
 	}
 
 	// host 정규화: 소문자화 + 옵션에 따른 www. 제거
-	u.Host = strings.ToLower(u.Host)
+	// u.Host 는 포트를 포함하므로 (예: "Example.com:8080"),
+	// 호스트만 소문자화하고 포트는 보존하여 fetch 가능성을 깨지 않습니다.
+	hostname := strings.ToLower(u.Hostname())
 	if n.config.stripWWW {
-		u.Host = strings.TrimPrefix(u.Host, "www.")
+		hostname = strings.TrimPrefix(hostname, "www.")
+	}
+	if port := u.Port(); port != "" {
+		u.Host = hostname + ":" + port
+	} else {
+		u.Host = hostname
 	}
 
 	// query 정규화: 화이트리스트에 없는 파라미터 제거 + 키 정렬
+	// 화이트리스트 매칭은 hostname (포트 제외) 기준 — 포트는 fetch 라우팅 정보일 뿐
+	// 컨텐츠 정체성에는 영향 없음.
 	if u.RawQuery != "" {
-		u.RawQuery = n.filterQuery(u.Host, u.RawQuery)
+		u.RawQuery = n.filterQuery(hostname, u.RawQuery)
 	}
 
 	// trailing slash 제거 (루트 경로 "/"는 보존)
@@ -167,6 +178,11 @@ func (n *Normalizer) Normalize(rawURL string) (string, error) {
 // filterQuery는 호스트별 화이트리스트에 따라 query 파라미터를 필터링합니다.
 // url.Values.Encode 는 키 순으로 정렬된 결과를 반환하므로
 // 동일 컨텐츠는 항상 동일한 query 정규형을 갖습니다.
+//
+// 키 매칭은 case-insensitive — `Article_ID`/`article_id` 가 동일하게 처리됩니다.
+// ParseQuery 실패 시:
+//   - 화이트리스트 호스트: 원본 rawQuery 보존 (필수 파라미터 손실 방지)
+//   - 미등록 호스트: 빈 문자열 (전부 제거 정책 유지)
 func (n *Normalizer) filterQuery(host, rawQuery string) string {
 	allowed := n.allowedFor(host)
 	if len(allowed) == 0 {
@@ -176,12 +192,13 @@ func (n *Normalizer) filterQuery(host, rawQuery string) string {
 
 	values, err := url.ParseQuery(rawQuery)
 	if err != nil {
-		// 파싱 실패 시 안전하게 query 전체 제거
-		return ""
+		// 화이트리스트 호스트의 ParseQuery 실패 시 원본을 유지하여
+		// 잘못된 파싱으로 인한 필수 파라미터 손실/fetch 실패를 방지합니다.
+		return rawQuery
 	}
 
 	for k := range values {
-		if _, ok := allowed[k]; !ok {
+		if _, ok := allowed[normalizeParamKey(k)]; !ok {
 			values.Del(k)
 		}
 	}
@@ -207,6 +224,12 @@ func (n *Normalizer) allowedFor(host string) map[string]struct{} {
 func normalizeHostKey(host string) string {
 	h := strings.ToLower(host)
 	return strings.TrimPrefix(h, "www.")
+}
+
+// normalizeParamKey는 query 파라미터 키를 화이트리스트 매칭용으로 정규화합니다.
+// 단순 소문자화 — 등록·필터링 양쪽이 동일 규칙을 따라야 일관된 매칭이 보장됩니다.
+func normalizeParamKey(key string) string {
+	return strings.ToLower(key)
 }
 
 // defaultNormalizer는 NormalizeURL 패키지 헬퍼가 사용하는 기본 인스턴스입니다.

--- a/test/pkg/links/normalizer_test.go
+++ b/test/pkg/links/normalizer_test.go
@@ -214,6 +214,71 @@ func TestNormalizer_Idempotent(t *testing.T) {
 	assert.Equal(t, first, second)
 }
 
+// TestNormalizer_WithAllowedParams_ParamKeyCaseInsensitive:
+// 파라미터 키 매칭은 case-insensitive 여야 합니다.
+// 등록된 키와 입력 URL의 키 대소문자가 달라도 동일하게 보존되며,
+// 결과 정규형은 결정적이어야 합니다 (회귀 방지).
+func TestNormalizer_WithAllowedParams_ParamKeyCaseInsensitive(t *testing.T) {
+	n := links.NewNormalizer(
+		links.WithAllowedParams("example.com", "Article_ID"), // 등록 시 mixed case
+	)
+
+	// 입력 URL 의 키 대소문자가 달라도 동일하게 매칭되어야 함
+	tests := []struct {
+		name string
+		in   string
+	}{
+		{"lowercase input", "https://example.com/a?article_id=42"},
+		{"uppercase input", "https://example.com/a?ARTICLE_ID=42"},
+		{"mixed case input", "https://example.com/a?Article_ID=42"},
+		{"alternative case", "https://example.com/a?article_ID=42"},
+	}
+
+	results := make([]string, 0, len(tests))
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := n.Normalize(tt.in)
+			require.NoError(t, err)
+			// article_id 가 보존되어야 함 (제거되지 않음)
+			assert.Contains(t, got, "=42", "허용된 파라미터가 제거되어 버림")
+			results = append(results, got)
+		})
+	}
+
+	// 모든 변형이 동일한 정규형이 되는지 추가 검증은 어려움(키 case는 url.Values 가
+	// 입력 그대로 유지) — 핵심은 "보존" 여부이며 위에서 검증됨.
+	// 단, 모두 query 부분에 "=42" 가 살아있어야 함이 회귀 방지의 핵심.
+}
+
+// TestNormalizer_PortPreservedAndWhitelistMatched:
+// u.Host 가 포트를 포함해도 화이트리스트 매칭은 hostname 기준으로 동작해야 하며,
+// 포트는 출력에 보존되어야 합니다 (fetch 라우팅 정보 손실 방지).
+func TestNormalizer_PortPreservedAndWhitelistMatched(t *testing.T) {
+	n := links.NewNormalizer(
+		links.WithAllowedParams("example.com", "id"),
+	)
+
+	got, err := n.Normalize("https://example.com:8080/a?id=42&utm_source=x")
+	require.NoError(t, err)
+	assert.Equal(t, "https://example.com:8080/a?id=42", got,
+		"포트 보존 + 화이트리스트 매칭(포트 무시)이 동시 동작해야 함")
+}
+
+// TestNormalizer_ParseQueryFailure_WhitelistedHost_PreservesOriginal:
+// 화이트리스트 등록 호스트에서 ParseQuery 실패 시 원본 query 가 보존되어야 합니다
+// (필수 파라미터 손실로 인한 fetch 실패 방지).
+func TestNormalizer_ParseQueryFailure_WhitelistedHost_PreservesOriginal(t *testing.T) {
+	n := links.NewNormalizer(
+		links.WithAllowedParams("example.com", "id"),
+	)
+
+	// %ZZ 는 잘못된 percent encoding → ParseQuery 실패 유도
+	got, err := n.Normalize("https://example.com/a?id=42&bad=%ZZ")
+	require.NoError(t, err)
+	// 원본 query 가 보존됨 (전부 제거가 아님)
+	assert.Contains(t, got, "id=42", "화이트리스트 호스트의 ParseQuery 실패 시 원본 query 가 손실되면 안 됨")
+}
+
 // TestNormalizer_DedupesEquivalentURLs:
 // 정규화의 핵심 효과 — tracking 파라미터만 다른 두 URL은 동일한 정규형을 가져야 함.
 // 이 테스트는 중복 탐지/파티션 키 일관성의 회귀를 차단합니다.

--- a/test/pkg/links/normalizer_test.go
+++ b/test/pkg/links/normalizer_test.go
@@ -1,0 +1,232 @@
+package links_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"issuetracker/pkg/links"
+)
+
+// TestNormalizeURL_Defaults는 패키지 레벨 NormalizeURL의 기본 동작을 검증합니다.
+// 기본 옵션: forceHTTPS=true, stripWWW=false, stripTrailingSlash=true,
+// stripFragment=true, query 화이트리스트 비어있음(전부 제거).
+func TestNormalizeURL_Defaults(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{
+			name: "empty input returns empty",
+			in:   "",
+			want: "",
+		},
+		{
+			name: "http upgraded to https",
+			in:   "http://example.com/article/123",
+			want: "https://example.com/article/123",
+		},
+		{
+			name: "tracking params stripped (utm/fbclid/gclid/ref)",
+			in:   "https://example.com/a?utm_source=tw&utm_medium=social&fbclid=x&gclid=y&ref=feed",
+			want: "https://example.com/a",
+		},
+		{
+			name: "all params stripped by default (no whitelist)",
+			in:   "https://example.com/a?id=42&page=2",
+			want: "https://example.com/a",
+		},
+		{
+			name: "trailing slash stripped from non-root path",
+			in:   "https://example.com/article/",
+			want: "https://example.com/article",
+		},
+		{
+			name: "root trailing slash preserved",
+			in:   "https://example.com/",
+			want: "https://example.com/",
+		},
+		{
+			name: "fragment stripped",
+			in:   "https://example.com/a#section-2",
+			want: "https://example.com/a",
+		},
+		{
+			name: "host lowercased",
+			in:   "https://Example.COM/Path",
+			want: "https://example.com/Path",
+		},
+		{
+			name: "www preserved by default",
+			in:   "https://www.example.com/a",
+			want: "https://www.example.com/a",
+		},
+		{
+			name: "https preserved",
+			in:   "https://example.com/a",
+			want: "https://example.com/a",
+		},
+		{
+			name: "compound: tracking + fragment + trailing slash",
+			in:   "http://Example.com/article/?utm_source=x&utm_campaign=y#top",
+			want: "https://example.com/article",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := links.NormalizeURL(tt.in)
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+// TestNormalizeURL_InvalidURL_ReturnsError:
+// 파싱 불가능한 URL은 에러 반환을 보장합니다.
+func TestNormalizeURL_InvalidURL_ReturnsError(t *testing.T) {
+	// net/url 은 매우 관대해서 대부분 입력을 받아들임 — control character 정도가 실패 케이스
+	_, err := links.NormalizeURL("ht\x00tp://broken")
+	assert.Error(t, err)
+}
+
+// TestNormalizeURL_RelativeURL_ReturnsAsIs:
+// host 가 없는 상대 URL 은 정규화 대상이 아니므로 변경 없이 반환합니다.
+func TestNormalizeURL_RelativeURL_ReturnsAsIs(t *testing.T) {
+	got, err := links.NormalizeURL("/article/123")
+	require.NoError(t, err)
+	assert.Equal(t, "/article/123", got)
+}
+
+// TestNormalizer_WithAllowedParams_KeepsWhitelistedKeys:
+// 사이트별 화이트리스트에 등록된 파라미터는 보존되고, 나머지는 제거됩니다.
+// 동일 호스트에 대해 여러 번 등록 시 키 집합이 누적됩니다.
+func TestNormalizer_WithAllowedParams_KeepsWhitelistedKeys(t *testing.T) {
+	n := links.NewNormalizer(
+		links.WithAllowedParams("news.naver.com", "article_id"),
+		links.WithAllowedParams("news.naver.com", "office_id"), // 누적 등록
+	)
+
+	got, err := n.Normalize("https://news.naver.com/main/read.naver?article_id=123&office_id=001&utm_source=feed")
+	require.NoError(t, err)
+	assert.Equal(t, "https://news.naver.com/main/read.naver?article_id=123&office_id=001", got)
+}
+
+// TestNormalizer_WithAllowedParams_QuerySorted:
+// 동일 컨텐츠에 대해 항상 동일한 정규형을 보장하기 위해
+// 보존된 query 키는 사전순으로 정렬되어야 합니다.
+func TestNormalizer_WithAllowedParams_QuerySorted(t *testing.T) {
+	n := links.NewNormalizer(
+		links.WithAllowedParams("youtube.com", "v", "t"),
+	)
+
+	// 입력 순서와 무관하게 동일 결과
+	a, err := n.Normalize("https://youtube.com/watch?t=10&v=abc")
+	require.NoError(t, err)
+	b, err := n.Normalize("https://youtube.com/watch?v=abc&t=10")
+	require.NoError(t, err)
+
+	assert.Equal(t, a, b)
+	assert.Equal(t, "https://youtube.com/watch?t=10&v=abc", a)
+}
+
+// TestNormalizer_WithAllowedParams_HostMatchingCaseInsensitive:
+// 호스트 매칭은 case-insensitive 이며 "www." 접두사가 자동 정규화됩니다.
+// 등록 시 host 와 입력 URL의 host 가 대소문자/www 차이에도 매칭되어야 합니다.
+func TestNormalizer_WithAllowedParams_HostMatchingCaseInsensitive(t *testing.T) {
+	n := links.NewNormalizer(
+		links.WithAllowedParams("Example.com", "id"), // 등록 시 대문자 + www 없음
+	)
+
+	// 입력은 소문자 + www. 접두사
+	got, err := n.Normalize("https://www.example.com/a?id=42&utm_source=x")
+	require.NoError(t, err)
+	assert.Equal(t, "https://www.example.com/a?id=42", got)
+}
+
+// TestNormalizer_WithAllowedParams_OtherHostStripsAll:
+// 화이트리스트에 등록되지 않은 호스트는 기본 동작(전부 제거)을 따릅니다.
+func TestNormalizer_WithAllowedParams_OtherHostStripsAll(t *testing.T) {
+	n := links.NewNormalizer(
+		links.WithAllowedParams("youtube.com", "v"),
+	)
+
+	got, err := n.Normalize("https://other.com/a?v=abc&id=42")
+	require.NoError(t, err)
+	assert.Equal(t, "https://other.com/a", got)
+}
+
+// TestNormalizer_WithStripWWW_RemovesWWWPrefix:
+// 옵션을 활성화하면 "www." 접두사가 제거됩니다.
+func TestNormalizer_WithStripWWW_RemovesWWWPrefix(t *testing.T) {
+	n := links.NewNormalizer(links.WithStripWWW())
+
+	got, err := n.Normalize("https://www.example.com/a")
+	require.NoError(t, err)
+	assert.Equal(t, "https://example.com/a", got)
+}
+
+// TestNormalizer_WithKeepHTTP_DoesNotUpgradeScheme:
+// 옵션을 활성화하면 http 스킴이 그대로 유지됩니다.
+func TestNormalizer_WithKeepHTTP_DoesNotUpgradeScheme(t *testing.T) {
+	n := links.NewNormalizer(links.WithKeepHTTP())
+
+	got, err := n.Normalize("http://example.com/a")
+	require.NoError(t, err)
+	assert.Equal(t, "http://example.com/a", got)
+}
+
+// TestNormalizer_WithKeepTrailingSlash_PreservesSlash:
+// 옵션을 활성화하면 경로 끝 "/" 가 보존됩니다.
+func TestNormalizer_WithKeepTrailingSlash_PreservesSlash(t *testing.T) {
+	n := links.NewNormalizer(links.WithKeepTrailingSlash())
+
+	got, err := n.Normalize("https://example.com/article/")
+	require.NoError(t, err)
+	assert.Equal(t, "https://example.com/article/", got)
+}
+
+// TestNormalizer_WithKeepFragment_PreservesFragment:
+// 옵션을 활성화하면 fragment("#...") 가 보존됩니다.
+func TestNormalizer_WithKeepFragment_PreservesFragment(t *testing.T) {
+	n := links.NewNormalizer(links.WithKeepFragment())
+
+	got, err := n.Normalize("https://example.com/a#section")
+	require.NoError(t, err)
+	assert.Equal(t, "https://example.com/a#section", got)
+}
+
+// TestNormalizer_Idempotent: 정규화 결과를 다시 정규화해도 동일한 결과여야 합니다.
+// 멱등성은 다회 적용되는 파이프라인 (예: 재시도, 캐시)에서 일관성 보장에 필수입니다.
+func TestNormalizer_Idempotent(t *testing.T) {
+	n := links.NewNormalizer(
+		links.WithStripWWW(),
+		links.WithAllowedParams("example.com", "id"),
+	)
+
+	first, err := n.Normalize("http://Www.Example.com/article/?id=1&utm=x#top")
+	require.NoError(t, err)
+	second, err := n.Normalize(first)
+	require.NoError(t, err)
+
+	assert.Equal(t, first, second)
+}
+
+// TestNormalizer_DedupesEquivalentURLs:
+// 정규화의 핵심 효과 — tracking 파라미터만 다른 두 URL은 동일한 정규형을 가져야 함.
+// 이 테스트는 중복 탐지/파티션 키 일관성의 회귀를 차단합니다.
+func TestNormalizer_DedupesEquivalentURLs(t *testing.T) {
+	n := links.NewNormalizer()
+
+	a, err := n.Normalize("https://example.com/article/123?utm_source=twitter")
+	require.NoError(t, err)
+	b, err := n.Normalize("https://example.com/article/123?utm_source=facebook&fbclid=xyz")
+	require.NoError(t, err)
+	c, err := n.Normalize("http://example.com/article/123/#comments")
+	require.NoError(t, err)
+
+	assert.Equal(t, a, b, "동일 기사의 추적 파라미터 변형은 같은 정규형이어야 함")
+	assert.Equal(t, a, c, "scheme/trailing slash/fragment 차이도 같은 정규형이어야 함")
+}


### PR DESCRIPTION
## 연관 이슈
- Closes #41

<!--
PR title 예시: [FEAT#issue번호]: 어쩌구저쩌
-->

<br>

## 구현 내용

### `pkg/links/normalizer.go` — Normalizer 추가
- `NewNormalizer(opts ...NormalizeOption)` / `(*Normalizer).Normalize(url) (string, error)`
- 패키지 레벨 헬퍼 `NormalizeURL(url) (string, error)` (기본 옵션 인스턴스)
- **기본 동작**: 모든 query 파라미터 제거, http→https, trailing slash 제거 (루트 보존), fragment 제거, host 소문자화
- **사이트별 화이트리스트**: `WithAllowedParams(host, params...)` — 호스트별 보존 파라미터 키 등록 (case-insensitive + `www.` 정규화 매칭)
- **옵션**: `WithStripWWW`(opt-in, fetch 안전 우선), `WithKeepHTTP`, `WithKeepTrailingSlash`, `WithKeepFragment`
- 멱등성 — 정규화 결과를 다시 정규화해도 동일 (재시도/캐시 일관성)

### `internal/crawler/worker/pool.go` — 3 적용 지점
| # | 위치 | 효과 |
|---|------|------|
| ① | `pollMessages` (unmarshal 직후) `job.Target.URL = normalizeURL(...)` | URLCache·JobLocker 키 일관성 |
| ② | `publishNormalized` (Store 직전) `content.CanonicalURL = normalizeURL(content.URL)` | DB content 중복 탐지 |
| ③ | `publishNormalized` Kafka `Message.Key = content.CanonicalURL` | 동일 기사 → 동일 파티션 (ordering·CB) |

### 호환성 — `SetNormalizer` 옵셔널 setter
- 미설정 시 `normalizeURL` 헬퍼가 원본 URL 반환 → **기존 동작 유지**
- 기존 4개 생성자 (`NewKafkaConsumerPool*`) 시그니처 무변경 → 기존 테스트 무수정 통과
- 정규화 실패/빈 결과 시 원본으로 fallback → fetch/저장 경로 안전성 보장

### 테스트 — `test/pkg/links/normalizer_test.go` (13개)
- 기본 동작 (table-driven, 11 케이스): tracking 제거, scheme upgrade, slash, fragment, host case
- 화이트리스트 누적 등록, 키 정렬, 호스트 case-insensitive 매칭, 미등록 호스트 처리
- 옵션 토글: `WithStripWWW`, `WithKeepHTTP`, `WithKeepTrailingSlash`, `WithKeepFragment`
- 멱등성, 중복 탐지 (tracking 변형 → 동일 정규형)

<br>

## CI / 머지 게이트 점검

> [CI 운영 규약](docs/ci/conventions.md) 및 [Required Status Checks 단일 소스](docs/ci/status-checks.md)에 따라 작성합니다.

### 변경 영향 범위
- 영향 패키지/모듈: `pkg/links` (신규 파일), `internal/crawler/worker` (pool.go 정규화 hook 추가)
- 위험도(택1): `Low` / **`Medium`** / `High`
  - 정규화는 옵셔널이며 미설정 시 기존 동작 유지 — 기본 위험 낮음
  - 운영 환경에서 `SetNormalizer` 활성화 시 사이트별 화이트리스트 등록이 누락되면 query 파라미터 의존 사이트(예: `news.naver.com?article_id=...`)의 fetch 가 깨질 수 있음 → 운영 도입 시 사이트별 정책 등록 필수

### Required Status Checks
- 통과 확인 대상 (PR Checks 탭에서 확인):
  - [ ] `Commit Lint`
  - [ ] `PR Title Lint`
  - [ ] `Format Check`
  - [ ] `Build`
  - [ ] `Test`
  - [ ] `Lint`

### 롤백 계획
- 본 PR을 revert 시 `SetNormalizer` 호출이 없는 한 동작 변화 없음 (옵셔널 hook). 운영 도입 후 문제 발생 시 `SetNormalizer(nil)` 으로 즉시 비활성화 가능.

<br>

## TODO
- [x] `pkg/links.Normalizer` 구현 (사이트별 파라미터 화이트리스트 포함)
- [x] 단위 테스트 13개 (기본/옵션/멱등성/중복 탐지)
- [x] 적용 지점 ① Target.URL (`pollMessages`)
- [x] 적용 지점 ② Content.CanonicalURL (`publishNormalized`)
- [x] 적용 지점 ③ Kafka 파티션 키 (`publishNormalized`)
- [ ] (후속) 운영 도입 시 사이트별 화이트리스트 등록: 네이버 (`article_id`, `office_id`), YouTube (`v`), 기타 RSS 파라미터 사이트

<br>

## 논의 사항
- `SetNormalizer` 활성화 정책: 도입 시점·범위 (모든 환경 일괄 vs 단계적), 사이트별 화이트리스트 등록을 어디(설정 파일 vs 코드)에서 관리할지
- `Content.URL` 자체는 보존 (CanonicalURL만 정규화) — 파서가 추출한 원본 추적 가능. 후속 PR에서 파서가 `<link rel=canonical>` 을 추출하는 경우 `content.URL` vs `content.CanonicalURL` 정책 정리 필요
- 로깅 추가 여부: 정규화 적용 전/후 URL 차이를 DEBUG 로그로 남길지 (대량 트래픽 환경 고려)

<br>
