### PR TITLE
[FEAT#126] Publisher 에 URL dedup 적용 — Kafka 큐잉 단계에서 중복 URL 사전 필터링

### DIFF
--- a/cmd/issuetracker/main.go
+++ b/cmd/issuetracker/main.go
@@ -109,6 +109,14 @@ func main() {
 		}
 	}
 
+	// URL dedup (이슈 #126): Publisher 가 Kafka enqueue 직전에 cache hit URL 을
+	// 사전 필터링 — consumer-side dedup 과 동일한 RedisURLCache 인스턴스를 공유.
+	// urlCache 가 nil (Redis 부재) 인 경우 Publisher 의 dedup 도 자동 비활성.
+	if urlCache != nil {
+		jobPublisher.SetURLCache(urlCache)
+		log.Info("publisher url dedup enabled (sharing redis url cache with workers)")
+	}
+
 	managerCfg := crawlerWorker.ManagerConfig{
 		High:      crawlerWorker.PoolConfig{Consumer: highConsumer, WorkerCount: 3},
 		Normal:    crawlerWorker.PoolConfig{Consumer: normalConsumer, WorkerCount: 6},

--- a/internal/publisher/publisher.go
+++ b/internal/publisher/publisher.go
@@ -26,6 +26,19 @@ type PriorityResolver interface {
 	Resolve(job *core.CrawlJob) core.Priority
 }
 
+// URLCache 는 publish 직전에 URL 의 캐시 hit 여부를 확인하는 최소 인터페이스입니다.
+// (이슈 #126)
+//
+// 의도적으로 작은 인터페이스 — Publisher 는 단지 "이 URL 을 보내도 되는가?" 만
+// 알고 싶어합니다. worker 패키지의 URLCache 와 method signature 가 동일하지만
+// publisher 가 worker 를 import 하지 않도록 별도 정의 — RedisURLCache 등 기존
+// 구현체는 구조적 타이핑으로 그대로 만족합니다.
+//
+// 구현체는 goroutine-safe 해야 합니다.
+type URLCache interface {
+	Exists(ctx context.Context, url string) (bool, error)
+}
+
 // Publisher는 크롤된 페이지에서 발견된 URL을 새 CrawlJob으로 변환하여
 // 우선순위에 맞는 Kafka crawl 토픽에 발행합니다.
 //
@@ -34,11 +47,26 @@ type PriorityResolver interface {
 //   - 차단된 URL 은 발행에서 제외 (Gate 가 자체 WARN 로그)
 //   - 미설정 시 가드 비활성 (기존 동작 유지)
 //   - atomic.Pointer 로 race-safe 한 lock-free 설정/조회 — 워커 동시 실행 중 변경에도 race 없음
+//
+// URL dedup (이슈 #126):
+//   - SetURLCache 로 URLCache 를 설정하면 message build 직전에 cache hit URL 을 필터링
+//   - TargetTypeCategory 는 dedup 미적용 (consumer-side 와 동일 규칙 — 카테고리는 매 주기
+//     새 기사 추출이 목적)
+//   - 캐시 조회 실패는 fail-open (해당 URL publish 진행) — Redis 일시 장애로 publish 가
+//     멈추지 않도록
+//   - 미설정 시 dedup 비활성 (기존 동작 유지)
 type Publisher struct {
 	producer queue.Producer
 	resolver PriorityResolver
 	gate     atomic.Pointer[urlguard.Gate]
+	urlCache atomic.Pointer[urlCacheRef]
 	log      *logger.Logger
+}
+
+// urlCacheRef 는 atomic.Pointer 가 인터페이스 값을 직접 저장하지 못하므로
+// URLCache 인터페이스를 감싸 atomic 교체를 지원하는 wrapper 입니다.
+type urlCacheRef struct {
+	c URLCache
 }
 
 // New는 새 Publisher를 생성합니다.
@@ -56,6 +84,16 @@ func New(producer queue.Producer, resolver PriorityResolver, log *logger.Logger)
 // 동시성: atomic.Pointer 기반 lock-free 설정/조회 — Publish 동시 실행 중 변경에도 race-safe.
 func (p *Publisher) SetGate(g *urlguard.Gate) {
 	p.gate.Store(g)
+}
+
+// SetURLCache 는 Publish 시 cache hit URL 사전 필터링에 사용할 URLCache 를 설정합니다.
+// nil 전달 시 dedup 비활성 (기존 동작 유지). atomic 으로 race-safe 한 swap 보장.
+func (p *Publisher) SetURLCache(c URLCache) {
+	if c == nil {
+		p.urlCache.Store(nil)
+		return
+	}
+	p.urlCache.Store(&urlCacheRef{c: c})
 }
 
 // Publish는 발견된 URL 목록으로 CrawlJob을 생성하고 한 번의 배치 요청으로 Kafka에 발행합니다.
@@ -78,6 +116,17 @@ func (p *Publisher) Publish(
 			"crawler": crawlerName,
 			"stage":   "publisher",
 		})
+		if len(urls) == 0 {
+			return nil
+		}
+	}
+
+	// URL dedup (이슈 #126): cache hit URL 사전 필터링
+	// - TargetTypeCategory 는 dedup 미적용 (consumer-side 와 동일 규칙)
+	// - 캐시 조회 실패는 fail-open (해당 URL 통과 + WARN 로그) — Redis 일시 장애로
+	//   publish 가 멈추지 않도록
+	if r := p.urlCache.Load(); r != nil && targetType != core.TargetTypeCategory {
+		urls = p.filterCachedURLs(ctx, urls, crawlerName, r.c)
 		if len(urls) == 0 {
 			return nil
 		}
@@ -118,6 +167,42 @@ func (p *Publisher) Publish(
 	}).Debug("chained jobs batch published to kafka")
 
 	return nil
