### PR TITLE
[FIX#72]: 셧다운 강등 조건을 ctx.Err() 단독으로 — chromedp false positive 차단

### DIFF
--- a/internal/crawler/domain/news/handler.go
+++ b/internal/crawler/domain/news/handler.go
@@ -225,15 +225,16 @@ func NewBrowserFetchHandler(fetcher NewsFetcher, log *logger.Logger) *BrowserFet
 
 // Handle은 헤드리스 브라우저로 페이지를 가져옵니다.
 //
-// graceful shutdown 처리: ctx 가 취소된 상태에서 발생한 에러는 정상 종료 흐름의 일부이므로
-// DEBUG 로 강등하여 알림·대시보드에서 오탐을 만들지 않습니다.
+// graceful shutdown 처리: 호출자 ctx 가 취소된 상태에서 발생한 에러는 정상 종료 흐름의
+// 일부이므로 DEBUG 로 강등하여 알림·대시보드에서 오탐을 만들지 않습니다.
 //
-// 강등 조건 (둘 중 하나):
-//  1. ctx.Err() != nil — 호출자 컨텍스트가 이미 취소됨 (셧다운 발화)
-//  2. errors.Is(err, context.Canceled) — 에러 chain 에 cancel 포함
-//
-// chromedp CDP_006 의 errors.Join(deadline, canceled) 묶음에서도 errors.Is 가 chain 을
-// 따라 매칭됩니다. 한편 fetch 자체의 deadline timeout(셧다운과 무관) 은 정상 ERROR 로 유지.
+// 강등 조건은 ctx.Err() != nil 단독:
+//   - chromedp 는 정상 timeout 후 내부 cleanup 으로 errors.Join 에 context.Canceled 를
+//     포함시키는 경우가 있음 (CDP_006 의 captureErr=Canceled). 이 정상 케이스를 셧다운으로
+//     오인하지 않으려면 errors.Is(err, context.Canceled) 검사 사용 금지 — 호출자 ctx 의
+//     상태(ctx.Err) 만이 "셧다운에 의한 cancel 인지" 의 진실의 단일 소스(SoT).
+//   - kafka-go 등 다른 라이브러리는 부모 ctx cancel 시에만 context.Canceled 를 반환하지만,
+//     일관성·안전성을 위해 동일 정책 적용.
 func (h *BrowserFetchHandler) Handle(ctx context.Context, job *core.CrawlJob) (*core.RawContent, error) {
 	raw, err := h.fetcher.Fetch(ctx, job.Target)
 	if err != nil {
@@ -241,7 +242,7 @@ func (h *BrowserFetchHandler) Handle(ctx context.Context, job *core.CrawlJob) (*
 			"handler": "browser",
 			"url":     job.Target.URL,
 		})
-		if ctx.Err() != nil || errors.Is(err, context.Canceled) {
+		if ctx.Err() != nil {
 			fl.WithError(err).Debug("browser fetch canceled during shutdown")
 		} else {
 			fl.WithError(err).Error("browser fetch failed, all strategies exhausted")

--- a/internal/crawler/worker/pool.go
+++ b/internal/crawler/worker/pool.go
@@ -706,15 +706,16 @@ func (p *KafkaConsumerPool) requeueWithRetry(ctx context.Context, job *core.Craw
 // shutdown 직후 in-flight Kafka 작업(DLQ publish, commit, requeue)이 ctx cancel 로
 // 실패하는 것은 정상 종료 흐름의 일부이므로 ERROR 알림에서 제외합니다.
 //
-// 강등 조건 (둘 중 하나):
-//  1. ctx.Err() != nil — 부모 ctx 가 이미 cancel/deadline 인 상태에서의 후속 실패
-//  2. errors.Is(err, context.Canceled) — 에러 chain 에 cancel 이 포함됨
-//
-// drain context (context.WithoutCancel(ctx) + WithTimeout) 가 자체 타임아웃에 걸려
-// context.DeadlineExceeded 로 실패하는 경우에도 부모 ctx.Err() 검사로 셧다운 케이스를
-// 식별합니다 — 이 경우는 정상 종료 흐름이므로 함께 강등합니다.
+// 강등 조건은 ctx.Err() != nil 단독:
+//   - "셧다운으로 인한 cancel 인지" 의 진실의 단일 소스(SoT)는 호출자 ctx 의 상태.
+//   - 일부 라이브러리(예: chromedp)는 정상 timeout 후 내부 cleanup 으로 errors chain 에
+//     context.Canceled 를 포함시키는 경우가 있음. errors.Is(err, context.Canceled) 로
+//     판별하면 이 정상 케이스가 셧다운으로 오인되어 운영 모니터링에서 누락됨 (false positive).
+//   - drain context (context.WithoutCancel(ctx) + WithTimeout) 가 자체 timeout 으로
+//     context.DeadlineExceeded 를 반환하는 경우에도, 그 시점에 부모 ctx 가 cancel 됐다면
+//     ctx.Err() 검사로 셧다운으로 분류됨.
 func logShutdownAware(ctx context.Context, log *logger.Logger, err error, msg string) {
-	if (ctx != nil && ctx.Err() != nil) || errors.Is(err, context.Canceled) {
+	if ctx != nil && ctx.Err() != nil {
 		log.WithError(err).Debug(msg)
 		return
 	}

--- a/test/internal/crawler_core/errors_test.go
+++ b/test/internal/crawler_core/errors_test.go
@@ -50,9 +50,11 @@ func TestCrawlerError_Unwrap(t *testing.T) {
 }
 
 // TestCrawlerError_ErrorsIs_ContextCanceled_ChainUnwrap:
-// 이슈 #72 회귀 방지 — graceful shutdown 처리는 핸들러·풀 곳곳에서
-// errors.Is(err, context.Canceled) 로 cancel 케이스를 식별합니다.
-// CrawlerError 가 Unwrap() 을 통해 chain 을 보존해야 이 식별이 동작합니다.
+// CrawlerError 가 Unwrap 을 통해 wrap 된 sentinel 에러를 chain 에서 노출하는지 검증합니다.
+// 디버깅·로깅 목적으로 errors.Is 매칭이 chain 을 따라 동작해야 하는 일반 invariant.
+//
+// 주의: 셧다운 분류는 이 매칭이 아닌 ctx.Err() 단독으로 수행합니다 (handler.go,
+// pool.go logShutdownAware). 외부 라이브러리의 cleanup cancel false positive 차단.
 //
 // chromedp CDP_006 처럼 errors.Join(runErr, captureErr) 형태로 두 에러를
 // 묶은 경우에도 chain 을 따라 매칭되어야 합니다.

--- a/test/internal/domain/news/browser_handler_shutdown_test.go
+++ b/test/internal/domain/news/browser_handler_shutdown_test.go
@@ -1,0 +1,132 @@
+package news_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"issuetracker/internal/crawler/core"
+	"issuetracker/internal/crawler/domain/news"
+	"issuetracker/pkg/logger"
+)
+
+// stubFetcher 는 NewsFetcher 인터페이스를 만족하는 테스트용 더블입니다.
+// 지정된 raw/err 를 그대로 반환합니다.
+type stubFetcher struct {
+	raw *core.RawContent
+	err error
+}
+
+func (s *stubFetcher) Fetch(_ context.Context, _ core.Target) (*core.RawContent, error) {
+	return s.raw, s.err
+}
+
+// captureLogger 는 io.Writer 로 bytes.Buffer 를 사용하는 logger 를 생성합니다.
+// Debug 레벨로 설정하여 DEBUG/ERROR 모든 로그를 캡쳐합니다.
+func captureLogger(buf *bytes.Buffer) *logger.Logger {
+	cfg := logger.DefaultConfig()
+	cfg.Output = buf
+	cfg.Level = logger.LevelDebug
+	return logger.New(cfg)
+}
+
+// extractLevels 는 JSON 줄 단위 로그에서 'level' 필드 값들을 추출합니다.
+func extractLevels(t *testing.T, buf *bytes.Buffer) []string {
+	t.Helper()
+	var levels []string
+	for _, line := range strings.Split(strings.TrimSpace(buf.String()), "\n") {
+		if line == "" {
+			continue
+		}
+		var entry map[string]interface{}
+		require.NoError(t, json.Unmarshal([]byte(line), &entry))
+		if lvl, ok := entry["level"].(string); ok {
+			levels = append(levels, lvl)
+		}
+	}
+	return levels
+}
+
+// TestBrowserFetchHandler_NormalTimeout_LogsError:
+// 회귀 방지 — chromedp CDP_006 처럼 errors.Join 에 context.Canceled 가 포함된 정상 timeout
+// 케이스가 호출자 ctx 와 무관하게 ERROR 로 기록되어야 함을 검증합니다.
+//
+// 이전 구현(errors.Is(err, context.Canceled) || ctx.Err() != nil) 은 chromedp 내부 cleanup
+// 으로 발생한 context.Canceled 를 셧다운으로 오인하여 정상 timeout 을 DEBUG 로 강등시키는
+// false positive 가 있었습니다. 본 테스트는 그 회귀를 차단합니다.
+func TestBrowserFetchHandler_NormalTimeout_LogsError(t *testing.T) {
+	buf := &bytes.Buffer{}
+	log := captureLogger(buf)
+
+	// chromedp 의 CDP_006 형태: errors.Join(deadline, canceled)
+	// 외부에서 보면 errors.Is(err, context.Canceled) == true
+	chromedpErr := &core.CrawlerError{
+		Category: core.ErrCategoryTimeout,
+		Code:     "CDP_006",
+		Message:  "render timeout and graceful capture failed",
+		Err:      errors.Join(context.DeadlineExceeded, context.Canceled),
+	}
+	fetcher := &stubFetcher{err: chromedpErr}
+
+	handler := news.NewBrowserFetchHandler(fetcher, log)
+
+	// 호출자 ctx 는 정상 (셧다운 발화 전)
+	_, err := handler.Handle(context.Background(), categoryJob("https://example.com"))
+	require.Error(t, err)
+
+	levels := extractLevels(t, buf)
+	require.NotEmpty(t, levels)
+	assert.Contains(t, levels, "error",
+		"호출자 ctx 가 정상이면 errors.Is(canceled) 가 true 여도 ERROR 로 기록되어야 함 — "+
+			"chromedp 내부 cleanup cancel 을 셧다운으로 오인 금지")
+	assert.NotContains(t, levels, "debug",
+		"정상 timeout 케이스가 셧다운으로 오인되어 DEBUG 로 강등되면 안 됨")
+}
+
+// TestBrowserFetchHandler_ShutdownCanceled_LogsDebug:
+// 호출자 ctx 가 cancel 된 셧다운 케이스에서는 DEBUG 로 강등되어야 함.
+func TestBrowserFetchHandler_ShutdownCanceled_LogsDebug(t *testing.T) {
+	buf := &bytes.Buffer{}
+	log := captureLogger(buf)
+
+	fetcher := &stubFetcher{err: errors.New("any fetch error")}
+	handler := news.NewBrowserFetchHandler(fetcher, log)
+
+	// 호출자 ctx 가 이미 cancel 된 상태 (셧다운 시뮬레이션)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err := handler.Handle(ctx, categoryJob("https://example.com"))
+	require.Error(t, err)
+
+	levels := extractLevels(t, buf)
+	require.NotEmpty(t, levels)
+	assert.Contains(t, levels, "debug",
+		"호출자 ctx 가 cancel 된 셧다운 케이스는 DEBUG 로 강등되어야 함")
+	assert.NotContains(t, levels, "error",
+		"셧다운 케이스가 ERROR 로 기록되어 알림 노이즈를 만들면 안 됨")
+}
+
+// TestBrowserFetchHandler_PlainNetworkError_LogsError:
+// 일반 네트워크 에러(canceled chain 없음) + 정상 ctx → ERROR (정상 동작 확인).
+func TestBrowserFetchHandler_PlainNetworkError_LogsError(t *testing.T) {
+	buf := &bytes.Buffer{}
+	log := captureLogger(buf)
+
+	fetcher := &stubFetcher{err: errors.New("dial tcp: connection refused")}
+	handler := news.NewBrowserFetchHandler(fetcher, log)
+
+	_, err := handler.Handle(context.Background(), categoryJob("https://example.com"))
+	require.Error(t, err)
+
+	levels := extractLevels(t, buf)
+	require.NotEmpty(t, levels)
+	assert.Contains(t, levels, "error",
+		"일반 네트워크 에러는 ERROR 로 기록되어야 함")
+}

--- a/test/internal/worker/pool_test.go
+++ b/test/internal/worker/pool_test.go
@@ -651,8 +651,15 @@ func TestKafkaConsumerPool_CommitMessage_DrainRetry_BothFail_StillTwoCalls(t *te
 }
 
 // TestErrorsJoin_PreservesContextCanceled 는 errors.Join 으로 묶인 에러에서
-// errors.Is(err, context.Canceled) 가 chain 을 따라 매칭되는지 검증합니다.
-// pool.go 의 drain retry 실패 처리 경로가 이 invariant 에 의존합니다.
+// errors.Is 가 chain 을 따라 두 원인을 모두 매칭함을 검증합니다.
+//
+// 본 invariant 는 호출자가 에러 원인을 분류할 때 활용 가능한 표준 Go 시맨틱이며,
+// pool.go 의 drain retry 실패 처리 경로에서 errors.Join 으로 두 에러를 보존하는
+// 정책의 기반이 됩니다 (디버깅·로깅 시 두 원인 모두 노출).
+//
+// 주의: logShutdownAware 의 셧다운 분류는 errors.Is(canceled) 가 아닌 ctx.Err() 단독으로
+// 판정합니다. 외부 라이브러리(예: chromedp)가 정상 동작 중에도 cleanup cancel 을
+// 에러 chain 에 포함시키는 false positive 를 차단하기 위함입니다.
 func TestErrorsJoin_PreservesContextCanceled(t *testing.T) {
 	original := context.Canceled
 	retryErr := context.DeadlineExceeded
@@ -660,7 +667,7 @@ func TestErrorsJoin_PreservesContextCanceled(t *testing.T) {
 	joined := errors.Join(original, retryErr)
 
 	assert.True(t, errors.Is(joined, context.Canceled),
-		"errors.Join 으로 묶여도 logShutdownAware 가 셧다운으로 분류 가능해야 함")
+		"errors.Join 으로 묶인 첫 원인이 chain 에서 매칭되어야 함")
 	assert.True(t, errors.Is(joined, context.DeadlineExceeded),
-		"두 번째 에러도 chain 에서 매칭되어야 함")
+		"두 번째 원인도 chain 에서 매칭되어야 함")
 }


### PR DESCRIPTION
## 연관 이슈
- Closes #72

<br>

## 구현 내용

### 문제 — false positive 강등
PR #113 의 강등 조건 \`ctx.Err() != nil OR errors.Is(err, context.Canceled)\` 은 **chromedp 의 정상 timeout 케이스도 셧다운으로 오인하여 DEBUG 로 강등**하는 false positive 가 있었음.

**근거 — debug.log 라인 478~515 (\`21:57:11~21:57:13\`)**:
\`\`\`
[timeout:CDP_006] render timeout and graceful capture failed:
  context deadline exceeded
  context canceled
\`\`\`
- shutdown 시점은 \`21:59:41\` — 위 ERROR 들은 **2분 전 발생한 정상 timeout**
- 흐름: \`chromedp.Run(runCtx)\` 의 30초 timeout 으로 \`runErr=DeadlineExceeded\` → \`captureOuterHTML(browserCtx)\` 시도 → chromedp 내부 cleanup 으로 \`captureErr=Canceled\` 발생 → \`errors.Join(runErr, captureErr)\` 으로 묶임
- 호출자 \`ctx\` 는 정상 (shutdown 전), 하지만 \`errors.Is(err, context.Canceled) == true\` → 잘못 강등됨

### 수정 — ctx.Err() 단독
"셧다운으로 인한 cancel 인지" 의 진실의 단일 소스(SoT)는 **호출자 ctx 의 상태**.

| 파일 | 변경 |
|---|---|
| [internal/crawler/domain/news/handler.go:244](internal/crawler/domain/news/handler.go#L244) | \`if ctx.Err() != nil || errors.Is(err, context.Canceled)\` → \`if ctx.Err() != nil\` |
| [internal/crawler/worker/pool.go:716](internal/crawler/worker/pool.go#L716) (\`logShutdownAware\`) | 동일 단독화 + 주석 보강 |

\`pool.go\` 측은 kafka-go 가 부모 ctx cancel 시에만 \`context.Canceled\` 를 반환하므로 이전 OR 조건도 실질 결함은 없었으나, 일관성·방어적 설계로 동일 정책 적용.

### 회귀 방지 테스트 ([test/internal/domain/news/browser_handler_shutdown_test.go](test/internal/domain/news/browser_handler_shutdown_test.go) 신규)
- \`TestBrowserFetchHandler_NormalTimeout_LogsError\` — chromedp CDP_006 형태(\`errors.Join(deadline, canceled)\`) + 정상 ctx → **ERROR 기록 검증** (이전 구현이 깨졌던 케이스)
- \`TestBrowserFetchHandler_ShutdownCanceled_LogsDebug\` — 호출자 ctx 가 cancel 된 셧다운 케이스 → DEBUG 기록 검증
- \`TestBrowserFetchHandler_PlainNetworkError_LogsError\` — 일반 네트워크 에러 + 정상 ctx → ERROR 기록 검증
- 모두 \`logger.Config.Output\` 에 \`bytes.Buffer\` 를 주입하여 JSON \`level\` 필드를 직접 검증

### 코멘트 갱신
- \`test/internal/worker/pool_test.go::TestErrorsJoin_PreservesContextCanceled\` — \`errors.Join\` chain 매칭은 일반 invariant 이며, 셧다운 분류와는 별개임을 명시
- \`test/internal/crawler_core/errors_test.go::TestCrawlerError_ErrorsIs_ContextCanceled_ChainUnwrap\` — 동일 명시

<br>

## CI / 머지 게이트 점검

> [CI 운영 규약](docs/ci/conventions.md) 및 [Required Status Checks 단일 소스](docs/ci/status-checks.md)에 따라 작성합니다.

### 변경 영향 범위
- 영향 패키지/모듈: \`internal/crawler/domain/news\`, \`internal/crawler/worker\`, 관련 테스트 3개
- 위험도(택1): \`Low\` / **\`Medium\`** / \`High\`
  - 강등 조건이 좁아져 그동안 잘못 DEBUG 로 강등되던 chromedp 정상 timeout 들이 다시 ERROR 로 노출됨
  - 이는 의도된 변화 — 진짜 운영 모니터링이 가능해짐. 반대로 알림 룰 보정 필요할 수 있음 (운영 사이드)

### Required Status Checks
- 통과 확인 대상 (PR Checks 탭에서 확인):
  - [ ] \`Commit Lint\`
  - [ ] \`PR Title Lint\`
  - [ ] \`Format Check\`
  - [ ] \`Build\`
  - [ ] \`Test\`
  - [ ] \`Lint\`

### 롤백 계획
- 단일 revert 로 즉시 복원 가능 (외부 인터페이스 변경 없음). 운영 도입 후 알림 노이즈가 과한 경우 부분 revert 또는 구체적 source 별 강등 정책 추가 검토.

<br>

## TODO
- [x] handler.go 강등 조건 단독화
- [x] pool.go logShutdownAware 단독화
- [x] BrowserFetchHandler 회귀 테스트 (3개)
- [x] 기존 테스트의 부정확해진 코멘트 갱신
- [ ] (운영 후속) 알림 룰에서 \`shutting_down=true\` 필터 외에 chromedp source 한정 강등이 필요하면 source 컨텍스트 기반 정책 검토

<br>

## 논의 사항
- 본 PR 은 #72 의 의도(셧다운 시에만 강등)를 정확히 구현하기 위한 후속 fix. PR #113 의 4개 commit 은 그대로 유지되며 본 PR 만 추가됨.
- chromedp 가 cleanup cancel 을 errors chain 에 포함시키는 동작은 chromedp v0.x 의 특성. 향후 chromedp 업그레이드 시 동작이 바뀔 수 있어 회귀 테스트로 잠금.
