### PR TITLE
[FEAT#117]: HTTP/2 stream error 모니터링 metric 추가

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,22 +4,23 @@ go 1.24.0
 
 require (
 	github.com/PuerkitoBio/goquery v1.11.0
+	github.com/chromedp/cdproto v0.0.0-20250724212937-08a3db8b4327
 	github.com/chromedp/chromedp v0.14.2
 	github.com/jackc/pgx/v5 v5.8.0
 	github.com/joho/godotenv v1.5.1
 	github.com/mmcdole/gofeed v1.3.0
+	github.com/redis/go-redis/v9 v9.18.0
 	github.com/rs/zerolog v1.34.0
 	github.com/segmentio/kafka-go v0.4.50
 	github.com/stretchr/testify v1.11.1
+	golang.org/x/net v0.48.0
 	google.golang.org/grpc v1.79.1
 	google.golang.org/protobuf v1.36.11
-	github.com/redis/go-redis/v9 v9.18.0
 )
 
 require (
 	github.com/andybalholm/cascadia v1.3.3 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
-	github.com/chromedp/cdproto v0.0.0-20250724212937-08a3db8b4327 // indirect
 	github.com/chromedp/sysutil v1.1.0 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f // indirect
@@ -43,7 +44,6 @@ require (
 	github.com/rogpeppe/go-internal v1.14.1 // indirect
 	github.com/stretchr/objx v0.5.2 // indirect
 	go.uber.org/atomic v1.11.0 // indirect
-	golang.org/x/net v0.48.0 // indirect
 	golang.org/x/sync v0.19.0 // indirect
 	golang.org/x/sys v0.39.0 // indirect
 	golang.org/x/text v0.32.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -2,6 +2,10 @@ github.com/PuerkitoBio/goquery v1.11.0 h1:jZ7pwMQXIITcUXNH83LLk+txlaEy6NVOfTuP43
 github.com/PuerkitoBio/goquery v1.11.0/go.mod h1:wQHgxUOU3JGuj3oD/QFfxUdlzW6xPHfqyHre6VMY4DQ=
 github.com/andybalholm/cascadia v1.3.3 h1:AG2YHrzJIm4BZ19iwJ/DAua6Btl3IwJX+VI4kktS1LM=
 github.com/andybalholm/cascadia v1.3.3/go.mod h1:xNd9bqTn98Ln4DwST8/nG+H0yuB8Hmgu1YHNnWw0GeA=
+github.com/bsm/ginkgo/v2 v2.12.0 h1:Ny8MWAHyOepLGlLKYmXG4IEkioBysk6GpaRTLC8zwWs=
+github.com/bsm/ginkgo/v2 v2.12.0/go.mod h1:SwYbGRRDovPVboqFv0tPTcG1sN61LM1Z4ARdbAV9g4c=
+github.com/bsm/gomega v1.27.10 h1:yeMWxP2pV2fG3FgAODIY8EiRE3dy0aeFYt4l7wh6yKA=
+github.com/bsm/gomega v1.27.10/go.mod h1:JyEr/xRbxbtgWNi8tIEVPUYZ5Dzef52k01W3YH0H+O0=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/chromedp/cdproto v0.0.0-20250724212937-08a3db8b4327 h1:UQ4AU+BGti3Sy/aLU8KVseYKNALcX9UXY6DfpwQ6J8E=
@@ -52,6 +56,8 @@ github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnr
 github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=
 github.com/klauspost/compress v1.15.9 h1:wKRjX6JRtDdrE9qwa4b/Cip7ACOshUI4smpCQanqjSY=
 github.com/klauspost/compress v1.15.9/go.mod h1:PhcZ0MbTNciWF3rruxRgKxI5NkcHHrHUDtV4Yw2GlzU=
+github.com/klauspost/cpuid/v2 v2.0.9 h1:lgaqFMSdTdQYdZ04uHyN2d/eKdOMyi2YLSvlQIBFYa4=
+github.com/klauspost/cpuid/v2 v2.0.9/go.mod h1:FInQzS24/EEf25PyTYn52gqo7WaD8xa0213Md/qVLRg=
 github.com/kr/pretty v0.3.0 h1:WgNl7dwNpEZ6jJ9k1snq4pZsg7DOEN8hP9Xw0Tsjwk0=
 github.com/kr/pretty v0.3.0/go.mod h1:640gp4NfQd8pI5XOwp5fnNeVWj67G7CFk/SaSQn7NBk=
 github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
@@ -102,6 +108,8 @@ github.com/xdg-go/scram v1.1.2/go.mod h1:RT/sEzTbU5y00aCK8UOx6R7YryM0iF1N2MOmC3k
 github.com/xdg-go/stringprep v1.0.4 h1:XLI/Ng3O1Atzq0oBs3TWm+5ZVgkq2aqdlvP9JtoZ6c8=
 github.com/xdg-go/stringprep v1.0.4/go.mod h1:mPGuuIYwz7CmR2bT9j4GbQqutWS1zV24gijq1dTyGkM=
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
+github.com/zeebo/xxh3 v1.0.2 h1:xZmwmqxHZA8AI603jOQ0tMqmBr9lPeFwGg6d+xy9DC0=
+github.com/zeebo/xxh3 v1.0.2/go.mod h1:5NWz9Sef7zIDm2JHfFlcQvNekmcEl9ekUZQQKCYaDcA=
 go.opentelemetry.io/auto/sdk v1.2.1 h1:jXsnJ4Lmnqd11kwkBV2LgLoFMZKizbCi5fNZ/ipaZ64=
 go.opentelemetry.io/auto/sdk v1.2.1/go.mod h1:KRTj+aOaElaLi+wW1kO/DZRXwkF4C5xPbEe3ZiIhN7Y=
 go.opentelemetry.io/otel v1.39.0 h1:8yPrr/S0ND9QEfTfdP9V+SiwT4E0G7Y5MO7p85nis48=

--- a/internal/crawler/core/http2_metrics.go
+++ b/internal/crawler/core/http2_metrics.go
@@ -37,8 +37,16 @@ func NewHTTP2ErrorCounter() *HTTP2ErrorCounter {
 //
 // 빈 errType 도 키로 그대로 저장합니다 (http2 라이브러리가 빈 문자열을 보내는
 // 경우는 알려져 있지 않으나 방어적으로 데이터를 잃지 않도록 함).
+//
+// hot path 알로케이션 회피: LoadOrStore 의 인자(new(atomic.Uint64))는 호출 시점에
+// 매번 평가되어 errType 이 이미 존재해도 알로케이션이 발생합니다. 카운터는 read-mostly
+// 패턴(최초 1회 생성 후 반복 Add)이므로 Load 우선 시도로 hot path 의 GC 부담을 제거.
 func (c *HTTP2ErrorCounter) Increment(errType string) uint64 {
-	val, _ := c.counts.LoadOrStore(errType, new(atomic.Uint64))
+	val, ok := c.counts.Load(errType)
+	if !ok {
+		// 최초 등록 또는 동시 첫 등록 race — LoadOrStore 가 winner/loser 처리
+		val, _ = c.counts.LoadOrStore(errType, new(atomic.Uint64))
+	}
 	return val.(*atomic.Uint64).Add(1)
 }
 

--- a/internal/crawler/core/http2_metrics.go
+++ b/internal/crawler/core/http2_metrics.go
@@ -1,0 +1,83 @@
+package core
+
+import (
+	"sort"
+	"sync"
+	"sync/atomic"
+)
+
+// HTTP2ErrorCounter 는 HTTP/2 stream/connection error 발생 횟수를 에러 유형별로
+// 카운트합니다. golang.org/x/net/http2 의 Transport.CountError hook 에 연결되어
+// 호출됩니다. goroutine-safe 합니다.
+//
+// 운영 진단 시 다음과 같이 snapshot 으로 조회합니다:
+//
+//	snap := core.DefaultHTTP2ErrorCounter.Snapshot()
+//	for errType, count := range snap {
+//	    log.Printf("%s: %d", errType, count)
+//	}
+//
+// 본 카운터는 이슈 #71 의 'received DATA after END_STREAM' 같은 protocol error 의
+// 재발 빈도 추적을 목표로 합니다. 빈도 추이가 충분히 누적되면 후속 단계
+// (ForceHTTP1 옵션화, 풀 제거 hook) 도입 여부를 결정합니다.
+type HTTP2ErrorCounter struct {
+	// counts: errType(string) → *atomic.Uint64
+	// sync.Map 사용 이유: 키 집합이 사전 미정 + 동시 increment + 쓰기 패턴이 read-mostly
+	// (대부분의 카운터는 최초 1회 생성 후 atomic.Add 만 호출됨)
+	counts sync.Map
+}
+
+// NewHTTP2ErrorCounter 는 새로운 카운터 인스턴스를 생성합니다.
+func NewHTTP2ErrorCounter() *HTTP2ErrorCounter {
+	return &HTTP2ErrorCounter{}
+}
+
+// Increment 는 errType 카운터를 원자적으로 1 증가시키고 증가 후 값을 반환합니다.
+// 동일 errType 에 대해 안전하게 동시 호출 가능합니다.
+//
+// 빈 errType 도 키로 그대로 저장합니다 (http2 라이브러리가 빈 문자열을 보내는
+// 경우는 알려져 있지 않으나 방어적으로 데이터를 잃지 않도록 함).
+func (c *HTTP2ErrorCounter) Increment(errType string) uint64 {
+	val, _ := c.counts.LoadOrStore(errType, new(atomic.Uint64))
+	return val.(*atomic.Uint64).Add(1)
+}
+
+// Snapshot 은 현재 모든 errType 카운터의 정합성 있는 단일 시점 사본을 반환합니다.
+// 반환된 map 은 호출자가 자유롭게 수정해도 카운터에 영향을 주지 않습니다.
+//
+// 정합성 보장: 각 키에 대해 atomic.Load 를 사용하므로 개별 카운터는 정확합니다.
+// 단, 전체 map 은 단일 트랜잭션이 아니므로 Snapshot 호출 중에 새 카운터가
+// 추가되거나 기존 카운터가 증가할 수 있습니다 (모니터링 용도로 충분).
+func (c *HTTP2ErrorCounter) Snapshot() map[string]uint64 {
+	out := make(map[string]uint64)
+	c.counts.Range(func(key, value interface{}) bool {
+		out[key.(string)] = value.(*atomic.Uint64).Load()
+		return true
+	})
+	return out
+}
+
+// SortedSnapshot 은 Snapshot 결과를 errType 사전순으로 정렬한 슬라이스로 반환합니다.
+// 로깅이나 진단 출력에서 결정적 순서가 필요할 때 사용합니다.
+func (c *HTTP2ErrorCounter) SortedSnapshot() []HTTP2ErrorEntry {
+	snap := c.Snapshot()
+	out := make([]HTTP2ErrorEntry, 0, len(snap))
+	for k, v := range snap {
+		out = append(out, HTTP2ErrorEntry{ErrorType: k, Count: v})
+	}
+	sort.Slice(out, func(i, j int) bool {
+		return out[i].ErrorType < out[j].ErrorType
+	})
+	return out
+}
+
+// HTTP2ErrorEntry 는 SortedSnapshot 의 단일 항목을 나타냅니다.
+type HTTP2ErrorEntry struct {
+	ErrorType string
+	Count     uint64
+}
+
+// DefaultHTTP2ErrorCounter 는 패키지 전역 기본 카운터입니다.
+// http_client.go 의 transport hook 이 본 인스턴스에 카운트를 누적합니다.
+// 운영 진단 시 core.DefaultHTTP2ErrorCounter.Snapshot() / SortedSnapshot() 으로 조회.
+var DefaultHTTP2ErrorCounter = NewHTTP2ErrorCounter()

--- a/internal/crawler/core/http_client.go
+++ b/internal/crawler/core/http_client.go
@@ -8,6 +8,8 @@ import (
 	"net/http"
 	"time"
 
+	"golang.org/x/net/http2"
+
 	"issuetracker/pkg/logger"
 )
 
@@ -18,6 +20,13 @@ const (
 
 // defaultHTTPClient는 기본 HTTP 클라이언트를 생성합니다.
 // Connection pooling과 timeout을 적용합니다.
+//
+// HTTP/2 stream/connection error 모니터링 (이슈 #71/#117):
+//   - http2.ConfigureTransports 로 base transport 에 http2 transport 를 명시 구성
+//   - http2.Transport.CountError hook 으로 에러 유형별 카운트 (DefaultHTTP2ErrorCounter 누적)
+//   - 에러 발생 시 WARN 로그로 즉시 가시화 — 운영 모니터링/알림에서 빈도 추적 가능
+//   - ConfigureTransports 가 실패하면 (예: ForceAttemptHTTP2=false 일 때) 모니터링만 비활성화되고
+//     HTTP 클라이언트는 정상 동작 — fail-open 정책
 func defaultHTTPClient(config Config) *http.Client {
 	transport := &http.Transport{
 		MaxIdleConns:        config.MaxIdleConns,
@@ -27,11 +36,29 @@ func defaultHTTPClient(config Config) *http.Client {
 		ForceAttemptHTTP2:   true,
 	}
 
+	if h2t, err := http2.ConfigureTransports(transport); err == nil && h2t != nil {
+		h2t.CountError = recordHTTP2Error
+	}
+
 	return &http.Client{
 		Transport: transport,
 		// timeout은 request level에서 적용
 		Timeout: 0,
 	}
+}
+
+// recordHTTP2Error 는 http2.Transport.CountError 콜백입니다.
+// errType 은 http2 라이브러리가 정의한 안정적 식별자 (예: "stream_error_protocol",
+// "conn_error_received_data_after_end_stream") 로 모니터링 라벨로 그대로 사용 가능합니다.
+//
+// 본 콜백은 http2 내부 goroutine 에서 호출되므로 ctx 를 받지 못합니다.
+// 따라서 logger.FromContext(context.Background()) 의 fallback 기본 logger 를 사용합니다.
+func recordHTTP2Error(errType string) {
+	count := DefaultHTTP2ErrorCounter.Increment(errType)
+	logger.FromContext(context.Background()).WithFields(map[string]interface{}{
+		"http2_error_type": errType,
+		"count":            count,
+	}).Warn("http2 protocol error observed")
 }
 
 // StandardHTTPClient는 표준 HTTP 클라이언트 구현입니다.

--- a/internal/crawler/core/http_client.go
+++ b/internal/crawler/core/http_client.go
@@ -63,12 +63,23 @@ func defaultHTTPClient(config Config) *http.Client {
 //
 // 본 콜백은 http2 내부 goroutine 에서 호출되므로 ctx 를 받지 못합니다.
 // 따라서 logger.FromContext(context.Background()) 의 fallback 기본 logger 를 사용합니다.
+//
+// 로그 레벨 정책:
+//   - 첫 발생 (count == 1): WARN — 신규 errType 출현은 운영자가 알아야 할 신호
+//   - 이후 발생: DEBUG — 동일 errType 의 반복은 카운터에만 누적, 로그 폭주 방지
+//
+// 빈도 추이는 DefaultHTTP2ErrorCounter.Snapshot() 으로 일관 조회.
 func recordHTTP2Error(errType string) {
 	count := DefaultHTTP2ErrorCounter.Increment(errType)
-	logger.FromContext(context.Background()).WithFields(map[string]interface{}{
+	log := logger.FromContext(context.Background()).WithFields(map[string]interface{}{
 		"http2_error_type": errType,
 		"count":            count,
-	}).Warn("http2 protocol error observed")
+	})
+	if count == 1 {
+		log.Warn("http2 protocol error observed (first occurrence)")
+	} else {
+		log.Debug("http2 protocol error observed")
+	}
 }
 
 // StandardHTTPClient는 표준 HTTP 클라이언트 구현입니다.

--- a/internal/crawler/core/http_client.go
+++ b/internal/crawler/core/http_client.go
@@ -36,7 +36,17 @@ func defaultHTTPClient(config Config) *http.Client {
 		ForceAttemptHTTP2:   true,
 	}
 
-	if h2t, err := http2.ConfigureTransports(transport); err == nil && h2t != nil {
+	// fail-open: 실패해도 HTTP 동작은 정상 유지하되, 운영자가 원인 파악할 수 있도록
+	// 실패 사실과 사유를 WARN 로그로 1회 가시화 (transport 생성 시점이므로 1회 호출).
+	h2t, err := http2.ConfigureTransports(transport)
+	switch {
+	case err != nil:
+		logger.FromContext(context.Background()).WithError(err).
+			Warn("http2 monitoring disabled: failed to configure http2 transport")
+	case h2t == nil:
+		logger.FromContext(context.Background()).
+			Warn("http2 monitoring disabled: configured http2 transport is nil")
+	default:
 		h2t.CountError = recordHTTP2Error
 	}
 

--- a/internal/crawler/core/http_client.go
+++ b/internal/crawler/core/http_client.go
@@ -24,9 +24,9 @@ const (
 // HTTP/2 stream/connection error 모니터링 (이슈 #71/#117):
 //   - http2.ConfigureTransports 로 base transport 에 http2 transport 를 명시 구성
 //   - http2.Transport.CountError hook 으로 에러 유형별 카운트 (DefaultHTTP2ErrorCounter 누적)
-//   - 에러 발생 시 WARN 로그로 즉시 가시화 — 운영 모니터링/알림에서 빈도 추적 가능
-//   - ConfigureTransports 가 실패하면 (예: ForceAttemptHTTP2=false 일 때) 모니터링만 비활성화되고
-//     HTTP 클라이언트는 정상 동작 — fail-open 정책
+//   - 에러 발생 시 로그로 가시화 — 운영 모니터링/알림에서 빈도 추적 가능
+//   - ConfigureTransports 가 실패하면 모니터링만 비활성화되고 HTTP 클라이언트는 정상 동작
+//     (fail-open 정책). 실패 사실은 WARN 로그로 가시화하여 운영자가 원인 파악 가능.
 func defaultHTTPClient(config Config) *http.Client {
 	transport := &http.Transport{
 		MaxIdleConns:        config.MaxIdleConns,

--- a/test/internal/crawler_core/http2_metrics_test.go
+++ b/test/internal/crawler_core/http2_metrics_test.go
@@ -1,0 +1,122 @@
+package core_test
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	core "issuetracker/internal/crawler/core"
+)
+
+// TestHTTP2ErrorCounter_Increment_StartsFromOne:
+// 새 errType 의 첫 Increment 는 1 을 반환해야 함.
+func TestHTTP2ErrorCounter_Increment_StartsFromOne(t *testing.T) {
+	c := core.NewHTTP2ErrorCounter()
+	got := c.Increment("stream_error_received_data_after_end_stream")
+	assert.Equal(t, uint64(1), got)
+}
+
+// TestHTTP2ErrorCounter_Increment_AccumulatesPerErrType:
+// 동일 errType 반복 호출 시 카운트가 누적되어야 함.
+func TestHTTP2ErrorCounter_Increment_AccumulatesPerErrType(t *testing.T) {
+	c := core.NewHTTP2ErrorCounter()
+	for i := uint64(1); i <= 10; i++ {
+		got := c.Increment("conn_error_protocol")
+		assert.Equal(t, i, got)
+	}
+}
+
+// TestHTTP2ErrorCounter_Increment_SeparatesErrTypes:
+// 서로 다른 errType 은 독립적으로 카운트되어야 함.
+func TestHTTP2ErrorCounter_Increment_SeparatesErrTypes(t *testing.T) {
+	c := core.NewHTTP2ErrorCounter()
+
+	c.Increment("type_a")
+	c.Increment("type_a")
+	c.Increment("type_b")
+
+	snap := c.Snapshot()
+	assert.Equal(t, uint64(2), snap["type_a"])
+	assert.Equal(t, uint64(1), snap["type_b"])
+}
+
+// TestHTTP2ErrorCounter_Snapshot_EmptyCounter:
+// 한 번도 Increment 안 된 카운터의 Snapshot 은 빈 map 이어야 함 (nil 아님).
+func TestHTTP2ErrorCounter_Snapshot_EmptyCounter(t *testing.T) {
+	c := core.NewHTTP2ErrorCounter()
+	snap := c.Snapshot()
+	require.NotNil(t, snap)
+	assert.Empty(t, snap)
+}
+
+// TestHTTP2ErrorCounter_Snapshot_IndependentFromInternal:
+// 반환된 snapshot map 을 수정해도 카운터 내부 상태에 영향을 주지 않아야 함.
+func TestHTTP2ErrorCounter_Snapshot_IndependentFromInternal(t *testing.T) {
+	c := core.NewHTTP2ErrorCounter()
+	c.Increment("foo")
+
+	snap := c.Snapshot()
+	snap["foo"] = 999
+	snap["new_key"] = 1
+
+	snap2 := c.Snapshot()
+	assert.Equal(t, uint64(1), snap2["foo"], "snapshot 수정이 카운터에 반영되면 안 됨")
+	assert.NotContains(t, snap2, "new_key", "snapshot 에 추가한 키가 카운터에 반영되면 안 됨")
+}
+
+// TestHTTP2ErrorCounter_Concurrent_SafeIncrement:
+// 다중 goroutine 동시 Increment 가 race 없이 정확한 합계를 보장해야 함.
+// `-race` 플래그로 race detector 검증.
+func TestHTTP2ErrorCounter_Concurrent_SafeIncrement(t *testing.T) {
+	c := core.NewHTTP2ErrorCounter()
+
+	const goroutines = 50
+	const incrementsPerGoroutine = 100
+
+	var wg sync.WaitGroup
+	for i := 0; i < goroutines; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for j := 0; j < incrementsPerGoroutine; j++ {
+				c.Increment("concurrent_test")
+			}
+		}()
+	}
+	wg.Wait()
+
+	snap := c.Snapshot()
+	assert.Equal(t, uint64(goroutines*incrementsPerGoroutine), snap["concurrent_test"],
+		"동시 Increment 의 총합이 정확해야 함 (race 없음)")
+}
+
+// TestHTTP2ErrorCounter_SortedSnapshot_Deterministic:
+// SortedSnapshot 은 errType 사전순으로 결정적 순서를 반환해야 함.
+func TestHTTP2ErrorCounter_SortedSnapshot_Deterministic(t *testing.T) {
+	c := core.NewHTTP2ErrorCounter()
+	// 의도적으로 사전순과 다른 입력 순서
+	c.Increment("zebra")
+	c.Increment("alpha")
+	c.Increment("alpha")
+	c.Increment("middle")
+
+	got := c.SortedSnapshot()
+	require.Len(t, got, 3)
+	assert.Equal(t, "alpha", got[0].ErrorType)
+	assert.Equal(t, uint64(2), got[0].Count)
+	assert.Equal(t, "middle", got[1].ErrorType)
+	assert.Equal(t, uint64(1), got[1].Count)
+	assert.Equal(t, "zebra", got[2].ErrorType)
+	assert.Equal(t, uint64(1), got[2].Count)
+}
+
+// TestDefaultHTTP2ErrorCounter_NotNil:
+// 패키지 전역 기본 카운터가 초기화되어 있어야 함 (nil dereference 방지).
+func TestDefaultHTTP2ErrorCounter_NotNil(t *testing.T) {
+	require.NotNil(t, core.DefaultHTTP2ErrorCounter)
+	// 기본 카운터에 카운트를 추가해도 다른 테스트에 영향 없도록 readonly 체크만
+	snap := core.DefaultHTTP2ErrorCounter.Snapshot()
+	assert.NotNil(t, snap)
+}


### PR DESCRIPTION
## 연관 이슈
- Closes #117 (모니터링 분리 sub-issue)
- Refs #71 (umbrella tracker — 본 PR 머지 후에도 열린 상태 유지, 빈도 추이 누적 후 다음 단계 결정)

<!--
PR title 예시: [FEAT#issue번호]: 어쩌구저쩌
-->

<br>

## 구현 내용

### 모듈 — `internal/crawler/core/http2_metrics.go` (신규)
- `HTTP2ErrorCounter` 구조체: `sync.Map` 기반 errType→`*atomic.Uint64` 매핑 (race-safe)
- `Increment(errType) uint64` — 1 증가 후 누적값 반환
- `Snapshot() map[string]uint64` — 정합성 있는 단일 시점 사본, 호출자가 수정해도 내부 상태 보호
- `SortedSnapshot() []HTTP2ErrorEntry` — errType 사전순 결정적 출력 (로깅·진단용)
- `DefaultHTTP2ErrorCounter` — 패키지 전역 기본 인스턴스 (운영 진단: `core.DefaultHTTP2ErrorCounter.Snapshot()`)

### Transport hook — `internal/crawler/core/http_client.go` 수정
- `defaultHTTPClient` 의 `&http.Transport{...}` 생성 직후 `http2.ConfigureTransports(transport)` 적용
- 반환된 `*http2.Transport` 의 `CountError` 콜백을 `recordHTTP2Error` 로 설정
- `recordHTTP2Error(errType)`: 카운터 증가 + WARN 로그 (`http2_error_type`, `count` 필드)
- **fail-open**: `ConfigureTransports` 가 실패해도 모니터링만 비활성화되고 HTTP 동작은 정상

### 의존성
- `golang.org/x/net` 을 indirect → direct 로 승격 (`go mod tidy` 결과)

### 테스트 — `test/internal/crawler_core/http2_metrics_test.go` (신규, 8건)
- `Increment_StartsFromOne` / `Increment_AccumulatesPerErrType` / `Increment_SeparatesErrTypes`
- `Snapshot_EmptyCounter` / `Snapshot_IndependentFromInternal`
- `Concurrent_SafeIncrement` — 50 goroutine × 100 increments race detector 검증
- `SortedSnapshot_Deterministic`
- `DefaultHTTP2ErrorCounter_NotNil`

<br>

## CI / 머지 게이트 점검

> [CI 운영 규약](docs/ci/conventions.md) 및 [Required Status Checks 단일 소스](docs/ci/status-checks.md)에 따라 작성합니다.

### 변경 영향 범위
- 영향 패키지/모듈: `internal/crawler/core` (http_client.go 수정, http2_metrics.go 신규), 관련 테스트 1개 추가, `go.mod` 정리
- 위험도(택1): **`Low`** / `Medium` / `High`
  - HTTP/2 transport 자체의 동작은 변경 없음 (CountError 는 read-only hook)
  - fail-open 정책으로 모니터링 활성화 실패 시 기존 동작 보존
  - 새 의존성 없음 (x/net 은 이미 transitive 로 포함됨, direct 승격만)

### Required Status Checks
- 통과 확인 대상 (PR Checks 탭에서 확인):
  - [ ] `Commit Lint`
  - [ ] `PR Title Lint`
  - [ ] `Format Check`
  - [ ] `Build`
  - [ ] `Test`
  - [ ] `Lint`

### 롤백 계획
- 단일 revert 로 즉시 복원 가능. 모니터링 외 다른 코드 경로 영향 없음.
- 운영 도입 후 카운터 메모리 사용이 우려되면(에러 유형이 무한 증가하는 비정상 케이스) 카운터 인스턴스에 cap 추가하는 별도 PR 검토.

<br>

## TODO
- [x] HTTP2ErrorCounter 모듈 (atomic counter + Snapshot/SortedSnapshot)
- [x] http_client.go transport 에 CountError hook 연결
- [x] 단위 테스트 8건 (race detector 포함)
- [x] go.mod 정리

<br>

## 논의 사항
- 카운터를 외부 시스템(Prometheus 등) 으로 노출할지는 별도 후속 작업. 현재는 in-process 카운터 + WARN 로그로 시작.
- 운영에서 누적된 빈도 추이 확인 후 #71 의 다음 단계 (소스별 ForceHTTP1 옵션화, 풀 제거 hook) 진행 여부 결정.
- 본 PR 머지 후에도 #71 은 열린 상태 유지 — Refs 만 사용하여 자동 close 방지.