### PR TITLE
[REFAC#82] Redis ZSET 기반 delayed retry queue — worker 슬롯 점유 해소

### DIFF
--- a/cmd/issuetracker/main.go
+++ b/cmd/issuetracker/main.go
@@ -91,6 +91,8 @@ func main() {
 	// Redis 초기화 실패 시에도 크롤링이 중단되지 않도록 graceful degrade합니다.
 	var jobLocker crawlerWorker.JobLocker
 	var urlCache crawlerWorker.URLCache
+	var retryScheduler crawlerWorker.RetryScheduler
+	var retrySchedulerStop func()
 	redisCfg, err := config.LoadRedis()
 	if err != nil {
 		log.WithError(err).Warn("failed to load redis config, falling back to noop job locker and url cache")
@@ -106,7 +108,27 @@ func main() {
 			}).Info("redis connected for job locker and url cache")
 			jobLocker = crawlerWorker.NewRedisJobLocker(redisClient, crawlerWorker.DefaultJobLockTTL)
 			urlCache = crawlerWorker.NewRedisURLCache(redisClient, redisCfg.URLCacheTTL)
+
+			// Delayed retry queue (이슈 #82): retry 를 Redis ZSET 에 보관하고 별도
+			// goroutine 이 ScheduledAt 도달 시 Kafka 에 발행 — worker 슬롯 점유 회피.
+			// Redis 부재 시 worker 가 lazy 로 KafkaImmediateRetryScheduler 를 사용 (기존 동작).
+			redisRetry := crawlerWorker.NewRedisDelayedRetryScheduler(
+				redisClient, crawlerProducer,
+				crawlerWorker.DefaultRedisRetrySchedulerConfig(),
+				log,
+			)
+			runCtx, cancelRun := context.WithCancel(ctx)
+			go redisRetry.Run(runCtx)
+			retryScheduler = redisRetry
+			retrySchedulerStop = func() {
+				cancelRun()
+				redisRetry.Stop()
+			}
+			log.Info("redis delayed retry queue enabled (worker slot occupancy on retry resolved)")
 		}
+	}
+	if retrySchedulerStop != nil {
+		defer retrySchedulerStop()
 	}
 
 	// URL dedup (이슈 #126): Publisher 가 Kafka enqueue 직전에 cache hit URL 을
@@ -118,11 +140,12 @@ func main() {
 	}
 
 	managerCfg := crawlerWorker.ManagerConfig{
-		High:      crawlerWorker.PoolConfig{Consumer: highConsumer, WorkerCount: 3},
-		Normal:    crawlerWorker.PoolConfig{Consumer: normalConsumer, WorkerCount: 6},
-		Low:       crawlerWorker.PoolConfig{Consumer: lowConsumer, WorkerCount: 2},
-		JobLocker: jobLocker,
-		URLCache:  urlCache,
+		High:           crawlerWorker.PoolConfig{Consumer: highConsumer, WorkerCount: 3},
+		Normal:         crawlerWorker.PoolConfig{Consumer: normalConsumer, WorkerCount: 6},
+		Low:            crawlerWorker.PoolConfig{Consumer: lowConsumer, WorkerCount: 2},
+		JobLocker:      jobLocker,
+		URLCache:       urlCache,
+		RetryScheduler: retryScheduler,
 	}
 
 	manager := crawlerWorker.NewPoolManager(managerCfg, crawlerProducer, registry, contentSvc, resolver, log)

--- a/cmd/issuetracker/main.go
+++ b/cmd/issuetracker/main.go
@@ -118,7 +118,7 @@ func main() {
 				log,
 			)
 			runCtx, cancelRun := context.WithCancel(ctx)
