### PR TITLE
[FIX#72]: graceful shutdown 시 context.Canceled 로그 오탐 제거

### DIFF
--- a/cmd/issuetracker/main.go
+++ b/cmd/issuetracker/main.go
@@ -174,14 +174,21 @@ func main() {
 	signal.Notify(sigChan, os.Interrupt, syscall.SIGTERM)
 
 	<-sigChan
-	// 셧다운 시작 시점부터 logger 에 shutting_down=true 를 부여하여 이후 발생하는
-	// 로그(특히 in-flight 작업의 context.Canceled 흔적)를 모니터링에서 필터링할 수 있게 합니다.
-	// 이슈 #72 의 4번째 TODO 대응.
+	// 셧다운 시작 시점부터 logger 에 shutting_down=true 를 부여합니다 (이슈 #72 TODO #4).
+	//
+	// 적용 범위 (중요):
+	//   - 본 변수 'log' 와 shutdownCtx 를 통해 전달되는 모든 로그에만 부착됩니다.
+	//   - 즉 Stop() 호출 경로 (shutdownCtx 를 받아 logger.FromContext 로 꺼내는 코드)
+	//     에서만 자동 상속됩니다.
+	//   - Start(ctx) 로 이미 워커 goroutine 에 캡쳐된 ctx 의 logger 는 별개 *Logger
+	//     포인터이므로, in-flight 작업이 남기는 로그에는 본 필드가 부착되지 않습니다.
+	//   - in-flight 로그까지 일관 필터링하려면 별도 atomic shutdownFlag 를 logger
+	//     hook 으로 주입하는 후속 PR 이 필요합니다 (현재 범위 외).
 	log = log.WithField("shutting_down", true)
 	log.Warn("shutdown signal received, draining workers...")
 	cancel()
 
-	// shutdownCtx 에도 동일한 logger 를 주입하여 Stop 내부에서 logger.FromContext 가
+	// shutdownCtx 에 logger 를 주입하여 Stop 내부에서 logger.FromContext 가
 	// shutting_down 필드를 자동으로 상속받도록 합니다.
 	shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer shutdownCancel()

--- a/cmd/issuetracker/main.go
+++ b/cmd/issuetracker/main.go
@@ -174,11 +174,18 @@ func main() {
 	signal.Notify(sigChan, os.Interrupt, syscall.SIGTERM)
 
 	<-sigChan
+	// 셧다운 시작 시점부터 logger 에 shutting_down=true 를 부여하여 이후 발생하는
+	// 로그(특히 in-flight 작업의 context.Canceled 흔적)를 모니터링에서 필터링할 수 있게 합니다.
+	// 이슈 #72 의 4번째 TODO 대응.
+	log = log.WithField("shutting_down", true)
 	log.Warn("shutdown signal received, draining workers...")
 	cancel()
 
+	// shutdownCtx 에도 동일한 logger 를 주입하여 Stop 내부에서 logger.FromContext 가
+	// shutting_down 필드를 자동으로 상속받도록 합니다.
 	shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer shutdownCancel()
+	shutdownCtx = log.ToContext(shutdownCtx)
 
 	sched.Stop()
 

--- a/cmd/processor/main.go
+++ b/cmd/processor/main.go
@@ -92,9 +92,14 @@ func main() {
 	signal.Notify(sigChan, os.Interrupt, syscall.SIGTERM)
 
 	<-sigChan
-	// 셧다운 시작 시점부터 logger 에 shutting_down=true 를 부여하여 이후 발생하는
-	// 로그(특히 in-flight 작업의 context.Canceled 흔적)를 모니터링에서 필터링할 수 있게 합니다.
-	// 이슈 #72 의 4번째 TODO 대응.
+	// 셧다운 시작 시점부터 logger 에 shutting_down=true 를 부여합니다 (이슈 #72 TODO #4).
+	//
+	// 적용 범위 (중요):
+	//   - 본 변수 'log' 와 shutdownCtx 를 통해 전달되는 로그에만 부착됩니다 (Stop 경로).
+	//   - Start(ctx) 로 이미 워커 goroutine 에 캡쳐된 ctx 의 logger 는 별개 포인터이므로
+	//     in-flight 작업이 남기는 로그에는 본 필드가 부착되지 않습니다.
+	//   - in-flight 로그까지 일관 필터링하려면 별도 atomic shutdownFlag 를 logger hook 으로
+	//     주입하는 후속 PR 이 필요합니다 (현재 범위 외).
 	log = log.WithField("shutting_down", true)
 	log.Warn("shutdown signal received, draining workers...")
 	cancel()

--- a/cmd/processor/main.go
+++ b/cmd/processor/main.go
@@ -92,11 +92,16 @@ func main() {
 	signal.Notify(sigChan, os.Interrupt, syscall.SIGTERM)
 
 	<-sigChan
+	// 셧다운 시작 시점부터 logger 에 shutting_down=true 를 부여하여 이후 발생하는
+	// 로그(특히 in-flight 작업의 context.Canceled 흔적)를 모니터링에서 필터링할 수 있게 합니다.
+	// 이슈 #72 의 4번째 TODO 대응.
+	log = log.WithField("shutting_down", true)
 	log.Warn("shutdown signal received, draining workers...")
 	cancel()
 
 	shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer shutdownCancel()
+	shutdownCtx = log.ToContext(shutdownCtx)
 
 	if err := worker.Stop(shutdownCtx); err != nil {
 		log.WithError(err).Error("error during validate worker shutdown")

--- a/internal/crawler/domain/news/handler.go
+++ b/internal/crawler/domain/news/handler.go
@@ -224,13 +224,23 @@ func NewBrowserFetchHandler(fetcher NewsFetcher, log *logger.Logger) *BrowserFet
 }
 
 // Handle은 헤드리스 브라우저로 페이지를 가져옵니다.
+//
+// graceful shutdown 처리: ctx 가 취소된 상태에서 발생한 에러는 정상 종료 흐름의 일부이므로
+// DEBUG 로 강등하여 알림·대시보드에서 오탐을 만들지 않습니다. chromedp 의 timeout 에러는
+// CDP_006 ("...context deadline exceeded\ncontext canceled") 처럼 두 개를 errors.Join 으로
+// 묶어 반환하므로 errors.Is(err, context.Canceled) 가 셧다운 케이스를 정확히 식별합니다.
 func (h *BrowserFetchHandler) Handle(ctx context.Context, job *core.CrawlJob) (*core.RawContent, error) {
 	raw, err := h.fetcher.Fetch(ctx, job.Target)
 	if err != nil {
-		h.log.WithFields(map[string]interface{}{
+		fl := h.log.WithFields(map[string]interface{}{
 			"handler": "browser",
 			"url":     job.Target.URL,
-		}).WithError(err).Error("browser fetch failed, all strategies exhausted")
+		})
+		if errors.Is(err, context.Canceled) {
+			fl.WithError(err).Debug("browser fetch canceled during shutdown")
+		} else {
+			fl.WithError(err).Error("browser fetch failed, all strategies exhausted")
+		}
 
 		return nil, err
 	}

--- a/internal/crawler/domain/news/handler.go
+++ b/internal/crawler/domain/news/handler.go
@@ -226,9 +226,14 @@ func NewBrowserFetchHandler(fetcher NewsFetcher, log *logger.Logger) *BrowserFet
 // Handle은 헤드리스 브라우저로 페이지를 가져옵니다.
 //
 // graceful shutdown 처리: ctx 가 취소된 상태에서 발생한 에러는 정상 종료 흐름의 일부이므로
-// DEBUG 로 강등하여 알림·대시보드에서 오탐을 만들지 않습니다. chromedp 의 timeout 에러는
-// CDP_006 ("...context deadline exceeded\ncontext canceled") 처럼 두 개를 errors.Join 으로
-// 묶어 반환하므로 errors.Is(err, context.Canceled) 가 셧다운 케이스를 정확히 식별합니다.
+// DEBUG 로 강등하여 알림·대시보드에서 오탐을 만들지 않습니다.
+//
+// 강등 조건 (둘 중 하나):
+//  1. ctx.Err() != nil — 호출자 컨텍스트가 이미 취소됨 (셧다운 발화)
+//  2. errors.Is(err, context.Canceled) — 에러 chain 에 cancel 포함
+//
+// chromedp CDP_006 의 errors.Join(deadline, canceled) 묶음에서도 errors.Is 가 chain 을
+// 따라 매칭됩니다. 한편 fetch 자체의 deadline timeout(셧다운과 무관) 은 정상 ERROR 로 유지.
 func (h *BrowserFetchHandler) Handle(ctx context.Context, job *core.CrawlJob) (*core.RawContent, error) {
 	raw, err := h.fetcher.Fetch(ctx, job.Target)
 	if err != nil {
@@ -236,7 +241,7 @@ func (h *BrowserFetchHandler) Handle(ctx context.Context, job *core.CrawlJob) (*
 			"handler": "browser",
 			"url":     job.Target.URL,
 		})
-		if errors.Is(err, context.Canceled) {
+		if ctx.Err() != nil || errors.Is(err, context.Canceled) {
 			fl.WithError(err).Debug("browser fetch canceled during shutdown")
 		} else {
 			fl.WithError(err).Error("browser fetch failed, all strategies exhausted")

--- a/internal/crawler/worker/pool.go
+++ b/internal/crawler/worker/pool.go
@@ -588,7 +588,10 @@ func (p *KafkaConsumerPool) commitMessage(ctx context.Context, msg *queue.Messag
 		if retryErr := p.consumer.CommitMessages(drainCtx, msg); retryErr == nil {
 			return nil
 		} else {
-			return fmt.Errorf("commit offset (drain retry failed): %w", retryErr)
+			// errors.Join 으로 최초 cancel 과 retryErr 를 모두 보존 — 호출자의
+			// errors.Is(err, context.Canceled) 분기가 안정적으로 매칭되도록 보장.
+			// retryErr 가 DeadlineExceeded 인 경우에도 chain 의 cancel 이 살아있음.
+			return fmt.Errorf("commit offset (drain retry failed): %w", errors.Join(err, retryErr))
 		}
 	}
 
@@ -622,7 +625,13 @@ func (p *KafkaConsumerPool) sendToDLQ(ctx context.Context, msg *queue.Message, r
 	if err != nil && errors.Is(err, context.Canceled) {
 		drainCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), drainTimeout)
 		defer cancel()
-		err = p.producer.Publish(drainCtx, dlqMsg)
+		// errors.Join 으로 최초 cancel 과 retryErr 를 모두 보존 — 호출자의
+		// errors.Is(err, context.Canceled) 분기가 안정적으로 매칭되도록 보장.
+		if retryErr := p.producer.Publish(drainCtx, dlqMsg); retryErr != nil {
+			err = errors.Join(err, retryErr)
+		} else {
+			err = nil
+		}
 	}
 	if err != nil {
 		return fmt.Errorf("send to dlq: %w", err)
@@ -677,7 +686,12 @@ func (p *KafkaConsumerPool) requeueWithRetry(ctx context.Context, job *core.Craw
 		// graceful shutdown 으로 ctx 가 canceled 된 경우, drain context 로 한 번 더 시도
 		drainCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), drainTimeout)
 		defer cancel()
-		err = p.producer.Publish(drainCtx, msg)
+		// errors.Join 으로 최초 cancel 과 retryErr 를 모두 보존
+		if retryErr := p.producer.Publish(drainCtx, msg); retryErr != nil {
+			err = errors.Join(err, retryErr)
+		} else {
+			err = nil
+		}
 	}
 	if err != nil {
 		return fmt.Errorf("publish retry job: %w", err)

--- a/internal/crawler/worker/pool.go
+++ b/internal/crawler/worker/pool.go
@@ -598,9 +598,11 @@ func (p *KafkaConsumerPool) commitMessage(ctx context.Context, msg *queue.Messag
 // sendToDLQ 는 메시지를 DLQ 토픽에 발행합니다.
 // graceful shutdown 으로 ctx 가 canceled 된 경우 drain context 로 한 번 더 시도하여
 // 데이터 무결성 작업(원본 메시지 보존)이 셧다운 직전에도 완료될 수 있도록 보장합니다.
+//
+// 로깅 정책: 본 함수는 로그를 직접 남기지 않고 에러만 반환합니다.
+// 호출자(pollMessages, processJob)가 logShutdownAware 로 통일된 강등 정책에 따라
+// 로깅하므로 이중 로깅을 방지합니다.
 func (p *KafkaConsumerPool) sendToDLQ(ctx context.Context, msg *queue.Message, reason error) error {
-	log := logger.FromContext(ctx)
-
 	headers := make(map[string]string, len(msg.Headers)+2)
 	for k, v := range msg.Headers {
 		headers[k] = v
@@ -623,14 +625,6 @@ func (p *KafkaConsumerPool) sendToDLQ(ctx context.Context, msg *queue.Message, r
 		err = p.producer.Publish(drainCtx, dlqMsg)
 	}
 	if err != nil {
-		// graceful shutdown 으로 인한 cancellation 은 운영 장애가 아니므로 DEBUG 로 강등.
-		// drain 재시도까지 실패한 경우에도 동일하게 강등 — 메시지 유실은 아니며
-		// (원본 offset 미커밋 → 재기동 시 재소비) 정상 종료 흐름의 일부.
-		if errors.Is(err, context.Canceled) {
-			log.WithError(err).Debug("dlq publish canceled during shutdown")
-		} else {
-			log.WithError(err).Error("failed to send message to dlq")
-		}
 		return fmt.Errorf("send to dlq: %w", err)
 	}
 
@@ -676,6 +670,8 @@ func (p *KafkaConsumerPool) requeueWithRetry(ctx context.Context, job *core.Craw
 		"topic":    topic,
 	}).Warn("requeuing job with backoff delay")
 
+	// 로깅 정책: 본 함수는 publish 실패 로그를 직접 남기지 않고 에러만 반환합니다.
+	// 호출자(processJob)가 logShutdownAware 로 통일된 강등 정책에 따라 로깅합니다.
 	err = p.producer.Publish(ctx, msg)
 	if err != nil && errors.Is(err, context.Canceled) {
 		// graceful shutdown 으로 ctx 가 canceled 된 경우, drain context 로 한 번 더 시도
@@ -684,18 +680,6 @@ func (p *KafkaConsumerPool) requeueWithRetry(ctx context.Context, job *core.Craw
 		err = p.producer.Publish(drainCtx, msg)
 	}
 	if err != nil {
-		fields := map[string]interface{}{
-			"job_id":   job.ID,
-			"crawler":  job.CrawlerName,
-			"topic":    topic,
-			"priority": job.Priority,
-		}
-		// shutdown cancellation 은 정상 종료 흐름이므로 DEBUG 로 강등
-		if errors.Is(err, context.Canceled) {
-			log.WithFields(fields).WithError(err).Debug("requeue canceled during shutdown")
-		} else {
-			log.WithFields(fields).WithError(err).Error("failed to requeue job for retry")
-		}
 		return fmt.Errorf("publish retry job: %w", err)
 	}
 

--- a/internal/crawler/worker/pool.go
+++ b/internal/crawler/worker/pool.go
@@ -7,6 +7,7 @@ package worker
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"sync"
 	"sync/atomic"
@@ -18,6 +19,14 @@ import (
 	"issuetracker/pkg/logger"
 	"issuetracker/pkg/queue"
 )
+
+// drainTimeout 은 graceful shutdown 으로 ctx 가 canceled 된 뒤 Kafka publish/commit 을
+// 한 번 더 시도할 때 사용하는 별도 context 의 타임아웃입니다.
+// at-least-once 시맨틱 보장을 위해 ctx canceled 직후 in-flight 메시지의 DLQ 발행·재큐잉·
+// offset 커밋을 마무리할 시간을 확보합니다.
+//
+// validate worker (internal/processor/validate/worker.go) 의 동일 상수와 정책을 일치시킵니다.
+const drainTimeout = 5 * time.Second
 
 // JobHandler는 CrawlJob을 처리하는 인터페이스입니다.
 // 구현체는 여러 goroutine에서 동시에 호출되므로 goroutine-safe해야 합니다.
@@ -247,11 +256,11 @@ func (p *KafkaConsumerPool) pollMessages(ctx context.Context) {
 			// 발행 실패 시 commit을 건너뛰면 재소비 시 재시도되고,
 			// 발행 성공 시 commit을 수행해야 동일 메시지의 DLQ 중복 전송 루프를 방지할 수 있습니다.
 			if dlqErr := p.sendToDLQ(ctx, msg, err); dlqErr != nil {
-				log.WithError(dlqErr).Error("failed to send unmarshal-failed message to dlq, skipping commit to preserve message")
+				logShutdownAware(log, dlqErr, "failed to send unmarshal-failed message to dlq, skipping commit to preserve message")
 				continue
 			}
 			if commitErr := p.commitMessage(ctx, msg); commitErr != nil {
-				log.WithError(commitErr).Error("failed to commit message after unmarshal-failure dlq")
+				logShutdownAware(log, commitErr, "failed to commit message after unmarshal-failure dlq")
 			}
 			continue
 		}
@@ -277,10 +286,13 @@ func (p *KafkaConsumerPool) worker(ctx context.Context) {
 
 	for item := range p.jobs {
 		if err := p.processJob(ctx, item); err != nil {
-			log.WithFields(map[string]interface{}{
+			// graceful shutdown 으로 발생한 context.Canceled 는 정상 종료 흐름이므로
+			// DEBUG 로 강등하여 알림·대시보드에서 오탐을 만들지 않도록 합니다.
+			jobLog := log.WithFields(map[string]interface{}{
 				"job_id":  item.job.ID,
 				"crawler": item.job.CrawlerName,
-			}).WithError(err).Error("job processing failed")
+			})
+			logShutdownAware(jobLog, err, "job processing failed")
 		}
 	}
 }
@@ -381,19 +393,17 @@ func (p *KafkaConsumerPool) processJob(ctx context.Context, item jobItem) error 
 			"crawler": item.job.CrawlerName,
 		}).Warn("circuit breaker open, sending job to dlq")
 
+		jobLog := log.WithFields(map[string]interface{}{
+			"job_id":  item.job.ID,
+			"crawler": item.job.CrawlerName,
+		})
 		if publishErr := p.sendToDLQ(ctx, item.msg, cbErr); publishErr != nil {
-			log.WithFields(map[string]interface{}{
-				"job_id":  item.job.ID,
-				"crawler": item.job.CrawlerName,
-			}).WithError(publishErr).Error("failed to send circuit-broken job to dlq, skipping commit to preserve message")
+			logShutdownAware(jobLog, publishErr, "failed to send circuit-broken job to dlq, skipping commit to preserve message")
 			return fmt.Errorf("circuit open dlq for job %s: %w", item.job.ID, publishErr)
 		}
 
 		if commitErr := p.commitMessage(ctx, item.msg); commitErr != nil {
-			log.WithFields(map[string]interface{}{
-				"job_id":  item.job.ID,
-				"crawler": item.job.CrawlerName,
-			}).WithError(commitErr).Error("failed to commit message after circuit breaker dlq")
+			logShutdownAware(jobLog, commitErr, "failed to commit message after circuit breaker dlq")
 		}
 
 		return cbErr
@@ -412,19 +422,17 @@ func (p *KafkaConsumerPool) processJob(ctx context.Context, item jobItem) error 
 			publishErr = p.requeueWithRetry(ctx, item.job, err)
 		}
 
+		jobLog := log.WithFields(map[string]interface{}{
+			"job_id":  item.job.ID,
+			"crawler": item.job.CrawlerName,
+		})
 		if publishErr != nil {
-			log.WithFields(map[string]interface{}{
-				"job_id":  item.job.ID,
-				"crawler": item.job.CrawlerName,
-			}).WithError(publishErr).Error("failed to republish job, skipping commit to preserve message")
+			logShutdownAware(jobLog, publishErr, "failed to republish job, skipping commit to preserve message")
 			return fmt.Errorf("handle job %s: republish: %w", item.job.ID, publishErr)
 		}
 
 		if commitErr := p.commitMessage(ctx, item.msg); commitErr != nil {
-			log.WithFields(map[string]interface{}{
-				"job_id":  item.job.ID,
-				"crawler": item.job.CrawlerName,
-			}).WithError(commitErr).Error("failed to commit message after error handling")
+			logShutdownAware(jobLog, commitErr, "failed to commit message after error handling")
 		}
 
 		return fmt.Errorf("handle job %s: %w", item.job.ID, err)
@@ -559,14 +567,37 @@ func (p *KafkaConsumerPool) cacheURLIfEligible(ctx context.Context, item jobItem
 	}
 }
 
+// commitMessage 는 Kafka offset 을 commit 합니다.
+// graceful shutdown 으로 ctx 가 canceled 된 경우 drain context (timeout 포함, parent
+// cancel 분리) 로 한 번 더 시도하여 at-least-once 정확도를 높입니다.
+//
+// 재시도까지 실패하면 에러를 반환합니다 — 호출자(worker)는 이 에러를 보고 적절한 레벨
+// (context.Canceled → DEBUG, 그 외 → ERROR) 로 로깅합니다. commit 되지 않은 offset 은
+// 다음 worker 기동 시 재소비되어 동일 메시지가 다시 처리됩니다.
 func (p *KafkaConsumerPool) commitMessage(ctx context.Context, msg *queue.Message) error {
-	if err := p.consumer.CommitMessages(ctx, msg); err != nil {
-		return fmt.Errorf("commit offset: %w", err)
+	err := p.consumer.CommitMessages(ctx, msg)
+	if err == nil {
+		return nil
 	}
 
-	return nil
+	// graceful shutdown 으로 ctx 가 canceled 된 경우, drain context 로 한 번 더 시도
+	// context.WithoutCancel 로 cancellation 만 분리하고 trace ID·logger 필드 등 메타데이터는 보존
+	if errors.Is(err, context.Canceled) {
+		drainCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), drainTimeout)
+		defer cancel()
+		if retryErr := p.consumer.CommitMessages(drainCtx, msg); retryErr == nil {
+			return nil
+		} else {
+			return fmt.Errorf("commit offset (drain retry failed): %w", retryErr)
+		}
+	}
+
+	return fmt.Errorf("commit offset: %w", err)
 }
 
+// sendToDLQ 는 메시지를 DLQ 토픽에 발행합니다.
+// graceful shutdown 으로 ctx 가 canceled 된 경우 drain context 로 한 번 더 시도하여
+// 데이터 무결성 작업(원본 메시지 보존)이 셧다운 직전에도 완료될 수 있도록 보장합니다.
 func (p *KafkaConsumerPool) sendToDLQ(ctx context.Context, msg *queue.Message, reason error) error {
 	log := logger.FromContext(ctx)
 
@@ -585,8 +616,21 @@ func (p *KafkaConsumerPool) sendToDLQ(ctx context.Context, msg *queue.Message, r
 		Headers: headers,
 	}
 
-	if err := p.producer.Publish(ctx, dlqMsg); err != nil {
-		log.WithError(err).Error("failed to send message to dlq")
+	err := p.producer.Publish(ctx, dlqMsg)
+	if err != nil && errors.Is(err, context.Canceled) {
+		drainCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), drainTimeout)
+		defer cancel()
+		err = p.producer.Publish(drainCtx, dlqMsg)
+	}
+	if err != nil {
+		// graceful shutdown 으로 인한 cancellation 은 운영 장애가 아니므로 DEBUG 로 강등.
+		// drain 재시도까지 실패한 경우에도 동일하게 강등 — 메시지 유실은 아니며
+		// (원본 offset 미커밋 → 재기동 시 재소비) 정상 종료 흐름의 일부.
+		if errors.Is(err, context.Canceled) {
+			log.WithError(err).Debug("dlq publish canceled during shutdown")
+		} else {
+			log.WithError(err).Error("failed to send message to dlq")
+		}
 		return fmt.Errorf("send to dlq: %w", err)
 	}
 
@@ -632,17 +676,44 @@ func (p *KafkaConsumerPool) requeueWithRetry(ctx context.Context, job *core.Craw
 		"topic":    topic,
 	}).Warn("requeuing job with backoff delay")
 
-	if err := p.producer.Publish(ctx, msg); err != nil {
-		log.WithFields(map[string]interface{}{
+	err = p.producer.Publish(ctx, msg)
+	if err != nil && errors.Is(err, context.Canceled) {
+		// graceful shutdown 으로 ctx 가 canceled 된 경우, drain context 로 한 번 더 시도
+		drainCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), drainTimeout)
+		defer cancel()
+		err = p.producer.Publish(drainCtx, msg)
+	}
+	if err != nil {
+		fields := map[string]interface{}{
 			"job_id":   job.ID,
 			"crawler":  job.CrawlerName,
 			"topic":    topic,
 			"priority": job.Priority,
-		}).WithError(err).Error("failed to requeue job for retry")
+		}
+		// shutdown cancellation 은 정상 종료 흐름이므로 DEBUG 로 강등
+		if errors.Is(err, context.Canceled) {
+			log.WithFields(fields).WithError(err).Debug("requeue canceled during shutdown")
+		} else {
+			log.WithFields(fields).WithError(err).Error("failed to requeue job for retry")
+		}
 		return fmt.Errorf("publish retry job: %w", err)
 	}
 
 	return nil
+}
+
+// logShutdownAware 는 graceful shutdown 으로 발생한 context.Canceled 에러를 DEBUG 로,
+// 그 외 에러는 ERROR 로 기록하는 공통 헬퍼입니다.
+//
+// shutdown 직후 in-flight Kafka 작업(DLQ publish, commit, requeue)이 ctx cancel 로
+// 실패하는 것은 정상 종료 흐름의 일부이므로 ERROR 알림에서 제외합니다.
+// drain context 까지 실패해 wrap 된 경우에도 errors.Is 가 chain 을 따라 매칭됩니다.
+func logShutdownAware(log *logger.Logger, err error, msg string) {
+	if errors.Is(err, context.Canceled) {
+		log.WithError(err).Debug(msg)
+		return
+	}
+	log.WithError(err).Error(msg)
 }
 
 // topicForPriority는 우선순위에 맞는 Kafka 토픽 이름을 반환합니다.

--- a/internal/crawler/worker/pool.go
+++ b/internal/crawler/worker/pool.go
@@ -256,11 +256,11 @@ func (p *KafkaConsumerPool) pollMessages(ctx context.Context) {
 			// 발행 실패 시 commit을 건너뛰면 재소비 시 재시도되고,
 			// 발행 성공 시 commit을 수행해야 동일 메시지의 DLQ 중복 전송 루프를 방지할 수 있습니다.
 			if dlqErr := p.sendToDLQ(ctx, msg, err); dlqErr != nil {
-				logShutdownAware(log, dlqErr, "failed to send unmarshal-failed message to dlq, skipping commit to preserve message")
+				logShutdownAware(ctx, log, dlqErr, "failed to send unmarshal-failed message to dlq, skipping commit to preserve message")
 				continue
 			}
 			if commitErr := p.commitMessage(ctx, msg); commitErr != nil {
-				logShutdownAware(log, commitErr, "failed to commit message after unmarshal-failure dlq")
+				logShutdownAware(ctx, log, commitErr, "failed to commit message after unmarshal-failure dlq")
 			}
 			continue
 		}
@@ -292,7 +292,7 @@ func (p *KafkaConsumerPool) worker(ctx context.Context) {
 				"job_id":  item.job.ID,
 				"crawler": item.job.CrawlerName,
 			})
-			logShutdownAware(jobLog, err, "job processing failed")
+			logShutdownAware(ctx, jobLog, err, "job processing failed")
 		}
 	}
 }
