### PR TITLE
[FEAT#135] news_articles 에 validator 결과 추적 (validation_status / reject_code / reject_detail)

### DIFF
--- a/cmd/issuetracker/main.go
+++ b/cmd/issuetracker/main.go
@@ -208,7 +208,7 @@ func main() {
 	validateProducer := queue.NewProducer(validateKafkaCfg)
 	defer validateProducer.Close()
 
-	validateWorker := validate.NewWorker(validateConsumer, validateProducer, contentSvc, validateWorkerCount, validateCfg)
+	validateWorker := validate.NewWorker(validateConsumer, validateProducer, contentSvc, newsRepo, validateWorkerCount, validateCfg)
 	validateWorker.Start(ctx)
 
 	log.WithFields(map[string]interface{}{

--- a/cmd/processor/main.go
+++ b/cmd/processor/main.go
@@ -68,6 +68,9 @@ func main() {
 	contentRepo := pgstore.NewContentRepository(pool, log)
 	contentSvc := service.NewContentService(contentRepo, log)
 
+	// 이슈 #135 — validator 결과 (passed/rejected) 를 news_articles 에 기록하여 사후 추적 가능.
+	newsRepo := pgstore.NewNewsArticleRepository(pool, log)
+
 	// ── 4. Consumer / Producer 생성 ───────────────────────────────────────────
 	// Consumer: issuetracker.normalized 구독
 	// Producer: issuetracker.validated, issuetracker.dlq 발행
@@ -78,7 +81,7 @@ func main() {
 	defer producer.Close()
 
 	// ── 5. Validate Worker 시작 ───────────────────────────────────────────────
-	worker := validate.NewWorker(consumer, producer, contentSvc, validateWorkerCount, validateCfg)
+	worker := validate.NewWorker(consumer, producer, contentSvc, newsRepo, validateWorkerCount, validateCfg)
 	worker.Start(ctx)
 
 	log.WithFields(map[string]interface{}{

--- a/internal/processor/validate/community/validator.go
+++ b/internal/processor/validate/community/validator.go
@@ -37,7 +37,24 @@ func (v *Validator) Validate(_ context.Context, content *core.Content) processor
 	errs = append(errs, v.detectFlood(content)...)
 
 	score := v.qualityScore(content)
-	isValid := len(errs) == 0 && score >= float32(v.cfg.CommunityQualityThreshold)
+	threshold := float32(v.cfg.CommunityQualityThreshold)
+
+	// 이슈 #135 — 품질 점수 임계 미달이고 다른 reject 사유 없는 경우, quality_low 에러를
+	// breakdown 과 함께 명시적으로 추가하여 reject 사유의 사후 추적을 가능하게 한다.
+	if score < threshold && len(errs) == 0 {
+		bodyScore := v.scoreBody(content.Body)
+		metaScore := scoreMeta(content)
+		errs = append(errs, processor.ValidationError{
+			Field: "QualityScore",
+			Rule:  "quality_low",
+			Message: fmt.Sprintf(
+				"quality score %.3f below threshold %.3f (body=%.3f, meta=%.3f)",
+				score, threshold, bodyScore, metaScore,
+			),
+		})
+	}
+
+	isValid := len(errs) == 0 && score >= threshold
 
 	return processor.ValidationResult{
 		IsValid:      isValid,

--- a/internal/processor/validate/news/validator.go
+++ b/internal/processor/validate/news/validator.go
@@ -40,7 +40,25 @@ func (v *Validator) Validate(_ context.Context, content *core.Content) processor
 	errs = append(errs, v.detectSpam(content)...)
 
 	score := v.qualityScore(content)
-	isValid := len(errs) == 0 && score >= float32(v.cfg.NewsQualityThreshold)
+	threshold := float32(v.cfg.NewsQualityThreshold)
+
+	// 이슈 #135 — 품질 점수 임계 미달이고 다른 reject 사유 없는 경우, quality_low 에러를
+	// breakdown 과 함께 명시적으로 추가. 이전에는 errs=[] 인 채로 reject 되어 사후 추적 불가.
+	if score < threshold && len(errs) == 0 {
+		wordScore := v.scoreWordCount(content.WordCount)
+		metaScore := scoreMetadata(content)
+		structScore := scoreStructure(content)
+		errs = append(errs, processor.ValidationError{
+			Field: "QualityScore",
+			Rule:  "quality_low",
+			Message: fmt.Sprintf(
+				"quality score %.3f below threshold %.3f (word=%.3f, meta=%.3f, struct=%.3f)",
+				score, threshold, wordScore, metaScore, structScore,
+			),
+		})
+	}
+
+	isValid := len(errs) == 0 && score >= threshold
 
 	return processor.ValidationResult{
 		IsValid:      isValid,

--- a/internal/processor/validate/validator.go
+++ b/internal/processor/validate/validator.go
@@ -63,7 +63,8 @@ func (p *validatorProcessor) Process(ctx context.Context, content *core.Content)
 }
 
 // codeForValidationResult는 ValidationResult.Errors 에서 첫 번째 룰을 참조하여
-// 가장 적절한 에러 코드를 결정합니다. errors 가 비어있으면 임계 미달로 간주합니다.
+// 가장 적절한 에러 코드를 결정합니다. errors 가 비어있으면 임계 미달로 간주합니다 (legacy 안전망 —
+// 이슈 #135 이후 validator 들은 임계 미달 시 명시적으로 quality_low 룰을 errors 에 추가합니다).
 func codeForValidationResult(result processor.ValidationResult) string {
 	if len(result.Errors) == 0 {
 		return core.CodeValQualityLow
@@ -78,6 +79,8 @@ func codeForValidationResult(result processor.ValidationResult) string {
 		return core.CodeValMissingField
 	case "spam_caps", "spam_punct", "spam_flood":
 		return core.CodeValSpam
+	case "quality_low":
+		return core.CodeValQualityLow
 	default:
 		return core.CodeValInvalidFormat
 	}

--- a/internal/processor/validate/worker.go
+++ b/internal/processor/validate/worker.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"issuetracker/internal/crawler/core"
+	"issuetracker/internal/storage"
 	"issuetracker/internal/storage/service"
 	"issuetracker/pkg/config"
 	"issuetracker/pkg/logger"
@@ -29,33 +30,39 @@ const drainTimeout = 5 * time.Second
 // validates it, and publishes ContentRef to issuetracker.validated.
 // On failure, deletes the contents record and routes to DLQ.
 type Worker struct {
-	consumer    queue.Consumer
-	producer    queue.Producer
-	contentSvc  service.ContentService
-	cfg         config.ValidateConfig
-	workerCount int
-	jobs        chan *queue.Message
-	wg          sync.WaitGroup
-	pollWg      sync.WaitGroup
-	pollCancel  context.CancelFunc
+	consumer        queue.Consumer
+	producer        queue.Producer
+	contentSvc      service.ContentService
+	newsArticleRepo storage.NewsArticleRepository // 이슈 #135 — validator 결과 추적 (nil 허용, 미주입 시 update 단계 skip)
+	cfg             config.ValidateConfig
+	workerCount     int
+	jobs            chan *queue.Message
+	wg              sync.WaitGroup
+	pollWg          sync.WaitGroup
+	pollCancel      context.CancelFunc
 }
 
 // NewWorker는 새로운 Worker를 생성합니다.
 // workerCount는 동시에 실행되는 처리 goroutine 수를 결정합니다.
+//
+// newsArticleRepo (이슈 #135) 가 nil 이 아니면 validator 결과 (passed/rejected) 를
+// news_articles 테이블에 기록합니다. nil 이면 update 단계를 건너뜁니다 — 기존 동작 보존.
 func NewWorker(
 	consumer queue.Consumer,
 	producer queue.Producer,
 	contentSvc service.ContentService,
+	newsArticleRepo storage.NewsArticleRepository,
 	workerCount int,
 	cfg config.ValidateConfig,
 ) *Worker {
 	return &Worker{
-		consumer:    consumer,
-		producer:    producer,
-		contentSvc:  contentSvc,
-		cfg:         cfg,
-		workerCount: workerCount,
-		jobs:        make(chan *queue.Message, workerCount*2),
+		consumer:        consumer,
+		producer:        producer,
+		contentSvc:      contentSvc,
+		newsArticleRepo: newsArticleRepo,
+		cfg:             cfg,
+		workerCount:     workerCount,
+		jobs:            make(chan *queue.Message, workerCount*2),
 	}
 }
 
@@ -202,6 +209,10 @@ func (w *Worker) process(ctx context.Context, msg *queue.Message) error {
 				"country": content.Country,
 			}).WithError(err).Info("content validation failed, deleting content and sending to dlq")
 
+			// 이슈 #135 — contents.Delete 직전에 news_articles 에 reject 사유 기록.
+			// 순서가 중요: Delete 후엔 ref.URL 확보 어렵고, 사후 추적 단일 source 가 깨진다.
+			w.recordValidationRejected(ctx, content.URL, err)
+
 			if delErr := w.contentSvc.Delete(ctx, ref.ID); delErr != nil {
 				log.WithFields(map[string]interface{}{
 					"job_id": pm.ID,
@@ -224,6 +235,10 @@ func (w *Worker) process(ctx context.Context, msg *queue.Message) error {
 		}
 		return w.commit(ctx, msg)
 	}
+
+	// 이슈 #135 — 검증 통과: news_articles 에 passed 기록 (publish 전에 호출하여 publish 실패 시
+	// 재처리되더라도 status 는 이미 정확. UpdateValidationStatus 는 idempotent 라 재호출 안전).
+	w.recordValidationPassed(ctx, content.URL)
 
 	if err := w.publishValidatedRef(ctx, &ref, &pm, msg); err != nil {
 		// graceful shutdown 으로 ctx 가 canceled 된 경우, drain context 로 publish-then-commit 재시도.
@@ -279,6 +294,58 @@ func (w *Worker) publishValidatedRef(ctx context.Context, ref *core.ContentRef, 
 	}
 
 	return w.producer.Publish(ctx, outMsg)
+}
+
+// recordValidationRejected 는 validator 영구 실패 시 news_articles 에 reject 메타데이터를
+// 기록합니다 (이슈 #135). 호출은 contentSvc.Delete 직전에 이루어져야 합니다.
+//
+// 본 메소드는 모든 실패를 best-effort 로 처리합니다 — repo 미주입(nil), URL 미존재(ErrNotFound),
+// DB 일시 장애 등 어떤 실패도 메인 처리 흐름을 차단하지 않습니다. 추적이 끊겨도 contents.Delete
+// 와 DLQ 라우팅은 그대로 진행되어야 하기 때문입니다.
+//
+// reject_code 는 errors.As 로 *core.CrawlerError 를 추출하여 .Code (VAL_xxx) 를 사용합니다.
+// reject_detail 은 err.Error() 의 message 부분 — VAL_005 의 quality breakdown 보강은
+// 별도 단계 (이슈 #135 P0-4) 에서 진행됩니다.
+func (w *Worker) recordValidationRejected(ctx context.Context, url string, reason error) {
+	if w.newsArticleRepo == nil || url == "" {
+		return
+	}
+	log := logger.FromContext(ctx)
+
+	var (
+		code   string
+		detail = reason.Error()
+	)
+	var crawlerErr *core.CrawlerError
+	if errors.As(reason, &crawlerErr) {
+		code = crawlerErr.Code
+	}
+
+	if err := w.newsArticleRepo.UpdateValidationStatus(
+		ctx, url, storage.ValidationStatusRejected, code, detail,
+	); err != nil {
+		log.WithFields(map[string]interface{}{
+			"url":         url,
+			"reject_code": code,
+		}).WithError(err).Warn("failed to record validation rejection in news_articles")
+	}
+}
+
+// recordValidationPassed 는 validator 통과 시 news_articles.validation_status 를
+// 'passed' 로 갱신합니다 (이슈 #135). best-effort — 실패가 메인 흐름을 차단하지 않습니다.
+func (w *Worker) recordValidationPassed(ctx context.Context, url string) {
+	if w.newsArticleRepo == nil || url == "" {
+		return
+	}
+	log := logger.FromContext(ctx)
+
+	if err := w.newsArticleRepo.UpdateValidationStatus(
+		ctx, url, storage.ValidationStatusPassed, "", "",
+	); err != nil {
+		log.WithFields(map[string]interface{}{
+			"url": url,
+		}).WithError(err).Warn("failed to record validation pass in news_articles")
+	}
 }
 
 // sendToDLQ는 메시지를 DLQ 토픽으로 발행합니다.

--- a/internal/processor/validate/worker.go
+++ b/internal/processor/validate/worker.go
@@ -319,6 +319,9 @@ func (w *Worker) recordValidationRejected(ctx context.Context, url string, reaso
 	var crawlerErr *core.CrawlerError
 	if errors.As(reason, &crawlerErr) {
 		code = crawlerErr.Code
+		// CrawlerError.Error() 는 "[<cat>:<code>] <msg>" 포맷이라 reject_code 와 중복.
+		// reject_detail 에는 message 본문만 저장한다 (Gemini code review 피드백).
+		detail = crawlerErr.Message
 	}
 
 	if err := w.newsArticleRepo.UpdateValidationStatus(

--- a/internal/storage/news_article.go
+++ b/internal/storage/news_article.go
@@ -7,6 +7,19 @@ import (
 	"time"
 )
 
+// ValidationStatus 는 validator 처리 결과의 라이프사이클을 나타냅니다 (이슈 #135).
+//
+// 전이: Pending → (validator) → Passed | Rejected
+//
+//   - Pending  : chain_handler 가 INSERT 한 직후 기본값
+//   - Passed   : validator 통과 (issuetracker.validated 발행 직후)
+//   - Rejected : validator maxRetries 영구 실패 (contentSvc.Delete 직전)
+const (
+	ValidationStatusPending  = "pending"
+	ValidationStatusPassed   = "passed"
+	ValidationStatusRejected = "rejected"
+)
+
 // NewsArticleRecord는 news_articles 테이블의 단일 행을 나타냅니다.
 //
 // NewsArticleRecord represents a single row in the news_articles table.
@@ -27,6 +40,12 @@ type NewsArticleRecord struct {
 	PublishedAt *time.Time // nil: 발행 시각 불명
 	FetchedAt   time.Time
 	CreatedAt   time.Time
+
+	// validator 추적 (이슈 #135) — Insert 시점에는 항상 default (Pending, NULL, NULL).
+	// validator worker 가 UpdateValidationStatus 로 갱신.
+	ValidationStatus string  // "pending" | "passed" | "rejected"
+	RejectCode       *string // VAL_001 ~ VAL_006 (Rejected 시에만 non-nil)
+	RejectDetail     *string // validator errors array JSON (Rejected 시에만 non-nil)
 }
 
 // NewsArticleRepository는 news_articles 테이블에 대한 데이터 접근 인터페이스입니다.
@@ -46,6 +65,15 @@ type NewsArticleRepository interface {
 	// List는 필터 조건에 맞는 기사 목록을 published_at DESC 순으로 반환합니다.
 	// Limit이 0이면 기본값(50)을 사용합니다.
 	List(ctx context.Context, filter NewsArticleFilter) ([]*NewsArticleRecord, error)
+
+	// UpdateValidationStatus 는 URL 기준으로 validator 결과 메타데이터를 갱신합니다 (이슈 #135).
+	//
+	// status 가 ValidationStatusRejected 가 아니면 code/detail 은 NULL 로 저장됩니다 (호출자가
+	// 빈 문자열을 넘겨도 됨). URL 이 존재하지 않으면 ErrNotFound 를 반환합니다.
+	//
+	// validator worker 는 contentSvc.Delete 직전에 본 메소드를 호출하여 reject 메타데이터를
+	// news_articles 에 보관합니다 — contents 에서 record 가 사라져도 사후 추적 가능.
+	UpdateValidationStatus(ctx context.Context, url, status, code, detail string) error
 }
 
 // NewsArticleFilter는 List 조회 시 사용하는 필터 조건입니다.

--- a/internal/storage/postgres/news_article.go
+++ b/internal/storage/postgres/news_article.go
@@ -66,7 +66,8 @@ const sqlGetByURL = `
 SELECT
   id, source_name, source_type, country, language,
   url, title, body, summary, author,
-  category, tags, image_urls, published_at, fetched_at, created_at
+  category, tags, image_urls, published_at, fetched_at, created_at,
+  validation_status, reject_code, reject_detail
 FROM news_articles
 WHERE url = $1
 `
@@ -97,7 +98,8 @@ func (r *pgNewsArticleRepository) List(ctx context.Context, f storage.NewsArticl
 SELECT
   id, source_name, source_type, country, language,
   url, title, body, summary, author,
-  category, tags, image_urls, published_at, fetched_at, created_at
+  category, tags, image_urls, published_at, fetched_at, created_at,
+  validation_status, reject_code, reject_detail
 FROM news_articles
 WHERE 1=1`
 
@@ -156,10 +158,48 @@ func scanNewsArticle(s scanner) (*storage.NewsArticleRecord, error) {
 		&a.ID, &a.SourceName, &a.SourceType, &a.Country, &a.Language,
 		&a.URL, &a.Title, &a.Body, &a.Summary, &a.Author,
 		&a.Category, &a.Tags, &a.ImageURLs, &a.PublishedAt, &a.FetchedAt, &a.CreatedAt,
+		&a.ValidationStatus, &a.RejectCode, &a.RejectDetail,
 	)
 	if err != nil {
 		return nil, err
 	}
 
 	return a, nil
+}
+
+const sqlUpdateValidationStatus = `
+UPDATE news_articles
+SET
+  validation_status = $2,
+  reject_code       = $3,
+  reject_detail     = $4
+WHERE url = $1
+`
+
+// UpdateValidationStatus 는 URL 기준으로 validator 결과 메타데이터를 갱신합니다 (이슈 #135).
+//
+// status 가 storage.ValidationStatusRejected 가 아니면 code/detail 인자는 무시되고 NULL 로 저장됩니다.
+// URL 이 존재하지 않으면 storage.ErrNotFound 를 반환합니다.
+func (r *pgNewsArticleRepository) UpdateValidationStatus(ctx context.Context, url, status, code, detail string) error {
+	var (
+		codeArg   any
+		detailArg any
+	)
+	if status == storage.ValidationStatusRejected {
+		if code != "" {
+			codeArg = code
+		}
+		if detail != "" {
+			detailArg = detail
+		}
+	}
+
+	tag, err := r.pool.Exec(ctx, sqlUpdateValidationStatus, url, status, codeArg, detailArg)
+	if err != nil {
+		return fmt.Errorf("update validation status %s: %w", url, err)
+	}
+	if tag.RowsAffected() == 0 {
+		return storage.ErrNotFound
+	}
+	return nil
 }

--- a/migrations/down/005_news_articles_validation_tracking.sql
+++ b/migrations/down/005_news_articles_validation_tracking.sql
@@ -1,0 +1,9 @@
+-- 005_news_articles_validation_tracking 롤백 — 역순으로 모든 변경 사항 제거
+
+DROP INDEX IF EXISTS idx_news_articles_validation_status;
+
+ALTER TABLE news_articles
+  DROP CONSTRAINT IF EXISTS news_articles_validation_status_check,
+  DROP COLUMN IF EXISTS reject_detail,
+  DROP COLUMN IF EXISTS reject_code,
+  DROP COLUMN IF EXISTS validation_status;

--- a/migrations/up/005_news_articles_validation_tracking.sql
+++ b/migrations/up/005_news_articles_validation_tracking.sql
@@ -1,0 +1,24 @@
+-- 005_news_articles_validation_tracking: validator 결과 추적용 컬럼 추가 (이슈 #135)
+--
+-- 배경:
+--   #132 라이브 검증으로 validator 가 maxRetries 영구 실패 시 contents 에서 record 를
+--   삭제하면 reject 사유 추적이 불가능함이 확정됐다 (worker.go:205, contentSvc.Delete).
+--   news_articles 는 chain_handler 가 INSERT 한 후 그대로 남으므로 검증 결과 메타데이터를
+--   여기에 보관하여 사후 추적 / 운영 metric / 알림 기반 작업의 단일 source 로 활용한다.
+--
+-- 변경 사항:
+--   1. validation_status — pending / passed / rejected
+--   2. reject_code      — VAL_001 ~ VAL_006 등 (rejected 시에만 NOT NULL 의미)
+--   3. reject_detail    — validator errors array JSON 직렬화
+--   4. 인덱스           — (validation_status, created_at DESC)
+
+ALTER TABLE news_articles
+  ADD COLUMN validation_status TEXT NOT NULL DEFAULT 'pending',
+  ADD COLUMN reject_code       VARCHAR(20),
+  ADD COLUMN reject_detail     TEXT,
+  ADD CONSTRAINT news_articles_validation_status_check
+    CHECK (validation_status IN ('pending', 'passed', 'rejected'));
+
+-- reject 분포 / 시계열 조회 가속 (운영 metric / 대시보드 지원)
+CREATE INDEX IF NOT EXISTS idx_news_articles_validation_status
+  ON news_articles (validation_status, created_at DESC);

--- a/test/internal/processor/validate/worker_test.go
+++ b/test/internal/processor/validate/worker_test.go
@@ -100,6 +100,33 @@ func (m *mockContentService) Delete(ctx context.Context, id string) error {
 	return args.Error(0)
 }
 
+// mockNewsArticleRepository 는 이슈 #135 — Worker 가 reject/passed 결과를 news_articles 에
+// 기록하는지 검증하기 위한 mock 입니다.
+type mockNewsArticleRepository struct{ mock.Mock }
+
+func (m *mockNewsArticleRepository) Insert(ctx context.Context, a *storage.NewsArticleRecord) error {
+	args := m.Called(ctx, a)
+	return args.Error(0)
+}
+
+func (m *mockNewsArticleRepository) GetByURL(ctx context.Context, url string) (*storage.NewsArticleRecord, error) {
+	args := m.Called(ctx, url)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*storage.NewsArticleRecord), args.Error(1)
+}
+
+func (m *mockNewsArticleRepository) List(ctx context.Context, f storage.NewsArticleFilter) ([]*storage.NewsArticleRecord, error) {
+	args := m.Called(ctx, f)
+	return args.Get(0).([]*storage.NewsArticleRecord), args.Error(1)
+}
+
+func (m *mockNewsArticleRepository) UpdateValidationStatus(ctx context.Context, url, status, code, detail string) error {
+	args := m.Called(ctx, url, status, code, detail)
+	return args.Error(0)
+}
+
 // ─────────────────────────────────────────────────────────────────────────────
 // 헬퍼
 // ─────────────────────────────────────────────────────────────────────────────
@@ -138,6 +165,11 @@ func newWorker(consumer queue.Consumer, producer queue.Producer, contentSvc serv
 	// 이슈 #135 — newsArticleRepo nil 전달 시 worker 가 update 단계를 skip 하므로 기존 테스트
 	// 시나리오를 그대로 보존. 별도 테스트가 newsArticleRepo 호출 동작을 검증.
 	return validate.NewWorker(consumer, producer, contentSvc, nil, 1, config.DefaultValidateConfig())
+}
+
+// newWorkerWithRepo 는 이슈 #135 의 reject/passed 추적 동작을 테스트할 때 사용합니다.
+func newWorkerWithRepo(consumer queue.Consumer, producer queue.Producer, contentSvc service.ContentService, repo storage.NewsArticleRepository) *validate.Worker {
+	return validate.NewWorker(consumer, producer, contentSvc, repo, 1, config.DefaultValidateConfig())
 }
 
 func runWorker(t *testing.T, consumer *mockConsumer, w *validate.Worker, msg *queue.Message) {
@@ -657,4 +689,109 @@ func TestValidateWorker_DLQDrainsOnContextCanceled(t *testing.T) {
 
 	producer.AssertNumberOfCalls(t, "Publish", 2)
 	consumer.AssertCalled(t, "CommitMessages", mock.Anything, mock.Anything)
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 이슈 #135 — news_articles validation_status 추적 동작 테스트
+// ─────────────────────────────────────────────────────────────────────────────
+
+func TestValidateWorker_InvalidContent_RecordsRejectedInNewsArticles(t *testing.T) {
+	consumer := new(mockConsumer)
+	producer := new(mockProducer)
+	contentSvc := new(mockContentService)
+	repo := new(mockNewsArticleRepository)
+
+	w := newWorkerWithRepo(consumer, producer, contentSvc, repo)
+
+	content := newNewsContent()
+	content.Title = "x"
+	content.Body = "short body"
+	content.PublishedAt = time.Time{}
+	msg := makeProcessingMessage(content, 3) // maxRetries 도달 → deleting 경로
+
+	contentSvc.On("GetByID", mock.Anything, content.ID).Return(content, nil)
+	contentSvc.On("Delete", mock.Anything, content.ID).Return(nil)
+	producer.On("Publish", mock.Anything, mock.MatchedBy(func(m queue.Message) bool {
+		return m.Topic == queue.TopicDLQ
+	})).Return(nil)
+	consumer.On("CommitMessages", mock.Anything, mock.Anything).Return(nil)
+
+	// reject 메타데이터가 url 기준으로 update 되어야 함. code 는 VAL_xxx, detail 은 비어있지 않음.
+	repo.On("UpdateValidationStatus",
+		mock.Anything,
+		content.URL,
+		storage.ValidationStatusRejected,
+		mock.MatchedBy(func(code string) bool { return strings.HasPrefix(code, "VAL_") }),
+		mock.MatchedBy(func(detail string) bool { return detail != "" }),
+	).Return(nil).Once()
+
+	runWorker(t, consumer, w, msg)
+
+	repo.AssertExpectations(t)
+}
+
+func TestValidateWorker_ValidContent_RecordsPassedInNewsArticles(t *testing.T) {
+	consumer := new(mockConsumer)
+	producer := new(mockProducer)
+	contentSvc := new(mockContentService)
+	repo := new(mockNewsArticleRepository)
+
+	w := newWorkerWithRepo(consumer, producer, contentSvc, repo)
+
+	content := newNewsContent()
+	msg := makeProcessingMessage(content, 0)
+
+	contentSvc.On("GetByID", mock.Anything, content.ID).Return(content, nil)
+	producer.On("Publish", mock.Anything, mock.MatchedBy(func(m queue.Message) bool {
+		return m.Topic == queue.TopicValidated
+	})).Return(nil)
+	consumer.On("CommitMessages", mock.Anything, mock.Anything).Return(nil)
+
+	// passed 시에는 code/detail 모두 빈 문자열로 호출 (UpdateValidationStatus 가 NULL 로 저장)
+	repo.On("UpdateValidationStatus",
+		mock.Anything,
+		content.URL,
+		storage.ValidationStatusPassed,
+		"",
+		"",
+	).Return(nil).Once()
+
+	runWorker(t, consumer, w, msg)
+
+	repo.AssertExpectations(t)
+}
+
+func TestValidateWorker_RecordRejectedFailure_DoesNotBlockMainFlow(t *testing.T) {
+	consumer := new(mockConsumer)
+	producer := new(mockProducer)
+	contentSvc := new(mockContentService)
+	repo := new(mockNewsArticleRepository)
+
+	w := newWorkerWithRepo(consumer, producer, contentSvc, repo)
+
+	content := newNewsContent()
+	content.Title = "x"
+	content.Body = "short body"
+	content.PublishedAt = time.Time{}
+	msg := makeProcessingMessage(content, 3)
+
+	contentSvc.On("GetByID", mock.Anything, content.ID).Return(content, nil)
+	contentSvc.On("Delete", mock.Anything, content.ID).Return(nil)
+	producer.On("Publish", mock.Anything, mock.MatchedBy(func(m queue.Message) bool {
+		return m.Topic == queue.TopicDLQ
+	})).Return(nil)
+	consumer.On("CommitMessages", mock.Anything, mock.Anything).Return(nil)
+
+	// repo update 실패 — best-effort 정책상 worker 메인 흐름 (Delete + DLQ) 은 그대로 진행되어야 함
+	repo.On("UpdateValidationStatus",
+		mock.Anything, content.URL, storage.ValidationStatusRejected,
+		mock.Anything, mock.Anything,
+	).Return(errors.New("simulated db error")).Once()
+
+	runWorker(t, consumer, w, msg)
+
+	contentSvc.AssertCalled(t, "Delete", mock.Anything, content.ID)
+	producer.AssertCalled(t, "Publish", mock.Anything, mock.MatchedBy(func(m queue.Message) bool {
+		return m.Topic == queue.TopicDLQ
+	}))
 }

--- a/test/internal/processor/validate/worker_test.go
+++ b/test/internal/processor/validate/worker_test.go
@@ -135,7 +135,9 @@ func makeProcessingMessage(content *core.Content, retryCount int) *queue.Message
 }
 
 func newWorker(consumer queue.Consumer, producer queue.Producer, contentSvc service.ContentService) *validate.Worker {
-	return validate.NewWorker(consumer, producer, contentSvc, 1, config.DefaultValidateConfig())
+	// 이슈 #135 — newsArticleRepo nil 전달 시 worker 가 update 단계를 skip 하므로 기존 테스트
+	// 시나리오를 그대로 보존. 별도 테스트가 newsArticleRepo 호출 동작을 검증.
+	return validate.NewWorker(consumer, producer, contentSvc, nil, 1, config.DefaultValidateConfig())
 }
 
 func runWorker(t *testing.T, consumer *mockConsumer, w *validate.Worker, msg *queue.Message) {


### PR DESCRIPTION
## 연관 이슈
- Closes #135
- 후속: #132 (closed) — validator-as-cause 가설 라이브 검증 결과의 P0 작업 항목 구현

<br>

## 구현 내용

#132 라이브 검증 결과(5건 deleting = +5 news_only delta = SHA-256 1:1 매칭) 로 validator maxRetries 영구 실패 시 `contentSvc.Delete` 호출이 정합성 차이의 직접 원인임이 확정됐다. 본 PR은 이슈 #135 의 P0 작업 — **사후 추적 단일 source 마련 + VAL_005 detail 보강**을 구현한다. 5개 논리적 커밋:

1. **`[FEAT]` migration 005** — `news_articles` 에 `validation_status` (pending/passed/rejected) + `reject_code` (VAL_xxx) + `reject_detail` 컬럼 추가, `(validation_status, created_at DESC)` 인덱스 + CHECK 제약
2. **`[FEAT]` Repository** — `NewsArticleRepository.UpdateValidationStatus(ctx, url, status, code, detail)` 추가, URL 미존재 시 `ErrNotFound`. Rejected 가 아니면 code/detail 은 NULL 저장
3. **`[FEAT]` Worker wire** — `validate.Worker` 에 `newsArticleRepo` 의존성 주입 (nil 허용). `recordValidationRejected` (`contentSvc.Delete` **직전** 호출) + `recordValidationPassed`. best-effort. `cmd/issuetracker`, `cmd/processor` 양쪽 main 에 wiring 추가
4. **`[FIX]` VAL_005 breakdown** — 임계 미달 시 `errors=[]` 채로 reject 되어 사후 추적 불가하던 문제 해결. `news/validator.go`, `community/validator.go` 모두 `score < threshold && len(errs)==0` 인 경우 `quality_low` 룰 + breakdown 추가
5. **`[FEAT]` Tests** — Worker reject/passed 추적 + best-effort 정책 단위 테스트 3건, `mockNewsArticleRepository` 신규

라이브 검증 (#132) 의 5건 deleting 사례가 본 변경 후엔 `news_articles.validation_status='rejected'`, `reject_code='VAL_005'/'VAL_006'`, `reject_detail` 에 의미있는 메시지가 보존된다.

<br>

## CI / 머지 게이트 점검

### 변경 영향 범위
- 영향 패키지/모듈: `migrations/`, `internal/storage/{,postgres/}`, `internal/processor/validate/{,news/,community/}`, `cmd/{issuetracker,processor}`, `test/internal/processor/validate/`
- 위험도: `Low` — 신규 컬럼 (default `pending`), Worker 의 newsArticleRepo nil 시 기존 동작 보존

### Required Status Checks
- 통과 확인 대상:
  - [ ] `Commit Lint`
  - [ ] `PR Title Lint`
  - [ ] `Linked Issue Check`
  - [ ] `Format Check`
  - [ ] `Build`
  - [ ] `Test`
  - [ ] `Lint`

로컬 검증: `go test -race -count=1 ./...` (19 패키지) / `gofmt -l .` clean / `go build ./...` 모두 통과.

### 롤백 계획
- 코드 롤백: 단일 PR revert
- DB 롤백: `migrations/down/005_news_articles_validation_tracking.sql` 가 인덱스 → 제약 → 컬럼 순으로 역순 제거
- 컬럼이 default `pending` 이라 코드 롤백 후에도 데이터 유실 없음

<br>

## TODO
- (별도 PR) P1: Prometheus metric `issuetracker_validator_rejects_total{code,source}` + Grafana 대시보드
- (별도 PR) P2: 시간당 reject baseline (5~9/h) 초과 시 알림
- (선택) 과거 911건 news_only URL 의 일회성 backfill — `validation_status='rejected'` 일괄 update

<br>

## 논의 사항
- `UpdateValidationStatus` 호출 순서를 publishValidatedRef **직전**으로 잡았다 — publish 후 호출하면 publish 실패로 재처리될 때 status가 일시적으로 잘못된 상태가 될 수 있다. UpdateValidationStatus 는 idempotent 라 재호출 안전.
- VAL_005 이외 코드(VAL_001~004, 006)는 이미 `Errors[0].Rule` 매핑이 정확하므로 breakdown 추가 안 함 — 필요 시 후속 PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)