-			go redisRetry.Run(runCtx)
+			redisRetry.Start(runCtx) // 내부에서 wg.Add 후 go Run — 패닉 안전
 			retryScheduler = redisRetry
 			retrySchedulerStop = func() {
 				cancelRun()

--- a/internal/crawler/worker/manager.go
+++ b/internal/crawler/worker/manager.go
@@ -28,12 +28,15 @@ type PoolConfig struct {
 // ManagerConfig aggregates the three per-priority pool configs.
 // JobLocker가 nil이면 NoopJobLocker가 사용되어 중복 처리 방지가 비활성화됩니다.
 // URLCache가 nil이면 NoopURLCache가 사용되어 URL 캐싱이 비활성화됩니다.
+// RetryScheduler가 nil이면 각 Pool 이 lazy 로 KafkaImmediateRetryScheduler 를 생성하여
+// 기존 동작 (즉시 Kafka publish + worker sleep) 을 유지합니다 (이슈 #82).
 type ManagerConfig struct {
-	High      PoolConfig
-	Normal    PoolConfig
-	Low       PoolConfig
-	JobLocker JobLocker
-	URLCache  URLCache
+	High           PoolConfig
+	Normal         PoolConfig
+	Low            PoolConfig
+	JobLocker      JobLocker
+	URLCache       URLCache
+	RetryScheduler RetryScheduler
 }
 
 // ─────────────────────────────────────────────────────────────────────────
@@ -84,10 +87,16 @@ func NewPoolManager(
 	cbRegistry := NewCircuitBreakerRegistry(DefaultCircuitBreakerConfig)
 
 	newPool := func(pc PoolConfig) *KafkaConsumerPool {
-		return NewKafkaConsumerPoolWithOptions(
+		pool := NewKafkaConsumerPoolWithOptions(
 			pc.Consumer, producer, handler, contentSvc, pc.WorkerCount,
 			cbRegistry, jobLocker, urlCache,
 		)
+		// 단일 RetryScheduler 인스턴스를 세 우선순위 Pool 이 공유합니다 (이슈 #82) —
+		// Redis 기반 구현에서 ZSET/연결 풀이 통일되도록.
+		if cfg.RetryScheduler != nil {
+			pool.SetRetryScheduler(cfg.RetryScheduler)
+		}
+		return pool
 	}
 
 	return &PoolManager{

--- a/internal/crawler/worker/pool.go
+++ b/internal/crawler/worker/pool.go
@@ -80,6 +80,11 @@ type KafkaConsumerPool struct {
 	// processJob 진입 직후 검사하여 차단된 URL 의 처리를 skip 하고 message 만 commit.
 	// atomic.Pointer 로 race-safe 한 lock-free 설정/조회.
 	gate atomic.Pointer[urlguard.Gate]
+	// retryScheduler 는 재시도 발행 시점을 관리하는 RetryScheduler 입니다 (이슈 #82).
+	// 미설정(nil) 이면 lazy 로 KafkaImmediateRetryScheduler 가 사용되어 기존 동작 유지 —
+	// 즉시 priority 토픽에 publish + worker 가 ScheduledAt 까지 sleep.
+	// atomic.Pointer 로 race-safe 설정 — Start 이후 SetRetryScheduler 호출에도 안전.
+	retryScheduler atomic.Pointer[retrySchedulerHolder]
 	// pollDone은 pollMessages goroutine이 완전히 종료됐음을 알리는 신호입니다.
 	// close(p.jobs) 전에 반드시 이 채널이 닫혔음을 확인해야 합니다.
 	pollDone chan struct{}
@@ -154,6 +159,17 @@ func NewKafkaConsumerPoolWithOptions(
 		jobs:     make(chan jobItem, workerCount*2),
 		pollDone: make(chan struct{}),
 	}
+}
+
+// SetRetryScheduler 는 requeueWithRetry 시 사용할 RetryScheduler 를 설정합니다 (이슈 #82).
+// nil 전달 시 fallback 인 KafkaImmediateRetryScheduler (lazy 생성) 가 사용됩니다 —
+// 기존 동작 보존. atomic 교체로 Start 이후에도 race-safe.
+func (p *KafkaConsumerPool) SetRetryScheduler(rs RetryScheduler) {
+	if rs == nil {
+		p.retryScheduler.Store(nil)
+		return
+	}
+	p.retryScheduler.Store(&retrySchedulerHolder{s: rs})
 }
 
 // SetGate 는 processJob 진입 시 URL 검사에 사용할 urlguard.Gate 를 설정합니다 (이슈 #119).
@@ -679,30 +695,14 @@ func (p *KafkaConsumerPool) requeueWithRetry(ctx context.Context, job *core.Craw
 	job.RetryCount++
 
 	// RetryCount 기반 exponential backoff 계산 후 ScheduledAt에 저장합니다.
-	// worker는 메시지를 소비한 뒤 processJob에서 ScheduledAt까지 대기하여 backoff를 적용합니다.
+	// 실제 지연 적용은 RetryScheduler 구현체가 책임집니다 (이슈 #82):
+	//   - KafkaImmediateRetryScheduler (fallback): 즉시 publish — worker 가 sleep
+	//   - RedisDelayedRetryScheduler: Redis ZSET 보관 — worker 슬롯 점유 없음
 	backoffDelay := core.CalculateBackoff(kafkaRequeuePolicy, job.RetryCount)
 	job.ScheduledAt = time.Now().Add(backoffDelay)
 
-	data, err := job.Marshal()
-	if err != nil {
-		log.WithFields(map[string]interface{}{
-			"job_id":  job.ID,
-			"crawler": job.CrawlerName,
-		}).WithError(err).Error("failed to marshal job for retry")
-		return fmt.Errorf("marshal job for retry: %w", err)
-	}
-
+	scheduler := p.resolveRetryScheduler()
 	topic := topicForPriority(job.Priority)
-
-	msg := queue.Message{
-		Topic: topic,
-		Key:   []byte(job.ID),
-		Value: data,
-		Headers: map[string]string{
-			"retry-count": fmt.Sprintf("%d", job.RetryCount),
-			"last-error":  reason.Error(),
-		},
-	}
 
 	log.WithFields(map[string]interface{}{
 		"job_id":   job.ID,
@@ -714,13 +714,13 @@ func (p *KafkaConsumerPool) requeueWithRetry(ctx context.Context, job *core.Craw
 
 	// 로깅 정책: 본 함수는 publish 실패 로그를 직접 남기지 않고 에러만 반환합니다.
 	// 호출자(processJob)가 logShutdownAware 로 통일된 강등 정책에 따라 로깅합니다.
-	err = p.producer.Publish(ctx, msg)
+	err := scheduler.Enqueue(ctx, job, reason)
 	if err != nil && errors.Is(err, context.Canceled) {
 		// graceful shutdown 으로 ctx 가 canceled 된 경우, drain context 로 한 번 더 시도
 		drainCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), drainTimeout)
 		defer cancel()
 		// errors.Join 으로 최초 cancel 과 retryErr 를 모두 보존
-		if retryErr := p.producer.Publish(drainCtx, msg); retryErr != nil {
+		if retryErr := scheduler.Enqueue(drainCtx, job, reason); retryErr != nil {
 			err = errors.Join(err, retryErr)
 		} else {
 			err = nil
@@ -731,6 +731,16 @@ func (p *KafkaConsumerPool) requeueWithRetry(ctx context.Context, job *core.Craw
 	}
 
 	return nil
+}
+
+// resolveRetryScheduler 는 SetRetryScheduler 로 주입된 구현체를 반환하고, 미설정 시
+// 기존 동작 (즉시 Kafka publish + worker sleep) 을 보존하는 KafkaImmediateRetryScheduler
+// 를 lazy 생성합니다. 매 호출마다 새 인스턴스이지만 stateless 이므로 비용 무시 가능.
+func (p *KafkaConsumerPool) resolveRetryScheduler() RetryScheduler {
+	if h := p.retryScheduler.Load(); h != nil {
+		return h.s
+	}
+	return NewKafkaImmediateRetryScheduler(p.producer)
 }
 
 // logShutdownAware 는 graceful shutdown 으로 발생한 컨텍스트성 에러를 DEBUG 로,

--- a/internal/crawler/worker/retry_scheduler.go
+++ b/internal/crawler/worker/retry_scheduler.go
@@ -306,7 +306,17 @@ func (s *RedisDelayedRetryScheduler) republish(ctx context.Context, item pkgredi
 		}).WithError(err).Warn("retry republish failed, rescheduling in redis")
 
 		retryAt := time.Now().Add(s.cfg.RepublishFailureBackoff)
-		if reErr := s.client.EnqueueRetry(ctx, item.JobID, item.Payload, retryAt); reErr != nil {
+		// 셧다운 중 (ctx canceled) 에는 reschedule 까지 ctx 에러로 실패 → 다음 인스턴스가
+		// 원본 score 로 즉시 재peek (정합성 보존). 그래도 의도된 backoff 를 유지하려면
+		// drain context 로 한 번 더 시도 (Copilot #5 — 셧다운 윈도우 안전성).
+		// 원본 ctx 가 canceled 가 아니면 그대로 사용.
+		enqueueCtx := ctx
+		var cancelDrain context.CancelFunc
+		if ctx.Err() != nil {
+			enqueueCtx, cancelDrain = context.WithTimeout(context.WithoutCancel(ctx), drainTimeout)
+			defer cancelDrain()
+		}
+		if reErr := s.client.EnqueueRetry(enqueueCtx, item.JobID, item.Payload, retryAt); reErr != nil {
 			s.log.WithFields(map[string]interface{}{
 				"job_id":  item.JobID,
 				"crawler": job.CrawlerName,

--- a/internal/crawler/worker/retry_scheduler.go
+++ b/internal/crawler/worker/retry_scheduler.go
@@ -1,0 +1,74 @@
+package worker
+
+import (
+	"context"
+	"fmt"
+
+	"issuetracker/internal/crawler/core"
+	"issuetracker/pkg/queue"
+)
+
+// RetryScheduler 는 처리 실패한 CrawlJob 의 재시도 발행 시점을 관리하는 인터페이스입니다
+// (이슈 #82).
+//
+// 두 가지 구현 전략을 추상화합니다:
+//   - KafkaImmediateRetryScheduler: 즉시 Kafka 에 재발행하고 worker 가 ScheduledAt 까지
+//     대기 — 기존 동작 보존 (worker 슬롯 점유 문제 그대로)
+//   - RedisDelayedRetryScheduler: Redis ZSET 에 보관하고 별도 goroutine 이 ScheduledAt
+//     도달 시 Kafka 에 발행 — worker 슬롯 점유 회피
+//
+// 호출자 (worker pool) 는 ScheduledAt 과 RetryCount 를 미리 셋팅한 job 을 전달합니다.
+// 구현체는 lastErr 의 메시지를 last-error 헤더로 보존해야 합니다.
+type RetryScheduler interface {
+	Enqueue(ctx context.Context, job *core.CrawlJob, lastErr error) error
+}
+
+// KafkaImmediateRetryScheduler 는 기존 worker 의 inline requeue 동작을 그대로 옮긴
+// 기본/fallback 구현체입니다 (Redis 부재 시 사용).
+//
+// 흐름:
+//  1. job 을 Marshal
+//  2. priority 토픽으로 즉시 publish (ScheduledAt 은 미래 시각으로 셋팅된 상태)
+//  3. worker 가 메시지 fetch 후 processJob 진입 시 ScheduledAt 까지 sleep — 워커 슬롯 점유
+//
+// 본 구현은 이슈 #82 가 지적한 처리량 급감을 그대로 갖지만, Redis 미설정 환경 (단일 인스턴스
+// 개발/테스트, 통합 redis 장애) 에서 retry 자체는 동작하도록 보존합니다.
+type KafkaImmediateRetryScheduler struct {
+	producer queue.Producer
+}
+
+// NewKafkaImmediateRetryScheduler 는 KafkaImmediateRetryScheduler 를 생성합니다.
+func NewKafkaImmediateRetryScheduler(producer queue.Producer) *KafkaImmediateRetryScheduler {
+	return &KafkaImmediateRetryScheduler{producer: producer}
+}
+
+// Enqueue 는 job 을 priority 토픽에 즉시 publish 합니다.
+func (s *KafkaImmediateRetryScheduler) Enqueue(ctx context.Context, job *core.CrawlJob, lastErr error) error {
+	data, err := job.Marshal()
+	if err != nil {
+		return fmt.Errorf("marshal job for retry: %w", err)
+	}
+
+	msg := queue.Message{
+		Topic:   topicForPriority(job.Priority),
+		Key:     []byte(job.ID),
+		Value:   data,
+		Headers: retryHeaders(job, lastErr),
+	}
+
+	if err := s.producer.Publish(ctx, msg); err != nil {
+		return fmt.Errorf("publish retry job %s: %w", job.ID, err)
+	}
+	return nil
+}
+
+// retryHeaders 는 retry-count / last-error 표준 헤더를 구성합니다 — 두 구현체가 공유.
+func retryHeaders(job *core.CrawlJob, lastErr error) map[string]string {
+	h := map[string]string{
+		"retry-count": fmt.Sprintf("%d", job.RetryCount),
+	}
+	if lastErr != nil {
+		h["last-error"] = lastErr.Error()
+	}
+	return h
+}

--- a/internal/crawler/worker/retry_scheduler.go
+++ b/internal/crawler/worker/retry_scheduler.go
@@ -2,10 +2,16 @@ package worker
 
 import (
 	"context"
+	"encoding/json"
+	"errors"
 	"fmt"
+	"sync"
+	"time"
 
 	"issuetracker/internal/crawler/core"
+	"issuetracker/pkg/logger"
 	"issuetracker/pkg/queue"
+	pkgredis "issuetracker/pkg/redis"
 )
 
 // RetryScheduler 는 처리 실패한 CrawlJob 의 재시도 발행 시점을 관리하는 인터페이스입니다
@@ -71,4 +77,222 @@ func retryHeaders(job *core.CrawlJob, lastErr error) map[string]string {
 		h["last-error"] = lastErr.Error()
 	}
 	return h
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Redis-backed delayed retry scheduler (이슈 #82 본 PR 의 핵심)
+// ─────────────────────────────────────────────────────────────────────────────
+
+// retryQueueClient 는 RedisDelayedRetryScheduler 가 사용하는 Redis 연산을 추상화합니다.
+// pkg/redis.Client 가 구조적으로 만족하며, 테스트는 mock 으로 교체합니다.
+type retryQueueClient interface {
+	EnqueueRetry(ctx context.Context, jobID string, payload []byte, scheduledAt time.Time) error
+	PopDueRetries(ctx context.Context, now time.Time, limit int) ([]pkgredis.DueRetry, error)
+}
+
+// RedisRetrySchedulerConfig 는 RedisDelayedRetryScheduler 의 polling 동작을 제어합니다.
+type RedisRetrySchedulerConfig struct {
+	// PollInterval: 폴링 주기 (default: 1s). 너무 짧으면 Redis 부하, 너무 길면 retry latency 상승
+	PollInterval time.Duration
+
+	// BatchSize: 한 폴 사이클에서 가져오는 최대 due 항목 수 (default: 50)
+	BatchSize int
+
+	// RepublishFailureBackoff: Kafka publish 실패 시 동일 항목을 재 enqueue 할 지연
+	// (default: 1s). 일시적 Kafka 장애 흡수용 — Redis enqueue 까지 실패하면 데이터 손실
+	RepublishFailureBackoff time.Duration
+}
+
+// DefaultRedisRetrySchedulerConfig 는 운영 기본값을 반환합니다.
+func DefaultRedisRetrySchedulerConfig() RedisRetrySchedulerConfig {
+	return RedisRetrySchedulerConfig{
+		PollInterval:            1 * time.Second,
+		BatchSize:               50,
+		RepublishFailureBackoff: 1 * time.Second,
+	}
+}
+
+// RedisDelayedRetryScheduler 는 Redis ZSET 에 retry 를 보관하고 별도 goroutine 이
+// ScheduledAt 도달 항목을 Kafka 에 발행하는 구현체입니다 (이슈 #82).
+//
+// 핵심 효과: requeue 는 Redis 에만 저장되므로 worker 가 메시지를 소비한 뒤 sleep 하지
+// 않고 즉시 다음 정상 job 처리로 넘어갑니다. 워커 슬롯 점유 문제 해소.
+//
+// 영속성: Redis ZSET 보관 + entry STRING 24h TTL. 프로세스 crash 시에도 다른 인스턴스가
+// 이어 받아 처리 가능 (다중 인스턴스 race 는 다운스트림 JobLocker 가 흡수).
+//
+// 라이프사이클: New → Run(ctx) (별도 goroutine) → ctx cancel → goroutine 정리 → Stop 대기.
+type RedisDelayedRetryScheduler struct {
+	client   retryQueueClient
+	producer queue.Producer
+	cfg      RedisRetrySchedulerConfig
+	log      *logger.Logger
+	wg       sync.WaitGroup
+}
+
+// NewRedisDelayedRetryScheduler 는 RedisDelayedRetryScheduler 를 생성합니다.
+// cfg 의 0 값 필드는 DefaultRedisRetrySchedulerConfig 로 보정합니다.
+func NewRedisDelayedRetryScheduler(client retryQueueClient, producer queue.Producer, cfg RedisRetrySchedulerConfig, log *logger.Logger) *RedisDelayedRetryScheduler {
+	def := DefaultRedisRetrySchedulerConfig()
+	if cfg.PollInterval <= 0 {
+		cfg.PollInterval = def.PollInterval
+	}
+	if cfg.BatchSize <= 0 {
+		cfg.BatchSize = def.BatchSize
+	}
+	if cfg.RepublishFailureBackoff <= 0 {
+		cfg.RepublishFailureBackoff = def.RepublishFailureBackoff
+	}
+	return &RedisDelayedRetryScheduler{
+		client:   client,
+		producer: producer,
+		cfg:      cfg,
+		log:      log,
+	}
+}
+
+// Enqueue 는 job 을 Redis ZSET 에 등록합니다. job.ScheduledAt 이 도달하면 Run 루프가
+// Kafka 에 발행합니다.
+//
+// payload 는 {job: <marshaled>, last_err: <string>} JSON — Run 시 동일 헤더 재구성을 위해
+// 두 정보를 모두 보존.
+func (s *RedisDelayedRetryScheduler) Enqueue(ctx context.Context, job *core.CrawlJob, lastErr error) error {
+	jobBytes, err := job.Marshal()
+	if err != nil {
+		return fmt.Errorf("marshal job for redis retry: %w", err)
+	}
+
+	entry := redisRetryEntry{
+		JobBytes: jobBytes,
+		LastErr:  lastErrString(lastErr),
+	}
+	payload, err := json.Marshal(entry)
+	if err != nil {
+		return fmt.Errorf("marshal retry entry %s: %w", job.ID, err)
+	}
+
+	if err := s.client.EnqueueRetry(ctx, job.ID, payload, job.ScheduledAt); err != nil {
+		return fmt.Errorf("enqueue retry %s: %w", job.ID, err)
+	}
+	return nil
+}
+
+// Run 은 ctx 가 cancel 될 때까지 polling 을 반복합니다. Stop 이 wg 를 join 하므로
+// 별도 goroutine 으로 호출하세요.
+func (s *RedisDelayedRetryScheduler) Run(ctx context.Context) {
+	s.wg.Add(1)
+	defer s.wg.Done()
+
+	ticker := time.NewTicker(s.cfg.PollInterval)
+	defer ticker.Stop()
+
+	s.log.WithFields(map[string]interface{}{
+		"poll_interval_ms": s.cfg.PollInterval.Milliseconds(),
+		"batch_size":       s.cfg.BatchSize,
+	}).Info("redis delayed retry scheduler started")
+
+	for {
+		select {
+		case <-ctx.Done():
+			s.log.Info("redis delayed retry scheduler stopped")
+			return
+		case <-ticker.C:
+			s.pollOnce(ctx)
+		}
+	}
+}
+
+// Stop 은 Run goroutine 이 종료될 때까지 대기합니다 (ctx cancel 후 호출).
+func (s *RedisDelayedRetryScheduler) Stop() {
+	s.wg.Wait()
+}
+
+// pollOnce 는 due 항목을 한 batch 만큼 가져와 Kafka 에 발행합니다.
+func (s *RedisDelayedRetryScheduler) pollOnce(ctx context.Context) {
+	due, err := s.client.PopDueRetries(ctx, time.Now(), s.cfg.BatchSize)
+	if err != nil {
+		// ctx cancel 로 인한 에러는 정상 종료 흐름 — DEBUG 로 강등
+		if ctx.Err() != nil {
+			s.log.WithError(err).Debug("retry pop interrupted by shutdown")
+			return
+		}
+		s.log.WithError(err).Warn("failed to pop due retries from redis")
+		return
+	}
+
+	for _, item := range due {
+		s.republish(ctx, item)
+	}
+}
+
+// republish 는 단일 due 항목을 Kafka 에 발행합니다. 실패 시 item 을 짧은 backoff 로
+// 재 enqueue — Kafka 일시 장애 흡수.
+func (s *RedisDelayedRetryScheduler) republish(ctx context.Context, item pkgredis.DueRetry) {
+	var entry redisRetryEntry
+	if err := json.Unmarshal(item.Payload, &entry); err != nil {
+		// payload 손상 — 복구 불가, drop + ERROR (운영 이상 신호)
+		s.log.WithFields(map[string]interface{}{
+			"job_id": item.JobID,
+		}).WithError(err).Error("malformed retry payload, dropping")
+		return
+	}
+
+	var job core.CrawlJob
+	if err := json.Unmarshal(entry.JobBytes, &job); err != nil {
+		s.log.WithFields(map[string]interface{}{
+			"job_id": item.JobID,
+		}).WithError(err).Error("malformed retry job bytes, dropping")
+		return
+	}
+
+	var lastErr error
+	if entry.LastErr != "" {
+		lastErr = errors.New(entry.LastErr)
+	}
+
+	msg := queue.Message{
+		Topic:   topicForPriority(job.Priority),
+		Key:     []byte(item.JobID),
+		Value:   entry.JobBytes,
+		Headers: retryHeaders(&job, lastErr),
+	}
+
+	if err := s.producer.Publish(ctx, msg); err != nil {
+		// Kafka publish 실패 — Redis 에 짧은 backoff 로 재 enqueue 하여 다음 폴 사이클에 재시도
+		s.log.WithFields(map[string]interface{}{
+			"job_id":     item.JobID,
+			"crawler":    job.CrawlerName,
+			"backoff_ms": s.cfg.RepublishFailureBackoff.Milliseconds(),
+		}).WithError(err).Warn("retry republish failed, re-enqueuing to redis")
+
+		retryAt := time.Now().Add(s.cfg.RepublishFailureBackoff)
+		if reErr := s.client.EnqueueRetry(ctx, item.JobID, item.Payload, retryAt); reErr != nil {
+			// Redis 도 안 되는 상황 — 데이터 손실. ERROR 로 운영자가 인지하도록.
+			s.log.WithFields(map[string]interface{}{
+				"job_id":  item.JobID,
+				"crawler": job.CrawlerName,
+			}).WithError(reErr).Error("redis re-enqueue failed after publish error, retry job lost")
+		}
+		return
+	}
+
+	s.log.WithFields(map[string]interface{}{
+		"job_id":  item.JobID,
+		"crawler": job.CrawlerName,
+		"topic":   msg.Topic,
+	}).Debug("retry job republished from redis to kafka")
+}
+
+// redisRetryEntry 는 Redis 에 저장되는 retry payload 의 JSON 스키마입니다.
+type redisRetryEntry struct {
+	JobBytes []byte `json:"job"`
+	LastErr  string `json:"last_err"`
+}
+
+// lastErrString 은 nil 안전하게 에러 문자열을 추출합니다.
+func lastErrString(err error) string {
+	if err == nil {
+		return ""
+	}
+	return err.Error()
 }

--- a/internal/crawler/worker/retry_scheduler.go
+++ b/internal/crawler/worker/retry_scheduler.go
@@ -189,12 +189,26 @@ func (s *RedisDelayedRetryScheduler) Enqueue(ctx context.Context, job *core.Craw
 	return nil
 }
 
-// Run 은 ctx 가 cancel 될 때까지 polling 을 반복합니다. Stop 이 wg 를 join 하므로
-// 별도 goroutine 으로 호출하세요.
-func (s *RedisDelayedRetryScheduler) Run(ctx context.Context) {
+// Start 는 polling 루프를 별도 goroutine 으로 시작합니다.
+//
+// WaitGroup 안전성: wg.Add(1) 을 goroutine 시작 전에 호출하여 "Add called concurrently
+// with Wait" 패닉을 방지합니다 (Copilot 피드백 — 코드베이스의 internal/scheduler 와
+// 동일 패턴). Stop 이 wg.Wait() 으로 join 합니다.
+func (s *RedisDelayedRetryScheduler) Start(ctx context.Context) {
 	s.wg.Add(1)
-	defer s.wg.Done()
+	go func() {
+		defer s.wg.Done()
+		s.Run(ctx)
+	}()
+}
 
+// Run 은 ctx 가 cancel 될 때까지 polling 을 반복합니다. **동기 실행 루프** 만 담당하며
+// goroutine / WaitGroup 등록은 Start 또는 호출자가 책임집니다.
+//
+// 호출 패턴:
+//   - 권장: Start(ctx) 사용 (자동 wg 등록)
+//   - 직접 호출: 호출자가 wg.Add 를 미리 한 뒤 별도 goroutine 으로 호출 (Stop 이 wait)
+func (s *RedisDelayedRetryScheduler) Run(ctx context.Context) {
 	ticker := time.NewTicker(s.cfg.PollInterval)
 	defer ticker.Stop()
 
@@ -214,7 +228,7 @@ func (s *RedisDelayedRetryScheduler) Run(ctx context.Context) {
 	}
 }
 
-// Stop 은 Run goroutine 이 종료될 때까지 대기합니다 (ctx cancel 후 호출).
+// Stop 은 Start 로 시작된 goroutine 이 종료될 때까지 대기합니다 (ctx cancel 후 호출).
 func (s *RedisDelayedRetryScheduler) Stop() {
 	s.wg.Wait()
 }

--- a/internal/crawler/worker/retry_scheduler.go
+++ b/internal/crawler/worker/retry_scheduler.go
@@ -14,6 +14,12 @@ import (
 	pkgredis "issuetracker/pkg/redis"
 )
 
+// retrySchedulerHolder 는 atomic.Pointer 가 인터페이스를 직접 저장하지 못하므로
+// RetryScheduler 인터페이스 값을 감싸 atomic 교체를 지원하는 wrapper 입니다.
+type retrySchedulerHolder struct {
+	s RetryScheduler
+}
+
 // RetryScheduler 는 처리 실패한 CrawlJob 의 재시도 발행 시점을 관리하는 인터페이스입니다
 // (이슈 #82).
 //

--- a/internal/crawler/worker/retry_scheduler.go
+++ b/internal/crawler/worker/retry_scheduler.go
@@ -91,9 +91,15 @@ func retryHeaders(job *core.CrawlJob, lastErr error) map[string]string {
 
 // retryQueueClient 는 RedisDelayedRetryScheduler 가 사용하는 Redis 연산을 추상화합니다.
 // pkg/redis.Client 가 구조적으로 만족하며, 테스트는 mock 으로 교체합니다.
+//
+// peek-publish-ack 패턴 (이슈 #82, PR #128 피드백):
+//   - PeekDueRetries 는 due 항목을 조회만 하고 ZSET 에서 제거하지 않음
+//   - publish 성공 후 AckRetry 로 명시적 제거 → at-least-once 보장
+//   - publish 실패 시 backoff 적용한 재 EnqueueRetry (또는 무처리 후 다음 polling)
 type retryQueueClient interface {
 	EnqueueRetry(ctx context.Context, jobID string, payload []byte, scheduledAt time.Time) error
-	PopDueRetries(ctx context.Context, now time.Time, limit int) ([]pkgredis.DueRetry, error)
+	PeekDueRetries(ctx context.Context, now time.Time, limit int) ([]pkgredis.DueRetry, error)
+	AckRetry(ctx context.Context, jobID string) error
 }
 
 // RedisRetrySchedulerConfig 는 RedisDelayedRetryScheduler 의 polling 동작을 제어합니다.
@@ -213,16 +219,18 @@ func (s *RedisDelayedRetryScheduler) Stop() {
 	s.wg.Wait()
 }
 
-// pollOnce 는 due 항목을 한 batch 만큼 가져와 Kafka 에 발행합니다.
+// pollOnce 는 due 항목을 한 batch 만큼 peek 하여 Kafka 에 발행합니다.
+// peek 단계에서는 ZSET 에서 제거하지 않으며, publish 성공 후에만 AckRetry 로 제거 —
+// at-least-once 보장 (peek-publish-ack 패턴, PR #128 피드백).
 func (s *RedisDelayedRetryScheduler) pollOnce(ctx context.Context) {
-	due, err := s.client.PopDueRetries(ctx, time.Now(), s.cfg.BatchSize)
+	due, err := s.client.PeekDueRetries(ctx, time.Now(), s.cfg.BatchSize)
 	if err != nil {
 		// ctx cancel 로 인한 에러는 정상 종료 흐름 — DEBUG 로 강등
 		if ctx.Err() != nil {
-			s.log.WithError(err).Debug("retry pop interrupted by shutdown")
+			s.log.WithError(err).Debug("retry peek interrupted by shutdown")
 			return
 		}
-		s.log.WithError(err).Warn("failed to pop due retries from redis")
+		s.log.WithError(err).Warn("failed to peek due retries from redis")
 		return
 	}
 
@@ -231,15 +239,24 @@ func (s *RedisDelayedRetryScheduler) pollOnce(ctx context.Context) {
 	}
 }
 
-// republish 는 단일 due 항목을 Kafka 에 발행합니다. 실패 시 item 을 짧은 backoff 로
-// 재 enqueue — Kafka 일시 장애 흡수.
+// republish 는 단일 due 항목을 Kafka 에 발행합니다.
+//
+//   - publish 성공  → AckRetry 로 ZSET/entry 제거 (정상 종료)
+//   - publish 실패  → 짧은 backoff 로 EnqueueRetry 재호출 (ScheduledAt overwrite) →
+//     다음 폴 사이클에 재시도. EnqueueRetry 도 실패하면 ZSET 에 원본 ScheduledAt 으로
+//     항목이 남아 즉시 재peek 되며, JobLocker 가 Kafka 중복을 흡수
+//   - payload 손상 → AckRetry 로 제거 (drop) + ERROR (운영 이상 신호)
+//
+// 프로세스 crash 안전성: republish 어느 시점에 crash 가 일어나도 ZSET 에 원본 항목이
+// 남아있으므로 다음 instance / 재기동 시 재peek 됩니다.
 func (s *RedisDelayedRetryScheduler) republish(ctx context.Context, item pkgredis.DueRetry) {
 	var entry redisRetryEntry
 	if err := json.Unmarshal(item.Payload, &entry); err != nil {
-		// payload 손상 — 복구 불가, drop + ERROR (운영 이상 신호)
+		// payload 손상 — 복구 불가. ack 로 제거하여 무한 재peek 회피.
 		s.log.WithFields(map[string]interface{}{
 			"job_id": item.JobID,
 		}).WithError(err).Error("malformed retry payload, dropping")
+		s.ackOrLog(ctx, item.JobID, "drop on malformed payload")
 		return
 	}
 
@@ -248,6 +265,7 @@ func (s *RedisDelayedRetryScheduler) republish(ctx context.Context, item pkgredi
 		s.log.WithFields(map[string]interface{}{
 			"job_id": item.JobID,
 		}).WithError(err).Error("malformed retry job bytes, dropping")
+		s.ackOrLog(ctx, item.JobID, "drop on malformed job bytes")
 		return
 	}
 
@@ -264,29 +282,44 @@ func (s *RedisDelayedRetryScheduler) republish(ctx context.Context, item pkgredi
 	}
 
 	if err := s.producer.Publish(ctx, msg); err != nil {
-		// Kafka publish 실패 — Redis 에 짧은 backoff 로 재 enqueue 하여 다음 폴 사이클에 재시도
+		// Kafka publish 실패 — backoff 적용한 ScheduledAt 으로 EnqueueRetry 재호출하여
+		// 같은 jobID 의 score 를 미래로 overwrite (즉시 재peek 회피).
+		// EnqueueRetry 가 실패해도 ZSET 의 원본 항목이 남아있어 다음 폴에 재peek + 재시도.
 		s.log.WithFields(map[string]interface{}{
 			"job_id":     item.JobID,
 			"crawler":    job.CrawlerName,
 			"backoff_ms": s.cfg.RepublishFailureBackoff.Milliseconds(),
-		}).WithError(err).Warn("retry republish failed, re-enqueuing to redis")
+		}).WithError(err).Warn("retry republish failed, rescheduling in redis")
 
 		retryAt := time.Now().Add(s.cfg.RepublishFailureBackoff)
 		if reErr := s.client.EnqueueRetry(ctx, item.JobID, item.Payload, retryAt); reErr != nil {
-			// Redis 도 안 되는 상황 — 데이터 손실. ERROR 로 운영자가 인지하도록.
 			s.log.WithFields(map[string]interface{}{
 				"job_id":  item.JobID,
 				"crawler": job.CrawlerName,
-			}).WithError(reErr).Error("redis re-enqueue failed after publish error, retry job lost")
+			}).WithError(reErr).Warn("redis reschedule failed, item retains original score for immediate re-peek")
 		}
 		return
 	}
+
+	// publish 성공 → ZSET/entry 제거. ack 실패는 다음 폴 사이클에서 중복 publish 로 이어짐 —
+	// JobLocker 가 흡수하므로 정합성 문제 없으나 운영 가시성을 위해 WARN.
+	s.ackOrLog(ctx, item.JobID, "after successful publish")
 
 	s.log.WithFields(map[string]interface{}{
 		"job_id":  item.JobID,
 		"crawler": job.CrawlerName,
 		"topic":   msg.Topic,
 	}).Debug("retry job republished from redis to kafka")
+}
+
+// ackOrLog 는 AckRetry 호출 후 실패 시 WARN 로그만 남깁니다 (정합성은 JobLocker 가 흡수).
+func (s *RedisDelayedRetryScheduler) ackOrLog(ctx context.Context, jobID, reason string) {
+	if err := s.client.AckRetry(ctx, jobID); err != nil {
+		s.log.WithFields(map[string]interface{}{
+			"job_id": jobID,
+			"reason": reason,
+		}).WithError(err).Warn("retry ack failed, item may be re-peeked on next poll")
+	}
 }
 
 // redisRetryEntry 는 Redis 에 저장되는 retry payload 의 JSON 스키마입니다.

--- a/pkg/redis/retry_queue.go
+++ b/pkg/redis/retry_queue.go
@@ -1,0 +1,148 @@
+package redis
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	goredis "github.com/redis/go-redis/v9"
+)
+
+// RetryQueueZSetKey 는 retry job ID 를 ScheduledAt 기준으로 정렬해 보관하는 ZSET 키입니다.
+const RetryQueueZSetKey = "retry:queue"
+
+// retryEntryKeyPrefix 는 개별 retry job 의 직렬화 payload (job + lastError) 를 저장하는
+// STRING 키의 공통 접두사입니다. 실제 키는 retry:entry:<jobID> 형식.
+const retryEntryKeyPrefix = "retry:entry:"
+
+// retryEntryTTL 은 retry payload 의 안전 보관 TTL 입니다.
+// ZSET 에서 score 가 이 시점을 지나도 PopDue 가 호출되지 않으면 entry 가 자동 만료되어
+// stale data 가 영구히 남지 않도록 합니다 (운영 안전망).
+const retryEntryTTL = 24 * time.Hour
+
+// ErrRetryEntryGone 은 ZSET 에는 jobID 가 있지만 entry payload 가 만료/삭제되어
+// 더 이상 존재하지 않는 상태를 나타냅니다. 폴러는 이 케이스를 silent skip + WARN 으로
+// 처리하고 ZSET 에서도 ZREM 하여 일관성을 회복해야 합니다.
+var ErrRetryEntryGone = errors.New("retry entry payload missing")
+
+// retryEntryKey 는 jobID 에 대응하는 entry 키를 반환합니다.
+func retryEntryKey(jobID string) string {
+	return retryEntryKeyPrefix + jobID
+}
+
+// EnqueueRetry 는 jobID 와 payload 를 retry 큐에 등록합니다.
+//
+//   - ZADD retry:queue scheduledAt jobID
+//   - SET  retry:entry:<jobID> payload EX retryEntryTTL
+//
+// 동일 jobID 로 재호출 시 ZSET score 와 payload 모두 덮어씁니다 — 같은 job 이 여러 번
+// 재시도 큐에 들어가면 가장 최근 호출 기준으로 정렬됩니다.
+//
+// scheduledAt 은 절대 시각 (time.Time) — UnixNano 로 ZSET score 에 저장됩니다.
+func (c *Client) EnqueueRetry(ctx context.Context, jobID string, payload []byte, scheduledAt time.Time) error {
+	if jobID == "" {
+		return fmt.Errorf("enqueue retry: empty jobID")
+	}
+	if len(payload) == 0 {
+		return fmt.Errorf("enqueue retry %s: empty payload", jobID)
+	}
+
+	score := float64(scheduledAt.UnixNano())
+
+	// pipeline 으로 ZADD + SET 을 1 RTT 에 전송 — 두 명령 사이의 race window 를 최소화.
+	// (완전 atomic 은 아니지만 폴러가 ErrRetryEntryGone 으로 자체 복구하므로 충분.)
+	pipe := c.rdb.Pipeline()
+	pipe.ZAdd(ctx, RetryQueueZSetKey, goredis.Z{Score: score, Member: jobID})
+	pipe.Set(ctx, retryEntryKey(jobID), payload, retryEntryTTL)
+	if _, err := pipe.Exec(ctx); err != nil {
+		return fmt.Errorf("enqueue retry %s: %w", jobID, err)
+	}
+	return nil
+}
+
+// DueRetry 는 PopDueRetries 의 단일 결과 항목입니다.
+type DueRetry struct {
+	JobID   string
+	Payload []byte
+}
+
+// PopDueRetries 는 score (scheduledAt) 가 now 이하인 retry job 을 최대 limit 개 꺼내고
+// ZSET / entry STRING 모두에서 제거합니다.
+//
+// 절차 (per item):
+//  1. ZRANGEBYSCORE -inf~now LIMIT 0 limit  → 후보 jobID 목록
+//  2. 각 jobID 에 대해: GET payload → ZREM + DEL (pipeline)
+//     - GET 결과가 nil 이면 ErrRetryEntryGone 으로 분류, ZREM 만 수행하여 정합성 회복
+//
+// 다중 인스턴스 환경에서 동일 항목을 두 instance 가 동시에 ZRANGEBYSCORE 하는 race 가
+// 가능하지만, 다운스트림 worker 의 JobLocker 가 중복 처리를 차단하므로 정합성에는 문제 없음.
+// (Kafka publish 1~2회 발생 — 중복 처리는 JobLocker 가 silent skip)
+//
+// limit <= 0 이면 빈 슬라이스를 반환합니다.
+func (c *Client) PopDueRetries(ctx context.Context, now time.Time, limit int) ([]DueRetry, error) {
+	if limit <= 0 {
+		return nil, nil
+	}
+
+	maxScore := fmt.Sprintf("%d", now.UnixNano())
+	jobIDs, err := c.rdb.ZRangeByScore(ctx, RetryQueueZSetKey, &goredis.ZRangeBy{
+		Min:    "-inf",
+		Max:    maxScore,
+		Offset: 0,
+		Count:  int64(limit),
+	}).Result()
+	if err != nil {
+		return nil, fmt.Errorf("zrangebyscore retry queue: %w", err)
+	}
+	if len(jobIDs) == 0 {
+		return nil, nil
+	}
+
+	out := make([]DueRetry, 0, len(jobIDs))
+	for _, jobID := range jobIDs {
+		key := retryEntryKey(jobID)
+		payload, getErr := c.rdb.Get(ctx, key).Bytes()
+		if errors.Is(getErr, goredis.Nil) {
+			// payload 가 만료/삭제된 stale jobID 는 ZSET 에서도 정리.
+			// 호출자에게는 silent skip — 별도 시그널 없이 다음 jobID 로 진행.
+			if _, remErr := c.rdb.ZRem(ctx, RetryQueueZSetKey, jobID).Result(); remErr != nil {
+				return out, fmt.Errorf("zrem stale retry %s: %w", jobID, remErr)
+			}
+			continue
+		}
+		if getErr != nil {
+			return out, fmt.Errorf("get retry entry %s: %w", jobID, getErr)
+		}
+
+		// 정상 케이스: payload 확보 후 ZREM + DEL 을 pipeline 으로 한번에.
+		pipe := c.rdb.Pipeline()
+		pipe.ZRem(ctx, RetryQueueZSetKey, jobID)
+		pipe.Del(ctx, key)
+		if _, execErr := pipe.Exec(ctx); execErr != nil {
+			return out, fmt.Errorf("zrem+del retry %s: %w", jobID, execErr)
+		}
+
+		out = append(out, DueRetry{JobID: jobID, Payload: payload})
+	}
+
+	return out, nil
+}
+
+// PendingRetryCount 는 retry 큐에 보관된 항목 수를 반환합니다 (모니터링/디버깅용).
+func (c *Client) PendingRetryCount(ctx context.Context) (int64, error) {
+	n, err := c.rdb.ZCard(ctx, RetryQueueZSetKey).Result()
+	if err != nil {
+		return 0, fmt.Errorf("zcard retry queue: %w", err)
+	}
+	return n, nil
+}
+
+// DeleteRetryEntryForTest 는 entry STRING 만 직접 삭제하여 stale 시나리오 (entry 만료 +
+// ZSET 잔존) 를 인위적으로 재현하기 위한 테스트 전용 헬퍼입니다. 운영 코드 사용 금지.
+func (c *Client) DeleteRetryEntryForTest(ctx context.Context, jobID string) error {
+	if _, err := c.rdb.Del(ctx, retryEntryKey(jobID)).Result(); err != nil {
+		return fmt.Errorf("delete retry entry %s: %w", jobID, err)
+	}
+	return nil
+}

--- a/pkg/redis/retry_queue.go
+++ b/pkg/redis/retry_queue.go
@@ -64,26 +64,34 @@ func (c *Client) EnqueueRetry(ctx context.Context, jobID string, payload []byte,
 	return nil
 }
 
-// DueRetry 는 PopDueRetries 의 단일 결과 항목입니다.
+// DueRetry 는 PeekDueRetries 의 단일 결과 항목입니다.
 type DueRetry struct {
 	JobID   string
 	Payload []byte
 }
 
-// PopDueRetries 는 score (scheduledAt) 가 now 이하인 retry job 을 최대 limit 개 꺼내고
-// ZSET / entry STRING 모두에서 제거합니다.
+// PeekDueRetries 는 score (scheduledAt) 가 now 이하인 retry job 을 최대 limit 개 조회합니다.
+// **항목을 ZSET 에서 제거하지 않습니다** — at-least-once 보장: Kafka publish 성공 후
+// 호출자가 AckRetry 를 호출해 명시적으로 제거해야 합니다 (peek-publish-ack 패턴).
 //
 // 절차 (per item):
-//  1. ZRANGEBYSCORE -inf~now LIMIT 0 limit  → 후보 jobID 목록
-//  2. 각 jobID 에 대해: GET payload → ZREM + DEL (pipeline)
-//     - GET 결과가 nil 이면 ErrRetryEntryGone 으로 분류, ZREM 만 수행하여 정합성 회복
+//  1. ZRANGEBYSCORE -inf~now LIMIT 0 limit  → 후보 jobID 목록 (ZSET 유지)
+//  2. 각 jobID 에 대해 GET payload
+//     - GET 결과가 nil 인 stale jobID 는 ZSET 에서 자동 정리하고 결과에 포함하지 않음
 //
-// 다중 인스턴스 환경에서 동일 항목을 두 instance 가 동시에 ZRANGEBYSCORE 하는 race 가
-// 가능하지만, 다운스트림 worker 의 JobLocker 가 중복 처리를 차단하므로 정합성에는 문제 없음.
-// (Kafka publish 1~2회 발생 — 중복 처리는 JobLocker 가 silent skip)
+// 호출자 책임:
+//   - publish 성공 → AckRetry(ctx, jobID) 로 ZSET/entry 제거
+//   - publish 실패 → 아무것도 하지 않으면 다음 폴 사이클에 자동 재peek + 재시도
+//     (또는 EnqueueRetry 재호출로 ScheduledAt 을 미래로 옮겨 backoff 적용)
+//
+// 프로세스 crash 안전성: peek 후 ack 전에 crash 가 발생해도 항목이 ZSET 에 남아 있으므로
+// 다른 인스턴스 / 재기동 시 다시 peek 됩니다 — at-least-once 보장.
+//
+// 다중 인스턴스 race: 동시에 같은 jobID 를 peek + publish 가능 → Kafka 에 1~2회 중복
+// publish 발생 → 다운스트림 JobLocker 가 흡수 (정합성 문제 없음).
 //
 // limit <= 0 이면 빈 슬라이스를 반환합니다.
-func (c *Client) PopDueRetries(ctx context.Context, now time.Time, limit int) ([]DueRetry, error) {
+func (c *Client) PeekDueRetries(ctx context.Context, now time.Time, limit int) ([]DueRetry, error) {
 	if limit <= 0 {
 		return nil, nil
 	}
@@ -109,8 +117,8 @@ func (c *Client) PopDueRetries(ctx context.Context, now time.Time, limit int) ([
 		key := retryEntryKey(jobID)
 		payload, getErr := c.rdb.Get(ctx, key).Bytes()
 		if errors.Is(getErr, goredis.Nil) {
-			// payload 가 만료/삭제된 stale jobID 는 ZSET 에서도 정리.
-			// 호출자에게는 silent skip — 별도 시그널 없이 다음 jobID 로 진행.
+			// payload 가 만료/삭제된 stale jobID 는 ZSET 에서 자동 정리 (정합성 회복).
+			// 호출자에게는 노출하지 않음 — 다음 jobID 로 진행.
 			if _, remErr := c.rdb.ZRem(ctx, RetryQueueZSetKey, jobID).Result(); remErr != nil {
 				return out, fmt.Errorf("zrem stale retry %s: %w", jobID, remErr)
 			}
@@ -120,18 +128,28 @@ func (c *Client) PopDueRetries(ctx context.Context, now time.Time, limit int) ([
 			return out, fmt.Errorf("get retry entry %s: %w", jobID, getErr)
 		}
 
-		// 정상 케이스: payload 확보 후 ZREM + DEL 을 pipeline 으로 한번에.
-		pipe := c.rdb.Pipeline()
-		pipe.ZRem(ctx, RetryQueueZSetKey, jobID)
-		pipe.Del(ctx, key)
-		if _, execErr := pipe.Exec(ctx); execErr != nil {
-			return out, fmt.Errorf("zrem+del retry %s: %w", jobID, execErr)
-		}
-
 		out = append(out, DueRetry{JobID: jobID, Payload: payload})
 	}
 
 	return out, nil
+}
+
+// AckRetry 는 publish 성공한 retry job 을 ZSET 과 entry STRING 에서 제거합니다.
+// PeekDueRetries 후 publish 성공 시 반드시 호출해야 합니다 — 미호출 시 다음 폴 사이클에
+// 동일 jobID 가 재peek 되어 중복 publish 발생 (JobLocker 가 흡수).
+//
+// idempotent: 이미 제거된 항목에 대한 호출도 에러 없이 통과합니다.
+func (c *Client) AckRetry(ctx context.Context, jobID string) error {
+	if jobID == "" {
+		return fmt.Errorf("ack retry: empty jobID")
+	}
+	pipe := c.rdb.Pipeline()
+	pipe.ZRem(ctx, RetryQueueZSetKey, jobID)
+	pipe.Del(ctx, retryEntryKey(jobID))
+	if _, err := pipe.Exec(ctx); err != nil {
+		return fmt.Errorf("ack retry %s: %w", jobID, err)
+	}
+	return nil
 }
 
 // PendingRetryCount 는 retry 큐에 보관된 항목 수를 반환합니다 (모니터링/디버깅용).

--- a/pkg/redis/retry_queue.go
+++ b/pkg/redis/retry_queue.go
@@ -86,14 +86,16 @@ func (c *Client) PopDueRetries(ctx context.Context, now time.Time, limit int) ([
 	}
 
 	maxScore := fmt.Sprintf("%d", now.UnixNano())
-	jobIDs, err := c.rdb.ZRangeByScore(ctx, RetryQueueZSetKey, &goredis.ZRangeBy{
-		Min:    "-inf",
-		Max:    maxScore,
-		Offset: 0,
-		Count:  int64(limit),
+	jobIDs, err := c.rdb.ZRangeArgs(ctx, goredis.ZRangeArgs{
+		Key:     RetryQueueZSetKey,
+		Start:   "-inf",
+		Stop:    maxScore,
+		ByScore: true,
+		Offset:  0,
+		Count:   int64(limit),
 	}).Result()
 	if err != nil {
-		return nil, fmt.Errorf("zrangebyscore retry queue: %w", err)
+		return nil, fmt.Errorf("zrange byscore retry queue: %w", err)
 	}
 	if len(jobIDs) == 0 {
 		return nil, nil

--- a/pkg/redis/retry_queue.go
+++ b/pkg/redis/retry_queue.go
@@ -17,14 +17,9 @@ const RetryQueueZSetKey = "retry:queue"
 const retryEntryKeyPrefix = "retry:entry:"
 
 // retryEntryTTL 은 retry payload 의 안전 보관 TTL 입니다.
-// ZSET 에서 score 가 이 시점을 지나도 PopDue 가 호출되지 않으면 entry 가 자동 만료되어
+// ZSET 에서 score 가 이 시점을 지나도 PeekDue 가 호출되지 않으면 entry 가 자동 만료되어
 // stale data 가 영구히 남지 않도록 합니다 (운영 안전망).
 const retryEntryTTL = 24 * time.Hour
-
-// ErrRetryEntryGone 은 ZSET 에는 jobID 가 있지만 entry payload 가 만료/삭제되어
-// 더 이상 존재하지 않는 상태를 나타냅니다. 폴러는 이 케이스를 silent skip + WARN 으로
-// 처리하고 ZSET 에서도 ZREM 하여 일관성을 회복해야 합니다.
-var ErrRetryEntryGone = errors.New("retry entry payload missing")
 
 // retryEntryKey 는 jobID 에 대응하는 entry 키를 반환합니다.
 func retryEntryKey(jobID string) string {
@@ -54,7 +49,7 @@ func (c *Client) EnqueueRetry(ctx context.Context, jobID string, payload []byte,
 	score := float64(scheduledAt.UnixMilli())
 
 	// pipeline 으로 ZADD + SET 을 1 RTT 에 전송 — 두 명령 사이의 race window 를 최소화.
-	// (완전 atomic 은 아니지만 폴러가 ErrRetryEntryGone 으로 자체 복구하므로 충분.)
+	// (완전 atomic 은 아니지만 PeekDueRetries 가 GET=nil 인 stale jobID 를 자동 정리하므로 충분.)
 	pipe := c.rdb.Pipeline()
 	pipe.ZAdd(ctx, RetryQueueZSetKey, goredis.Z{Score: score, Member: jobID})
 	pipe.Set(ctx, retryEntryKey(jobID), payload, retryEntryTTL)
@@ -163,6 +158,11 @@ func (c *Client) PendingRetryCount(ctx context.Context) (int64, error) {
 
 // DeleteRetryEntryForTest 는 entry STRING 만 직접 삭제하여 stale 시나리오 (entry 만료 +
 // ZSET 잔존) 를 인위적으로 재현하기 위한 테스트 전용 헬퍼입니다. 운영 코드 사용 금지.
+//
+// 운영 빌드에서 노출되지만 `ForTest` 접미어로 의도를 명시. 본 프로젝트 컨벤션상
+// 테스트 파일이 `test/pkg/redis/` 별도 디렉토리에 위치하므로 (`package redis_test`),
+// 동일 패키지 내 `_test.go` helper 는 외부 테스트에서 접근 불가 — 부득이 exported
+// API 로 노출합니다.
 func (c *Client) DeleteRetryEntryForTest(ctx context.Context, jobID string) error {
 	if _, err := c.rdb.Del(ctx, retryEntryKey(jobID)).Result(); err != nil {
 		return fmt.Errorf("delete retry entry %s: %w", jobID, err)

--- a/pkg/redis/retry_queue.go
+++ b/pkg/redis/retry_queue.go
@@ -39,7 +39,10 @@ func retryEntryKey(jobID string) string {
 // 동일 jobID 로 재호출 시 ZSET score 와 payload 모두 덮어씁니다 — 같은 job 이 여러 번
 // 재시도 큐에 들어가면 가장 최근 호출 기준으로 정렬됩니다.
 //
-// scheduledAt 은 절대 시각 (time.Time) — UnixNano 로 ZSET score 에 저장됩니다.
+// scheduledAt 은 절대 시각 (time.Time) — UnixMilli 로 ZSET score 에 저장됩니다.
+// (Redis ZSET score 는 float64. UnixNano (≈1.78e18, 2026 기준) 는 float64 mantissa 한계
+// 2^53 (≈9e15) 를 초과해 정밀도 손실. UnixMilli (≈1.78e12) 는 안전 범위이며 retry 큐의
+// ms 단위 정렬은 실무 충분.)
 func (c *Client) EnqueueRetry(ctx context.Context, jobID string, payload []byte, scheduledAt time.Time) error {
 	if jobID == "" {
 		return fmt.Errorf("enqueue retry: empty jobID")
@@ -48,7 +51,7 @@ func (c *Client) EnqueueRetry(ctx context.Context, jobID string, payload []byte,
 		return fmt.Errorf("enqueue retry %s: empty payload", jobID)
 	}
 
-	score := float64(scheduledAt.UnixNano())
+	score := float64(scheduledAt.UnixMilli())
 
 	// pipeline 으로 ZADD + SET 을 1 RTT 에 전송 — 두 명령 사이의 race window 를 최소화.
 	// (완전 atomic 은 아니지만 폴러가 ErrRetryEntryGone 으로 자체 복구하므로 충분.)
@@ -85,7 +88,7 @@ func (c *Client) PopDueRetries(ctx context.Context, now time.Time, limit int) ([
 		return nil, nil
 	}
 
-	maxScore := fmt.Sprintf("%d", now.UnixNano())
+	maxScore := fmt.Sprintf("%d", now.UnixMilli()) // EnqueueRetry 의 score 단위와 일치
 	jobIDs, err := c.rdb.ZRangeArgs(ctx, goredis.ZRangeArgs{
 		Key:     RetryQueueZSetKey,
 		Start:   "-inf",

--- a/pkg/redis/retry_queue.go
+++ b/pkg/redis/retry_queue.go
@@ -107,23 +107,50 @@ func (c *Client) PeekDueRetries(ctx context.Context, now time.Time, limit int) (
 		return nil, nil
 	}
 
-	out := make([]DueRetry, 0, len(jobIDs))
+	// payload 들을 1 RTT 로 GET — 항목 N 개에 대해 round-trip N 번 → 1 번으로 압축
+	// (Copilot 피드백: 폴러 부하 / Redis latency 영향 완화).
+	type getResult struct {
+		jobID string
+		cmd   *goredis.StringCmd
+	}
+	getPipe := c.rdb.Pipeline()
+	results := make([]getResult, 0, len(jobIDs))
 	for _, jobID := range jobIDs {
-		key := retryEntryKey(jobID)
-		payload, getErr := c.rdb.Get(ctx, key).Bytes()
+		results = append(results, getResult{
+			jobID: jobID,
+			cmd:   getPipe.Get(ctx, retryEntryKey(jobID)),
+		})
+	}
+	// pipeline Exec 자체는 성공해도 개별 cmd 가 goredis.Nil 일 수 있으므로 그 에러는 무시.
+	// (개별 결과 검사에서 errors.Is(_, goredis.Nil) 로 stale 판정)
+	if _, execErr := getPipe.Exec(ctx); execErr != nil && !errors.Is(execErr, goredis.Nil) {
+		return nil, fmt.Errorf("pipeline get retry entries: %w", execErr)
+	}
+
+	out := make([]DueRetry, 0, len(jobIDs))
+	staleIDs := make([]string, 0)
+	for _, r := range results {
+		payload, getErr := r.cmd.Bytes()
 		if errors.Is(getErr, goredis.Nil) {
-			// payload 가 만료/삭제된 stale jobID 는 ZSET 에서 자동 정리 (정합성 회복).
-			// 호출자에게는 노출하지 않음 — 다음 jobID 로 진행.
-			if _, remErr := c.rdb.ZRem(ctx, RetryQueueZSetKey, jobID).Result(); remErr != nil {
-				return out, fmt.Errorf("zrem stale retry %s: %w", jobID, remErr)
-			}
+			// payload 가 만료/삭제된 stale jobID — 마지막에 batch ZREM 으로 일괄 정리.
+			staleIDs = append(staleIDs, r.jobID)
 			continue
 		}
 		if getErr != nil {
-			return out, fmt.Errorf("get retry entry %s: %w", jobID, getErr)
+			return out, fmt.Errorf("get retry entry %s: %w", r.jobID, getErr)
 		}
+		out = append(out, DueRetry{JobID: r.jobID, Payload: payload})
+	}
 
-		out = append(out, DueRetry{JobID: jobID, Payload: payload})
+	// stale jobID 들을 1 RTT 로 일괄 ZREM (정합성 회복).
+	if len(staleIDs) > 0 {
+		members := make([]interface{}, 0, len(staleIDs))
+		for _, id := range staleIDs {
+			members = append(members, id)
+		}
+		if _, remErr := c.rdb.ZRem(ctx, RetryQueueZSetKey, members...).Result(); remErr != nil {
+			return out, fmt.Errorf("batch zrem stale retries: %w", remErr)
+		}
 	}
 
 	return out, nil

--- a/test/internal/worker/retry_scheduler_test.go
+++ b/test/internal/worker/retry_scheduler_test.go
@@ -1,0 +1,101 @@
+package worker_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	"issuetracker/internal/crawler/core"
+	"issuetracker/internal/crawler/worker"
+	"issuetracker/pkg/queue"
+)
+
+// retryTestJob 은 RetryScheduler 테스트 전용 fixture 입니다.
+func retryTestJob(priority core.Priority) *core.CrawlJob {
+	return &core.CrawlJob{
+		ID:          "retry-test-1",
+		CrawlerName: "cnn",
+		Target: core.Target{
+			URL:  "https://edition.cnn.com/article/1",
+			Type: core.TargetTypeArticle,
+		},
+		Priority:    priority,
+		RetryCount:  2,
+		MaxRetries:  3,
+		Timeout:     30 * time.Second,
+		ScheduledAt: time.Now().Add(10 * time.Second),
+	}
+}
+
+// TestKafkaImmediateRetryScheduler_PublishesToPriorityTopic 는 job.Priority 에 따라
+// 올바른 crawl 토픽으로 publish 되고 retry-count / last-error 헤더가 부착됨을 검증.
+func TestKafkaImmediateRetryScheduler_PublishesToPriorityTopic(t *testing.T) {
+	cases := []struct {
+		name      string
+		priority  core.Priority
+		wantTopic string
+	}{
+		{"high → crawl.high", core.PriorityHigh, queue.TopicCrawlHigh},
+		{"normal → crawl.normal", core.PriorityNormal, queue.TopicCrawlNormal},
+		{"low → crawl.low", core.PriorityLow, queue.TopicCrawlLow},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			producer := new(mockProducer)
+			sched := worker.NewKafkaImmediateRetryScheduler(producer)
+
+			job := retryTestJob(tc.priority)
+			lastErr := errors.New("upstream 503")
+
+			producer.On("Publish", mock.Anything, mock.MatchedBy(func(m queue.Message) bool {
+				return m.Topic == tc.wantTopic &&
+					string(m.Key) == job.ID &&
+					m.Headers["retry-count"] == "2" &&
+					m.Headers["last-error"] == "upstream 503" &&
+					len(m.Value) > 0
+			})).Return(nil)
+
+			require.NoError(t, sched.Enqueue(context.Background(), job, lastErr))
+			producer.AssertExpectations(t)
+		})
+	}
+}
+
+// TestKafkaImmediateRetryScheduler_PublishError_Wrapped 는 producer 가 에러를 반환할 때
+// jobID 를 포함한 wrap 된 에러가 반환되는지 검증.
+func TestKafkaImmediateRetryScheduler_PublishError_Wrapped(t *testing.T) {
+	producer := new(mockProducer)
+	sched := worker.NewKafkaImmediateRetryScheduler(producer)
+
+	job := retryTestJob(core.PriorityNormal)
+	publishErr := errors.New("kafka unavailable")
+	producer.On("Publish", mock.Anything, mock.Anything).Return(publishErr)
+
+	err := sched.Enqueue(context.Background(), job, errors.New("any"))
+	require.Error(t, err)
+	assert.ErrorIs(t, err, publishErr, "원본 에러가 unwrap 가능해야 함")
+	assert.Contains(t, err.Error(), job.ID, "wrap 메시지에 jobID 포함")
+}
+
+// TestKafkaImmediateRetryScheduler_NilLastErr_OmitsHeader 는 lastErr=nil 시
+// last-error 헤더가 누락됨을 검증 (운영 보호 — nil deref 회피).
+func TestKafkaImmediateRetryScheduler_NilLastErr_OmitsHeader(t *testing.T) {
+	producer := new(mockProducer)
+	sched := worker.NewKafkaImmediateRetryScheduler(producer)
+
+	job := retryTestJob(core.PriorityNormal)
+
+	producer.On("Publish", mock.Anything, mock.MatchedBy(func(m queue.Message) bool {
+		_, hasLastErr := m.Headers["last-error"]
+		return !hasLastErr && m.Headers["retry-count"] == "2"
+	})).Return(nil)
+
+	require.NoError(t, sched.Enqueue(context.Background(), job, nil))
+	producer.AssertExpectations(t)
+}

--- a/test/internal/worker/retry_scheduler_test.go
+++ b/test/internal/worker/retry_scheduler_test.go
@@ -174,6 +174,36 @@ func (f *fakeRetryQueue) PeekDueRetries(_ context.Context, now time.Time, limit 
 	return out, nil
 }
 
+// fakeRetryQueueCapturingCtx 는 fakeRetryQueue 에 EnqueueRetry 호출 시 ctx.Err() 를
+// 캡처하는 기능을 추가한 변형입니다. drain context 적용 여부 검증 전용.
+//
+// 호출 시점의 ctx.Err() 를 보존 — ctx 자체를 보존하면 호출자의 defer cancelDrain 이후
+// 캡처값이 canceled 로 변할 수 있음 (테스트 false negative 방지).
+type fakeRetryQueueCapturingCtx struct {
+	*fakeRetryQueue
+	mu               sync.Mutex
+	lastCtxErrAtCall error
+	captured         bool
+}
+
+func newFakeRetryQueueCapturingCtx() *fakeRetryQueueCapturingCtx {
+	return &fakeRetryQueueCapturingCtx{fakeRetryQueue: newFakeRetryQueue()}
+}
+
+func (f *fakeRetryQueueCapturingCtx) EnqueueRetry(ctx context.Context, jobID string, payload []byte, scheduledAt time.Time) error {
+	f.mu.Lock()
+	f.lastCtxErrAtCall = ctx.Err()
+	f.captured = true
+	f.mu.Unlock()
+	return f.fakeRetryQueue.EnqueueRetry(ctx, jobID, payload, scheduledAt)
+}
+
+func (f *fakeRetryQueueCapturingCtx) lastEnqueueCtxErr() (error, bool) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.lastCtxErrAtCall, f.captured
+}
+
 func (f *fakeRetryQueue) AckRetry(_ context.Context, jobID string) error {
 	f.ackCallCount.Add(1)
 	if f.ackErr != nil {
@@ -453,6 +483,46 @@ func TestKafkaConsumerPool_SetRetryScheduler_BypassesInlinePublish(t *testing.T)
 	// 대신 Redis 큐에 등록되었는지 확인
 	assert.Len(t, q.snapshot(), 1, "주입된 RedisDelayedRetryScheduler 가 enqueue 받았음")
 	consumer.AssertCalled(t, "CommitMessages", mock.Anything, mock.Anything)
+}
+
+// TestRedisDelayedRetryScheduler_RepublishOnShutdown_UsesDrainCtx 는 ctx 가 canceled
+// 인 상태에서 publish 실패 → reschedule 경로가 drain context 로 EnqueueRetry 를
+// 한 번 더 시도해 backoff 를 보존함을 검증 (Copilot #5).
+//
+// 시나리오: producer.Publish 가 호출되는 순간 parent ctx 를 cancel + ctx.Canceled
+// 반환하여 셧다운 윈도우를 시뮬레이션. 이후 republish 가 EnqueueRetry 를 호출할 때
+// drain context 로 ctx.Err()=nil 인 상태여야 함.
+func TestRedisDelayedRetryScheduler_RepublishOnShutdown_UsesDrainCtx(t *testing.T) {
+	q := newFakeRetryQueueCapturingCtx()
+	prod := new(mockProducer)
+	cfg := worker.DefaultRedisRetrySchedulerConfig()
+	cfg.PollInterval = 10 * time.Millisecond
+	cfg.RepublishFailureBackoff = 5 * time.Second
+	sched := worker.NewRedisDelayedRetryScheduler(q, prod, cfg, retrySchedTestLogger())
+
+	job := retryTestJob(core.PriorityNormal)
+	job.ScheduledAt = time.Now().Add(-time.Second)
+	require.NoError(t, sched.Enqueue(context.Background(), job, errors.New("e")))
+	require.Equal(t, int32(1), q.enqueueCallCount.Load(), "초기 enqueue 1회 — ctx 정상")
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	// publish 가 호출되는 순간 parent ctx 를 cancel + ctx.Canceled 반환 → 셧다운 윈도우 시뮬
+	prod.On("Publish", mock.Anything, mock.Anything).Run(func(_ mock.Arguments) {
+		cancel()
+	}).Return(context.Canceled)
+
+	sched.Start(ctx)
+	require.Eventually(t, func() bool {
+		return q.enqueueCallCount.Load() >= 2 // 초기 + 재 enqueue
+	}, time.Second, 5*time.Millisecond, "shutdown 윈도우에서도 reschedule 시도")
+	sched.Stop()
+
+	// 마지막 enqueue 호출 시점의 ctx.Err() 가 nil 이어야 함 (drain context 적용)
+	ctxErr, captured := q.lastEnqueueCtxErr()
+	require.True(t, captured, "EnqueueRetry 가 최소 1회 호출됨")
+	assert.NoError(t, ctxErr,
+		"shutdown 중 reschedule 은 drain context 로 호출되어 호출 시점 ctx.Err()=nil")
 }
 
 // TestRedisDelayedRetryScheduler_StartStop_NoWaitGroupPanic 는 Start → ctx cancel → Stop

--- a/test/internal/worker/retry_scheduler_test.go
+++ b/test/internal/worker/retry_scheduler_test.go
@@ -328,6 +328,41 @@ func TestRedisDelayedRetryScheduler_Run_PopError_LogsAndContinues(t *testing.T) 
 	prod.AssertNotCalled(t, "Publish", mock.Anything, mock.Anything)
 }
 
+// TestKafkaConsumerPool_SetRetryScheduler_BypassesInlinePublish 는 SetRetryScheduler 로
+// 주입한 구현체가 호출되어 producer.Publish 가 우회됨을 검증.
+// 기존 fallback 경로 (SetRetryScheduler 미설정) 와의 회귀 분리.
+func TestKafkaConsumerPool_SetRetryScheduler_BypassesInlinePublish(t *testing.T) {
+	consumer := new(mockConsumer)
+	producer := new(mockProducer)
+	handler := new(mockJobHandler)
+	contentSvc := new(mockContentService)
+
+	pool := worker.NewKafkaConsumerPool(consumer, producer, handler, contentSvc, 1)
+
+	q := newFakeRetryQueue()
+	customScheduler := worker.NewRedisDelayedRetryScheduler(q, producer, worker.RedisRetrySchedulerConfig{
+		PollInterval:            time.Hour, // 폴링이 일어나지 않도록 충분히 길게
+		BatchSize:               1,
+		RepublishFailureBackoff: time.Hour,
+	}, retrySchedTestLogger())
+	pool.SetRetryScheduler(customScheduler)
+
+	job := newTestJob()
+	job.RetryCount = 1 // requeue 경로 (MaxRetries 미달)
+	msg := marshaledJobMsg(t, job)
+
+	handler.On("Handle", mock.Anything, job).Return(nil, errors.New("transient"))
+	consumer.On("CommitMessages", mock.Anything, mock.Anything).Return(nil)
+
+	runPool(t, consumer, pool, msg)
+
+	// inline producer.Publish 는 호출되지 않아야 함 — 모든 retry 가 Redis 경로로
+	producer.AssertNotCalled(t, "Publish", mock.Anything, mock.Anything)
+	// 대신 Redis 큐에 등록되었는지 확인
+	assert.Len(t, q.snapshot(), 1, "주입된 RedisDelayedRetryScheduler 가 enqueue 받았음")
+	consumer.AssertCalled(t, "CommitMessages", mock.Anything, mock.Anything)
+}
+
 // TestRedisDelayedRetryScheduler_DefaultConfigBoundary 는 cfg 의 0/음수 값이 default 로
 // 보정됨을 검증 (NewRedisDelayedRetryScheduler 의 fail-safe).
 func TestRedisDelayedRetryScheduler_DefaultConfigBoundary(t *testing.T) {

--- a/test/internal/worker/retry_scheduler_test.go
+++ b/test/internal/worker/retry_scheduler_test.go
@@ -110,14 +110,19 @@ func TestKafkaImmediateRetryScheduler_NilLastErr_OmitsHeader(t *testing.T) {
 // ─────────────────────────────────────────────────────────────────────────────
 
 // fakeRetryQueue 는 retryQueueClient 인터페이스를 만족하는 in-memory 더블입니다.
-// 진짜 Redis 가 없어도 Run 루프와 Enqueue/Pop 흐름을 결정적으로 검증합니다.
+// 진짜 Redis 가 없어도 Run 루프와 Enqueue/Peek/Ack 흐름을 결정적으로 검증합니다.
+//
+// peek-publish-ack 패턴 (PR #128 피드백): PeekDueRetries 는 항목을 ZSET 에 남겨두고
+// AckRetry 호출 시에만 제거합니다 — 진짜 Redis 와 동일 시맨틱.
 type fakeRetryQueue struct {
 	mu               sync.Mutex
 	items            []fakeRetryItem // ScheduledAt 정렬 유지
 	enqueueErr       error
-	popErr           error
+	peekErr          error
+	ackErr           error
 	enqueueCallCount atomic.Int32
-	popCallCount     atomic.Int32
+	peekCallCount    atomic.Int32
+	ackCallCount     atomic.Int32
 }
 
 type fakeRetryItem struct {
@@ -148,25 +153,41 @@ func (f *fakeRetryQueue) EnqueueRetry(_ context.Context, jobID string, payload [
 	return nil
 }
 
-func (f *fakeRetryQueue) PopDueRetries(_ context.Context, now time.Time, limit int) ([]pkgredis.DueRetry, error) {
-	f.popCallCount.Add(1)
-	if f.popErr != nil {
-		return nil, f.popErr
+func (f *fakeRetryQueue) PeekDueRetries(_ context.Context, now time.Time, limit int) ([]pkgredis.DueRetry, error) {
+	f.peekCallCount.Add(1)
+	if f.peekErr != nil {
+		return nil, f.peekErr
 	}
 	f.mu.Lock()
 	defer f.mu.Unlock()
 
 	out := make([]pkgredis.DueRetry, 0)
-	remaining := make([]fakeRetryItem, 0, len(f.items))
 	for _, it := range f.items {
-		if !it.scheduledAt.After(now) && len(out) < limit {
-			out = append(out, pkgredis.DueRetry{JobID: it.jobID, Payload: it.payload})
+		if it.scheduledAt.After(now) {
 			continue
 		}
-		remaining = append(remaining, it)
+		if len(out) >= limit {
+			break
+		}
+		out = append(out, pkgredis.DueRetry{JobID: it.jobID, Payload: it.payload})
 	}
-	f.items = remaining
 	return out, nil
+}
+
+func (f *fakeRetryQueue) AckRetry(_ context.Context, jobID string) error {
+	f.ackCallCount.Add(1)
+	if f.ackErr != nil {
+		return f.ackErr
+	}
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	for i, it := range f.items {
+		if it.jobID == jobID {
+			f.items = append(f.items[:i], f.items[i+1:]...)
+			return nil
+		}
+	}
+	return nil // idempotent: 이미 제거된 항목도 에러 없이
 }
 
 func (f *fakeRetryQueue) sortLocked() {
@@ -272,6 +293,77 @@ func TestRedisDelayedRetryScheduler_Run_FutureItemsNotPublished(t *testing.T) {
 	prod.AssertNotCalled(t, "Publish", mock.Anything, mock.Anything)
 }
 
+// TestRedisDelayedRetryScheduler_AckOnlyAfterSuccessfulPublish 는 peek-publish-ack
+// 패턴의 핵심 보증을 검증: publish 성공 시에만 AckRetry 호출, 실패 시 ack 없이
+// 항목이 큐에 남아 다음 폴 사이클에 재peek 가능 (at-least-once, PR #128 피드백 #1).
+func TestRedisDelayedRetryScheduler_AckOnlyAfterSuccessfulPublish(t *testing.T) {
+	q := newFakeRetryQueue()
+	prod := new(mockProducer)
+	cfg := worker.DefaultRedisRetrySchedulerConfig()
+	cfg.PollInterval = 10 * time.Millisecond
+	cfg.RepublishFailureBackoff = time.Hour // re-enqueue 가 즉시 재peek 되지 않도록
+	sched := worker.NewRedisDelayedRetryScheduler(q, prod, cfg, retrySchedTestLogger())
+
+	job := retryTestJob(core.PriorityNormal)
+	job.ScheduledAt = time.Now().Add(-time.Second)
+	require.NoError(t, sched.Enqueue(context.Background(), job, errors.New("e")))
+
+	// publish 가 처음에는 실패 → 두 번째에는 성공
+	publishCalls := atomic.Int32{}
+	prod.On("Publish", mock.Anything, mock.Anything).Return(errors.New("kafka transient")).Once().Run(func(_ mock.Arguments) {
+		publishCalls.Add(1)
+	})
+	prod.On("Publish", mock.Anything, mock.Anything).Return(nil).Run(func(_ mock.Arguments) {
+		publishCalls.Add(1)
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() { sched.Run(ctx); close(done) }()
+
+	// 두 번째 publish 가 성공할 때까지 대기 — RepublishFailureBackoff=1h 이므로 score 가
+	// 미래로 옮겨져 있을 텐데, 동일 jobID 에 대한 재 enqueue 가 어떻게 동작하는지 확인:
+	// 첫 publish 실패 후 fakeRetryQueue 에 score=now+1h 로 overwrite → peek 안 됨.
+	// 따라서 본 테스트는 첫 publish 실패 시 ack 가 호출되지 않았음을 검증하는 데 집중.
+	require.Eventually(t, func() bool {
+		return publishCalls.Load() >= 1
+	}, time.Second, 5*time.Millisecond, "최소 1회 publish 시도")
+
+	// 첫 publish 실패 시점에서 ack 호출 0회여야 함
+	cancel()
+	<-done
+
+	assert.Equal(t, int32(0), q.ackCallCount.Load(),
+		"publish 실패 시 ack 호출되지 않음 — 항목이 ZSET 에 남아 at-least-once 보장")
+}
+
+// TestRedisDelayedRetryScheduler_AckCalledAfterPublishSuccess 는 publish 성공 시
+// AckRetry 가 1회 호출되어 ZSET 에서 제거됨을 검증.
+func TestRedisDelayedRetryScheduler_AckCalledAfterPublishSuccess(t *testing.T) {
+	q := newFakeRetryQueue()
+	prod := new(mockProducer)
+	cfg := worker.DefaultRedisRetrySchedulerConfig()
+	cfg.PollInterval = 10 * time.Millisecond
+	sched := worker.NewRedisDelayedRetryScheduler(q, prod, cfg, retrySchedTestLogger())
+
+	job := retryTestJob(core.PriorityNormal)
+	job.ScheduledAt = time.Now().Add(-time.Second)
+	require.NoError(t, sched.Enqueue(context.Background(), job, errors.New("e")))
+
+	prod.On("Publish", mock.Anything, mock.Anything).Return(nil)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() { sched.Run(ctx); close(done) }()
+
+	require.Eventually(t, func() bool {
+		return q.ackCallCount.Load() >= 1 && len(q.snapshot()) == 0
+	}, time.Second, 5*time.Millisecond, "publish 성공 후 ack 1회 + 큐에서 제거")
+
+	cancel()
+	<-done
+}
+
 // TestRedisDelayedRetryScheduler_Run_PublishFailure_ReEnqueues 는 Kafka publish 실패 시
 // 항목이 짧은 backoff 로 재 enqueue 됨을 검증.
 func TestRedisDelayedRetryScheduler_Run_PublishFailure_ReEnqueues(t *testing.T) {
@@ -305,11 +397,11 @@ func TestRedisDelayedRetryScheduler_Run_PublishFailure_ReEnqueues(t *testing.T) 
 	assert.True(t, snap[0].scheduledAt.After(time.Now()), "재 enqueue 의 ScheduledAt 이 미래로 설정")
 }
 
-// TestRedisDelayedRetryScheduler_Run_PopError_LogsAndContinues 는 Pop 실패 시 다음
+// TestRedisDelayedRetryScheduler_Run_PeekError_LogsAndContinues 는 Peek 실패 시 다음
 // 폴 사이클로 계속 진행됨을 검증 (panic 없이 회복).
-func TestRedisDelayedRetryScheduler_Run_PopError_LogsAndContinues(t *testing.T) {
+func TestRedisDelayedRetryScheduler_Run_PeekError_LogsAndContinues(t *testing.T) {
 	q := newFakeRetryQueue()
-	q.popErr = errors.New("redis transient")
+	q.peekErr = errors.New("redis transient")
 	prod := new(mockProducer)
 	cfg := worker.DefaultRedisRetrySchedulerConfig()
 	cfg.PollInterval = 10 * time.Millisecond
@@ -320,7 +412,7 @@ func TestRedisDelayedRetryScheduler_Run_PopError_LogsAndContinues(t *testing.T) 
 	go func() { sched.Run(ctx); close(done) }()
 
 	require.Eventually(t, func() bool {
-		return q.popCallCount.Load() >= 3 // 여러 폴 사이클 진행 = 패닉/조기 종료 없음
+		return q.peekCallCount.Load() >= 3 // 여러 폴 사이클 진행 = 패닉/조기 종료 없음
 	}, time.Second, 5*time.Millisecond)
 
 	cancel()

--- a/test/internal/worker/retry_scheduler_test.go
+++ b/test/internal/worker/retry_scheduler_test.go
@@ -2,7 +2,10 @@ package worker_test
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -12,7 +15,9 @@ import (
 
 	"issuetracker/internal/crawler/core"
 	"issuetracker/internal/crawler/worker"
+	"issuetracker/pkg/logger"
 	"issuetracker/pkg/queue"
+	pkgredis "issuetracker/pkg/redis"
 )
 
 // retryTestJob 은 RetryScheduler 테스트 전용 fixture 입니다.
@@ -98,4 +103,249 @@ func TestKafkaImmediateRetryScheduler_NilLastErr_OmitsHeader(t *testing.T) {
 
 	require.NoError(t, sched.Enqueue(context.Background(), job, nil))
 	producer.AssertExpectations(t)
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// RedisDelayedRetryScheduler 테스트 — fakeRetryQueue 로 in-memory ZSET emulate
+// ─────────────────────────────────────────────────────────────────────────────
+
+// fakeRetryQueue 는 retryQueueClient 인터페이스를 만족하는 in-memory 더블입니다.
+// 진짜 Redis 가 없어도 Run 루프와 Enqueue/Pop 흐름을 결정적으로 검증합니다.
+type fakeRetryQueue struct {
+	mu               sync.Mutex
+	items            []fakeRetryItem // ScheduledAt 정렬 유지
+	enqueueErr       error
+	popErr           error
+	enqueueCallCount atomic.Int32
+	popCallCount     atomic.Int32
+}
+
+type fakeRetryItem struct {
+	jobID       string
+	payload     []byte
+	scheduledAt time.Time
+}
+
+func newFakeRetryQueue() *fakeRetryQueue { return &fakeRetryQueue{} }
+
+func (f *fakeRetryQueue) EnqueueRetry(_ context.Context, jobID string, payload []byte, scheduledAt time.Time) error {
+	f.enqueueCallCount.Add(1)
+	if f.enqueueErr != nil {
+		return f.enqueueErr
+	}
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	// 동일 jobID 가 있으면 덮어씀 (실제 ZADD 동작과 일치)
+	for i, it := range f.items {
+		if it.jobID == jobID {
+			f.items[i] = fakeRetryItem{jobID: jobID, payload: payload, scheduledAt: scheduledAt}
+			f.sortLocked()
+			return nil
+		}
+	}
+	f.items = append(f.items, fakeRetryItem{jobID: jobID, payload: payload, scheduledAt: scheduledAt})
+	f.sortLocked()
+	return nil
+}
+
+func (f *fakeRetryQueue) PopDueRetries(_ context.Context, now time.Time, limit int) ([]pkgredis.DueRetry, error) {
+	f.popCallCount.Add(1)
+	if f.popErr != nil {
+		return nil, f.popErr
+	}
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	out := make([]pkgredis.DueRetry, 0)
+	remaining := make([]fakeRetryItem, 0, len(f.items))
+	for _, it := range f.items {
+		if !it.scheduledAt.After(now) && len(out) < limit {
+			out = append(out, pkgredis.DueRetry{JobID: it.jobID, Payload: it.payload})
+			continue
+		}
+		remaining = append(remaining, it)
+	}
+	f.items = remaining
+	return out, nil
+}
+
+func (f *fakeRetryQueue) sortLocked() {
+	// 단순 삽입 정렬 — 테스트용 (n 이 작음)
+	for i := 1; i < len(f.items); i++ {
+		for j := i; j > 0 && f.items[j-1].scheduledAt.After(f.items[j].scheduledAt); j-- {
+			f.items[j], f.items[j-1] = f.items[j-1], f.items[j]
+		}
+	}
+}
+
+func (f *fakeRetryQueue) snapshot() []fakeRetryItem {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	out := make([]fakeRetryItem, len(f.items))
+	copy(out, f.items)
+	return out
+}
+
+func retrySchedTestLogger() *logger.Logger { return logger.New(logger.DefaultConfig()) }
+
+// TestRedisDelayedRetryScheduler_Enqueue_StoresJobAndLastErr 는 Enqueue 가 jobID/payload/
+// ScheduledAt 을 정확히 store 하는지 + payload 가 job + last-err JSON 임을 검증.
+func TestRedisDelayedRetryScheduler_Enqueue_StoresJobAndLastErr(t *testing.T) {
+	q := newFakeRetryQueue()
+	prod := new(mockProducer)
+	sched := worker.NewRedisDelayedRetryScheduler(q, prod, worker.DefaultRedisRetrySchedulerConfig(), retrySchedTestLogger())
+
+	job := retryTestJob(core.PriorityNormal)
+	require.NoError(t, sched.Enqueue(context.Background(), job, errors.New("upstream 503")))
+
+	snap := q.snapshot()
+	require.Len(t, snap, 1)
+	assert.Equal(t, job.ID, snap[0].jobID)
+	assert.WithinDuration(t, job.ScheduledAt, snap[0].scheduledAt, time.Second)
+
+	// payload 의 last_err 디코드 검증
+	var entry struct {
+		JobBytes []byte `json:"job"`
+		LastErr  string `json:"last_err"`
+	}
+	require.NoError(t, json.Unmarshal(snap[0].payload, &entry))
+	assert.Equal(t, "upstream 503", entry.LastErr)
+	assert.NotEmpty(t, entry.JobBytes)
+}
+
+// TestRedisDelayedRetryScheduler_Run_PublishesDueItems 는 Run 루프가 due 항목을
+// Kafka 에 발행하고 priority → topic 매핑/headers 가 올바른지 검증.
+func TestRedisDelayedRetryScheduler_Run_PublishesDueItems(t *testing.T) {
+	q := newFakeRetryQueue()
+	prod := new(mockProducer)
+	cfg := worker.DefaultRedisRetrySchedulerConfig()
+	cfg.PollInterval = 10 * time.Millisecond
+	sched := worker.NewRedisDelayedRetryScheduler(q, prod, cfg, retrySchedTestLogger())
+
+	job := retryTestJob(core.PriorityHigh)
+	job.ScheduledAt = time.Now().Add(-time.Second) // due
+	require.NoError(t, sched.Enqueue(context.Background(), job, errors.New("err")))
+
+	prod.On("Publish", mock.Anything, mock.MatchedBy(func(m queue.Message) bool {
+		return m.Topic == queue.TopicCrawlHigh &&
+			string(m.Key) == job.ID &&
+			m.Headers["retry-count"] == "2" &&
+			m.Headers["last-error"] == "err"
+	})).Return(nil)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() { sched.Run(ctx); close(done) }()
+
+	require.Eventually(t, func() bool {
+		return len(q.snapshot()) == 0
+	}, time.Second, 5*time.Millisecond, "due 항목이 publish 후 큐에서 제거되어야 함")
+
+	cancel()
+	<-done
+	prod.AssertExpectations(t)
+}
+
+// TestRedisDelayedRetryScheduler_Run_FutureItemsNotPublished 는 ScheduledAt 이 미래인
+// 항목은 Run 이 publish 하지 않음을 검증.
+func TestRedisDelayedRetryScheduler_Run_FutureItemsNotPublished(t *testing.T) {
+	q := newFakeRetryQueue()
+	prod := new(mockProducer)
+	cfg := worker.DefaultRedisRetrySchedulerConfig()
+	cfg.PollInterval = 10 * time.Millisecond
+	sched := worker.NewRedisDelayedRetryScheduler(q, prod, cfg, retrySchedTestLogger())
+
+	job := retryTestJob(core.PriorityNormal)
+	job.ScheduledAt = time.Now().Add(10 * time.Second) // 미래
+	require.NoError(t, sched.Enqueue(context.Background(), job, errors.New("err")))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() { sched.Run(ctx); close(done) }()
+
+	// 폴링이 몇 번 일어날 시간 대기
+	time.Sleep(50 * time.Millisecond)
+	cancel()
+	<-done
+
+	assert.Len(t, q.snapshot(), 1, "미래 항목은 큐에 그대로 남아 있어야 함")
+	prod.AssertNotCalled(t, "Publish", mock.Anything, mock.Anything)
+}
+
+// TestRedisDelayedRetryScheduler_Run_PublishFailure_ReEnqueues 는 Kafka publish 실패 시
+// 항목이 짧은 backoff 로 재 enqueue 됨을 검증.
+func TestRedisDelayedRetryScheduler_Run_PublishFailure_ReEnqueues(t *testing.T) {
+	q := newFakeRetryQueue()
+	prod := new(mockProducer)
+	cfg := worker.DefaultRedisRetrySchedulerConfig()
+	cfg.PollInterval = 10 * time.Millisecond
+	cfg.RepublishFailureBackoff = 5 * time.Second // 다시 due 가 되지 않을 만큼 충분히 길게
+	sched := worker.NewRedisDelayedRetryScheduler(q, prod, cfg, retrySchedTestLogger())
+
+	job := retryTestJob(core.PriorityNormal)
+	job.ScheduledAt = time.Now().Add(-time.Second)
+	require.NoError(t, sched.Enqueue(context.Background(), job, errors.New("e")))
+
+	prod.On("Publish", mock.Anything, mock.Anything).Return(errors.New("kafka down"))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() { sched.Run(ctx); close(done) }()
+
+	// 첫 publish 실패 후 재 enqueue 가 일어날 때까지 대기 (enqueue >=2 = 최초 + 재)
+	require.Eventually(t, func() bool {
+		return q.enqueueCallCount.Load() >= 2
+	}, time.Second, 5*time.Millisecond, "publish 실패 후 재 enqueue 발생해야 함")
+
+	cancel()
+	<-done
+
+	snap := q.snapshot()
+	require.Len(t, snap, 1, "publish 실패한 항목이 다시 큐에 보관됨")
+	assert.True(t, snap[0].scheduledAt.After(time.Now()), "재 enqueue 의 ScheduledAt 이 미래로 설정")
+}
+
+// TestRedisDelayedRetryScheduler_Run_PopError_LogsAndContinues 는 Pop 실패 시 다음
+// 폴 사이클로 계속 진행됨을 검증 (panic 없이 회복).
+func TestRedisDelayedRetryScheduler_Run_PopError_LogsAndContinues(t *testing.T) {
+	q := newFakeRetryQueue()
+	q.popErr = errors.New("redis transient")
+	prod := new(mockProducer)
+	cfg := worker.DefaultRedisRetrySchedulerConfig()
+	cfg.PollInterval = 10 * time.Millisecond
+	sched := worker.NewRedisDelayedRetryScheduler(q, prod, cfg, retrySchedTestLogger())
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() { sched.Run(ctx); close(done) }()
+
+	require.Eventually(t, func() bool {
+		return q.popCallCount.Load() >= 3 // 여러 폴 사이클 진행 = 패닉/조기 종료 없음
+	}, time.Second, 5*time.Millisecond)
+
+	cancel()
+	<-done
+	prod.AssertNotCalled(t, "Publish", mock.Anything, mock.Anything)
+}
+
+// TestRedisDelayedRetryScheduler_DefaultConfigBoundary 는 cfg 의 0/음수 값이 default 로
+// 보정됨을 검증 (NewRedisDelayedRetryScheduler 의 fail-safe).
+func TestRedisDelayedRetryScheduler_DefaultConfigBoundary(t *testing.T) {
+	q := newFakeRetryQueue()
+	prod := new(mockProducer)
+	// 모든 필드 0 — default 로 보정되어야 함
+	sched := worker.NewRedisDelayedRetryScheduler(q, prod, worker.RedisRetrySchedulerConfig{}, retrySchedTestLogger())
+
+	// Run 이 정상 시작되어 폴 1회 이상 호출되어야 함 (default PollInterval=1s 면 너무 길어
+	// 테스트 timing 이 위험하므로, ctx 즉시 cancel 후 panic/start 여부만 확인)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // 즉시 취소
+	done := make(chan struct{})
+	go func() { sched.Run(ctx); close(done) }()
+	select {
+	case <-done:
+		// 정상 종료
+	case <-time.After(time.Second):
+		t.Fatal("Run 이 ctx cancel 후 즉시 종료되어야 함")
+	}
 }

--- a/test/internal/worker/retry_scheduler_test.go
+++ b/test/internal/worker/retry_scheduler_test.go
@@ -455,6 +455,39 @@ func TestKafkaConsumerPool_SetRetryScheduler_BypassesInlinePublish(t *testing.T)
 	consumer.AssertCalled(t, "CommitMessages", mock.Anything, mock.Anything)
 }
 
+// TestRedisDelayedRetryScheduler_StartStop_NoWaitGroupPanic 는 Start → ctx cancel → Stop
+// 흐름이 race-free 하고 panic 없음을 검증 (Copilot #4 — wg.Add/Wait 패턴 안전성).
+//
+// "Add called concurrently with Wait" 패닉을 재현하려면 Start 직후 즉시 Stop 호출이
+// 필요하므로 0 sleep 으로 즉시 cancel + Stop. wg.Add 가 goroutine 시작 전에 일어나면
+// Stop 의 wg.Wait() 이 정확히 join 후 반환.
+func TestRedisDelayedRetryScheduler_StartStop_NoWaitGroupPanic(t *testing.T) {
+	q := newFakeRetryQueue()
+	prod := new(mockProducer)
+	cfg := worker.DefaultRedisRetrySchedulerConfig()
+	cfg.PollInterval = 10 * time.Millisecond
+	sched := worker.NewRedisDelayedRetryScheduler(q, prod, cfg, retrySchedTestLogger())
+
+	ctx, cancel := context.WithCancel(context.Background())
+	sched.Start(ctx)
+
+	// 즉시 종료 — Start 와 Stop 의 race window 가 wg 패닉을 유발하지 않아야 함
+	cancel()
+
+	stopped := make(chan struct{})
+	go func() {
+		sched.Stop()
+		close(stopped)
+	}()
+
+	select {
+	case <-stopped:
+		// 정상 종료
+	case <-time.After(time.Second):
+		t.Fatal("Stop 이 1초 내 반환해야 함 — wg.Wait deadlock 의심")
+	}
+}
+
 // TestRedisDelayedRetryScheduler_DefaultConfigBoundary 는 cfg 의 0/음수 값이 default 로
 // 보정됨을 검증 (NewRedisDelayedRetryScheduler 의 fail-safe).
 func TestRedisDelayedRetryScheduler_DefaultConfigBoundary(t *testing.T) {

--- a/test/pkg/redis/retry_queue_test.go
+++ b/test/pkg/redis/retry_queue_test.go
@@ -11,25 +11,25 @@ import (
 	pkgredis "issuetracker/pkg/redis"
 )
 
-// retryQueueCleanup 은 테스트 간 격리를 위해 retry 키를 모두 삭제합니다.
-// 본 테스트 파일은 newTestClient 가 노출하는 단일 Redis 인스턴스를 공유하므로
-// 각 테스트 시작 전에 호출해 stale 데이터를 제거해야 합니다.
+// retryQueueCleanup 은 테스트 간 격리를 위해 retry 큐의 모든 항목을 PeekDueRetries +
+// AckRetry 로 정리합니다 (peek-publish-ack 패턴이라 PopDueRetries 같은 atomic remove 가 없음).
 func retryQueueCleanup(t *testing.T, client *pkgredis.Client) {
 	t.Helper()
 	ctx := context.Background()
-	// PendingRetryCount 로 ZSET 존재 여부 확인 — 0 이면 entry 키도 없을 가능성 높지만
-	// 기존 테스트가 남긴 entry STRING 도 정리하기 위해 ZRange 로 jobID 목록을 받고 DEL.
 	for {
-		due, err := client.PopDueRetries(ctx, time.Now().Add(time.Hour), 100)
+		due, err := client.PeekDueRetries(ctx, time.Now().Add(time.Hour), 100)
 		require.NoError(t, err)
 		if len(due) == 0 {
 			return
 		}
+		for _, item := range due {
+			require.NoError(t, client.AckRetry(ctx, item.JobID))
+		}
 	}
 }
 
-// TestEnqueueRetry_PopDue_BasicRoundtrip 는 등록 → 만기 후 pop 의 기본 흐름을 검증합니다.
-func TestEnqueueRetry_PopDue_BasicRoundtrip(t *testing.T) {
+// TestEnqueueRetry_PeekAck_BasicRoundtrip 는 등록 → 만기 후 peek → ack 의 기본 흐름을 검증합니다.
+func TestEnqueueRetry_PeekAck_BasicRoundtrip(t *testing.T) {
 	client := newTestClient(t)
 	retryQueueCleanup(t, client)
 	ctx := context.Background()
@@ -40,20 +40,27 @@ func TestEnqueueRetry_PopDue_BasicRoundtrip(t *testing.T) {
 
 	require.NoError(t, client.EnqueueRetry(ctx, jobID, payload, scheduledAt))
 
-	due, err := client.PopDueRetries(ctx, time.Now(), 10)
+	// 1차 peek — 항목이 ZSET 에 남아있어야 하므로 두 번째 peek 도 동일 결과
+	due, err := client.PeekDueRetries(ctx, time.Now(), 10)
 	require.NoError(t, err)
 	require.Len(t, due, 1)
 	assert.Equal(t, jobID, due[0].JobID)
 	assert.Equal(t, payload, due[0].Payload)
 
-	// 두 번째 pop 은 비어있어야 함 (이미 ZREM/DEL)
-	due2, err := client.PopDueRetries(ctx, time.Now(), 10)
+	// peek 만으로는 큐에서 제거되지 않음 (at-least-once 핵심)
+	due2, err := client.PeekDueRetries(ctx, time.Now(), 10)
 	require.NoError(t, err)
-	assert.Empty(t, due2, "pop 후 ZSET/entry 모두 정리되어야 함")
+	assert.Len(t, due2, 1, "peek 후에도 ZSET 에 남아 있어야 at-least-once 보장")
+
+	// ack 호출 후에 비로소 제거
+	require.NoError(t, client.AckRetry(ctx, jobID))
+	due3, err := client.PeekDueRetries(ctx, time.Now(), 10)
+	require.NoError(t, err)
+	assert.Empty(t, due3, "ack 후 ZSET/entry 모두 정리되어야 함")
 }
 
-// TestPopDueRetries_FuturScheduled_NotReturned 는 score 가 미래인 항목은 반환되지 않음을 검증.
-func TestPopDueRetries_FutureScheduled_NotReturned(t *testing.T) {
+// TestPeekDueRetries_FutureScheduled_NotReturned 는 score 가 미래인 항목은 반환되지 않음을 검증.
+func TestPeekDueRetries_FutureScheduled_NotReturned(t *testing.T) {
 	client := newTestClient(t)
 	retryQueueCleanup(t, client)
 	ctx := context.Background()
@@ -61,9 +68,9 @@ func TestPopDueRetries_FutureScheduled_NotReturned(t *testing.T) {
 	jobID := "test-job-future-" + time.Now().Format(time.RFC3339Nano)
 	require.NoError(t, client.EnqueueRetry(ctx, jobID, []byte("x"), time.Now().Add(10*time.Second)))
 
-	due, err := client.PopDueRetries(ctx, time.Now(), 10)
+	due, err := client.PeekDueRetries(ctx, time.Now(), 10)
 	require.NoError(t, err)
-	assert.Empty(t, due, "미래 scheduled 항목은 pop 대상 아님")
+	assert.Empty(t, due, "미래 scheduled 항목은 peek 대상 아님")
 
 	// 단, count 에는 잡혀야 함
 	n, err := client.PendingRetryCount(ctx)
@@ -74,8 +81,8 @@ func TestPopDueRetries_FutureScheduled_NotReturned(t *testing.T) {
 	retryQueueCleanup(t, client)
 }
 
-// TestPopDueRetries_OrderByScheduledAt 는 score 순 (가장 오래된 먼저) 으로 반환됨을 검증.
-func TestPopDueRetries_OrderByScheduledAt(t *testing.T) {
+// TestPeekDueRetries_OrderByScheduledAt 는 score 순 (가장 오래된 먼저) 으로 반환됨을 검증.
+func TestPeekDueRetries_OrderByScheduledAt(t *testing.T) {
 	client := newTestClient(t)
 	retryQueueCleanup(t, client)
 	ctx := context.Background()
@@ -83,21 +90,23 @@ func TestPopDueRetries_OrderByScheduledAt(t *testing.T) {
 	now := time.Now()
 	prefix := "test-job-order-" + now.Format(time.RFC3339Nano) + "-"
 
-	// 의도적으로 역순 enqueue — pop 결과가 score 순이어야 함
+	// 의도적으로 역순 enqueue — peek 결과가 score 순이어야 함
 	require.NoError(t, client.EnqueueRetry(ctx, prefix+"c", []byte("c"), now.Add(-1*time.Second)))
 	require.NoError(t, client.EnqueueRetry(ctx, prefix+"a", []byte("a"), now.Add(-3*time.Second)))
 	require.NoError(t, client.EnqueueRetry(ctx, prefix+"b", []byte("b"), now.Add(-2*time.Second)))
 
-	due, err := client.PopDueRetries(ctx, now, 10)
+	due, err := client.PeekDueRetries(ctx, now, 10)
 	require.NoError(t, err)
 	require.Len(t, due, 3)
 	assert.Equal(t, prefix+"a", due[0].JobID, "가장 오래된 score 가 먼저")
 	assert.Equal(t, prefix+"b", due[1].JobID)
 	assert.Equal(t, prefix+"c", due[2].JobID)
+
+	retryQueueCleanup(t, client)
 }
 
-// TestPopDueRetries_LimitRespected 는 limit 인자가 반환 개수를 제한함을 검증.
-func TestPopDueRetries_LimitRespected(t *testing.T) {
+// TestPeekDueRetries_LimitRespected 는 limit 인자가 반환 개수를 제한함을 검증.
+func TestPeekDueRetries_LimitRespected(t *testing.T) {
 	client := newTestClient(t)
 	retryQueueCleanup(t, client)
 	ctx := context.Background()
@@ -108,24 +117,24 @@ func TestPopDueRetries_LimitRespected(t *testing.T) {
 		require.NoError(t, client.EnqueueRetry(ctx, prefix+string(rune('0'+i)), []byte("x"), now.Add(-time.Second)))
 	}
 
-	due, err := client.PopDueRetries(ctx, now, 2)
+	due, err := client.PeekDueRetries(ctx, now, 2)
 	require.NoError(t, err)
 	assert.Len(t, due, 2, "limit=2 면 정확히 2건만 반환")
 
-	// 나머지 3건 정리
+	// 나머지 정리
 	retryQueueCleanup(t, client)
 }
 
-// TestPopDueRetries_LimitZero_ReturnsEmpty 는 limit<=0 가 즉시 빈 결과를 반환함을 검증.
-func TestPopDueRetries_LimitZero_ReturnsEmpty(t *testing.T) {
+// TestPeekDueRetries_LimitZero_ReturnsEmpty 는 limit<=0 가 즉시 빈 결과를 반환함을 검증.
+func TestPeekDueRetries_LimitZero_ReturnsEmpty(t *testing.T) {
 	client := newTestClient(t)
 	ctx := context.Background()
 
-	due, err := client.PopDueRetries(ctx, time.Now(), 0)
+	due, err := client.PeekDueRetries(ctx, time.Now(), 0)
 	require.NoError(t, err)
 	assert.Empty(t, due)
 
-	due2, err := client.PopDueRetries(ctx, time.Now(), -5)
+	due2, err := client.PeekDueRetries(ctx, time.Now(), -5)
 	require.NoError(t, err)
 	assert.Empty(t, due2)
 }
@@ -140,23 +149,25 @@ func TestEnqueueRetry_Reschedule_OverwritesScore(t *testing.T) {
 	jobID := "test-job-reschedule-" + time.Now().Format(time.RFC3339Nano)
 	now := time.Now()
 
-	// 첫 번째: 미래 (pop 대상 아님)
+	// 첫 번째: 미래 (peek 대상 아님)
 	require.NoError(t, client.EnqueueRetry(ctx, jobID, []byte("v1"), now.Add(10*time.Second)))
-	due, err := client.PopDueRetries(ctx, now, 10)
+	due, err := client.PeekDueRetries(ctx, now, 10)
 	require.NoError(t, err)
-	assert.Empty(t, due, "첫 enqueue 는 미래 scheduled — pop 대상 아님")
+	assert.Empty(t, due, "첫 enqueue 는 미래 scheduled — peek 대상 아님")
 
 	// 두 번째: 과거로 재스케줄 + payload 교체
 	require.NoError(t, client.EnqueueRetry(ctx, jobID, []byte("v2"), now.Add(-time.Second)))
-	due, err = client.PopDueRetries(ctx, now, 10)
+	due, err = client.PeekDueRetries(ctx, now, 10)
 	require.NoError(t, err)
 	require.Len(t, due, 1)
 	assert.Equal(t, []byte("v2"), due[0].Payload, "재호출 payload 가 우선")
+
+	retryQueueCleanup(t, client)
 }
 
-// TestPopDueRetries_StaleEntryGone_SkipsAndCleansZSet 는 entry STRING 만 만료/삭제되어
+// TestPeekDueRetries_StaleEntryGone_SkipsAndCleansZSet 는 entry STRING 만 만료/삭제되어
 // ZSET 에는 jobID 가 남은 stale 상태에서 silent skip + ZSET 정합 회복을 검증.
-func TestPopDueRetries_StaleEntryGone_SkipsAndCleansZSet(t *testing.T) {
+func TestPeekDueRetries_StaleEntryGone_SkipsAndCleansZSet(t *testing.T) {
 	client := newTestClient(t)
 	retryQueueCleanup(t, client)
 	ctx := context.Background()
@@ -167,7 +178,7 @@ func TestPopDueRetries_StaleEntryGone_SkipsAndCleansZSet(t *testing.T) {
 	// entry STRING 만 직접 삭제하여 stale 상태 인위적으로 조성
 	require.NoError(t, client.DeleteRetryEntryForTest(ctx, jobID))
 
-	due, err := client.PopDueRetries(ctx, time.Now(), 10)
+	due, err := client.PeekDueRetries(ctx, time.Now(), 10)
 	require.NoError(t, err)
 	assert.Empty(t, due, "stale jobID 는 silent skip — 호출자에게 노출 안 함")
 
@@ -175,4 +186,20 @@ func TestPopDueRetries_StaleEntryGone_SkipsAndCleansZSet(t *testing.T) {
 	n, err := client.PendingRetryCount(ctx)
 	require.NoError(t, err)
 	assert.Equal(t, int64(0), n, "ZSET 에서도 stale jobID 가 제거되어 정합 회복")
+}
+
+// TestAckRetry_Idempotent 는 이미 제거된 항목에 대한 AckRetry 가 에러 없이 no-op 임을 검증.
+func TestAckRetry_Idempotent(t *testing.T) {
+	client := newTestClient(t)
+	retryQueueCleanup(t, client)
+	ctx := context.Background()
+
+	// 존재하지 않는 jobID 에 대한 ack — idempotent
+	require.NoError(t, client.AckRetry(ctx, "nonexistent-job"))
+
+	// enqueue → ack → 재 ack → 모두 에러 없음
+	jobID := "test-job-idempotent-" + time.Now().Format(time.RFC3339Nano)
+	require.NoError(t, client.EnqueueRetry(ctx, jobID, []byte("x"), time.Now()))
+	require.NoError(t, client.AckRetry(ctx, jobID))
+	require.NoError(t, client.AckRetry(ctx, jobID))
 }

--- a/test/pkg/redis/retry_queue_test.go
+++ b/test/pkg/redis/retry_queue_test.go
@@ -1,0 +1,178 @@
+package redis_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	pkgredis "issuetracker/pkg/redis"
+)
+
+// retryQueueCleanup 은 테스트 간 격리를 위해 retry 키를 모두 삭제합니다.
+// 본 테스트 파일은 newTestClient 가 노출하는 단일 Redis 인스턴스를 공유하므로
+// 각 테스트 시작 전에 호출해 stale 데이터를 제거해야 합니다.
+func retryQueueCleanup(t *testing.T, client *pkgredis.Client) {
+	t.Helper()
+	ctx := context.Background()
+	// PendingRetryCount 로 ZSET 존재 여부 확인 — 0 이면 entry 키도 없을 가능성 높지만
+	// 기존 테스트가 남긴 entry STRING 도 정리하기 위해 ZRange 로 jobID 목록을 받고 DEL.
+	for {
+		due, err := client.PopDueRetries(ctx, time.Now().Add(time.Hour), 100)
+		require.NoError(t, err)
+		if len(due) == 0 {
+			return
+		}
+	}
+}
+
+// TestEnqueueRetry_PopDue_BasicRoundtrip 는 등록 → 만기 후 pop 의 기본 흐름을 검증합니다.
+func TestEnqueueRetry_PopDue_BasicRoundtrip(t *testing.T) {
+	client := newTestClient(t)
+	retryQueueCleanup(t, client)
+	ctx := context.Background()
+
+	jobID := "test-job-roundtrip-" + time.Now().Format(time.RFC3339Nano)
+	payload := []byte(`{"foo":"bar"}`)
+	scheduledAt := time.Now().Add(-time.Second) // 이미 만기
+
+	require.NoError(t, client.EnqueueRetry(ctx, jobID, payload, scheduledAt))
+
+	due, err := client.PopDueRetries(ctx, time.Now(), 10)
+	require.NoError(t, err)
+	require.Len(t, due, 1)
+	assert.Equal(t, jobID, due[0].JobID)
+	assert.Equal(t, payload, due[0].Payload)
+
+	// 두 번째 pop 은 비어있어야 함 (이미 ZREM/DEL)
+	due2, err := client.PopDueRetries(ctx, time.Now(), 10)
+	require.NoError(t, err)
+	assert.Empty(t, due2, "pop 후 ZSET/entry 모두 정리되어야 함")
+}
+
+// TestPopDueRetries_FuturScheduled_NotReturned 는 score 가 미래인 항목은 반환되지 않음을 검증.
+func TestPopDueRetries_FutureScheduled_NotReturned(t *testing.T) {
+	client := newTestClient(t)
+	retryQueueCleanup(t, client)
+	ctx := context.Background()
+
+	jobID := "test-job-future-" + time.Now().Format(time.RFC3339Nano)
+	require.NoError(t, client.EnqueueRetry(ctx, jobID, []byte("x"), time.Now().Add(10*time.Second)))
+
+	due, err := client.PopDueRetries(ctx, time.Now(), 10)
+	require.NoError(t, err)
+	assert.Empty(t, due, "미래 scheduled 항목은 pop 대상 아님")
+
+	// 단, count 에는 잡혀야 함
+	n, err := client.PendingRetryCount(ctx)
+	require.NoError(t, err)
+	assert.GreaterOrEqual(t, n, int64(1))
+
+	// 후속 정리
+	retryQueueCleanup(t, client)
+}
+
+// TestPopDueRetries_OrderByScheduledAt 는 score 순 (가장 오래된 먼저) 으로 반환됨을 검증.
+func TestPopDueRetries_OrderByScheduledAt(t *testing.T) {
+	client := newTestClient(t)
+	retryQueueCleanup(t, client)
+	ctx := context.Background()
+
+	now := time.Now()
+	prefix := "test-job-order-" + now.Format(time.RFC3339Nano) + "-"
+
+	// 의도적으로 역순 enqueue — pop 결과가 score 순이어야 함
+	require.NoError(t, client.EnqueueRetry(ctx, prefix+"c", []byte("c"), now.Add(-1*time.Second)))
+	require.NoError(t, client.EnqueueRetry(ctx, prefix+"a", []byte("a"), now.Add(-3*time.Second)))
+	require.NoError(t, client.EnqueueRetry(ctx, prefix+"b", []byte("b"), now.Add(-2*time.Second)))
+
+	due, err := client.PopDueRetries(ctx, now, 10)
+	require.NoError(t, err)
+	require.Len(t, due, 3)
+	assert.Equal(t, prefix+"a", due[0].JobID, "가장 오래된 score 가 먼저")
+	assert.Equal(t, prefix+"b", due[1].JobID)
+	assert.Equal(t, prefix+"c", due[2].JobID)
+}
+
+// TestPopDueRetries_LimitRespected 는 limit 인자가 반환 개수를 제한함을 검증.
+func TestPopDueRetries_LimitRespected(t *testing.T) {
+	client := newTestClient(t)
+	retryQueueCleanup(t, client)
+	ctx := context.Background()
+
+	now := time.Now()
+	prefix := "test-job-limit-" + now.Format(time.RFC3339Nano) + "-"
+	for i := 0; i < 5; i++ {
+		require.NoError(t, client.EnqueueRetry(ctx, prefix+string(rune('0'+i)), []byte("x"), now.Add(-time.Second)))
+	}
+
+	due, err := client.PopDueRetries(ctx, now, 2)
+	require.NoError(t, err)
+	assert.Len(t, due, 2, "limit=2 면 정확히 2건만 반환")
+
+	// 나머지 3건 정리
+	retryQueueCleanup(t, client)
+}
+
+// TestPopDueRetries_LimitZero_ReturnsEmpty 는 limit<=0 가 즉시 빈 결과를 반환함을 검증.
+func TestPopDueRetries_LimitZero_ReturnsEmpty(t *testing.T) {
+	client := newTestClient(t)
+	ctx := context.Background()
+
+	due, err := client.PopDueRetries(ctx, time.Now(), 0)
+	require.NoError(t, err)
+	assert.Empty(t, due)
+
+	due2, err := client.PopDueRetries(ctx, time.Now(), -5)
+	require.NoError(t, err)
+	assert.Empty(t, due2)
+}
+
+// TestEnqueueRetry_Reschedule_OverwritesScore 는 같은 jobID 로 재호출 시 score 가
+// 갱신됨을 검증 (가장 최근 호출이 우선).
+func TestEnqueueRetry_Reschedule_OverwritesScore(t *testing.T) {
+	client := newTestClient(t)
+	retryQueueCleanup(t, client)
+	ctx := context.Background()
+
+	jobID := "test-job-reschedule-" + time.Now().Format(time.RFC3339Nano)
+	now := time.Now()
+
+	// 첫 번째: 미래 (pop 대상 아님)
+	require.NoError(t, client.EnqueueRetry(ctx, jobID, []byte("v1"), now.Add(10*time.Second)))
+	due, err := client.PopDueRetries(ctx, now, 10)
+	require.NoError(t, err)
+	assert.Empty(t, due, "첫 enqueue 는 미래 scheduled — pop 대상 아님")
+
+	// 두 번째: 과거로 재스케줄 + payload 교체
+	require.NoError(t, client.EnqueueRetry(ctx, jobID, []byte("v2"), now.Add(-time.Second)))
+	due, err = client.PopDueRetries(ctx, now, 10)
+	require.NoError(t, err)
+	require.Len(t, due, 1)
+	assert.Equal(t, []byte("v2"), due[0].Payload, "재호출 payload 가 우선")
+}
+
+// TestPopDueRetries_StaleEntryGone_SkipsAndCleansZSet 는 entry STRING 만 만료/삭제되어
+// ZSET 에는 jobID 가 남은 stale 상태에서 silent skip + ZSET 정합 회복을 검증.
+func TestPopDueRetries_StaleEntryGone_SkipsAndCleansZSet(t *testing.T) {
+	client := newTestClient(t)
+	retryQueueCleanup(t, client)
+	ctx := context.Background()
+
+	jobID := "test-job-stale-" + time.Now().Format(time.RFC3339Nano)
+	require.NoError(t, client.EnqueueRetry(ctx, jobID, []byte("x"), time.Now().Add(-time.Second)))
+
+	// entry STRING 만 직접 삭제하여 stale 상태 인위적으로 조성
+	require.NoError(t, client.DeleteRetryEntryForTest(ctx, jobID))
+
+	due, err := client.PopDueRetries(ctx, time.Now(), 10)
+	require.NoError(t, err)
+	assert.Empty(t, due, "stale jobID 는 silent skip — 호출자에게 노출 안 함")
+
+	// ZSET 도 정리되었는지 확인 (count==0)
+	n, err := client.PendingRetryCount(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, int64(0), n, "ZSET 에서도 stale jobID 가 제거되어 정합 회복")
+}


### PR DESCRIPTION
## 연관 이슈
- Closes #82

<br>

## 구현 내용

이슈 #82 의 표 중 **옵션 4 (Redis Sorted Set 기반 delay)** 를 채택했습니다. 이미 의존성으로 사용 중인 Redis 를 활용하여 추가 인프라 없이 retry 의 delay 를 worker 외부로 분리합니다.

**구조 변경 전후 비교:**

```
[기존]                                              [본 PR]
worker fetch → processJob → time.Sleep(delay)      worker fetch → processJob → 즉시 처리
   ↑                              ↑                   ↑
   │                  worker 슬롯 점유                Redis ZSET 에서 별도 goroutine 이
재발행: requeueWithRetry             ─→               due 항목을 폴링·재발행
   └─ Kafka publish (ScheduledAt 미래)              ─→ Kafka publish (ScheduledAt 도달 시)
```

**5개 논리 단위 커밋:**

1. `pkg/redis/retry_queue.go` (NEW) — ZSET 기반 delayed queue 연산
   - `EnqueueRetry`: ZADD score=ScheduledAt jobID + SET retry:entry:<id> payload (24h TTL)
   - `PopDueRetries`: ZRANGEBYSCORE -inf~now LIMIT N + 각 jobID 별 GET + ZREM/DEL pipeline
   - Stale 처리 (entry 만료 + ZSET 잔존): silent skip + ZREM 으로 정합 회복
   - 다중 인스턴스 race 는 다운스트림 JobLocker 가 흡수
   - 7개 테스트 (Redis 부재 시 skip 패턴 — 기존 url_cache_test, lock_test 와 동일)

2. `internal/crawler/worker/retry_scheduler.go` (NEW) — `RetryScheduler` 인터페이스 + `KafkaImmediateRetryScheduler`
   - 기존 inline requeue 동작을 그대로 추출 — Redis 부재 시 fallback
   - `retryHeaders` 헬퍼: 두 구현체가 retry-count / last-error 헤더 공유

3. `internal/crawler/worker/retry_scheduler.go` 확장 — `RedisDelayedRetryScheduler`
   - `Enqueue`: job + lastErr 를 JSON entry 로 묶어 Redis ZSET 저장 (worker 호출 후 즉시 반환)
   - `Run`: ticker 기반 폴 루프 (default 1s, 50 batch) — due 항목을 priority 토픽에 재발행
   - `republish`: Kafka publish 실패 시 짧은 backoff 로 Redis 재 enqueue (Kafka 일시 장애 흡수). Redis 재 enqueue 도 실패하면 ERROR + 데이터 손실 (운영자 인지)
   - `pollOnce`: ctx cancel 시 graceful 종료, `Stop` 으로 wg join

4. `internal/crawler/worker/pool.go` MODIFY — inline requeue → RetryScheduler 위임
   - `retryScheduler atomic.Pointer` + `SetRetryScheduler` 메서드 (Gate 와 동일 패턴)
   - `requeueWithRetry`: Marshal/Header 구성/Publish 인라인 코드 제거 → `Enqueue(ctx, job, reason)` 위임
   - `resolveRetryScheduler`: 미주입 시 `KafkaImmediateRetryScheduler` lazy 생성 → 기존 동작 (즉시 publish + worker sleep) 그대로 보존, **회귀 0**
   - `manager.go`: `ManagerConfig.RetryScheduler` 추가 (단일 인스턴스를 세 우선순위 Pool 이 공유)
   - `pkg/redis/retry_queue.go`: `ZRangeByScore` (deprecated) → `ZRangeArgs{ByScore:true}` (staticcheck SA1019)

5. `cmd/issuetracker/main.go` MODIFY — 부트스트랩 통합
   - Redis 가 초기화된 경우 `RedisDelayedRetryScheduler` 생성 + `Run` goroutine 시작 + `defer` 로 cancel + `Stop` 대기
   - `ManagerConfig.RetryScheduler` 로 주입 (모든 priority Pool 이 단일 인스턴스 공유)
   - Redis 부재 / 초기화 실패 시 `retryScheduler=nil` → 각 Pool 이 lazy 로 `KafkaImmediateRetryScheduler` fallback

**총 13개 신규 테스트:**
- `test/pkg/redis/retry_queue_test.go`: roundtrip / future-not-returned / score-order / limit / limit<=0 / 재호출-overwrite / stale entry silent-skip
- `test/internal/worker/retry_scheduler_test.go`: priority→topic 매핑 / publish error wrap / nil lastErr 헤더 누락 / Enqueue payload 검증 / Run due 발행 / 미래 항목 미발행 / publish 실패 재 enqueue / pop 에러 회복 / 0 cfg → default 보정 / SetRetryScheduler 가 inline publish 우회

**핵심 효과:**
- 외부 소스 일시 장애 (429 / 5xx) 로 retry 가 폭증해도 worker 슬롯이 sleep 으로 묶이지 않음
- 동일 priority 의 정상 job 처리량이 retry 사이클의 영향에서 분리됨
- Redis ZSET 영속성 + 24h entry TTL 로 프로세스 crash 에도 retry 데이터 보존
- 다중 인스턴스 환경에서도 안전 (다운스트림 JobLocker 가 race 흡수)

<br>

## CI / 머지 게이트 점검

> [CI 운영 규약](docs/ci/conventions.md) 및 [Required Status Checks 단일 소스](docs/ci/status-checks.md)에 따라 작성합니다.

### 변경 영향 범위
- 영향 패키지/모듈: `pkg/redis`, `internal/crawler/worker`, `cmd/issuetracker`
- 위험도(택1): `Medium`
- 근거:
  - **Low risk** 측면: Redis 부재 시 lazy fallback 으로 기존 동작 100% 보존 (회귀 잠금 테스트 포함). 모든 기존 pool 테스트 통과.
  - **Medium risk 측면**: retry 경로의 핵심 구조 변경이며, Redis 활성 환경에서는 retry 메시지가 Kafka 대신 Redis 에 일시 보관되는 새 데이터 흐름이 도입됨. 운영 모니터링에서 `retry:queue` ZCARD 추적 필요.

### Required Status Checks
- 통과 확인 대상 (PR Checks 탭에서 확인):
  - [ ] `Commit Lint`
  - [ ] `PR Title Lint`
  - [ ] `Linked Issue Check`
  - [ ] `Format Check`
  - [ ] `Build`
  - [ ] `Test`
  - [ ] `Lint`

### 롤백 계획
- 운영 중 Redis ZSET 경로에 문제가 발견되면 `cmd/issuetracker/main.go` 의 `RetryScheduler` 부트스트랩 블록 (5줄) 을 주석 처리하여 즉시 fallback (`KafkaImmediateRetryScheduler`) 로 복귀 — 코드 롤백 불필요
- `retry:queue` ZSET 에 잔존 항목은 24h entry TTL 로 자연 정리되며, 필요 시 `redis-cli DEL retry:queue` + `redis-cli --scan --pattern 'retry:entry:*' | xargs redis-cli DEL` 로 수동 청소
- 코드 차원에서는 본 PR 의 5개 커밋을 차례로 revert

<br>

## TODO
- (옵션) Prometheus 메트릭: `retry:queue` ZCARD / publish failure rate 노출 — 별도 follow-up 이슈로 추적
- (옵션) Lua script 로 `ZRANGEBYSCORE + ZREM + GET + DEL` atomicity 강화 — 현재는 race 시 최대 N회 중복 publish (JobLocker 가 흡수). 운영 관측 후 필요 시 도입
- (옵션) RedisRetrySchedulerConfig 의 PollInterval / BatchSize 를 환경변수로 노출 — 현재는 default 고정

<br>

## 논의 사항
- `RepublishFailureBackoff` 가 1s 로 짧음 — Kafka 가 5분 이상 다운되면 Redis 가 메모리 압박을 받을 수 있음. 운영 관측 후 backoff 가속 (exponential) 또는 retry 횟수 제한 추가 검토.
- ZSET 의 score 가 UnixNano (int64) 인데 Redis 는 score 를 float64 로 저장 — 약 2^53 이후 정밀도 손실 가능 (현재 시각 기준 약 285년 후로 실용적 영향 0).

<br>