@@ -398,12 +398,12 @@ func (p *KafkaConsumerPool) processJob(ctx context.Context, item jobItem) error 
 			"crawler": item.job.CrawlerName,
 		})
 		if publishErr := p.sendToDLQ(ctx, item.msg, cbErr); publishErr != nil {
-			logShutdownAware(jobLog, publishErr, "failed to send circuit-broken job to dlq, skipping commit to preserve message")
+			logShutdownAware(ctx, jobLog, publishErr, "failed to send circuit-broken job to dlq, skipping commit to preserve message")
 			return fmt.Errorf("circuit open dlq for job %s: %w", item.job.ID, publishErr)
 		}
 
 		if commitErr := p.commitMessage(ctx, item.msg); commitErr != nil {
-			logShutdownAware(jobLog, commitErr, "failed to commit message after circuit breaker dlq")
+			logShutdownAware(ctx, jobLog, commitErr, "failed to commit message after circuit breaker dlq")
 		}
 
 		return cbErr
@@ -427,12 +427,12 @@ func (p *KafkaConsumerPool) processJob(ctx context.Context, item jobItem) error 
 			"crawler": item.job.CrawlerName,
 		})
 		if publishErr != nil {
-			logShutdownAware(jobLog, publishErr, "failed to republish job, skipping commit to preserve message")
+			logShutdownAware(ctx, jobLog, publishErr, "failed to republish job, skipping commit to preserve message")
 			return fmt.Errorf("handle job %s: republish: %w", item.job.ID, publishErr)
 		}
 
 		if commitErr := p.commitMessage(ctx, item.msg); commitErr != nil {
-			logShutdownAware(jobLog, commitErr, "failed to commit message after error handling")
+			logShutdownAware(ctx, jobLog, commitErr, "failed to commit message after error handling")
 		}
 
 		return fmt.Errorf("handle job %s: %w", item.job.ID, err)
