### PR TITLE
[FEAT#119] URL 가드 — Scheduler/Publisher/Consumer 단일 공통 Gate 적용

### DIFF
--- a/internal/crawler/worker/pool.go
+++ b/internal/crawler/worker/pool.go
@@ -18,6 +18,7 @@ import (
 	"issuetracker/pkg/links"
 	"issuetracker/pkg/logger"
 	"issuetracker/pkg/queue"
+	"issuetracker/pkg/urlguard"
 )
 
 // drainTimeout 은 graceful shutdown 으로 ctx 가 canceled 된 뒤 Kafka publish/commit 을
@@ -74,6 +75,11 @@ type KafkaConsumerPool struct {
 	// atomic.Pointer 를 사용하여 polling/worker goroutine 의 동시 Load 와
 	// SetNormalizer 의 Store 사이에 race 가 발생하지 않도록 보장합니다.
 	normalizer atomic.Pointer[links.Normalizer]
+	// gate 는 URL 가드 (이슈 #119) 입니다.
+	// 미설정(nil) 이면 가드 비활성 — 모든 job 이 처리됩니다.
+	// processJob 진입 직후 검사하여 차단된 URL 의 처리를 skip 하고 message 만 commit.
+	// atomic.Pointer 로 race-safe 한 lock-free 설정/조회.
+	gate atomic.Pointer[urlguard.Gate]
 	// pollDone은 pollMessages goroutine이 완전히 종료됐음을 알리는 신호입니다.
 	// close(p.jobs) 전에 반드시 이 채널이 닫혔음을 확인해야 합니다.
 	pollDone chan struct{}
@@ -148,6 +154,17 @@ func NewKafkaConsumerPoolWithOptions(
 		jobs:     make(chan jobItem, workerCount*2),
 		pollDone: make(chan struct{}),
 	}
+}
+
+// SetGate 는 processJob 진입 시 URL 검사에 사용할 urlguard.Gate 를 설정합니다 (이슈 #119).
+// 미설정(nil) 시 가드 비활성 — 모든 job 이 정상 처리됩니다.
+//
+// 차단 시 동작: handler.Handle 호출 없이 메시지만 commit (큐에서 제거).
+// → 누적된 stale URL 메시지가 retry 사이클에 다시 발행되는 것을 차단.
+//
+// 동시성: atomic.Pointer 기반 lock-free — Start 이후 변경에도 race-safe.
+func (p *KafkaConsumerPool) SetGate(g *urlguard.Gate) {
+	p.gate.Store(g)
 }
 
 // SetNormalizer는 URL 정규화기를 설정합니다.
@@ -299,6 +316,19 @@ func (p *KafkaConsumerPool) worker(ctx context.Context) {
 
 func (p *KafkaConsumerPool) processJob(ctx context.Context, item jobItem) error {
 	log := logger.FromContext(ctx)
+
+	// URL 가드 (이슈 #119): processJob 진입 직후 차단 URL 을 즉시 거르고 commit
+	// → handler 호출·lock 획득·backoff 대기 등 모든 비용 회피
+	// → stale URL 메시지가 큐에서 즉시 제거되어 retry 사이클 차단
+	if g := p.gate.Load(); g != nil && item.job != nil {
+		if !g.Allow(item.job.Target.URL, map[string]interface{}{
+			"crawler": item.job.CrawlerName,
+			"job_id":  item.job.ID,
+			"stage":   "consumer",
+		}) {
+			return p.commitMessage(ctx, item.msg)
+		}
+	}
 
 	// 재큐잉 시 설정된 ScheduledAt이 미래면 해당 시점까지 대기합니다.
 	// JobLocker 획득 전에 대기하는 이유는 다음과 같습니다:

--- a/internal/crawler/worker/pool.go
+++ b/internal/crawler/worker/pool.go
@@ -320,7 +320,10 @@ func (p *KafkaConsumerPool) processJob(ctx context.Context, item jobItem) error 
 	// URL 가드 (이슈 #119): processJob 진입 직후 차단 URL 을 즉시 거르고 commit
 	// → handler 호출·lock 획득·backoff 대기 등 모든 비용 회피
 	// → stale URL 메시지가 큐에서 즉시 제거되어 retry 사이클 차단
-	if g := p.gate.Load(); g != nil && item.job != nil {
+	//
+	// item.job 은 pollMessages 에서 unmarshal 성공 후에만 jobs 채널로 전송되므로
+	// 본 시점에 nil 일 수 없음 (방어 검사 불필요).
+	if g := p.gate.Load(); g != nil {
 		if !g.Allow(item.job.Target.URL, map[string]interface{}{
 			"crawler": item.job.CrawlerName,
 			"job_id":  item.job.ID,

--- a/internal/publisher/publisher.go
+++ b/internal/publisher/publisher.go
@@ -16,6 +16,7 @@ import (
 	"issuetracker/internal/crawler/core"
 	"issuetracker/pkg/logger"
 	"issuetracker/pkg/queue"
+	"issuetracker/pkg/urlguard"
 )
 
 // PriorityResolver는 CrawlJob의 우선순위를 결정하는 인터페이스입니다.
@@ -26,9 +27,15 @@ type PriorityResolver interface {
 
 // Publisher는 크롤된 페이지에서 발견된 URL을 새 CrawlJob으로 변환하여
 // 우선순위에 맞는 Kafka crawl 토픽에 발행합니다.
+//
+// URL 가드 (이슈 #119):
+//   - SetGate 로 urlguard.Gate 를 설정하면 PublishBatch 직전에 urls 슬라이스를 필터링
+//   - 차단된 URL 은 발행에서 제외 (Gate 가 자체 WARN 로그)
+//   - 미설정 시 가드 비활성 (기존 동작 유지)
 type Publisher struct {
 	producer queue.Producer
 	resolver PriorityResolver
+	gate     *urlguard.Gate
 	log      *logger.Logger
 }
 
@@ -39,6 +46,14 @@ func New(producer queue.Producer, resolver PriorityResolver, log *logger.Logger)
 		resolver: resolver,
 		log:      log,
 	}
+}
+
+// SetGate 는 Publish 시 urls 사전 필터링에 사용할 urlguard.Gate 를 설정합니다.
+// 미설정(nil) 시 가드 비활성 — 모든 urls 가 그대로 publish 됩니다.
+//
+// 동시성: 워커 시작 전에만 설정해야 합니다.
+func (p *Publisher) SetGate(g *urlguard.Gate) {
+	p.gate = g
 }
 
 // Publish는 발견된 URL 목록으로 CrawlJob을 생성하고 한 번의 배치 요청으로 Kafka에 발행합니다.
@@ -52,6 +67,18 @@ func (p *Publisher) Publish(
 ) error {
 	if len(urls) == 0 {
 		return nil
+	}
+
+	// URL 가드 (이슈 #119): 차단된 URL 을 사전 필터링
+	// Gate 가 자체 WARN 로그 + url/reason/crawler/stage 필드 자동 부착
+	if p.gate != nil {
+		urls = p.gate.Filter(urls, map[string]interface{}{
+			"crawler": crawlerName,
+			"stage":   "publisher",
+		})
+		if len(urls) == 0 {
+			return nil
+		}
 	}
 
 	msgs := make([]queue.Message, 0, len(urls))

--- a/internal/publisher/publisher.go
+++ b/internal/publisher/publisher.go
@@ -11,6 +11,7 @@ import (
 	"crypto/rand"
 	"encoding/hex"
 	"fmt"
+	"sync/atomic"
 	"time"
 
 	"issuetracker/internal/crawler/core"
@@ -32,10 +33,11 @@ type PriorityResolver interface {
 //   - SetGate 로 urlguard.Gate 를 설정하면 PublishBatch 직전에 urls 슬라이스를 필터링
 //   - 차단된 URL 은 발행에서 제외 (Gate 가 자체 WARN 로그)
 //   - 미설정 시 가드 비활성 (기존 동작 유지)
+//   - atomic.Pointer 로 race-safe 한 lock-free 설정/조회 — 워커 동시 실행 중 변경에도 race 없음
 type Publisher struct {
 	producer queue.Producer
 	resolver PriorityResolver
-	gate     *urlguard.Gate
+	gate     atomic.Pointer[urlguard.Gate]
 	log      *logger.Logger
 }
 
@@ -51,9 +53,9 @@ func New(producer queue.Producer, resolver PriorityResolver, log *logger.Logger)
 // SetGate 는 Publish 시 urls 사전 필터링에 사용할 urlguard.Gate 를 설정합니다.
 // 미설정(nil) 시 가드 비활성 — 모든 urls 가 그대로 publish 됩니다.
 //
-// 동시성: 워커 시작 전에만 설정해야 합니다.
+// 동시성: atomic.Pointer 기반 lock-free 설정/조회 — Publish 동시 실행 중 변경에도 race-safe.
 func (p *Publisher) SetGate(g *urlguard.Gate) {
-	p.gate = g
+	p.gate.Store(g)
 }
 
 // Publish는 발견된 URL 목록으로 CrawlJob을 생성하고 한 번의 배치 요청으로 Kafka에 발행합니다.
@@ -71,8 +73,8 @@ func (p *Publisher) Publish(
 
 	// URL 가드 (이슈 #119): 차단된 URL 을 사전 필터링
 	// Gate 가 자체 WARN 로그 + url/reason/crawler/stage 필드 자동 부착
-	if p.gate != nil {
-		urls = p.gate.Filter(urls, map[string]interface{}{
+	if g := p.gate.Load(); g != nil {
+		urls = g.Filter(urls, map[string]interface{}{
 			"crawler": crawlerName,
 			"stage":   "publisher",
 		})

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -10,14 +10,21 @@ import (
 
 	"issuetracker/internal/crawler/core"
 	"issuetracker/pkg/logger"
+	"issuetracker/pkg/urlguard"
 )
 
 // Scheduler는 등록된 ScheduleEntry 목록을 기반으로 주기적으로 시드 CrawlJob을 생성하고
 // Emitter를 통해 Kafka crawl 토픽에 발행합니다.
 // 체이닝 Job(크롤된 페이지에서 발견된 URL)은 internal/publisher 패키지가 담당합니다.
+//
+// URL 가드 (이슈 #119):
+//   - SetGate 로 urlguard.Gate 를 설정하면 publish 직전에 entry.URL 검사
+//   - 차단된 URL 은 Emit 호출 없이 silent drop + WARN 로그
+//   - 미설정 시 가드 비활성 (기존 동작 유지)
 type Scheduler struct {
 	entries    []ScheduleEntry
 	emitter    Emitter
+	gate       *urlguard.Gate
 	log        *logger.Logger
 	wg         sync.WaitGroup
 	maxRetries int
@@ -53,6 +60,14 @@ func (s *Scheduler) Start(ctx context.Context) {
 func (s *Scheduler) Stop() {
 	s.wg.Wait()
 	s.log.Info("scheduler stopped")
+}
+
+// SetGate 는 publish 직전 URL 검사에 사용할 urlguard.Gate 를 설정합니다.
+// 미설정(nil) 시 가드 비활성 — 모든 entry.URL 이 그대로 emit 됩니다.
+//
+// 동시성: Start 호출 전에만 설정해야 합니다 (run goroutine 과의 race 방지).
+func (s *Scheduler) SetGate(g *urlguard.Gate) {
+	s.gate = g
 }
 
 // run은 단일 ScheduleEntry에 대한 스케줄 루프입니다.
@@ -103,6 +118,17 @@ func (s *Scheduler) publish(ctx context.Context, entry ScheduleEntry) {
 			"url":     entry.URL,
 		}).WithError(err).Error("failed to generate job id")
 		return
+	}
+
+	// URL 가드 (이슈 #119): job 생성 직전에 entry.URL 검사
+	// 차단 시 emit 호출 없이 silent drop (가드가 WARN 로그 자동 생성)
+	if s.gate != nil {
+		if !s.gate.Allow(entry.URL, map[string]interface{}{
+			"crawler": entry.CrawlerName,
+			"stage":   "scheduler",
+		}) {
+			return
+		}
 	}
 
 	job := &core.CrawlJob{

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -6,6 +6,7 @@ import (
 	"encoding/hex"
 	"fmt"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"issuetracker/internal/crawler/core"
@@ -21,10 +22,11 @@ import (
 //   - SetGate 로 urlguard.Gate 를 설정하면 publish 직전에 entry.URL 검사
 //   - 차단된 URL 은 Emit 호출 없이 silent drop + WARN 로그
 //   - 미설정 시 가드 비활성 (기존 동작 유지)
+//   - atomic.Pointer 로 race-safe 한 lock-free 설정/조회 — Start 이후 변경에도 race 없음
 type Scheduler struct {
 	entries    []ScheduleEntry
 	emitter    Emitter
-	gate       *urlguard.Gate
+	gate       atomic.Pointer[urlguard.Gate]
 	log        *logger.Logger
 	wg         sync.WaitGroup
 	maxRetries int
@@ -65,9 +67,9 @@ func (s *Scheduler) Stop() {
 // SetGate 는 publish 직전 URL 검사에 사용할 urlguard.Gate 를 설정합니다.
 // 미설정(nil) 시 가드 비활성 — 모든 entry.URL 이 그대로 emit 됩니다.
 //
-// 동시성: Start 호출 전에만 설정해야 합니다 (run goroutine 과의 race 방지).
+// 동시성: atomic.Pointer 기반 lock-free 설정/조회 — Start 이후 변경에도 race-safe.
 func (s *Scheduler) SetGate(g *urlguard.Gate) {
-	s.gate = g
+	s.gate.Store(g)
 }
 
 // run은 단일 ScheduleEntry에 대한 스케줄 루프입니다.
@@ -122,8 +124,8 @@ func (s *Scheduler) publish(ctx context.Context, entry ScheduleEntry) {
 
 	// URL 가드 (이슈 #119): job 생성 직전에 entry.URL 검사
 	// 차단 시 emit 호출 없이 silent drop (가드가 WARN 로그 자동 생성)
-	if s.gate != nil {
-		if !s.gate.Allow(entry.URL, map[string]interface{}{
+	if g := s.gate.Load(); g != nil {
+		if !g.Allow(entry.URL, map[string]interface{}{
 			"crawler": entry.CrawlerName,
 			"stage":   "scheduler",
 		}) {

--- a/pkg/urlguard/gate.go
+++ b/pkg/urlguard/gate.go
@@ -1,0 +1,80 @@
+package urlguard
+
+import (
+	"context"
+
+	"issuetracker/pkg/logger"
+)
+
+// Gate 는 Guard 결과를 일관된 방식으로 적용·로깅하는 단일 공통 컴포넌트입니다.
+//
+// 본 패키지의 핵심 — Scheduler / Publisher / Consumer 등 모든 진입점이 동일한
+// Gate 인스턴스의 메서드를 호출하여 차단 정책을 적용합니다. 레이어별로 별도의
+// 데코레이터 타입을 만들지 않고, "decorator 처럼 동작" 하는 단일 helper 가 모든
+// 곳에서 재사용되는 형태.
+//
+// 두 가지 사용 패턴:
+//   - Allow(url, fields)   — 단일 URL 검사 (Scheduler/Worker 처럼 1건 처리)
+//   - Filter(urls, fields) — URL 슬라이스 필터링 (Publisher 처럼 다건 처리)
+//
+// 두 메서드 모두 차단 시 동일한 WARN 로그 형식을 사용 (url/reason 필드 + 호출자
+// 컨텍스트 필드) — 운영 모니터링에서 차단 이벤트를 일관되게 식별 가능.
+//
+// goroutine-safe — 내부 상태가 없으며 Guard 와 Logger 는 둘 다 race-safe 가정.
+type Gate struct {
+	guard Guard
+	log   *logger.Logger
+}
+
+// NewGate 는 주어진 guard 와 log 로 새 Gate 를 생성합니다.
+// guard 가 nil 이면 panic — 비활성화는 AllowAllGuard{} 명시 주입으로 표현.
+// log 가 nil 이면 logger.FromContext(context.Background()) 의 기본 logger 를 사용.
+func NewGate(guard Guard, log *logger.Logger) *Gate {
+	if guard == nil {
+		panic("urlguard: NewGate requires non-nil Guard (use AllowAllGuard{} to disable)")
+	}
+	if log == nil {
+		log = logger.FromContext(context.Background())
+	}
+	return &Gate{guard: guard, log: log}
+}
+
+// Allow 는 단일 URL 이 통과하는지 검사합니다.
+//
+// 통과(true): WARN 로그 없음.
+// 차단(false): "blocked by url guard" WARN 로그 + 호출자 fields + url/reason 자동 포함.
+//
+// fields 는 호출자 컨텍스트 (예: {"crawler":"cnn", "job_id":"...", "stage":"scheduler"})
+// 를 전달합니다. nil 가능 — 그 경우 url/reason 만 로깅.
+func (g *Gate) Allow(url string, fields map[string]interface{}) bool {
+	allowed, reason := g.guard.Allow(url)
+	if allowed {
+		return true
+	}
+
+	merged := make(map[string]interface{}, len(fields)+2)
+	for k, v := range fields {
+		merged[k] = v
+	}
+	merged["url"] = url
+	merged["reason"] = reason
+	g.log.WithFields(merged).Warn("blocked by url guard")
+	return false
+}
+
+// Filter 는 슬라이스에서 통과 URL 만 추려 반환합니다. 차단된 각 URL 에 대해
+// Allow 와 동일한 WARN 로그를 남깁니다.
+//
+// 입력이 빈 슬라이스 또는 nil 이면 빈 슬라이스를 반환합니다.
+// 모두 차단되어도 nil 이 아닌 빈 슬라이스를 반환 — 호출자가 len() 으로 일관 분기 가능.
+//
+// 호출자가 결과 슬라이스를 수정해도 입력 슬라이스에 영향이 없도록 새 슬라이스를 할당합니다.
+func (g *Gate) Filter(urls []string, fields map[string]interface{}) []string {
+	out := make([]string, 0, len(urls))
+	for _, url := range urls {
+		if g.Allow(url, fields) {
+			out = append(out, url)
+		}
+	}
+	return out
+}

--- a/pkg/urlguard/guard.go
+++ b/pkg/urlguard/guard.go
@@ -1,0 +1,31 @@
+// Package urlguard 는 URL 처리 가능 여부를 판정하는 술어(Guard) 와, 그 결과를 일관된
+// 방식으로 적용·로깅하는 단일 공통 컴포넌트(Gate) 를 제공합니다.
+//
+// Scheduler / Publisher / Consumer 등 시스템의 여러 진입점에서 동일한 Guard 와
+// Gate 를 공유하여 차단 정책을 일관되게 적용합니다 — 레이어별 별도 데코레이터를
+// 만들지 않고, 각 레이어가 동일한 Gate 인스턴스의 Allow/Filter 를 호출합니다.
+//
+// 사용 예:
+//
+//	gate := urlguard.NewGate(urlguard.Default(), log)
+//	scheduler.SetGate(gate)
+//	publisher.SetGate(gate)
+//	pool.SetGate(gate)
+package urlguard
+
+// Guard 는 URL 이 시스템에서 처리 가능한지 판정하는 술어입니다.
+// 구현체는 goroutine-safe 해야 합니다 (Gate 가 동시 호출됨).
+type Guard interface {
+	// Allow 는 url 을 허용할지 여부와, 차단된 경우의 사유 문자열을 반환합니다.
+	// allowed=true 시 reason 은 빈 문자열입니다.
+	Allow(url string) (allowed bool, reason string)
+}
+
+// AllowAllGuard 는 모든 URL 을 허용하는 no-op 구현입니다.
+// 가드 비활성화 또는 테스트 시 사용합니다.
+type AllowAllGuard struct{}
+
+// Allow 는 항상 (true, "") 를 반환합니다.
+func (AllowAllGuard) Allow(_ string) (bool, string) {
+	return true, ""
+}

--- a/pkg/urlguard/pattern.go
+++ b/pkg/urlguard/pattern.go
@@ -1,0 +1,72 @@
+package urlguard
+
+import (
+	"strings"
+)
+
+// PatternGuard 는 substring 패턴 기반의 Guard 구현입니다.
+// 등록된 패턴 중 하나라도 URL 에 포함되면 차단합니다 (case-insensitive).
+//
+// goroutine-safe — 생성 후 패턴 집합은 불변입니다 (NewPatternGuard 시 복사).
+//
+// 매칭 정책 (substring):
+//   - URL 을 소문자 변환 후 각 패턴(소문자 사전 변환됨)을 strings.Contains 로 검사
+//   - 호스트·경로·쿼리 어디에 포함되어도 매칭 (예: "/rss" 패턴은 "rss.cnn.com" 호스트와
+//     "/rss/foo.xml" path 양쪽에 매칭)
+//   - 단순 substring 매칭이 의도치 않은 매칭을 일으킬 수 있으므로 패턴은 보수적으로 선정
+type PatternGuard struct {
+	// patternsLower 는 소문자로 사전 변환된 패턴 집합입니다.
+	// Allow 호출마다 ToLower 를 반복하지 않기 위함.
+	patternsLower []string
+}
+
+// NewPatternGuard 는 주어진 substring 패턴들로 새 PatternGuard 를 생성합니다.
+// 패턴은 소문자로 사전 변환되어 저장되며, 호출자 슬라이스 변경으로부터 독립적인
+// 복사본을 보유합니다.
+func NewPatternGuard(patterns ...string) *PatternGuard {
+	lower := make([]string, len(patterns))
+	for i, p := range patterns {
+		lower[i] = strings.ToLower(p)
+	}
+	return &PatternGuard{patternsLower: lower}
+}
+
+// Allow 는 url 이 등록된 어떤 패턴과도 매칭되지 않으면 (true, "") 를,
+// 매칭되면 (false, "blocked by pattern: <pattern>") 을 반환합니다.
+// 빈 url 은 허용합니다 (호출자가 별도 검증).
+func (g *PatternGuard) Allow(url string) (bool, string) {
+	if url == "" {
+		return true, ""
+	}
+	lower := strings.ToLower(url)
+	for _, pat := range g.patternsLower {
+		if pat == "" {
+			continue
+		}
+		if strings.Contains(lower, pat) {
+			return false, "blocked by pattern: " + pat
+		}
+	}
+	return true, ""
+}
+
+// DefaultPatterns 는 도메인 디폴트 차단 패턴입니다.
+//
+// 정책 근거:
+//   - "/rss" : RSS 피드 URL 일괄 차단 (이슈 #119 의 CNN RSS 잔존 사고 대응).
+//     pkg/links 의 defaultExcludePatterns 와 동일 패턴.
+//   - "mailto:" / "tel:" : 비-HTTP 스킴은 외부 fetch 대상이 아님.
+//   - "javascript:" : 클라이언트 사이드 코드 — fetch 의미 없음.
+//
+// 운영 환경에서 추가 패턴이 필요한 경우 NewPatternGuard 로 별도 인스턴스 구성.
+var DefaultPatterns = []string{
+	"/rss",
+	"mailto:",
+	"tel:",
+	"javascript:",
+}
+
+// Default 는 DefaultPatterns 로 구성한 Guard 인스턴스를 반환합니다.
+func Default() Guard {
+	return NewPatternGuard(DefaultPatterns...)
+}

--- a/pkg/urlguard/pattern.go
+++ b/pkg/urlguard/pattern.go
@@ -50,7 +50,7 @@ func (g *PatternGuard) Allow(url string) (bool, string) {
 	return true, ""
 }
 
-// DefaultPatterns 는 도메인 디폴트 차단 패턴입니다.
+// defaultPatterns 는 도메인 디폴트 차단 패턴입니다 (unexported — 외부 변경 차단).
 //
 // 정책 근거:
 //   - "/rss" : RSS 피드 URL 일괄 차단 (이슈 #119 의 CNN RSS 잔존 사고 대응).
@@ -59,14 +59,28 @@ func (g *PatternGuard) Allow(url string) (bool, string) {
 //   - "javascript:" : 클라이언트 사이드 코드 — fetch 의미 없음.
 //
 // 운영 환경에서 추가 패턴이 필요한 경우 NewPatternGuard 로 별도 인스턴스 구성.
-var DefaultPatterns = []string{
+var defaultPatterns = []string{
 	"/rss",
 	"mailto:",
 	"tel:",
 	"javascript:",
 }
 
-// Default 는 DefaultPatterns 로 구성한 Guard 인스턴스를 반환합니다.
+// DefaultPatterns 는 디폴트 차단 패턴 목록의 복사본을 반환합니다.
+// 외부에서 수정해도 내부 상태와 다른 호출자의 결과에 영향을 주지 않습니다.
+//
+// 운영 진단/문서화 목적으로 패턴 목록을 조회하거나, 커스텀 PatternGuard 를
+// 구성할 때 base 로 사용하기 위함:
+//
+//	patterns := append(urlguard.DefaultPatterns(), "/extra-block")
+//	guard := urlguard.NewPatternGuard(patterns...)
+func DefaultPatterns() []string {
+	out := make([]string, len(defaultPatterns))
+	copy(out, defaultPatterns)
+	return out
+}
+
+// Default 는 디폴트 패턴으로 구성한 Guard 인스턴스를 반환합니다.
 func Default() Guard {
-	return NewPatternGuard(DefaultPatterns...)
+	return NewPatternGuard(defaultPatterns...)
 }

--- a/test/internal/publisher/publisher_gate_test.go
+++ b/test/internal/publisher/publisher_gate_test.go
@@ -1,0 +1,140 @@
+package publisher_test
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"issuetracker/internal/crawler/core"
+	"issuetracker/internal/publisher"
+	"issuetracker/pkg/logger"
+	"issuetracker/pkg/queue"
+	"issuetracker/pkg/urlguard"
+)
+
+// gateMockProducer 는 PublishBatch 호출 인자를 기록합니다.
+type gateMockProducer struct {
+	mu     sync.Mutex
+	calls  [][]queue.Message
+	retErr error
+}
+
+func (m *gateMockProducer) Publish(_ context.Context, _ queue.Message) error {
+	return nil
+}
+
+func (m *gateMockProducer) PublishBatch(_ context.Context, msgs []queue.Message) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	cpy := make([]queue.Message, len(msgs))
+	copy(cpy, msgs)
+	m.calls = append(m.calls, cpy)
+	return m.retErr
+}
+
+func (m *gateMockProducer) Close() error { return nil }
+
+func (m *gateMockProducer) batchUrls() []string {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if len(m.calls) == 0 {
+		return nil
+	}
+	out := make([]string, 0)
+	for _, msgs := range m.calls {
+		for _, msg := range msgs {
+			// Job 페이로드 파싱 없이 key 도 좋지만, 여기선 간단히 batch 길이 확인용
+			_ = msg
+		}
+		// 실제 URL 추출은 페이로드 파싱이 필요 — 길이만 검증
+	}
+	return out
+}
+
+func (m *gateMockProducer) batchSize() int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if len(m.calls) == 0 {
+		return 0
+	}
+	return len(m.calls[0])
+}
+
+// noopResolver 는 Priority Resolver 더블입니다 (항상 Normal 반환).
+type noopResolver struct{}
+
+func (noopResolver) Resolve(_ *core.CrawlJob) core.Priority { return core.PriorityNormal }
+
+func gateLog() *logger.Logger { return logger.New(logger.DefaultConfig()) }
+
+// TestPublisher_Gate_FiltersBlockedURLs:
+// urls 슬라이스에서 차단 대상이 사전 필터링되고 통과분만 batch publish.
+func TestPublisher_Gate_FiltersBlockedURLs(t *testing.T) {
+	prod := &gateMockProducer{}
+	pub := publisher.New(prod, noopResolver{}, gateLog())
+	pub.SetGate(urlguard.NewGate(urlguard.Default(), gateLog()))
+
+	urls := []string{
+		"https://edition.cnn.com/article/1",        // pass
+		"https://rss.cnn.com/rss/cnn_health.rss",   // block
+		"https://news.naver.com/main/read.naver",   // pass
+		"mailto:foo@example.com",                   // block
+	}
+	err := pub.Publish(context.Background(), "cnn", urls, core.TargetTypeArticle, 5*time.Second)
+	require.NoError(t, err)
+
+	assert.Equal(t, 2, prod.batchSize(), "통과 2건만 batch 에 포함")
+}
+
+// TestPublisher_Gate_AllBlocked_NoPublish:
+// 모두 차단되면 PublishBatch 호출 없이 nil 반환.
+func TestPublisher_Gate_AllBlocked_NoPublish(t *testing.T) {
+	prod := &gateMockProducer{}
+	pub := publisher.New(prod, noopResolver{}, gateLog())
+	pub.SetGate(urlguard.NewGate(urlguard.Default(), gateLog()))
+
+	err := pub.Publish(context.Background(), "cnn", []string{
+		"https://rss.cnn.com/rss/cnn_health.rss",
+		"mailto:x@y.z",
+	}, core.TargetTypeArticle, 5*time.Second)
+	require.NoError(t, err)
+
+	prod.mu.Lock()
+	defer prod.mu.Unlock()
+	assert.Empty(t, prod.calls, "전부 차단 시 PublishBatch 미호출")
+}
+
+// TestPublisher_NoGate_LegacyBehavior:
+// SetGate 미호출 시 모든 URL publish (기존 동작 유지).
+func TestPublisher_NoGate_LegacyBehavior(t *testing.T) {
+	prod := &gateMockProducer{}
+	pub := publisher.New(prod, noopResolver{}, gateLog())
+	// SetGate 호출 없음
+
+	urls := []string{
+		"https://rss.cnn.com/rss/cnn_health.rss",
+		"https://edition.cnn.com/article/1",
+	}
+	require.NoError(t, pub.Publish(context.Background(), "cnn", urls, core.TargetTypeArticle, 5*time.Second))
+
+	assert.Equal(t, 2, prod.batchSize(), "가드 미설정 — 모든 URL publish")
+}
+
+// TestPublisher_Gate_AllowAllGuard_NoFiltering:
+// AllowAllGuard 명시 사용 시 차단 없이 전체 publish.
+func TestPublisher_Gate_AllowAllGuard_NoFiltering(t *testing.T) {
+	prod := &gateMockProducer{}
+	pub := publisher.New(prod, noopResolver{}, gateLog())
+	pub.SetGate(urlguard.NewGate(urlguard.AllowAllGuard{}, gateLog()))
+
+	urls := []string{
+		"https://rss.cnn.com/rss/cnn_health.rss",
+		"mailto:foo@example.com",
+	}
+	require.NoError(t, pub.Publish(context.Background(), "cnn", urls, core.TargetTypeArticle, 5*time.Second))
+	assert.Equal(t, 2, prod.batchSize())
+}

--- a/test/internal/publisher/publisher_gate_test.go
+++ b/test/internal/publisher/publisher_gate_test.go
@@ -38,23 +38,6 @@ func (m *gateMockProducer) PublishBatch(_ context.Context, msgs []queue.Message)
 
 func (m *gateMockProducer) Close() error { return nil }
 
-func (m *gateMockProducer) batchUrls() []string {
-	m.mu.Lock()
-	defer m.mu.Unlock()
-	if len(m.calls) == 0 {
-		return nil
-	}
-	out := make([]string, 0)
-	for _, msgs := range m.calls {
-		for _, msg := range msgs {
-			// Job 페이로드 파싱 없이 key 도 좋지만, 여기선 간단히 batch 길이 확인용
-			_ = msg
-		}
-		// 실제 URL 추출은 페이로드 파싱이 필요 — 길이만 검증
-	}
-	return out
-}
-
 func (m *gateMockProducer) batchSize() int {
 	m.mu.Lock()
 	defer m.mu.Unlock()
@@ -79,10 +62,10 @@ func TestPublisher_Gate_FiltersBlockedURLs(t *testing.T) {
 	pub.SetGate(urlguard.NewGate(urlguard.Default(), gateLog()))
 
 	urls := []string{
-		"https://edition.cnn.com/article/1",        // pass
-		"https://rss.cnn.com/rss/cnn_health.rss",   // block
-		"https://news.naver.com/main/read.naver",   // pass
-		"mailto:foo@example.com",                   // block
+		"https://edition.cnn.com/article/1",      // pass
+		"https://rss.cnn.com/rss/cnn_health.rss", // block
+		"https://news.naver.com/main/read.naver", // pass
+		"mailto:foo@example.com",                 // block
 	}
 	err := pub.Publish(context.Background(), "cnn", urls, core.TargetTypeArticle, 5*time.Second)
 	require.NoError(t, err)

--- a/test/internal/scheduler/scheduler_gate_test.go
+++ b/test/internal/scheduler/scheduler_gate_test.go
@@ -1,7 +1,10 @@
 package scheduler_test
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -40,10 +43,59 @@ func gateTestLogger() *logger.Logger {
 	return logger.New(logger.DefaultConfig())
 }
 
+// safeBuffer 는 mutex 로 보호된 bytes.Buffer 입니다.
+// logger 가 goroutine 에서 Write 하고 테스트가 main 에서 String() 으로 읽는 동안
+// race 가 발생하지 않도록 보호합니다 (bytes.Buffer 는 thread-safe 하지 않음).
+type safeBuffer struct {
+	mu  sync.Mutex
+	buf bytes.Buffer
+}
+
+func (s *safeBuffer) Write(p []byte) (int, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.buf.Write(p)
+}
+
+func (s *safeBuffer) String() string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.buf.String()
+}
+
+// captureLogger 는 출력을 buf 로 캡쳐하는 logger 를 반환합니다.
+func captureLogger(buf *safeBuffer) *logger.Logger {
+	cfg := logger.DefaultConfig()
+	cfg.Output = buf
+	cfg.Level = logger.LevelDebug
+	return logger.New(cfg)
+}
+
+// hasBlockLog 는 buf 에 'blocked by url guard' WARN 로그가 1건 이상 존재하는지
+// 검사합니다 (JSON 라인별 파싱).
+func hasBlockLog(buf *safeBuffer, url string) bool {
+	for _, line := range strings.Split(buf.String(), "\n") {
+		if line == "" {
+			continue
+		}
+		var e map[string]interface{}
+		if json.Unmarshal([]byte(line), &e) != nil {
+			continue
+		}
+		if e["message"] == "blocked by url guard" && e["url"] == url {
+			return true
+		}
+	}
+	return false
+}
+
 // TestScheduler_Gate_BlocksRSSEntry:
-// SetGate 로 Default() 가드 설정 시 RSS URL entry 가 emit 되지 않아야 함.
+// SetGate 로 Default() 가드 설정 시 RSS URL entry 가 emit 되지 않고,
+// Gate 가 차단 WARN 로그를 남기는지 확인 — 단순 callCount==0 만 확인하면
+// 스케줄러가 한 번도 안 돌았는지 차단됐는지 구분 불가하므로 로그 신호로 검증.
 func TestScheduler_Gate_BlocksRSSEntry(t *testing.T) {
 	pub := &gateMockEmitter{}
+	gateLogBuf := &safeBuffer{}
 	entry := scheduler.ScheduleEntry{
 		CrawlerName: "cnn",
 		URL:         "https://rss.cnn.com/rss/cnn_health.rss",
@@ -54,16 +106,20 @@ func TestScheduler_Gate_BlocksRSSEntry(t *testing.T) {
 	}
 
 	sched := scheduler.New([]scheduler.ScheduleEntry{entry}, pub, gateTestLogger(), 3)
-	sched.SetGate(urlguard.NewGate(urlguard.Default(), gateTestLogger()))
+	// Gate 의 logger 를 캡쳐 — 차단 시 'blocked by url guard' 로그가 buf 에 기록됨
+	sched.SetGate(urlguard.NewGate(urlguard.Default(), captureLogger(gateLogBuf)))
 
 	ctx, cancel := context.WithCancel(context.Background())
 	sched.Start(ctx)
-	// 첫 즉시 실행 + 1~2회 tick 보장하는 시간만큼 대기
-	time.Sleep(150 * time.Millisecond)
+	// 가드 차단 로그가 발생할 때까지 대기 (실행 자체가 안 일어났으면 영원히 false → timeout 으로 fail)
+	require.Eventually(t, func() bool {
+		return hasBlockLog(gateLogBuf, "https://rss.cnn.com/rss/cnn_health.rss")
+	}, time.Second, 10*time.Millisecond,
+		"스케줄러가 publish 시도 후 가드가 RSS URL 을 차단해야 함 (차단 로그 1건 이상)")
 	cancel()
 	sched.Stop()
 
-	assert.Equal(t, 0, pub.callCount(), "RSS URL entry 는 가드에 의해 차단되어 emit 안 됨")
+	assert.Equal(t, 0, pub.callCount(), "차단된 entry 는 inner emit 호출 안 됨")
 }
 
 // TestScheduler_Gate_AllowsCategoryEntry:

--- a/test/internal/scheduler/scheduler_gate_test.go
+++ b/test/internal/scheduler/scheduler_gate_test.go
@@ -1,0 +1,136 @@
+package scheduler_test
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"issuetracker/internal/crawler/core"
+	"issuetracker/internal/scheduler"
+	"issuetracker/pkg/logger"
+	"issuetracker/pkg/urlguard"
+)
+
+// gateMockEmitter 는 Emit 호출 인자를 기록하는 테스트 더블입니다.
+type gateMockEmitter struct {
+	mu    sync.Mutex
+	jobs  []*core.CrawlJob
+	calls int
+}
+
+func (m *gateMockEmitter) Emit(_ context.Context, job *core.CrawlJob) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.jobs = append(m.jobs, job)
+	m.calls++
+	return nil
+}
+
+func (m *gateMockEmitter) callCount() int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.calls
+}
+
+func gateTestLogger() *logger.Logger {
+	return logger.New(logger.DefaultConfig())
+}
+
+// TestScheduler_Gate_BlocksRSSEntry:
+// SetGate 로 Default() 가드 설정 시 RSS URL entry 가 emit 되지 않아야 함.
+func TestScheduler_Gate_BlocksRSSEntry(t *testing.T) {
+	pub := &gateMockEmitter{}
+	entry := scheduler.ScheduleEntry{
+		CrawlerName: "cnn",
+		URL:         "https://rss.cnn.com/rss/cnn_health.rss",
+		TargetType:  core.TargetTypeFeed,
+		Interval:    50 * time.Millisecond,
+		Priority:    core.PriorityNormal,
+		Timeout:     5 * time.Second,
+	}
+
+	sched := scheduler.New([]scheduler.ScheduleEntry{entry}, pub, gateTestLogger(), 3)
+	sched.SetGate(urlguard.NewGate(urlguard.Default(), gateTestLogger()))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	sched.Start(ctx)
+	// 첫 즉시 실행 + 1~2회 tick 보장하는 시간만큼 대기
+	time.Sleep(150 * time.Millisecond)
+	cancel()
+	sched.Stop()
+
+	assert.Equal(t, 0, pub.callCount(), "RSS URL entry 는 가드에 의해 차단되어 emit 안 됨")
+}
+
+// TestScheduler_Gate_AllowsCategoryEntry:
+// 카테고리 URL entry 는 가드를 통과하여 정상 emit 되어야 함.
+func TestScheduler_Gate_AllowsCategoryEntry(t *testing.T) {
+	pub := &gateMockEmitter{}
+	entry := scheduler.ScheduleEntry{
+		CrawlerName: "cnn",
+		URL:         "https://edition.cnn.com/health",
+		TargetType:  core.TargetTypeCategory,
+		Interval:    50 * time.Millisecond,
+		Priority:    core.PriorityNormal,
+		Timeout:     5 * time.Second,
+	}
+
+	sched := scheduler.New([]scheduler.ScheduleEntry{entry}, pub, gateTestLogger(), 3)
+	sched.SetGate(urlguard.NewGate(urlguard.Default(), gateTestLogger()))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	sched.Start(ctx)
+	require.Eventually(t, func() bool { return pub.callCount() >= 1 }, time.Second, 10*time.Millisecond)
+	cancel()
+	sched.Stop()
+}
+
+// TestScheduler_NoGate_LegacyBehavior:
+// SetGate 미호출 시 모든 URL emit (기존 동작 유지).
+func TestScheduler_NoGate_LegacyBehavior(t *testing.T) {
+	pub := &gateMockEmitter{}
+	entry := scheduler.ScheduleEntry{
+		CrawlerName: "cnn",
+		URL:         "https://rss.cnn.com/rss/cnn_health.rss",
+		TargetType:  core.TargetTypeFeed,
+		Interval:    50 * time.Millisecond,
+		Priority:    core.PriorityNormal,
+		Timeout:     5 * time.Second,
+	}
+
+	sched := scheduler.New([]scheduler.ScheduleEntry{entry}, pub, gateTestLogger(), 3)
+	// SetGate 호출 없음 — 가드 비활성
+
+	ctx, cancel := context.WithCancel(context.Background())
+	sched.Start(ctx)
+	require.Eventually(t, func() bool { return pub.callCount() >= 1 }, time.Second, 10*time.Millisecond)
+	cancel()
+	sched.Stop()
+}
+
+// TestScheduler_Gate_AllowAllGuard_DelegatesAll:
+// AllowAllGuard 로 명시적 비활성화 시 모든 URL emit.
+func TestScheduler_Gate_AllowAllGuard_DelegatesAll(t *testing.T) {
+	pub := &gateMockEmitter{}
+	entry := scheduler.ScheduleEntry{
+		CrawlerName: "cnn",
+		URL:         "https://rss.cnn.com/rss/cnn_health.rss",
+		TargetType:  core.TargetTypeFeed,
+		Interval:    50 * time.Millisecond,
+		Priority:    core.PriorityNormal,
+		Timeout:     5 * time.Second,
+	}
+
+	sched := scheduler.New([]scheduler.ScheduleEntry{entry}, pub, gateTestLogger(), 3)
+	sched.SetGate(urlguard.NewGate(urlguard.AllowAllGuard{}, gateTestLogger()))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	sched.Start(ctx)
+	require.Eventually(t, func() bool { return pub.callCount() >= 1 }, time.Second, 10*time.Millisecond)
+	cancel()
+	sched.Stop()
+}

--- a/test/internal/worker/pool_gate_test.go
+++ b/test/internal/worker/pool_gate_test.go
@@ -1,0 +1,144 @@
+package worker_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+
+	"issuetracker/internal/crawler/core"
+	"issuetracker/internal/crawler/worker"
+	"issuetracker/pkg/logger"
+	"issuetracker/pkg/urlguard"
+)
+
+// TestKafkaConsumerPool_Gate_BlocksRSSURL_CommitsAndSkipsHandler:
+// 차단 URL job 은 handler.Handle 호출 없이 메시지만 commit 되어야 함 (큐에서 즉시 제거).
+//
+// 이슈 #119 의 핵심 효과 — stale URL 메시지가 retry 사이클 없이 정리됨을 보장.
+func TestKafkaConsumerPool_Gate_BlocksRSSURL_CommitsAndSkipsHandler(t *testing.T) {
+	consumer := new(mockConsumer)
+	producer := new(mockProducer)
+	handler := new(mockJobHandler)
+	contentSvc := new(mockContentService)
+
+	pool := worker.NewKafkaConsumerPool(consumer, producer, handler, contentSvc, 1)
+	pool.SetGate(urlguard.NewGate(urlguard.Default(), logger.New(logger.DefaultConfig())))
+
+	// 차단될 RSS URL 을 가진 job 메시지
+	job := newTestJob()
+	job.Target.URL = "https://rss.cnn.com/rss/cnn_health.rss"
+	msg := marshaledJobMsg(t, job)
+
+	// commit 만 호출되어야 하고 handler.Handle 은 호출되면 안 됨
+	consumer.On("CommitMessages", mock.Anything, mock.Anything).Return(nil)
+
+	runPool(t, consumer, pool, msg)
+
+	consumer.AssertCalled(t, "CommitMessages", mock.Anything, mock.Anything)
+	handler.AssertNotCalled(t, "Handle", mock.Anything, mock.Anything)
+	contentSvc.AssertNotCalled(t, "Store", mock.Anything, mock.Anything)
+	producer.AssertNotCalled(t, "Publish", mock.Anything, mock.Anything)
+}
+
+// TestKafkaConsumerPool_Gate_AllowsArticleURL_DelegatesToHandler:
+// 통과 URL 은 기존 처리 흐름으로 위임 (handler.Handle 호출 + content publish + commit).
+func TestKafkaConsumerPool_Gate_AllowsArticleURL_DelegatesToHandler(t *testing.T) {
+	consumer := new(mockConsumer)
+	producer := new(mockProducer)
+	handler := new(mockJobHandler)
+	contentSvc := new(mockContentService)
+
+	pool := worker.NewKafkaConsumerPool(consumer, producer, handler, contentSvc, 1)
+	pool.SetGate(urlguard.NewGate(urlguard.Default(), logger.New(logger.DefaultConfig())))
+
+	job := newTestJob()
+	job.Target.URL = "https://edition.cnn.com/health/article-123"
+	content := newTestContent()
+	msg := marshaledJobMsg(t, job)
+
+	handler.On("Handle", mock.Anything, job).Return([]*core.Content{content}, nil)
+	contentSvc.On("Store", mock.Anything, content).Return(content.ID, false, nil)
+	producer.On("Publish", mock.Anything, mock.Anything).Return(nil)
+	consumer.On("CommitMessages", mock.Anything, mock.Anything).Return(nil)
+
+	runPool(t, consumer, pool, msg)
+
+	handler.AssertCalled(t, "Handle", mock.Anything, job)
+	consumer.AssertCalled(t, "CommitMessages", mock.Anything, mock.Anything)
+}
+
+// TestKafkaConsumerPool_NoGate_LegacyBehavior:
+// SetGate 미호출 시 기존 동작 — 모든 URL 처리.
+func TestKafkaConsumerPool_NoGate_LegacyBehavior(t *testing.T) {
+	consumer := new(mockConsumer)
+	producer := new(mockProducer)
+	handler := new(mockJobHandler)
+	contentSvc := new(mockContentService)
+
+	pool := worker.NewKafkaConsumerPool(consumer, producer, handler, contentSvc, 1)
+	// SetGate 호출 없음
+
+	job := newTestJob()
+	job.Target.URL = "https://rss.cnn.com/rss/cnn_health.rss"
+	content := newTestContent()
+	msg := marshaledJobMsg(t, job)
+
+	// 가드 없으므로 RSS URL 도 handler 가 호출됨
+	handler.On("Handle", mock.Anything, job).Return([]*core.Content{content}, nil)
+	contentSvc.On("Store", mock.Anything, content).Return(content.ID, false, nil)
+	producer.On("Publish", mock.Anything, mock.Anything).Return(nil)
+	consumer.On("CommitMessages", mock.Anything, mock.Anything).Return(nil)
+
+	runPool(t, consumer, pool, msg)
+
+	handler.AssertCalled(t, "Handle", mock.Anything, job)
+}
+
+// TestKafkaConsumerPool_Gate_AllowAllGuard_DelegatesAll:
+// AllowAllGuard 명시 사용 시 모든 URL 위임 (가드 우회 옵션).
+func TestKafkaConsumerPool_Gate_AllowAllGuard_DelegatesAll(t *testing.T) {
+	consumer := new(mockConsumer)
+	producer := new(mockProducer)
+	handler := new(mockJobHandler)
+	contentSvc := new(mockContentService)
+
+	pool := worker.NewKafkaConsumerPool(consumer, producer, handler, contentSvc, 1)
+	pool.SetGate(urlguard.NewGate(urlguard.AllowAllGuard{}, logger.New(logger.DefaultConfig())))
+
+	job := newTestJob()
+	job.Target.URL = "https://rss.cnn.com/rss/cnn_health.rss"
+	content := newTestContent()
+	msg := marshaledJobMsg(t, job)
+
+	handler.On("Handle", mock.Anything, job).Return([]*core.Content{content}, nil)
+	contentSvc.On("Store", mock.Anything, content).Return(content.ID, false, nil)
+	producer.On("Publish", mock.Anything, mock.Anything).Return(nil)
+	consumer.On("CommitMessages", mock.Anything, mock.Anything).Return(nil)
+
+	runPool(t, consumer, pool, msg)
+
+	handler.AssertCalled(t, "Handle", mock.Anything, job)
+	assert.True(t, true) // sentinel
+}
+
+// TestKafkaConsumerPool_Gate_RaceFreeUpdate:
+// SetGate 가 atomic.Pointer 기반이므로 Start 이후에도 race 없음.
+// 본 테스트는 -race detector 로 검증 (실제 race 시 detector 가 fail).
+func TestKafkaConsumerPool_Gate_RaceFreeUpdate(t *testing.T) {
+	consumer := new(mockConsumer)
+	producer := new(mockProducer)
+	handler := new(mockJobHandler)
+	contentSvc := new(mockContentService)
+
+	pool := worker.NewKafkaConsumerPool(consumer, producer, handler, contentSvc, 1)
+
+	// 동시에 여러 번 SetGate 호출 — atomic.Pointer 가 보장
+	guards := []*urlguard.Gate{
+		urlguard.NewGate(urlguard.Default(), nil),
+		urlguard.NewGate(urlguard.AllowAllGuard{}, nil),
+	}
+	for i := 0; i < 100; i++ {
+		pool.SetGate(guards[i%2])
+	}
+}

--- a/test/internal/worker/pool_gate_test.go
+++ b/test/internal/worker/pool_gate_test.go
@@ -3,7 +3,6 @@ package worker_test
 import (
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 
 	"issuetracker/internal/crawler/core"
@@ -119,7 +118,6 @@ func TestKafkaConsumerPool_Gate_AllowAllGuard_DelegatesAll(t *testing.T) {
 	runPool(t, consumer, pool, msg)
 
 	handler.AssertCalled(t, "Handle", mock.Anything, job)
-	assert.True(t, true) // sentinel
 }
 
 // TestKafkaConsumerPool_Gate_RaceFreeUpdate:

--- a/test/pkg/urlguard/urlguard_test.go
+++ b/test/pkg/urlguard/urlguard_test.go
@@ -1,0 +1,262 @@
+package urlguard_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"issuetracker/pkg/logger"
+	"issuetracker/pkg/urlguard"
+)
+
+// ─────────────────────────────────────────────────────────────────────────────
+// PatternGuard 테스트
+// ─────────────────────────────────────────────────────────────────────────────
+
+func TestPatternGuard_Allow_TableDriven(t *testing.T) {
+	g := urlguard.NewPatternGuard("/rss", "mailto:", "tel:")
+
+	tests := []struct {
+		name        string
+		url         string
+		wantAllowed bool
+		wantReason  string
+	}{
+		{"empty url is allowed", "", true, ""},
+		{"plain http url", "https://example.com/article/123", true, ""},
+		{"rss path matches", "https://rss.cnn.com/rss/cnn_health.rss", false, "/rss"},
+		{"mailto blocked", "mailto:foo@example.com", false, "mailto:"},
+		{"tel blocked", "tel:+82-10-1234-5678", false, "tel:"},
+		{"case-insensitive match", "https://RSS.CNN.COM/RSS/topstories.rss", false, "/rss"},
+		{"non-rss domain unaffected", "https://news.naver.com/article/12345", true, ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, reason := g.Allow(tt.url)
+			assert.Equal(t, tt.wantAllowed, got, "url=%q", tt.url)
+			if !tt.wantAllowed {
+				assert.True(t, strings.Contains(reason, tt.wantReason),
+					"reason should mention pattern %q, got %q", tt.wantReason, reason)
+			} else {
+				assert.Empty(t, reason)
+			}
+		})
+	}
+}
+
+func TestPatternGuard_NoPatterns_AllowsAll(t *testing.T) {
+	g := urlguard.NewPatternGuard()
+	allowed, reason := g.Allow("https://example.com/anything")
+	assert.True(t, allowed)
+	assert.Empty(t, reason)
+}
+
+func TestPatternGuard_EmptyPatternIgnored(t *testing.T) {
+	g := urlguard.NewPatternGuard("", "/rss")
+	allowed, _ := g.Allow("https://example.com/article")
+	assert.True(t, allowed, "빈 패턴이 모든 URL 매칭하면 안 됨")
+}
+
+func TestPatternGuard_Concurrent_SafeAllow(t *testing.T) {
+	g := urlguard.NewPatternGuard("/rss")
+	var wg sync.WaitGroup
+	for i := 0; i < 50; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			for j := 0; j < 100; j++ {
+				if i%2 == 0 {
+					g.Allow("https://example.com/article")
+				} else {
+					g.Allow("https://rss.cnn.com/rss/foo.rss")
+				}
+			}
+		}(i)
+	}
+	wg.Wait()
+}
+
+func TestPatternGuard_PatternsCopied_FromCallerSlice(t *testing.T) {
+	patterns := []string{"/rss"}
+	g := urlguard.NewPatternGuard(patterns...)
+	patterns[0] = "/something_else"
+
+	allowed, _ := g.Allow("https://example.com/rss/foo")
+	assert.False(t, allowed, "원본 슬라이스 변경이 Guard 패턴에 반영되면 안 됨")
+}
+
+func TestDefault_BlocksRSSAndMailto(t *testing.T) {
+	g := urlguard.Default()
+
+	tests := []struct {
+		url     string
+		blocked bool
+	}{
+		{"https://rss.cnn.com/rss/cnn_health.rss", true},
+		{"mailto:user@example.com", true},
+		{"tel:+82-10-0000", true},
+		{"javascript:void(0)", true},
+		{"https://news.naver.com/article", false},
+		{"https://edition.cnn.com/health", false},
+	}
+
+	for _, tt := range tests {
+		got, _ := g.Allow(tt.url)
+		assert.Equal(t, !tt.blocked, got, "url=%q", tt.url)
+	}
+}
+
+func TestAllowAllGuard(t *testing.T) {
+	var g urlguard.Guard = urlguard.AllowAllGuard{}
+	got, reason := g.Allow("https://rss.cnn.com/rss/foo.rss")
+	assert.True(t, got)
+	assert.Empty(t, reason)
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Gate 테스트 — 단일 공통 컴포넌트
+// ─────────────────────────────────────────────────────────────────────────────
+
+// captureLogger 는 로그 출력을 bytes.Buffer 로 캡쳐하는 logger 를 반환합니다.
+func captureLogger(buf *bytes.Buffer) *logger.Logger {
+	cfg := logger.DefaultConfig()
+	cfg.Output = buf
+	cfg.Level = logger.LevelDebug
+	return logger.New(cfg)
+}
+
+// extractLogEntries 는 JSON 줄 단위 로그를 map 슬라이스로 파싱합니다.
+func extractLogEntries(t *testing.T, buf *bytes.Buffer) []map[string]interface{} {
+	t.Helper()
+	var entries []map[string]interface{}
+	for _, line := range strings.Split(strings.TrimSpace(buf.String()), "\n") {
+		if line == "" {
+			continue
+		}
+		var e map[string]interface{}
+		require.NoError(t, json.Unmarshal([]byte(line), &e))
+		entries = append(entries, e)
+	}
+	return entries
+}
+
+func TestGate_Allow_Pass_NoLog(t *testing.T) {
+	buf := &bytes.Buffer{}
+	gate := urlguard.NewGate(urlguard.Default(), captureLogger(buf))
+
+	ok := gate.Allow("https://edition.cnn.com/health", map[string]interface{}{"crawler": "cnn"})
+	assert.True(t, ok)
+	assert.Empty(t, buf.String(), "통과 시 로그 없음")
+}
+
+func TestGate_Allow_Block_LogsWarn(t *testing.T) {
+	buf := &bytes.Buffer{}
+	gate := urlguard.NewGate(urlguard.Default(), captureLogger(buf))
+
+	ok := gate.Allow("https://rss.cnn.com/rss/cnn_health.rss",
+		map[string]interface{}{"crawler": "cnn", "stage": "scheduler"})
+	assert.False(t, ok)
+
+	entries := extractLogEntries(t, buf)
+	require.Len(t, entries, 1)
+	assert.Equal(t, "warn", entries[0]["level"])
+	assert.Equal(t, "blocked by url guard", entries[0]["message"])
+	assert.Equal(t, "cnn", entries[0]["crawler"])
+	assert.Equal(t, "scheduler", entries[0]["stage"])
+	assert.Equal(t, "https://rss.cnn.com/rss/cnn_health.rss", entries[0]["url"])
+	assert.Contains(t, entries[0]["reason"], "/rss")
+}
+
+func TestGate_Allow_NilFields_StillLogs(t *testing.T) {
+	buf := &bytes.Buffer{}
+	gate := urlguard.NewGate(urlguard.Default(), captureLogger(buf))
+
+	ok := gate.Allow("https://rss.cnn.com/rss/foo.rss", nil)
+	assert.False(t, ok)
+	entries := extractLogEntries(t, buf)
+	require.Len(t, entries, 1)
+	assert.Equal(t, "warn", entries[0]["level"])
+	assert.Contains(t, entries[0], "url")
+	assert.Contains(t, entries[0], "reason")
+}
+
+func TestGate_Filter_PartialBlock(t *testing.T) {
+	buf := &bytes.Buffer{}
+	gate := urlguard.NewGate(urlguard.Default(), captureLogger(buf))
+
+	urls := []string{
+		"https://edition.cnn.com/article/1",
+		"https://rss.cnn.com/rss/cnn_health.rss",
+		"https://news.naver.com/main/read.naver?a=1",
+		"mailto:foo@example.com",
+	}
+	allowed := gate.Filter(urls, map[string]interface{}{"crawler": "cnn", "stage": "publisher"})
+
+	assert.Equal(t, []string{
+		"https://edition.cnn.com/article/1",
+		"https://news.naver.com/main/read.naver?a=1",
+	}, allowed)
+
+	entries := extractLogEntries(t, buf)
+	assert.Len(t, entries, 2, "차단된 2건만 로그")
+}
+
+func TestGate_Filter_AllPass_NoLog(t *testing.T) {
+	buf := &bytes.Buffer{}
+	gate := urlguard.NewGate(urlguard.Default(), captureLogger(buf))
+
+	urls := []string{"https://edition.cnn.com/a", "https://news.naver.com/b"}
+	allowed := gate.Filter(urls, nil)
+	assert.Equal(t, urls, allowed)
+	assert.Empty(t, buf.String())
+}
+
+func TestGate_Filter_AllBlocked_ReturnsEmptyNotNil(t *testing.T) {
+	gate := urlguard.NewGate(urlguard.Default(), captureLogger(&bytes.Buffer{}))
+
+	allowed := gate.Filter([]string{
+		"https://rss.cnn.com/rss/a.rss",
+		"mailto:x@y.z",
+	}, nil)
+	require.NotNil(t, allowed, "모두 차단되어도 nil 이 아닌 빈 슬라이스 반환")
+	assert.Empty(t, allowed)
+}
+
+func TestGate_Filter_EmptyInput(t *testing.T) {
+	gate := urlguard.NewGate(urlguard.Default(), captureLogger(&bytes.Buffer{}))
+
+	assert.Empty(t, gate.Filter(nil, nil))
+	assert.Empty(t, gate.Filter([]string{}, nil))
+}
+
+func TestGate_Filter_DoesNotMutateInput(t *testing.T) {
+	gate := urlguard.NewGate(urlguard.Default(), captureLogger(&bytes.Buffer{}))
+
+	input := []string{"https://edition.cnn.com/a", "https://rss.cnn.com/rss/b.rss"}
+	original := append([]string{}, input...)
+
+	_ = gate.Filter(input, nil)
+	assert.Equal(t, original, input, "Filter 가 입력 슬라이스를 변경하면 안 됨")
+}
+
+func TestNewGate_NilGuard_Panics(t *testing.T) {
+	assert.Panics(t, func() {
+		urlguard.NewGate(nil, nil)
+	})
+}
+
+func TestNewGate_NilLogger_UsesDefault(t *testing.T) {
+	// nil logger 는 panic 하지 않고 fallback 기본 logger 사용
+	gate := urlguard.NewGate(urlguard.Default(), nil)
+	require.NotNil(t, gate)
+	// 호출이 panic 하지 않는지만 검증 (출력은 stdout 으로 흘러감)
+	assert.NotPanics(t, func() {
+		gate.Allow("https://rss.cnn.com/rss/foo.rss", nil)
+	})
+}


### PR DESCRIPTION
## 연관 이슈
- Closes #119

<!--
PR title 예시: [FEAT#issue번호]: 어쩌구저쩌
-->

<br>

## 구현 내용

### 설계 핵심 — 단일 공통 \`Gate\` 컴포넌트

레이어별 별도 데코레이터 타입을 만들지 않고, **하나의 \`urlguard.Gate\` 인스턴스가 3개 진입점에서 재사용**되는 형태. "decorator 처럼 동작" 하는 단일 helper 가 모든 곳에서 호출됨.

\`\`\`
                    ┌─────────────────────────────────┐
                    │  pkg/urlguard.Gate (단일 공통)  │
                    │   - Allow(url, fields) bool     │
                    │   - Filter(urls, fields) []str  │
                    └────────┬────────────────────────┘
              ┌──────────────┼──────────────┐
              ↓              ↓              ↓
       ┌───────────┐  ┌───────────┐  ┌───────────┐
       │ Scheduler │  │ Publisher │  │  Worker   │
       │ .Allow()  │  │ .Filter() │  │ .Allow()  │
       └───────────┘  └───────────┘  └───────────┘
       publish 직전     batch 직전     processJob 진입
\`\`\`

### \`pkg/urlguard\` (신규 패키지)
- [\`guard.go\`](pkg/urlguard/guard.go): \`Guard\` 인터페이스 + \`AllowAllGuard\` (no-op)
- [\`pattern.go\`](pkg/urlguard/pattern.go): \`PatternGuard\` (substring/case-insensitive) + \`DefaultPatterns\` (\`/rss\`, \`mailto:\`, \`tel:\`, \`javascript:\`) + \`Default()\` 팩토리
- [\`gate.go\`](pkg/urlguard/gate.go): **\`Gate\`** — Guard + Logger 조합, \`Allow(url, fields)\` / \`Filter(urls, fields)\` 두 메서드로 단일/다건 처리 패턴 모두 지원, 차단 시 동일한 \`"blocked by url guard"\` WARN 로그 형식 (url/reason + 호출자 fields)

### 3개 진입점 통합 (모두 \`SetGate\` 옵셔널 setter)

| 레이어 | 메서드 | 호출 위치 | 차단 시 동작 |
|---|---|---|---|
| [Scheduler](internal/scheduler/scheduler.go) | \`Gate.Allow\` | \`publish()\` 진입 | emit 없이 silent drop |
| [Publisher](internal/publisher/publisher.go) | \`Gate.Filter\` | \`Publish()\` PublishBatch 직전 | 통과 URL 만 batch publish, 전부 차단 시 호출 skip |
| [Worker](internal/crawler/worker/pool.go) | \`Gate.Allow\` | \`processJob()\` 진입 직후 | handler 미호출 + 메시지 commit (큐에서 제거) |

- 모두 \`SetGate(g)\` 미호출 시 가드 비활성 — backward compat 보장
- Worker 의 \`SetGate\` 는 \`atomic.Pointer\` 기반 lock-free (Start 이후에도 race-safe)

### Worker 의 핵심 효과 (이슈 #119 해결)

processJob 진입 직후 차단 → handler.Handle / lock acquire / backoff wait 등 모든 비용 회피하고 메시지만 commit. **누적된 stale URL (예: 과거 RSS) 메시지가 retry 사이클로 다시 발행되는 것을 Consumer layer 에서 차단** → Scheduler/Publisher 가 새로 emit 하지 않더라도 큐 잔존 메시지를 정리.

### 테스트 커버리지

| 패키지 | 테스트 수 | 내용 |
|---|---|---|
| [test/pkg/urlguard](test/pkg/urlguard/urlguard_test.go) | 21 | PatternGuard 매칭/race/슬라이스 복사/Default + Gate 통과·차단·필터·로그 형식·nil 의존성 |
| [test/internal/scheduler](test/internal/scheduler/scheduler_gate_test.go) | 4 | RSS 차단 / 카테고리 통과 / 가드 미설정 legacy / AllowAll |
| [test/internal/publisher](test/internal/publisher/publisher_gate_test.go) | 4 | 부분 차단 / 전체 차단 / 미설정 legacy / AllowAll |
| [test/internal/worker](test/internal/worker/pool_gate_test.go) | 5 | RSS 차단 + commit / 카테고리 통과 / 미설정 legacy / AllowAll / SetGate race-free 100회 |

전체 회귀 테스트 통과 (\`go test -race ./...\`).

<br>

## CI / 머지 게이트 점검

> [CI 운영 규약](docs/ci/conventions.md) 및 [Required Status Checks 단일 소스](docs/ci/status-checks.md)에 따라 작성합니다.

### 변경 영향 범위
- 영향 패키지/모듈: \`pkg/urlguard\` (신규), \`internal/scheduler\`, \`internal/publisher\`, \`internal/crawler/worker\` + 각 테스트
- 위험도(택1): **\`Low\`** / \`Medium\` / \`High\`
  - 모든 통합이 옵셔널 \`SetGate\` 패턴 — 미호출 시 기존 동작 유지
  - 외부 인터페이스 변경 없음
  - 가드 활성화 시 차단된 URL 만 영향 — 정상 URL 무영향

### Required Status Checks
- 통과 확인 대상 (PR Checks 탭에서 확인):
  - [ ] \`Commit Lint\`
  - [ ] \`PR Title Lint\`
  - [ ] \`Format Check\`
  - [ ] \`Build\`
  - [ ] \`Test\`
  - [ ] \`Lint\`

### 롤백 계획
- 단일 revert 로 즉시 복원 가능. 운영 도입 후 false positive 발견 시 운영자가 \`SetGate(nil)\` 또는 \`SetGate(NewGate(AllowAllGuard{}, log))\` 로 즉시 비활성화 가능 (재배포 없이 reload 가능한 구성으로 후속 확장 가능).

<br>

## TODO
- [x] \`pkg/urlguard\` Guard/PatternGuard/Gate (3개 파일 + 21 테스트)
- [x] Scheduler 에 Gate.Allow 적용 (publish 직전)
- [x] Publisher 에 Gate.Filter 적용 (PublishBatch 직전)
- [x] Worker 에 Gate.Allow 적용 (processJob 진입 직후, atomic.Pointer)
- [x] 각 진입점별 통합 테스트 + 전체 회귀 통과

<br>

## 논의 사항
- \`cmd/issuetracker\` / \`cmd/processor\` 진입점에서 기본 Gate 와이어링은 본 PR 범위 외 (운영 도입 시 별도 PR 로 추가). 본 PR 머지만으로는 가드가 활성화되지 않음 — 의도된 보수적 도입.
- \`DefaultPatterns\` 의 \`/rss\` 패턴은 \`pkg/links\` 의 \`defaultExcludePatterns\` 와 동일 패턴 — 추후 두 곳을 단일 소스로 통합 검토.
- 운영 reload (재배포 없이 패턴 변경) 와 패턴별 통계 metric 은 후속 이슈로 분리.