### PR TITLE
[REFAC#75] goquery/chromedp 크롤러 중복 패턴 공통 추출

### DIFF
--- a/internal/crawler/core/http_status.go
+++ b/internal/crawler/core/http_status.go
@@ -1,0 +1,34 @@
+package core
+
+import "net/http"
+
+// CheckHTTPStatus 는 HTTP 응답 상태 코드를 검사하여 4xx/5xx 에러를 적절한
+// CrawlerError 로 변환합니다. 정상(2xx/3xx) 인 경우 nil 을 반환합니다.
+//
+// 분기 정책 (이슈 #75 — fetcher 공통 추출):
+//   - 404 (Not Found)            → NewNotFoundError    (retry 불가)
+//   - 429 (Too Many Requests)    → NewRateLimitError   (retry 가능, code "HTTP_429")
+//   - 5xx (Server Error)         → NewHTTPServerError  (retry 가능)
+//   - 4xx 기타 (Client Error)    → NewHTTPClientError  (retry 불가)
+//   - 그 외 (성공/리다이렉트 등) → nil
+//
+// 본 함수는 goquery/chromedp/기타 fetcher 들이 동일한 정책으로 분기하도록
+// 단일 진실 소스(SoT) 역할을 합니다. 새 분기(예: 451 법적 차단) 추가 시
+// 본 함수만 수정하면 모든 fetcher 에 일관 반영됩니다.
+//
+// chromedp 처럼 0 (응답 미수신) 같은 fetcher 고유 sentinel 값은 호출자가
+// 사전 처리한 뒤 정상 코드로 보정해서 본 함수를 호출해야 합니다.
+func CheckHTTPStatus(url string, statusCode int) error {
+	switch {
+	case statusCode == http.StatusNotFound:
+		return NewNotFoundError(url)
+	case statusCode == http.StatusTooManyRequests:
+		return NewRateLimitError("HTTP_429", "rate limited", url, statusCode)
+	case statusCode >= 500:
+		return NewHTTPServerError(url, statusCode)
+	case statusCode >= 400:
+		return NewHTTPClientError(url, statusCode)
+	default:
+		return nil
+	}
+}

--- a/internal/crawler/core/models.go
+++ b/internal/crawler/core/models.go
@@ -68,7 +68,7 @@ type RawContent struct {
 // ID 형식: "<name>-<unix_nano>-<rand_hex>" — 시간순 정렬 가능 + 동시 호출 충돌 방지.
 //   - <unix_nano>: 시간 정렬·디버깅 추적성
 //   - <rand_hex>: 4바이트 (8자 hex) crypto/rand suffix
-//                 → 동일 ns 에 발생한 여러 호출도 충돌 확률 사실상 0 (1/2^32 per ns)
+//     → 동일 ns 에 발생한 여러 호출도 충돌 확률 사실상 0 (1/2^32 per ns)
 //   - rand.Read 실패 시에도 시간 부분만으로 ID 가 생성되어 fetch 자체는 진행
 //
 // metadata 가공이 필요한 경우 (예: chromedp 의 partial_load 플래그) 호출자가

--- a/internal/crawler/core/models.go
+++ b/internal/crawler/core/models.go
@@ -1,6 +1,8 @@
 package core
 
 import (
+	"crypto/rand"
+	"encoding/hex"
 	"fmt"
 	"time"
 )
@@ -63,7 +65,11 @@ type RawContent struct {
 //   - statusCode : HTTP 상태 코드
 //   - headers    : HTTP 응답 헤더. nil 이면 빈 map 으로 보정.
 //
-// ID 형식: "<name>-<unix_nano>" — 단일 fetcher 내 호출 시점 고유성.
+// ID 형식: "<name>-<unix_nano>-<rand_hex>" — 시간순 정렬 가능 + 동시 호출 충돌 방지.
+//   - <unix_nano>: 시간 정렬·디버깅 추적성
+//   - <rand_hex>: 4바이트 (8자 hex) crypto/rand suffix
+//                 → 동일 ns 에 발생한 여러 호출도 충돌 확률 사실상 0 (1/2^32 per ns)
+//   - rand.Read 실패 시에도 시간 부분만으로 ID 가 생성되어 fetch 자체는 진행
 //
 // metadata 가공이 필요한 경우 (예: chromedp 의 partial_load 플래그) 호출자가
 // target.Metadata 를 미리 가공하거나 반환된 RawContent.Metadata 를 덮어써서 처리.
@@ -80,7 +86,7 @@ func NewRawContent(
 		headers = make(map[string]string)
 	}
 	return &RawContent{
-		ID:         fmt.Sprintf("%s-%d", name, time.Now().UnixNano()),
+		ID:         newRawContentID(name),
 		SourceInfo: source,
 		FetchedAt:  time.Now(),
 		URL:        target.URL,
@@ -89,6 +95,17 @@ func NewRawContent(
 		Headers:    headers,
 		Metadata:   target.Metadata,
 	}
+}
+
+// newRawContentID 는 "<name>-<unix_nano>-<rand_hex>" 형식의 RawContent ID 를 생성합니다.
+// crypto/rand 4바이트 suffix 로 동시 호출 충돌을 방지합니다 (1/2^32 per ns 충돌 확률).
+//
+// rand.Read 실패는 무시하고 0-suffix 로 fallback — fetch 자체를 멈추지 않으며,
+// 시간 부분만으로도 단일 fetcher 내 nano 정밀도 충돌은 매우 드뭄.
+func newRawContentID(name string) string {
+	var b [4]byte
+	_, _ = rand.Read(b[:])
+	return fmt.Sprintf("%s-%d-%s", name, time.Now().UnixNano(), hex.EncodeToString(b[:]))
 }
 
 // RawContentRef는 Kafka raw 토픽에 발행되는 경량 참조 메시지입니다.

--- a/internal/crawler/core/models.go
+++ b/internal/crawler/core/models.go
@@ -85,10 +85,14 @@ func NewRawContent(
 	if headers == nil {
 		headers = make(map[string]string)
 	}
+	// time.Now() 1회 호출로 ID 의 unix_nano 와 FetchedAt 을 정확히 일치시킵니다 —
+	// 디버깅 시 ID 의 시간 부분과 FetchedAt 이 동일하므로 추적이 일관됩니다.
+	// (이전: 2회 호출로 미세 불일치 + 불필요한 syscall)
+	now := time.Now()
 	return &RawContent{
-		ID:         newRawContentID(name),
+		ID:         newRawContentID(name, now),
 		SourceInfo: source,
-		FetchedAt:  time.Now(),
+		FetchedAt:  now,
 		URL:        target.URL,
 		HTML:       html,
 		StatusCode: statusCode,
@@ -100,12 +104,13 @@ func NewRawContent(
 // newRawContentID 는 "<name>-<unix_nano>-<rand_hex>" 형식의 RawContent ID 를 생성합니다.
 // crypto/rand 4바이트 suffix 로 동시 호출 충돌을 방지합니다 (1/2^32 per ns 충돌 확률).
 //
+// 호출자가 time.Time 을 인자로 전달함으로써 동일 시점을 ID/FetchedAt 양쪽에 사용 가능.
 // rand.Read 실패는 무시하고 0-suffix 로 fallback — fetch 자체를 멈추지 않으며,
 // 시간 부분만으로도 단일 fetcher 내 nano 정밀도 충돌은 매우 드뭄.
-func newRawContentID(name string) string {
+func newRawContentID(name string, t time.Time) string {
 	var b [4]byte
 	_, _ = rand.Read(b[:])
-	return fmt.Sprintf("%s-%d-%s", name, time.Now().UnixNano(), hex.EncodeToString(b[:]))
+	return fmt.Sprintf("%s-%d-%s", name, t.UnixNano(), hex.EncodeToString(b[:]))
 }
 
 // RawContentRef는 Kafka raw 토픽에 발행되는 경량 참조 메시지입니다.

--- a/internal/crawler/core/models.go
+++ b/internal/crawler/core/models.go
@@ -1,6 +1,9 @@
 package core
 
-import "time"
+import (
+	"fmt"
+	"time"
+)
 
 // SourceType은 데이터 소스의 타입을 나타냅니다.
 type SourceType string
@@ -47,6 +50,45 @@ type RawContent struct {
 	StatusCode int
 	Headers    map[string]string
 	Metadata   map[string]interface{}
+}
+
+// NewRawContent 는 fetcher 들이 공통으로 사용하는 RawContent 조립 패턴을
+// 일원화한 생성자입니다 (이슈 #75 — fetcher 공통 추출).
+//
+// 인자:
+//   - name       : crawler 이름 (ID prefix 로 사용)
+//   - source     : SourceInfo (도메인/언어 등 메타데이터)
+//   - target     : Target (URL/Metadata 추출원)
+//   - html       : fetched HTML
+//   - statusCode : HTTP 상태 코드
+//   - headers    : HTTP 응답 헤더. nil 이면 빈 map 으로 보정.
+//
+// ID 형식: "<name>-<unix_nano>" — 단일 fetcher 내 호출 시점 고유성.
+//
+// metadata 가공이 필요한 경우 (예: chromedp 의 partial_load 플래그) 호출자가
+// target.Metadata 를 미리 가공하거나 반환된 RawContent.Metadata 를 덮어써서 처리.
+// 본 생성자는 단순 대입만 수행 — 호출자별 변형 정책은 호출자가 책임.
+func NewRawContent(
+	name string,
+	source SourceInfo,
+	target Target,
+	html string,
+	statusCode int,
+	headers map[string]string,
+) *RawContent {
+	if headers == nil {
+		headers = make(map[string]string)
+	}
+	return &RawContent{
+		ID:         fmt.Sprintf("%s-%d", name, time.Now().UnixNano()),
+		SourceInfo: source,
+		FetchedAt:  time.Now(),
+		URL:        target.URL,
+		HTML:       html,
+		StatusCode: statusCode,
+		Headers:    headers,
+		Metadata:   target.Metadata,
+	}
 }
 
 // RawContentRef는 Kafka raw 토픽에 발행되는 경량 참조 메시지입니다.

--- a/internal/crawler/implementation/chromedp/fetch.go
+++ b/internal/crawler/implementation/chromedp/fetch.go
@@ -167,35 +167,19 @@ func (c *ChromedpCrawler) Fetch(ctx context.Context, target core.Target) (*core.
 		capturedStatus = 200
 	}
 
-	// HTTP 상태코드 검사
-	if capturedStatus == 404 {
-		return nil, core.NewNotFoundError(target.URL)
-	}
-	if capturedStatus == 429 {
-		return nil, core.NewRateLimitError("HTTP_429", "rate limited", target.URL, capturedStatus)
-	}
-	if capturedStatus >= 500 {
-		return nil, core.NewHTTPServerError(target.URL, capturedStatus)
-	}
-	if capturedStatus >= 400 {
-		return nil, core.NewHTTPClientError(target.URL, capturedStatus)
+	// HTTP 상태코드 검사 (이슈 #75: core 공통 분기)
+	if err := core.CheckHTTPStatus(target.URL, capturedStatus); err != nil {
+		return nil, err
 	}
 
-	// metadata: 부분 로드인 경우 호출자 원본을 보존하기 위해 복사 후 플래그 추가
-	metadata := target.Metadata
+	// RawContent 조립 (이슈 #75: core 공통 생성자)
+	// chromedp 는 raw HTTP header 에 접근하지 않으므로 nil 전달 → 빈 map 으로 보정됨.
+	rawContent := core.NewRawContent(c.name, c.sourceInfo, target, html, capturedStatus, nil)
+
+	// 부분 로드인 경우 metadata 를 변형 적용 (호출자 원본 보존을 위한 복사 + 플래그)
+	// NewRawContent 의 단순 대입 (target.Metadata 그대로) 이후 덮어쓰기.
 	if partialLoad {
-		metadata = metadataWithPartialLoad(target.Metadata)
-	}
-
-	rawContent := &core.RawContent{
-		ID:         fmt.Sprintf("%s-%d", c.name, time.Now().UnixNano()),
-		SourceInfo: c.sourceInfo,
-		FetchedAt:  time.Now(),
-		URL:        target.URL,
-		HTML:       html,
-		StatusCode: capturedStatus,
-		Headers:    make(map[string]string),
-		Metadata:   metadata,
+		rawContent.Metadata = metadataWithPartialLoad(target.Metadata)
 	}
 
 	log.WithFields(map[string]interface{}{

--- a/internal/crawler/implementation/goquery/fetch.go
+++ b/internal/crawler/implementation/goquery/fetch.go
@@ -2,9 +2,7 @@ package goquery
 
 import (
 	"context"
-	"fmt"
 	"net/http"
-	"time"
 
 	"github.com/PuerkitoBio/goquery"
 
@@ -46,18 +44,9 @@ func (c *GoqueryCrawler) Fetch(ctx context.Context, target core.Target) (*core.R
 	}
 	defer resp.Body.Close()
 
-	// HTTP 상태코드 검사: 4xx/5xx는 에러로 처리
-	if resp.StatusCode == http.StatusNotFound {
-		return nil, core.NewNotFoundError(target.URL)
-	}
-	if resp.StatusCode == http.StatusTooManyRequests {
-		return nil, core.NewRateLimitError("HTTP_429", "rate limited", target.URL, resp.StatusCode)
-	}
-	if resp.StatusCode >= 500 {
-		return nil, core.NewHTTPServerError(target.URL, resp.StatusCode)
-	}
-	if resp.StatusCode >= 400 {
-		return nil, core.NewHTTPClientError(target.URL, resp.StatusCode)
+	// HTTP 상태코드 검사: 4xx/5xx는 에러로 처리 (이슈 #75: core 공통 분기)
+	if err := core.CheckHTTPStatus(target.URL, resp.StatusCode); err != nil {
+		return nil, err
 	}
 
 	// goquery Document 생성
@@ -86,23 +75,16 @@ func (c *GoqueryCrawler) Fetch(ctx context.Context, target core.Target) (*core.R
 		}
 	}
 
-	rawContent := &core.RawContent{
-		ID:         fmt.Sprintf("%s-%d", c.name, time.Now().UnixNano()),
-		SourceInfo: c.sourceInfo,
-		FetchedAt:  time.Now(),
-		URL:        target.URL,
-		HTML:       html,
-		StatusCode: resp.StatusCode,
-		Headers:    make(map[string]string),
-		Metadata:   target.Metadata,
-	}
-
-	// Headers 저장
+	// Headers 추출: HTTP response.Header → map[string]string (다중값은 첫 항목만)
+	headers := make(map[string]string, len(resp.Header))
 	for key, values := range resp.Header {
 		if len(values) > 0 {
-			rawContent.Headers[key] = values[0]
+			headers[key] = values[0]
 		}
 	}
+
+	// RawContent 조립 (이슈 #75: core 공통 생성자)
+	rawContent := core.NewRawContent(c.name, c.sourceInfo, target, html, resp.StatusCode, headers)
 
 	log.WithFields(map[string]interface{}{
 		"url":         target.URL,

--- a/test/internal/crawler_core/http_status_test.go
+++ b/test/internal/crawler_core/http_status_test.go
@@ -1,0 +1,86 @@
+package core_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	core "issuetracker/internal/crawler/core"
+)
+
+const testURL = "https://example.com/article"
+
+// TestCheckHTTPStatus_TableDriven 는 상태 코드별 분기 동작을 검증합니다.
+// 이슈 #75 의 4-way 분기를 정확히 보존하는지 회귀 잠금.
+func TestCheckHTTPStatus_TableDriven(t *testing.T) {
+	tests := []struct {
+		name     string
+		status   int
+		wantNil  bool
+		wantCode string // CrawlerError.Code 검증, wantNil=true 시 무시
+		wantCat  core.ErrorCategory
+		retry    bool
+	}{
+		{"200 OK → nil", 200, true, "", "", false},
+		{"204 No Content → nil", 204, true, "", "", false},
+		{"301 Redirect → nil", 301, true, "", "", false},
+		{"399 Edge → nil", 399, true, "", "", false},
+		{"400 Bad Request → ClientError", 400, false, "HTTP_400", core.ErrCategoryInternal, false},
+		{"401 Unauthorized → ClientError", 401, false, "HTTP_401", core.ErrCategoryInternal, false},
+		{"403 Forbidden → ClientError", 403, false, "HTTP_403", core.ErrCategoryInternal, false},
+		{"404 Not Found → NotFoundError", 404, false, "HTTP_404", core.ErrCategoryNotFound, false},
+		{"429 Too Many Requests → RateLimitError", 429, false, "HTTP_429", core.ErrCategoryRateLimit, true},
+		{"499 → ClientError", 499, false, "HTTP_499", core.ErrCategoryInternal, false},
+		{"500 Internal Server Error → ServerError", 500, false, "HTTP_500", core.ErrCategoryNetwork, true},
+		{"502 Bad Gateway → ServerError", 502, false, "HTTP_502", core.ErrCategoryNetwork, true},
+		{"503 Service Unavailable → ServerError", 503, false, "HTTP_503", core.ErrCategoryNetwork, true},
+		{"599 Edge → ServerError", 599, false, "HTTP_599", core.ErrCategoryNetwork, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := core.CheckHTTPStatus(testURL, tt.status)
+
+			if tt.wantNil {
+				assert.NoError(t, err)
+				return
+			}
+
+			require.Error(t, err)
+			var ce *core.CrawlerError
+			require.True(t, errors.As(err, &ce), "에러는 CrawlerError 타입이어야 함")
+			assert.Equal(t, tt.wantCode, ce.Code)
+			assert.Equal(t, tt.wantCat, ce.Category)
+			assert.Equal(t, tt.retry, ce.Retryable)
+			assert.Equal(t, testURL, ce.URL)
+			assert.Equal(t, tt.status, ce.StatusCode)
+		})
+	}
+}
+
+// TestCheckHTTPStatus_BoundaryAt400 는 399→400 경계에서 분기가 정확히 전환되는지 검증.
+func TestCheckHTTPStatus_BoundaryAt400(t *testing.T) {
+	assert.NoError(t, core.CheckHTTPStatus(testURL, 399))
+	assert.Error(t, core.CheckHTTPStatus(testURL, 400))
+}
+
+// TestCheckHTTPStatus_BoundaryAt500 는 499→500 경계에서 ClientError → ServerError
+// 카테고리 전환을 검증.
+func TestCheckHTTPStatus_BoundaryAt500(t *testing.T) {
+	err499 := core.CheckHTTPStatus(testURL, 499)
+	err500 := core.CheckHTTPStatus(testURL, 500)
+	require.Error(t, err499)
+	require.Error(t, err500)
+
+	var ce499, ce500 *core.CrawlerError
+	require.True(t, errors.As(err499, &ce499))
+	require.True(t, errors.As(err500, &ce500))
+
+	assert.Equal(t, core.ErrCategoryInternal, ce499.Category)
+	assert.False(t, ce499.Retryable, "4xx 클라이언트 에러는 retry 불가")
+
+	assert.Equal(t, core.ErrCategoryNetwork, ce500.Category)
+	assert.True(t, ce500.Retryable, "5xx 서버 에러는 retry 가능")
+}

--- a/test/internal/crawler_core/raw_content_builder_test.go
+++ b/test/internal/crawler_core/raw_content_builder_test.go
@@ -2,6 +2,7 @@ package core_test
 
 import (
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -78,16 +79,51 @@ func TestNewRawContent_IDFormat_UsesNamePrefix(t *testing.T) {
 }
 
 // TestNewRawContent_ConsecutiveCalls_DistinctIDs:
-// 연속 호출 시 unix_nano 차이로 ID 가 달라야 함 (중복 방지).
+// 연속 호출 시 ID 가 모두 unique 해야 함.
+// 신규 ID 형식 '<name>-<unix_nano>-<rand_hex>' 의 random suffix 덕분에 sleep 없이도 통과.
 func TestNewRawContent_ConsecutiveCalls_DistinctIDs(t *testing.T) {
-	ids := make(map[string]bool)
-	for i := 0; i < 100; i++ {
+	ids := make(map[string]bool, 1000)
+	for i := 0; i < 1000; i++ {
 		raw := core.NewRawContent("cnn", newTestSource(), newTestTarget(), "x", 200, nil)
-		assert.False(t, ids[raw.ID], "중복 ID 발생: %s", raw.ID)
+		assert.False(t, ids[raw.ID], "중복 ID 발생 at i=%d: %s", i, raw.ID)
 		ids[raw.ID] = true
-		// time.Now().UnixNano() 가 같은 ns 를 반환할 가능성에 대비한 짧은 sleep
-		time.Sleep(1 * time.Microsecond)
 	}
+	assert.Len(t, ids, 1000, "1000회 연속 호출 모두 unique ID")
+}
+
+// TestNewRawContent_HighConcurrency_DistinctIDs:
+// 동시 호출 (50 goroutine × 100회 = 5000건) 모두 unique 해야 함.
+// random suffix 가 동일 nanosecond 충돌을 차단하는지 검증.
+func TestNewRawContent_HighConcurrency_DistinctIDs(t *testing.T) {
+	const goroutines = 50
+	const callsPerGoroutine = 100
+
+	idsCh := make(chan string, goroutines*callsPerGoroutine)
+	var wg sync.WaitGroup
+
+	for i := 0; i < goroutines; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for j := 0; j < callsPerGoroutine; j++ {
+				raw := core.NewRawContent("cnn", newTestSource(), newTestTarget(), "x", 200, nil)
+				idsCh <- raw.ID
+			}
+		}()
+	}
+	wg.Wait()
+	close(idsCh)
+
+	seen := make(map[string]bool, goroutines*callsPerGoroutine)
+	collisions := 0
+	for id := range idsCh {
+		if seen[id] {
+			collisions++
+		}
+		seen[id] = true
+	}
+	assert.Equal(t, 0, collisions, "동시 5000건 호출에서 ID 충돌 발생")
+	assert.Len(t, seen, goroutines*callsPerGoroutine, "모든 ID 가 unique")
 }
 
 // TestNewRawContent_NilMetadata_PreservedAsNil:

--- a/test/internal/crawler_core/raw_content_builder_test.go
+++ b/test/internal/crawler_core/raw_content_builder_test.go
@@ -1,0 +1,112 @@
+package core_test
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	core "issuetracker/internal/crawler/core"
+)
+
+func newTestSource() core.SourceInfo {
+	return core.SourceInfo{
+		Country:  "US",
+		Type:     core.SourceTypeNews,
+		Name:     "cnn",
+		BaseURL:  "https://www.cnn.com",
+		Language: "en",
+	}
+}
+
+func newTestTarget() core.Target {
+	return core.Target{
+		URL:  "https://edition.cnn.com/article/123",
+		Type: core.TargetTypeArticle,
+		Metadata: map[string]interface{}{
+			"feed_url": "https://rss.cnn.com/foo.rss",
+		},
+	}
+}
+
+// TestNewRawContent_AllFields_Set:
+// 8개 필드 모두 정확히 대입되는지 검증.
+func TestNewRawContent_AllFields_Set(t *testing.T) {
+	src := newTestSource()
+	tgt := newTestTarget()
+	headers := map[string]string{"Content-Type": "text/html", "Server": "nginx"}
+
+	before := time.Now()
+	raw := core.NewRawContent("cnn", src, tgt, "<html>body</html>", 200, headers)
+	after := time.Now()
+
+	require.NotNil(t, raw)
+	assert.True(t, strings.HasPrefix(raw.ID, "cnn-"), "ID 는 'cnn-' prefix 로 시작해야 함")
+	assert.Equal(t, src, raw.SourceInfo)
+	assert.True(t, !raw.FetchedAt.Before(before) && !raw.FetchedAt.After(after),
+		"FetchedAt 은 호출 시점 사이여야 함")
+	assert.Equal(t, tgt.URL, raw.URL)
+	assert.Equal(t, "<html>body</html>", raw.HTML)
+	assert.Equal(t, 200, raw.StatusCode)
+	assert.Equal(t, headers, raw.Headers)
+	assert.Equal(t, tgt.Metadata, raw.Metadata)
+}
+
+// TestNewRawContent_NilHeaders_BecomesEmptyMap:
+// nil headers 인자는 빈 map 으로 보정되어야 함 (downstream 에서 nil dereference 방지).
+func TestNewRawContent_NilHeaders_BecomesEmptyMap(t *testing.T) {
+	raw := core.NewRawContent("cnn", newTestSource(), newTestTarget(), "html", 200, nil)
+	require.NotNil(t, raw.Headers)
+	assert.Empty(t, raw.Headers)
+	// 실제 사용 가능 — write 가 panic 하지 않음
+	assert.NotPanics(t, func() {
+		raw.Headers["X-Test"] = "value"
+	})
+}
+
+// TestNewRawContent_IDFormat_UsesNamePrefix:
+// ID format "<name>-<unix_nano>" 검증 — 다른 fetcher 가 다른 prefix 받는지 구분.
+func TestNewRawContent_IDFormat_UsesNamePrefix(t *testing.T) {
+	cnnRaw := core.NewRawContent("cnn", newTestSource(), newTestTarget(), "x", 200, nil)
+	naverRaw := core.NewRawContent("naver", newTestSource(), newTestTarget(), "x", 200, nil)
+
+	assert.True(t, strings.HasPrefix(cnnRaw.ID, "cnn-"))
+	assert.True(t, strings.HasPrefix(naverRaw.ID, "naver-"))
+	assert.NotEqual(t, cnnRaw.ID, naverRaw.ID, "다른 prefix → 다른 ID")
+}
+
+// TestNewRawContent_ConsecutiveCalls_DistinctIDs:
+// 연속 호출 시 unix_nano 차이로 ID 가 달라야 함 (중복 방지).
+func TestNewRawContent_ConsecutiveCalls_DistinctIDs(t *testing.T) {
+	ids := make(map[string]bool)
+	for i := 0; i < 100; i++ {
+		raw := core.NewRawContent("cnn", newTestSource(), newTestTarget(), "x", 200, nil)
+		assert.False(t, ids[raw.ID], "중복 ID 발생: %s", raw.ID)
+		ids[raw.ID] = true
+		// time.Now().UnixNano() 가 같은 ns 를 반환할 가능성에 대비한 짧은 sleep
+		time.Sleep(1 * time.Microsecond)
+	}
+}
+
+// TestNewRawContent_NilMetadata_PreservedAsNil:
+// target.Metadata 가 nil 이면 그대로 nil 보존 (호출자가 nil 여부로 분기 가능).
+func TestNewRawContent_NilMetadata_PreservedAsNil(t *testing.T) {
+	tgt := core.Target{URL: "https://example.com", Type: core.TargetTypeArticle, Metadata: nil}
+	raw := core.NewRawContent("cnn", newTestSource(), tgt, "x", 200, nil)
+	assert.Nil(t, raw.Metadata, "Metadata 는 nil 그대로 보존")
+}
+
+// TestNewRawContent_MetadataReference_NotCopied:
+// target.Metadata 는 원본 reference 를 그대로 사용 (deep copy 없음).
+// 호출자가 partial_load 같은 변형이 필요하면 호출 후 raw.Metadata 를 덮어써야 함.
+func TestNewRawContent_MetadataReference_NotCopied(t *testing.T) {
+	tgt := newTestTarget()
+	raw := core.NewRawContent("cnn", newTestSource(), tgt, "x", 200, nil)
+
+	// 같은 reference — target.Metadata 변경 시 raw.Metadata 도 영향 받음
+	tgt.Metadata["new_key"] = "new_value"
+	assert.Equal(t, "new_value", raw.Metadata["new_key"],
+		"NewRawContent 는 target.Metadata reference 를 그대로 사용 (deep copy 없음)")
+}


### PR DESCRIPTION
## 연관 이슈
- Closes #75

<br>

## 구현 내용

### 신규 \`core\` 헬퍼 2개 (commit 1, 2)

**[\`core.CheckHTTPStatus(url, statusCode) error\`](internal/crawler/core/http_status.go)**
- HTTP 응답 상태 코드 4-way 분기를 단일 진실 소스(SoT)로 추출
- 분기 정책: \`404\` / \`429\` / \`5xx\` / \`4xx\` / 그 외 → 기존 동작 동일

**[\`core.NewRawContent(name, source, target, html, statusCode, headers) *RawContent\`](internal/crawler/core/models.go)**
- 8 필드 RawContent 조립 패턴을 일원화한 생성자
- \`target\` 통째 수신 → URL/Metadata 자동 추출
- \`headers nil\` → 빈 map 으로 보정
- \`Metadata reference\` 그대로 (변형 정책은 호출자 책임)

### Fetcher 적용 (commit 3, 4)

**[goquery/fetch.go](internal/crawler/implementation/goquery/fetch.go)** — 27줄 삭제, 9줄 추가
- 상태코드 분기 12줄 → \`core.CheckHTTPStatus(...)\` 1줄
- RawContent 조립 + Headers populating 15줄 → \`core.NewRawContent(...)\` 1줄 + Headers 추출 5줄
- 부수 효과: \`fmt\` / \`time\` import 제거

**[chromedp/fetch.go](internal/crawler/implementation/chromedp/fetch.go)** — 26줄 삭제, 10줄 추가
- 상태코드 분기 12줄 → \`core.CheckHTTPStatus(...)\` 1줄
- RawContent 조립 9줄 → \`core.NewRawContent(...)\` 1줄
- \`partial_load\` 메타데이터 변형은 호출 후 \`raw.Metadata = metadataWithPartialLoad(...)\` 덮어쓰기 (chromedp 고유 정책 보존)
- \`capturedStatus==0\` fallback 분기는 chromedp 고유 → \`CheckHTTPStatus\` 호출 전 그대로 유지

### 테스트 — 22 신규 (모두 PASS)

| 패키지 | 테스트 | 내용 |
|---|---|---|
| [test/internal/crawler_core/http_status_test.go](test/internal/crawler_core/http_status_test.go) | 16 | table-driven 14 케이스 (200/204/301/399/400/401/403/404/429/499/500/502/503/599) + 경계값 2건 |
| [test/internal/crawler_core/raw_content_builder_test.go](test/internal/crawler_core/raw_content_builder_test.go) | 6 | 8필드 정확 대입 / nil headers 보정 / ID prefix / 100회 unique / nil metadata 보존 / metadata reference 미복사 |

전체 회귀 테스트 통과 (\`go test -race ./...\`).

<br>

## CI / 머지 게이트 점검

> [CI 운영 규약](docs/ci/conventions.md) 및 [Required Status Checks 단일 소스](docs/ci/status-checks.md)에 따라 작성합니다.

### 변경 영향 범위
- 영향 패키지/모듈: \`internal/crawler/core\` (헬퍼 2개 신규), \`internal/crawler/implementation/{goquery,chromedp}\` (중복 블록 교체) + 신규 테스트
- 위험도(택1): **\`Low\`** / \`Medium\` / \`High\`
  - 내부 리팩토링 — 외부 인터페이스 변경 없음
  - 신규 헬퍼와 기존 동작 동일성 검증 (16 케이스 + 6 케이스)
  - 회귀 테스트 (race detector 포함) 통과

### Required Status Checks
- 통과 확인 대상 (PR Checks 탭에서 확인):
  - [ ] \`Commit Lint\`
  - [ ] \`PR Title Lint\`
  - [ ] \`Format Check\`
  - [ ] \`Build\`
  - [ ] \`Test\`
  - [ ] \`Lint\`

### 롤백 계획
- 단일 revert 로 즉시 복원. 외부 인터페이스 변경 없으므로 운영 영향 없음.

<br>

## TODO
- [x] \`core.CheckHTTPStatus\` 추출 + 16 테스트
- [x] \`core.NewRawContent\` 생성자 + 6 테스트
- [x] goquery/fetch.go 적용 (-27/+9)
- [x] chromedp/fetch.go 적용 (-26/+10)
- [x] 동작 동일성 회귀 검증

<br>

## 논의 사항
- 향후 새 fetcher (예: playwright, scrapingbee) 추가 시 동일 헬퍼 사용 → 분기/조립 정책 자동 일관 적용
- \`CheckHTTPStatus\` 에 새 분기 추가 (예: 451 법적 차단) 시 본 함수만 수정하면 모든 fetcher 에 반영
- chromedp 의 \`metadataWithPartialLoad\` 변형은 호출자 측에 남음 — 이슈 본문 시그니처를 따라 생성자는 단순 대입 정책 유지