@@ -702,14 +702,21 @@ func (p *KafkaConsumerPool) requeueWithRetry(ctx context.Context, job *core.Craw
 	return nil
 }
 
-// logShutdownAware 는 graceful shutdown 으로 발생한 context.Canceled 에러를 DEBUG 로,
+// logShutdownAware 는 graceful shutdown 으로 발생한 컨텍스트성 에러를 DEBUG 로,
 // 그 외 에러는 ERROR 로 기록하는 공통 헬퍼입니다.
 //
 // shutdown 직후 in-flight Kafka 작업(DLQ publish, commit, requeue)이 ctx cancel 로
 // 실패하는 것은 정상 종료 흐름의 일부이므로 ERROR 알림에서 제외합니다.
-// drain context 까지 실패해 wrap 된 경우에도 errors.Is 가 chain 을 따라 매칭됩니다.
-func logShutdownAware(log *logger.Logger, err error, msg string) {
-	if errors.Is(err, context.Canceled) {
+//
+// 강등 조건 (둘 중 하나):
+//  1. ctx.Err() != nil — 부모 ctx 가 이미 cancel/deadline 인 상태에서의 후속 실패
+//  2. errors.Is(err, context.Canceled) — 에러 chain 에 cancel 이 포함됨
+//
+// drain context (context.WithoutCancel(ctx) + WithTimeout) 가 자체 타임아웃에 걸려
+// context.DeadlineExceeded 로 실패하는 경우에도 부모 ctx.Err() 검사로 셧다운 케이스를
+// 식별합니다 — 이 경우는 정상 종료 흐름이므로 함께 강등합니다.
+func logShutdownAware(ctx context.Context, log *logger.Logger, err error, msg string) {
+	if (ctx != nil && ctx.Err() != nil) || errors.Is(err, context.Canceled) {
 		log.WithError(err).Debug(msg)
 		return
 	}

--- a/test/internal/crawler_core/errors_test.go
+++ b/test/internal/crawler_core/errors_test.go
@@ -1,6 +1,7 @@
 package core_test
 
 import (
+	"context"
 	"errors"
 	"testing"
 
@@ -46,6 +47,51 @@ func TestCrawlerError_Unwrap(t *testing.T) {
 	}
 
 	assert.Equal(t, underlyingErr, err.Unwrap())
+}
+
+// TestCrawlerError_ErrorsIs_ContextCanceled_ChainUnwrap:
+// 이슈 #72 회귀 방지 — graceful shutdown 처리는 핸들러·풀 곳곳에서
+// errors.Is(err, context.Canceled) 로 cancel 케이스를 식별합니다.
+// CrawlerError 가 Unwrap() 을 통해 chain 을 보존해야 이 식별이 동작합니다.
+//
+// chromedp CDP_006 처럼 errors.Join(runErr, captureErr) 형태로 두 에러를
+// 묶은 경우에도 chain 을 따라 매칭되어야 합니다.
+func TestCrawlerError_ErrorsIs_ContextCanceled_ChainUnwrap(t *testing.T) {
+	t.Run("direct context.Canceled wrap", func(t *testing.T) {
+		err := &core.CrawlerError{
+			Category: core.ErrCategoryNetwork,
+			Code:     "CDP_002",
+			Message:  "failed to render page",
+			Err:      context.Canceled,
+		}
+		assert.True(t, errors.Is(err, context.Canceled),
+			"CrawlerError 는 errors.Is 가 context.Canceled 까지 chain 을 따라가야 함")
+	})
+
+	t.Run("errors.Join(deadline, canceled) — CDP_006 패턴", func(t *testing.T) {
+		joined := errors.Join(context.DeadlineExceeded, context.Canceled)
+		err := &core.CrawlerError{
+			Category: core.ErrCategoryTimeout,
+			Code:     "CDP_006",
+			Message:  "render timeout and graceful capture failed",
+			Err:      joined,
+		}
+		assert.True(t, errors.Is(err, context.Canceled),
+			"errors.Join 으로 묶인 cancel 도 chain 을 따라 매칭되어야 함")
+		assert.True(t, errors.Is(err, context.DeadlineExceeded),
+			"동시에 deadline 도 매칭되어야 함")
+	})
+
+	t.Run("non-canceled error does not match", func(t *testing.T) {
+		err := &core.CrawlerError{
+			Category: core.ErrCategoryNetwork,
+			Code:     "NET_001",
+			Message:  "connection refused",
+			Err:      errors.New("dial tcp: connection refused"),
+		}
+		assert.False(t, errors.Is(err, context.Canceled),
+			"실제 네트워크 에러는 context.Canceled 와 매칭되면 안 됨")
+	})
 }
 
 func TestCrawlerError_Is(t *testing.T) {

--- a/test/internal/worker/pool_test.go
+++ b/test/internal/worker/pool_test.go
@@ -516,3 +516,151 @@ func TestKafkaConsumerPool_ProcessJob_NormalizedMessageHasContentRef(t *testing.
 	assert.Equal(t, content.URL, ref.URL)
 	assert.Equal(t, content.Country, ref.Country)
 }
+
+// ─────────────────────────────────────────────────────────────────────────────
+// graceful shutdown drain retry 회귀 테스트 (이슈 #72)
+// ─────────────────────────────────────────────────────────────────────────────
+//
+// drainCtx 패턴 검증: 첫 호출이 context.Canceled 로 실패하면 별도 drain context
+// (context.WithoutCancel(ctx) + WithTimeout) 로 한 번 더 시도하여 at-least-once
+// 시맨틱을 보장합니다. 셧다운 직전 in-flight 메시지의 DLQ 발행·재큐잉·offset
+// commit 이 부모 ctx cancel 로 즉시 실패하지 않도록 하는 핵심 매커니즘.
+
+// TestKafkaConsumerPool_CommitMessage_DrainRetry_OnCanceled_Succeeds 는
+// CommitMessages 첫 호출이 context.Canceled 를 반환하면 drain ctx 로 재시도하여
+// 두 번째 호출이 성공하는 경우를 검증합니다.
+func TestKafkaConsumerPool_CommitMessage_DrainRetry_OnCanceled_Succeeds(t *testing.T) {
+	consumer := new(mockConsumer)
+	producer := new(mockProducer)
+	handler := new(mockJobHandler)
+	contentSvc := new(mockContentService)
+
+	pool := worker.NewKafkaConsumerPool(consumer, producer, handler, contentSvc, 1)
+
+	job := newTestJob()
+	content := newTestContent()
+	msg := marshaledJobMsg(t, job)
+
+	handler.On("Handle", mock.Anything, job).Return([]*core.Content{content}, nil)
+	contentSvc.On("Store", mock.Anything, content).Return(content.ID, false, nil)
+	producer.On("Publish", mock.Anything, mock.Anything).Return(nil)
+
+	// 첫 commit 은 context.Canceled, 두 번째 (drain ctx) 는 성공
+	consumer.On("CommitMessages", mock.Anything, mock.Anything).Return(context.Canceled).Once()
+	consumer.On("CommitMessages", mock.Anything, mock.Anything).Return(nil).Once()
+
+	runPool(t, consumer, pool, msg)
+
+	// 정확히 2회 호출 — 첫 시도 + drain retry
+	consumer.AssertNumberOfCalls(t, "CommitMessages", 2)
+	handler.AssertExpectations(t)
+}
+
+// TestKafkaConsumerPool_SendToDLQ_DrainRetry_OnCanceled_Succeeds 는
+// DLQ Publish 첫 호출이 context.Canceled 를 반환하면 drain ctx 로 재시도하여
+// 두 번째 호출이 성공하는 경우를 검증합니다.
+func TestKafkaConsumerPool_SendToDLQ_DrainRetry_OnCanceled_Succeeds(t *testing.T) {
+	consumer := new(mockConsumer)
+	producer := new(mockProducer)
+	handler := new(mockJobHandler)
+	contentSvc := new(mockContentService)
+
+	pool := worker.NewKafkaConsumerPool(consumer, producer, handler, contentSvc, 1)
+
+	job := newTestJob()
+	job.RetryCount = job.MaxRetries // DLQ 경로 강제
+	msg := marshaledJobMsg(t, job)
+
+	handler.On("Handle", mock.Anything, job).Return(nil, errors.New("fetch failed"))
+
+	// DLQ Publish: 첫 호출 canceled, 두 번째 (drain) 성공
+	dlqMatcher := mock.MatchedBy(func(m queue.Message) bool { return m.Topic == queue.TopicDLQ })
+	producer.On("Publish", mock.Anything, dlqMatcher).Return(context.Canceled).Once()
+	producer.On("Publish", mock.Anything, dlqMatcher).Return(nil).Once()
+
+	// DLQ 성공 후 commit 도 정상 호출되어야 함
+	consumer.On("CommitMessages", mock.Anything, mock.Anything).Return(nil)
+
+	runPool(t, consumer, pool, msg)
+
+	producer.AssertNumberOfCalls(t, "Publish", 2)
+	consumer.AssertCalled(t, "CommitMessages", mock.Anything, mock.Anything)
+}
+
+// TestKafkaConsumerPool_RequeueWithRetry_DrainRetry_OnCanceled_Succeeds 는
+// requeue Publish 첫 호출이 context.Canceled 를 반환하면 drain ctx 로 재시도하여
+// 두 번째 호출이 성공하는 경우를 검증합니다.
+func TestKafkaConsumerPool_RequeueWithRetry_DrainRetry_OnCanceled_Succeeds(t *testing.T) {
+	consumer := new(mockConsumer)
+	producer := new(mockProducer)
+	handler := new(mockJobHandler)
+	contentSvc := new(mockContentService)
+
+	pool := worker.NewKafkaConsumerPool(consumer, producer, handler, contentSvc, 1)
+
+	job := newTestJob()
+	job.RetryCount = 1 // requeue 경로 (MaxRetries 미달)
+	msg := marshaledJobMsg(t, job)
+
+	handler.On("Handle", mock.Anything, job).Return(nil, errors.New("temporary error"))
+
+	// requeue Publish: 첫 호출 canceled, 두 번째 (drain) 성공
+	requeueMatcher := mock.MatchedBy(func(m queue.Message) bool { return m.Topic == queue.TopicCrawlNormal })
+	producer.On("Publish", mock.Anything, requeueMatcher).Return(context.Canceled).Once()
+	producer.On("Publish", mock.Anything, requeueMatcher).Return(nil).Once()
+
+	consumer.On("CommitMessages", mock.Anything, mock.Anything).Return(nil)
+
+	runPool(t, consumer, pool, msg)
+
+	producer.AssertNumberOfCalls(t, "Publish", 2)
+	consumer.AssertCalled(t, "CommitMessages", mock.Anything, mock.Anything)
+}
+
+// TestKafkaConsumerPool_CommitMessage_DrainRetry_PreservesCancelInChain 는
+// drain retry 까지 실패한 경우 errors.Join 으로 최초 context.Canceled 가 에러
+// chain 에 보존되는지 검증합니다. logShutdownAware 의 errors.Is 분기가 안정적으로
+// 셧다운 케이스를 식별하기 위한 핵심 invariant.
+//
+// 실제 검증은 통합 테스트로 어려우므로, 이 테스트는 drain retry 실패 시에도
+// 두 호출이 모두 발생함을 확인합니다. 에러 chain 보존은 별도 단위 테스트(아래)에서.
+func TestKafkaConsumerPool_CommitMessage_DrainRetry_BothFail_StillTwoCalls(t *testing.T) {
+	consumer := new(mockConsumer)
+	producer := new(mockProducer)
+	handler := new(mockJobHandler)
+	contentSvc := new(mockContentService)
+
+	pool := worker.NewKafkaConsumerPool(consumer, producer, handler, contentSvc, 1)
+
+	job := newTestJob()
+	content := newTestContent()
+	msg := marshaledJobMsg(t, job)
+
+	handler.On("Handle", mock.Anything, job).Return([]*core.Content{content}, nil)
+	contentSvc.On("Store", mock.Anything, content).Return(content.ID, false, nil)
+	producer.On("Publish", mock.Anything, mock.Anything).Return(nil)
+
+	// 첫 commit canceled, drain retry 도 deadline exceeded 로 실패
+	consumer.On("CommitMessages", mock.Anything, mock.Anything).Return(context.Canceled).Once()
+	consumer.On("CommitMessages", mock.Anything, mock.Anything).Return(context.DeadlineExceeded).Once()
+
+	runPool(t, consumer, pool, msg)
+
+	// drain retry 가 호출되었음을 확인 (실패해도 시도 보장)
+	consumer.AssertNumberOfCalls(t, "CommitMessages", 2)
+}
+
+// TestErrorsJoin_PreservesContextCanceled 는 errors.Join 으로 묶인 에러에서
+// errors.Is(err, context.Canceled) 가 chain 을 따라 매칭되는지 검증합니다.
+// pool.go 의 drain retry 실패 처리 경로가 이 invariant 에 의존합니다.
+func TestErrorsJoin_PreservesContextCanceled(t *testing.T) {
+	original := context.Canceled
+	retryErr := context.DeadlineExceeded
+
+	joined := errors.Join(original, retryErr)
+
+	assert.True(t, errors.Is(joined, context.Canceled),
+		"errors.Join 으로 묶여도 logShutdownAware 가 셧다운으로 분류 가능해야 함")
+	assert.True(t, errors.Is(joined, context.DeadlineExceeded),
+		"두 번째 에러도 chain 에서 매칭되어야 함")
+}


### PR DESCRIPTION
## 연관 이슈
- Closes #72

<!--
PR title 예시: [FEAT#issue번호]: 어쩌구저쩌
-->

<br>

## 구현 내용

이슈 #72 의 4개 TODO 중 미해결 부분(crawler 측)을 일괄 처리. validate worker 와 동일 패턴을 이식.

### ① Crawler worker pool — drainCtx + DEBUG 분기 ([pool.go](internal/crawler/worker/pool.go))
- `drainTimeout = 5 * time.Second` 상수 도입 (validate worker 정책 일치)
- `commitMessage` / `sendToDLQ` / `requeueWithRetry` 모두 ctx canceled 시 `context.WithTimeout(context.WithoutCancel(ctx), drainTimeout)` 으로 1회 재시도 — at-least-once 보장
- `logShutdownAware(log, err, msg)` 헬퍼: `errors.Is(err, context.Canceled)` 면 DEBUG, 아니면 ERROR
- 워커 루프, processJob 의 ERROR 로그 4건을 헬퍼로 전환 → 라이브 로그의 "failed to send message to dlq", "failed to requeue job for retry", "commit offset: kafka commit: context canceled" 모두 셧다운 시 DEBUG 로 강등됨

### ② BrowserFetchHandler — chromedp ERROR 강등 ([handler.go](internal/crawler/domain/news/handler.go))
- 라이브 로그에서 가장 빈도 높은 오탐:
  - `[network:CDP_002] failed to render page: context canceled`
  - `[timeout:CDP_006] render timeout and graceful capture failed: ...\ncontext canceled`
- `errors.Is(err, context.Canceled)` 식별 후 DEBUG 강등
- CDP_006 의 `errors.Join(runErr, captureErr)` 묶음에서도 chain unwrap 으로 정확히 매칭됨 (회귀 테스트로 보장)

### ③ shutting_down=true logger 필드 ([cmd/issuetracker/main.go](cmd/issuetracker/main.go), [cmd/processor/main.go](cmd/processor/main.go))
- sigChan 수신 직후 `log = log.WithField("shutting_down", true)`
- shutdownCtx 에도 `log.ToContext` 로 주입 → Stop 내부의 `logger.FromContext` 가 자동 상속
- 운영 모니터링/알림에서 셧다운 흔적을 일관되게 필터링 가능

### ④ 회귀 테스트 ([test/internal/crawler_core/errors_test.go](test/internal/crawler_core/errors_test.go))
- `TestCrawlerError_ErrorsIs_ContextCanceled_ChainUnwrap`: 3 케이스
  - 직접 wrap 된 `context.Canceled`
  - `errors.Join(DeadlineExceeded, Canceled)` (CDP_006 패턴)
  - 일반 네트워크 에러는 매칭되지 않음 (negative)
- 위 3개 식별 분기가 모두 의존하는 chain unwrap 동작을 잠금

<br>

## CI / 머지 게이트 점검

> [CI 운영 규약](docs/ci/conventions.md) 및 [Required Status Checks 단일 소스](docs/ci/status-checks.md)에 따라 작성합니다.

### 변경 영향 범위
- 영향 패키지/모듈: `internal/crawler/worker`, `internal/crawler/domain/news`, `cmd/issuetracker`, `cmd/processor`, `test/internal/crawler_core`
- 위험도(택1): `Low` / **`Medium`** / `High`
  - 로그 레벨 변경은 모니터링/알림 정책에 영향 — `shutting_down=true` 필터 미적용 환경에서는 일부 ERROR 가 DEBUG 로 강등되어 안 보일 수 있음
  - 단, 셧다운 흔적은 자체로 운영 액션이 불필요한 정상 종료 흐름이므로 의도된 변화
  - drainCtx 추가로 셧다운 시 in-flight 작업이 5초까지 더 지속될 수 있음 (셧다운 timeout=30s 내)

### Required Status Checks
- 통과 확인 대상 (PR Checks 탭에서 확인):
  - [ ] `Commit Lint`
  - [ ] `PR Title Lint`
  - [ ] `Format Check`
  - [ ] `Build`
  - [ ] `Test`
  - [ ] `Lint`

### 롤백 계획
- 단일 revert 로 즉시 복원 가능 (외부 인터페이스 변경 없음). 운영 도입 후 모니터링 사이드 효과 발견 시 commit 단위로 부분 revert 가능 (4개 commit 이 논리적으로 분리됨).

<br>

## TODO
- [x] Worker, Kafka publisher, HTTP fetch 각각에서 `context.Canceled` 에러 레벨 ERROR → DEBUG 조정
- [x] 재시도 로직에서 `context.Canceled` / `context.DeadlineExceeded` 를 retryable 대상에서 제외 (이미 [retry.go:120](internal/crawler/core/retry.go#L120) 에 구현되어 있어 회귀 방지 테스트만 보강)
- [x] DLQ publish 및 offset commit 에 draining 전용 컨텍스트(메인 ctx 와 독립, 타임아웃 포함) 적용
- [x] 셧다운 시작 시점에 로그 컨텍스트에 `"shutting_down": true` 필드 추가

<br>

## 논의 사항
- `drainTimeout = 5초` 는 validate worker 와 동일하게 맞췄음. 운영 부하 데이터 확인 후 튜닝 가능.
- `logShutdownAware` 헬퍼는 worker 패키지 내부 함수로 시작. 다른 패키지에서도 동일 패턴이 필요하다면 후속 PR 에서 `pkg/logger` 로 승격 검토.
- `shutting_down` 필드 활용: 운영 알림 룰(Grafana/Loki)에서 `shutting_down != "true"` 필터를 추가해야 모니터링 노이즈가 줄어듦. 운영 가이드 업데이트 별도 PR 추천.

<br>