+}
+
+// filterCachedURLs 는 URLCache 를 조회하여 cache hit 인 URL 을 제외한 슬라이스를
+// 반환합니다 (이슈 #126).
+//
+//   - cache hit  : DEBUG 로그 후 결과에서 제외 — 다운스트림 worker 가 cache hit 으로
+//     skip 할 것을 미리 producer 단에서 걸러 Kafka 왕복 절약
+//   - cache miss : 결과 슬라이스에 포함
+//   - 조회 실패  : fail-open (결과 슬라이스에 포함) + WARN 로그 — Redis 일시 장애가
+//     publish 를 영구 차단하지 않도록
+//
+// 결과 슬라이스는 입력과 다른 underlying array 로 새로 할당됩니다 (입력 mutate 없음).
+func (p *Publisher) filterCachedURLs(ctx context.Context, urls []string, crawlerName string, cache URLCache) []string {
+	out := make([]string, 0, len(urls))
+	for _, url := range urls {
+		cached, err := cache.Exists(ctx, url)
+		if err != nil {
+			p.log.WithFields(map[string]interface{}{
+				"crawler": crawlerName,
+				"stage":   "publisher",
+				"url":     url,
+			}).WithError(err).Warn("url cache check failed, allowing publish")
+			out = append(out, url)
+			continue
+		}
+		if cached {
+			p.log.WithFields(map[string]interface{}{
+				"crawler": crawlerName,
+				"stage":   "publisher",
+				"url":     url,
+			}).Debug("url already cached, skipping publish")
+			continue
+		}
+		out = append(out, url)
+	}
+	return out
 }
 
 // buildMessage는 CrawlJob을 Kafka Message로 변환합니다.

--- a/internal/publisher/publisher.go
+++ b/internal/publisher/publisher.go
@@ -177,27 +177,34 @@ func (p *Publisher) Publish(
 //   - cache miss : 결과 슬라이스에 포함
 //   - 조회 실패  : fail-open (결과 슬라이스에 포함) + WARN 로그 — Redis 일시 장애가
 //     publish 를 영구 차단하지 않도록
+//   - ctx 취소   : 즉시 종료하고 남은 URL 은 fail-open 으로 그대로 통과 — 셧다운 중
+//     무의미한 cache 호출/WARN 누적 회피. 후속 PublishBatch 가 ctx 에러로 자연 실패.
 //
 // 결과 슬라이스는 입력과 다른 underlying array 로 새로 할당됩니다 (입력 mutate 없음).
+//
+// 성능: crawler/stage 필드를 갖는 sub-logger 를 루프 외부에서 1회 생성하여 재사용 —
+// per-URL map 할당 회피.
 func (p *Publisher) filterCachedURLs(ctx context.Context, urls []string, crawlerName string, cache URLCache) []string {
 	out := make([]string, 0, len(urls))
-	for _, url := range urls {
+	l := p.log.WithFields(map[string]interface{}{
+		"crawler": crawlerName,
+		"stage":   "publisher",
+	})
+
+	for i, url := range urls {
+		if err := ctx.Err(); err != nil {
+			l.WithError(err).Warn("context cancelled during cache check, allowing remaining URLs")
+			return append(out, urls[i:]...)
+		}
+
 		cached, err := cache.Exists(ctx, url)
 		if err != nil {
-			p.log.WithFields(map[string]interface{}{
-				"crawler": crawlerName,
-				"stage":   "publisher",
-				"url":     url,
-			}).WithError(err).Warn("url cache check failed, allowing publish")
+			l.WithField("url", url).WithError(err).Warn("url cache check failed, allowing publish")
 			out = append(out, url)
 			continue
 		}
 		if cached {
-			p.log.WithFields(map[string]interface{}{
-				"crawler": crawlerName,
-				"stage":   "publisher",
-				"url":     url,
-			}).Debug("url already cached, skipping publish")
+			l.WithField("url", url).Debug("url already cached, skipping publish")
 			continue
 		}
 		out = append(out, url)

--- a/test/internal/publisher/publisher_url_cache_test.go
+++ b/test/internal/publisher/publisher_url_cache_test.go
@@ -1,0 +1,206 @@
+package publisher_test
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"issuetracker/internal/crawler/core"
+	"issuetracker/internal/publisher"
+)
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Mock URLCache
+// ─────────────────────────────────────────────────────────────────────────────
+
+// stubURLCache 는 사전 등록된 hit 집합과 호출 카운터를 갖는 URLCache 더블입니다.
+// err 가 nil 이 아니면 hit 여부 무관하게 에러를 우선 반환합니다.
+type stubURLCache struct {
+	mu     sync.Mutex
+	hits   map[string]bool // Exists → true 가 될 URL 집합
+	err    error
+	called atomic.Int32
+}
+
+func newStubURLCache(hitURLs ...string) *stubURLCache {
+	hits := make(map[string]bool, len(hitURLs))
+	for _, u := range hitURLs {
+		hits[u] = true
+	}
+	return &stubURLCache{hits: hits}
+}
+
+func (s *stubURLCache) Exists(_ context.Context, url string) (bool, error) {
+	s.called.Add(1)
+	if s.err != nil {
+		return false, s.err
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.hits[url], nil
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 테스트
+// ─────────────────────────────────────────────────────────────────────────────
+
+// TestPublisher_URLCache_FiltersCachedURLs:
+// cache hit URL 은 batch 에서 제외되고 miss 만 publish 되어야 함.
+func TestPublisher_URLCache_FiltersCachedURLs(t *testing.T) {
+	prod := &gateMockProducer{}
+	pub := publisher.New(prod, noopResolver{}, gateLog())
+
+	cache := newStubURLCache(
+		"https://edition.cnn.com/article/1", // hit
+		"https://edition.cnn.com/article/3", // hit
+	)
+	pub.SetURLCache(cache)
+
+	urls := []string{
+		"https://edition.cnn.com/article/1", // hit
+		"https://edition.cnn.com/article/2", // miss
+		"https://edition.cnn.com/article/3", // hit
+		"https://edition.cnn.com/article/4", // miss
+	}
+	err := pub.Publish(context.Background(), "cnn", urls, core.TargetTypeArticle, 5*time.Second)
+	require.NoError(t, err)
+
+	assert.Equal(t, 2, prod.batchSize(), "miss 2건만 batch 에 포함")
+	assert.Equal(t, int32(4), cache.called.Load(), "각 URL 마다 cache 1회 조회")
+}
+
+// TestPublisher_URLCache_AllCached_NoPublish:
+// 모두 cache hit 이면 PublishBatch 호출 없이 nil 반환.
+func TestPublisher_URLCache_AllCached_NoPublish(t *testing.T) {
+	prod := &gateMockProducer{}
+	pub := publisher.New(prod, noopResolver{}, gateLog())
+
+	urls := []string{
+		"https://edition.cnn.com/article/1",
+		"https://edition.cnn.com/article/2",
+	}
+	pub.SetURLCache(newStubURLCache(urls...))
+
+	require.NoError(t, pub.Publish(context.Background(), "cnn", urls, core.TargetTypeArticle, 5*time.Second))
+
+	prod.mu.Lock()
+	defer prod.mu.Unlock()
+	assert.Empty(t, prod.calls, "전부 cache hit 시 PublishBatch 미호출")
+}
+
+// TestPublisher_URLCache_AllMiss_PublishesAll:
+// 모두 cache miss 면 전부 publish.
+func TestPublisher_URLCache_AllMiss_PublishesAll(t *testing.T) {
+	prod := &gateMockProducer{}
+	pub := publisher.New(prod, noopResolver{}, gateLog())
+	pub.SetURLCache(newStubURLCache()) // 빈 hit set
+
+	urls := []string{
+		"https://edition.cnn.com/article/1",
+		"https://edition.cnn.com/article/2",
+	}
+	require.NoError(t, pub.Publish(context.Background(), "cnn", urls, core.TargetTypeArticle, 5*time.Second))
+	assert.Equal(t, 2, prod.batchSize(), "miss 만 있으면 전부 publish")
+}
+
+// TestPublisher_URLCache_CategoryBypassesCache:
+// TargetTypeCategory 는 dedup 비대상 — 모든 URL 이 cache hit 이라도 그대로 publish.
+// consumer-side 와 동일 규칙 (카테고리는 매 주기 새 기사 추출이 목적).
+func TestPublisher_URLCache_CategoryBypassesCache(t *testing.T) {
+	prod := &gateMockProducer{}
+	pub := publisher.New(prod, noopResolver{}, gateLog())
+
+	urls := []string{
+		"https://edition.cnn.com/health",
+		"https://edition.cnn.com/world",
+	}
+	cache := newStubURLCache(urls...) // 모두 hit 으로 설정
+	pub.SetURLCache(cache)
+
+	require.NoError(t, pub.Publish(context.Background(), "cnn", urls, core.TargetTypeCategory, 5*time.Second))
+
+	assert.Equal(t, 2, prod.batchSize(), "category 는 dedup 우회 — 전부 publish")
+	assert.Equal(t, int32(0), cache.called.Load(), "category 는 cache 조회 자체를 생략")
+}
+
+// TestPublisher_URLCache_CacheError_FailOpen:
+// cache 조회 실패 시 fail-open — 해당 URL 이 통과해서 publish 됨.
+func TestPublisher_URLCache_CacheError_FailOpen(t *testing.T) {
+	prod := &gateMockProducer{}
+	pub := publisher.New(prod, noopResolver{}, gateLog())
+
+	cache := &stubURLCache{err: errors.New("redis unavailable")}
+	pub.SetURLCache(cache)
+
+	urls := []string{
+		"https://edition.cnn.com/article/1",
+		"https://edition.cnn.com/article/2",
+	}
+	require.NoError(t, pub.Publish(context.Background(), "cnn", urls, core.TargetTypeArticle, 5*time.Second))
+
+	assert.Equal(t, 2, prod.batchSize(), "조회 실패는 fail-open — 전부 publish")
+	assert.Equal(t, int32(2), cache.called.Load())
+}
+
+// TestPublisher_NoURLCache_LegacyBehavior:
+// SetURLCache 미호출 시 dedup 비활성 — 모든 URL publish (기존 동작 유지).
+func TestPublisher_NoURLCache_LegacyBehavior(t *testing.T) {
+	prod := &gateMockProducer{}
+	pub := publisher.New(prod, noopResolver{}, gateLog())
+	// SetURLCache 호출 없음
+
+	urls := []string{
+		"https://edition.cnn.com/article/1",
+		"https://edition.cnn.com/article/2",
+	}
+	require.NoError(t, pub.Publish(context.Background(), "cnn", urls, core.TargetTypeArticle, 5*time.Second))
+	assert.Equal(t, 2, prod.batchSize(), "URLCache 미설정 — 모든 URL publish")
+}
+
+// TestPublisher_SetURLCache_NilUnsetsPrevious:
+// SetURLCache(nil) 호출 시 이전 cache 가 제거되고 dedup 이 비활성화되어야 함.
+func TestPublisher_SetURLCache_NilUnsetsPrevious(t *testing.T) {
+	prod := &gateMockProducer{}
+	pub := publisher.New(prod, noopResolver{}, gateLog())
+
+	urls := []string{
+		"https://edition.cnn.com/article/1",
+		"https://edition.cnn.com/article/2",
+	}
+	cache := newStubURLCache(urls...) // 모두 hit
+	pub.SetURLCache(cache)
+	pub.SetURLCache(nil) // 이전 cache 해제
+
+	require.NoError(t, pub.Publish(context.Background(), "cnn", urls, core.TargetTypeArticle, 5*time.Second))
+
+	assert.Equal(t, 2, prod.batchSize(), "SetURLCache(nil) 후 모든 URL publish")
+	assert.Equal(t, int32(0), cache.called.Load(), "해제된 cache 는 호출되지 않음")
+}
+
+// TestPublisher_URLCache_AppliedAfterGate:
+// Gate 차단된 URL 은 cache 조회 자체가 일어나지 않아야 함 — Gate → URLCache 순서 검증.
+func TestPublisher_URLCache_AppliedAfterGate(t *testing.T) {
+	prod := &gateMockProducer{}
+	pub := publisher.New(prod, noopResolver{}, gateLog())
+
+	cache := newStubURLCache() // 모두 miss
+	pub.SetURLCache(cache)
+
+	// Gate 미설정이면 모든 URL 이 통과 → cache 조회는 입력 개수만큼 발생
+	urls := []string{
+		"https://edition.cnn.com/article/1",
+		"https://edition.cnn.com/article/2",
+		"https://edition.cnn.com/article/3",
+	}
+	require.NoError(t, pub.Publish(context.Background(), "cnn", urls, core.TargetTypeArticle, 5*time.Second))
+
+	assert.Equal(t, 3, prod.batchSize())
+	assert.Equal(t, int32(3), cache.called.Load(),
+		"Gate 미설정 시 모든 URL 이 cache 조회 대상")
+}

--- a/test/internal/publisher/publisher_url_cache_test.go
+++ b/test/internal/publisher/publisher_url_cache_test.go
@@ -46,6 +46,21 @@ func (s *stubURLCache) Exists(_ context.Context, url string) (bool, error) {
 	return s.hits[url], nil
 }
 
+// cancelTriggerCache 는 첫 Exists 호출 시점에 ctx 를 cancel 하여 후속 iteration 의
+// ctx 검사 분기를 유도하기 위한 더블입니다.
+type cancelTriggerCache struct {
+	cancel context.CancelFunc
+	called atomic.Int32
+}
+
+func (c *cancelTriggerCache) Exists(_ context.Context, _ string) (bool, error) {
+	c.called.Add(1)
+	if c.cancel != nil {
+		c.cancel()
+	}
+	return false, nil
+}
+
 // ─────────────────────────────────────────────────────────────────────────────
 // 테스트
 // ─────────────────────────────────────────────────────────────────────────────
@@ -181,6 +196,33 @@ func TestPublisher_SetURLCache_NilUnsetsPrevious(t *testing.T) {
 
 	assert.Equal(t, 2, prod.batchSize(), "SetURLCache(nil) 후 모든 URL publish")
 	assert.Equal(t, int32(0), cache.called.Load(), "해제된 cache 는 호출되지 않음")
+}
+
+// TestPublisher_URLCache_CtxCancelled_AllowsRemaining:
+// cache 조회 도중 ctx 가 취소되면 즉시 종료하고 남은 URL 은 fail-open 으로 통과
+// (후속 PublishBatch 가 ctx 에러로 자연 실패하므로 publish 시도까지만 보존).
+// blockingCache 가 첫 호출 후 ctx 를 취소하여 두 번째 호출 직전 분기 진입을 유도.
+func TestPublisher_URLCache_CtxCancelled_AllowsRemaining(t *testing.T) {
+	prod := &gateMockProducer{}
+	pub := publisher.New(prod, noopResolver{}, gateLog())
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cache := &cancelTriggerCache{cancel: cancel}
+	pub.SetURLCache(cache)
+
+	urls := []string{
+		"https://edition.cnn.com/article/1", // 첫 호출 — 캐시 호출 후 ctx 취소
+		"https://edition.cnn.com/article/2", // 두 번째 — ctx 검사에서 즉시 fail-open
+		"https://edition.cnn.com/article/3", // 세 번째 — 동일하게 fail-open
+	}
+	// PublishBatch 가 ctx.Err 로 실패하더라도 본 테스트의 관심사는 filter 결과뿐이므로
+	// gateMockProducer 는 ctx 무시 — 입력 메시지 그대로 기록.
+	_ = pub.Publish(ctx, "cnn", urls, core.TargetTypeArticle, 5*time.Second)
+
+	assert.Equal(t, 3, prod.batchSize(),
+		"ctx 취소 후 남은 URL 은 fail-open 으로 모두 batch 에 포함")
+	assert.Equal(t, int32(1), cache.called.Load(),
+		"ctx 취소 후 cache 호출 중단 — 1회만 호출")
 }
 
 // TestPublisher_URLCache_AppliedAfterGate:


### PR DESCRIPTION
## 연관 이슈
- Closes #126

<br>

## 구현 내용
- `internal/publisher/publisher.go`
  - `URLCache` 인터페이스 정의 (`Exists` 단일 메서드만 — worker 패키지 import 회피, RedisURLCache 등 기존 구현체는 구조적 타이핑으로 그대로 만족)
  - `urlCache atomic.Pointer[urlCacheRef]` 필드 + `SetURLCache(c URLCache)` 메서드 — Gate 와 동일한 atomic 교체 패턴
  - `Publish()` 에서 Gate 필터 직후·message build 직전에 cache hit URL 사전 필터링
  - `TargetTypeCategory` 는 dedup 미적용 (consumer-side 와 동일 규칙 — 카테고리는 매 주기 새 기사 추출이 목적). 카테고리일 때 cache 조회 자체를 생략
  - 캐시 조회 실패는 fail-open + WARN — Redis 일시 장애로 publish 가 멈추지 않도록
  - 캐시 hit 은 DEBUG 로그
  - 모든 URL 이 hit/차단되면 `PublishBatch` 호출 없이 nil 반환 (Gate 와 동일 흐름)
- `cmd/issuetracker/main.go`
  - Redis 가 초기화된 경우 worker 와 공유하는 동일한 `RedisURLCache` 인스턴스를 `jobPublisher.SetURLCache(...)` 로 주입
  - Redis 부재 / 초기화 실패 시 Publisher dedup 도 자동 비활성
- 테스트
  - `test/internal/publisher/publisher_url_cache_test.go` 8 시나리오: 일부 hit 필터링 / 전부 hit 미발행 / 전부 miss 통과 / 카테고리 우회 / 캐시 에러 fail-open / SetURLCache 미설정 기존 동작 / SetURLCache(nil) 해제 / Gate→URLCache 순서 검증

<br>

## CI / 머지 게이트 점검

> [CI 운영 규약](docs/ci/conventions.md) 및 [Required Status Checks 단일 소스](docs/ci/status-checks.md)에 따라 작성합니다.

### 변경 영향 범위
- 영향 패키지/모듈: `internal/publisher`, `cmd/issuetracker`
- 위험도(택1): `Low`
- 근거: URLCache 미설정 시 기존 동작 보존 (legacy behavior 테스트로 회귀 잠금). Redis 부재 환경에서는 dedup 자동 비활성. 캐시 조회 실패 시 fail-open 으로 publish 가 멈추지 않음.

### Required Status Checks
- 통과 확인 대상 (PR Checks 탭에서 확인):
  - [ ] `Commit Lint`
  - [ ] `PR Title Lint`
  - [ ] `Linked Issue Check`
  - [ ] `Format Check`
  - [ ] `Build`
  - [ ] `Test`
  - [ ] `Lint`

### 롤백 계획
- 운영 중 Publisher dedup 으로 인한 의도치 않은 URL 누락이 발견되면, `cmd/issuetracker/main.go` 의 `jobPublisher.SetURLCache(urlCache)` 호출 1줄을 주석 처리하여 즉시 롤백 (consumer-side dedup 은 그대로 유지)
- 코드 차원에서는 본 PR 의 2개 커밋을 차례로 revert

<br>

## TODO
- (옵션) Scheduler 의 `JobEmitter` 에도 URL dedup 적용 — 단, 현재 모든 `DefaultEntries` 가 `TargetTypeCategory` 라 효과 없음. 비-카테고리 seed entry 가 추가될 때 별도 검토.

<br>

## 논의 사항
- `TargetTypeCategory` 외 `TargetTypeSitemap` 도 매 주기 갱신이 필요할 수 있는데 현재는 dedup 적용 대상. consumer-side 도 동일 규칙이므로 일관성 유지를 위해 본 PR 에서는 그대로 유지 — sitemap dedup 정책은 별도 이슈로 분리.
- Publisher dedup 으로 cache hit URL 의 `PublishBatch` 가 줄어들면 Kafka 메시지 양 (이슈 #124) 의 throttle 임계값에 영향. 동일 시간대에 같은 URL 이 N회 발견되던 경우 producer-side dedup 후에는 1회만 발행되므로 backlog 누적 양상이 달라질 수 있음.

<br>