### PR TITLE
[FEAT#137] DEBUG 레벨 작업 가시성 강화 — JobLocker / CircuitBreaker / RetryScheduler / WorkerPool lifecycle 로그

### DIFF
--- a/internal/crawler/worker/circuit_breaker.go
+++ b/internal/crawler/worker/circuit_breaker.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"sync"
 	"time"
+
+	"issuetracker/pkg/logger"
 )
 
 // cbState는 circuit breaker 상태를 나타냅니다.
@@ -61,6 +63,7 @@ var DefaultCircuitBreakerConfig = CircuitBreakerConfig{
 type CircuitBreaker struct {
 	config CircuitBreakerConfig
 	source string
+	log    *logger.Logger // 이슈 #137 — state 전이 가시성용 (nil 허용 — 미주입 시 로그 skip)
 
 	mu          sync.Mutex
 	state       cbState
@@ -69,10 +72,11 @@ type CircuitBreaker struct {
 	probeActive bool      // HalfOpen probe 진행 중 여부
 }
 
-func newCircuitBreaker(source string, config CircuitBreakerConfig) *CircuitBreaker {
+func newCircuitBreaker(source string, config CircuitBreakerConfig, log *logger.Logger) *CircuitBreaker {
 	return &CircuitBreaker{
 		config: config,
 		source: source,
+		log:    log,
 		state:  cbStateClosed,
 	}
 }
@@ -90,8 +94,12 @@ func (cb *CircuitBreaker) Allow() bool {
 	case cbStateOpen:
 		// OpenTimeout 경과 시 HalfOpen으로 전환하여 probe 허용
 		if time.Since(cb.openedAt) >= cb.config.OpenTimeout {
+			openFor := time.Since(cb.openedAt)
 			cb.state = cbStateHalfOpen
 			cb.probeActive = true
+			cb.logTransition("open", "half_open", map[string]interface{}{
+				"open_for_ms": openFor.Milliseconds(),
+			}, false)
 			return true
 		}
 		return false
@@ -119,6 +127,7 @@ func (cb *CircuitBreaker) RecordSuccess() {
 	if cb.state == cbStateHalfOpen {
 		cb.state = cbStateClosed
 		cb.probeActive = false
+		cb.logTransition("half_open", "closed", nil, false)
 	}
 }
 
@@ -135,6 +144,10 @@ func (cb *CircuitBreaker) RecordFailure() {
 		if cb.failures >= cb.config.MaxFailures {
 			cb.state = cbStateOpen
 			cb.openedAt = time.Now()
+			cb.logTransition("closed", "open", map[string]interface{}{
+				"failures":     cb.failures,
+				"max_failures": cb.config.MaxFailures,
+			}, true)
 		}
 
 	case cbStateHalfOpen:
@@ -142,6 +155,33 @@ func (cb *CircuitBreaker) RecordFailure() {
 		cb.state = cbStateOpen
 		cb.openedAt = time.Now()
 		cb.probeActive = false
+		cb.logTransition("half_open", "open", nil, true)
+	}
+}
+
+// logTransition 은 state 전이를 구조화 로그로 출력합니다 (이슈 #137).
+//
+// asWarn=true 면 WARN, false 면 INFO 레벨로 출력합니다 — open 으로 들어가는 전이는
+// 운영 알림 가치가 있어 WARN, 그 외 (probing/recovered) 는 INFO. logger 미주입 시 no-op.
+//
+// 호출자는 cb.mu 를 이미 보유하고 있어야 합니다 — 이 메소드는 추가 lock 을 잡지 않습니다.
+func (cb *CircuitBreaker) logTransition(from, to string, extra map[string]interface{}, asWarn bool) {
+	if cb.log == nil {
+		return
+	}
+	fields := map[string]interface{}{
+		"source":     cb.source,
+		"from_state": from,
+		"to_state":   to,
+	}
+	for k, v := range extra {
+		fields[k] = v
+	}
+	entry := cb.log.WithFields(fields)
+	if asWarn {
+		entry.Warn("circuit breaker state transition")
+	} else {
+		entry.Info("circuit breaker state transition")
 	}
 }
 
@@ -163,14 +203,17 @@ func (cb *CircuitBreaker) Failures() int {
 // goroutine-safe합니다.
 type CircuitBreakerRegistry struct {
 	config CircuitBreakerConfig
+	log    *logger.Logger // 이슈 #137 — 신규 CB 생성 시 주입 (nil 허용)
 	mu     sync.RWMutex
 	cbs    map[string]*CircuitBreaker
 }
 
 // NewCircuitBreakerRegistry는 CircuitBreakerRegistry를 생성합니다.
-func NewCircuitBreakerRegistry(config CircuitBreakerConfig) *CircuitBreakerRegistry {
+// log 가 nil 이 아니면 각 CB 의 state 전이 로그가 출력됩니다 (이슈 #137).
+func NewCircuitBreakerRegistry(config CircuitBreakerConfig, log *logger.Logger) *CircuitBreakerRegistry {
 	return &CircuitBreakerRegistry{
 		config: config,
+		log:    log,
 		cbs:    make(map[string]*CircuitBreaker),
 	}
 }
@@ -191,7 +234,7 @@ func (r *CircuitBreakerRegistry) Get(source string) *CircuitBreaker {
 	if cb, ok = r.cbs[source]; ok {
 		return cb
 	}
-	cb = newCircuitBreaker(source, r.config)
+	cb = newCircuitBreaker(source, r.config, r.log)
 	r.cbs[source] = cb
 	return cb
 }

--- a/internal/crawler/worker/manager.go
+++ b/internal/crawler/worker/manager.go
@@ -84,7 +84,8 @@ func NewPoolManager(
 
 	// 세 개 Pool이 동일한 CircuitBreakerRegistry를 공유하여
 	// 소스별 실패 카운팅이 우선순위 경계 없이 누적됩니다.
-	cbRegistry := NewCircuitBreakerRegistry(DefaultCircuitBreakerConfig)
+	// log 주입 (이슈 #137) — CB state 전이마다 INFO/WARN 로그.
+	cbRegistry := NewCircuitBreakerRegistry(DefaultCircuitBreakerConfig, log)
 
 	newPool := func(pc PoolConfig) *KafkaConsumerPool {
 		pool := NewKafkaConsumerPoolWithOptions(

--- a/internal/crawler/worker/manager.go
+++ b/internal/crawler/worker/manager.go
@@ -87,11 +87,13 @@ func NewPoolManager(
 	// log 주입 (이슈 #137) — CB state 전이마다 INFO/WARN 로그.
 	cbRegistry := NewCircuitBreakerRegistry(DefaultCircuitBreakerConfig, log)
 
-	newPool := func(pc PoolConfig) *KafkaConsumerPool {
+	newPool := func(pc PoolConfig, priorityName string) *KafkaConsumerPool {
 		pool := NewKafkaConsumerPoolWithOptions(
 			pc.Consumer, producer, handler, contentSvc, pc.WorkerCount,
 			cbRegistry, jobLocker, urlCache,
 		)
+		// 이슈 #137 — heartbeat 식별자 주입 (DEBUG 레벨에서 worker pool status 출력 활성)
+		pool.SetPriority(priorityName)
 		// 단일 RetryScheduler 인스턴스를 세 우선순위 Pool 이 공유합니다 (이슈 #82) —
 		// Redis 기반 구현에서 ZSET/연결 풀이 통일되도록.
 		if cfg.RetryScheduler != nil {
@@ -102,9 +104,9 @@ func NewPoolManager(
 
 	return &PoolManager{
 		pools: map[core.Priority]*KafkaConsumerPool{
-			core.PriorityHigh:   newPool(cfg.High),
-			core.PriorityNormal: newPool(cfg.Normal),
-			core.PriorityLow:    newPool(cfg.Low),
+			core.PriorityHigh:   newPool(cfg.High, "high"),
+			core.PriorityNormal: newPool(cfg.Normal, "normal"),
+			core.PriorityLow:    newPool(cfg.Low, "low"),
 		},
 		producer: producer,
 		resolver: resolver,

--- a/internal/crawler/worker/pool.go
+++ b/internal/crawler/worker/pool.go
@@ -385,11 +385,18 @@ func (p *KafkaConsumerPool) processJob(ctx context.Context, item jobItem) error 
 		log.WithFields(map[string]interface{}{
 			"job_id":  item.job.ID,
 			"crawler": item.job.CrawlerName,
-		}).Debug("job already being processed by another worker, skipping")
+		}).Debug("job lock already held by another worker, skipping")
 		// 다른 워커가 처리 중이므로 commit 없이 종료합니다.
 		// 처리 담당 워커의 commit에 의존하여, 해당 워커 장애 시 재처리가 보장되도록 합니다.
 		return nil
 	} else {
+		// 이슈 #137 — 운영자가 lock 획득 흐름을 추적할 수 있도록 DEBUG 로 success 기록.
+		log.WithFields(map[string]interface{}{
+			"job_id":  item.job.ID,
+			"crawler": item.job.CrawlerName,
+			"ttl_ms":  DefaultJobLockTTL.Milliseconds(),
+		}).Debug("job lock acquired")
+
 		defer func() {
 			// 셧다운 시 ctx가 취소되어도 락 해제는 반드시 수행되어야 합니다.
 			// 작업 ctx를 그대로 사용하면 Redis 호출이 즉시 실패해 락이 TTL(10분) 동안 점유됩니다.
@@ -400,7 +407,13 @@ func (p *KafkaConsumerPool) processJob(ctx context.Context, item jobItem) error 
 					"job_id":  item.job.ID,
 					"crawler": item.job.CrawlerName,
 				}).WithError(releaseErr).Warn("failed to release job lock")
+				return
 			}
+			// 이슈 #137 — release 성공도 DEBUG 로 짝을 맞춰 lifecycle 완성.
+			log.WithFields(map[string]interface{}{
+				"job_id":  item.job.ID,
+				"crawler": item.job.CrawlerName,
+			}).Debug("job lock released")
 		}()
 	}
 

--- a/internal/crawler/worker/pool.go
+++ b/internal/crawler/worker/pool.go
@@ -108,9 +108,11 @@ func NewKafkaConsumerPool(
 	contentSvc service.ContentService,
 	workerCount int,
 ) *KafkaConsumerPool {
+	// CircuitBreakerRegistry log 주입은 NewPoolManager 가 PoolManager 단위에서 처리.
+	// 본 헬퍼는 단순 호출용 (테스트/예제) 이라 logger 주입 안 함 — nil 이면 state 전이 로그 skip.
 	return NewKafkaConsumerPoolWithOptions(
 		consumer, producer, handler, contentSvc, workerCount,
-		NewCircuitBreakerRegistry(DefaultCircuitBreakerConfig),
+		NewCircuitBreakerRegistry(DefaultCircuitBreakerConfig, nil),
 		NoopJobLocker{},
 		NoopURLCache{},
 	)

--- a/internal/crawler/worker/pool.go
+++ b/internal/crawler/worker/pool.go
@@ -88,6 +88,13 @@ type KafkaConsumerPool struct {
 	// pollDone은 pollMessages goroutine이 완전히 종료됐음을 알리는 신호입니다.
 	// close(p.jobs) 전에 반드시 이 채널이 닫혔음을 확인해야 합니다.
 	pollDone chan struct{}
+
+	// 이슈 #137 — heartbeat 가시성. processJob 진입 시 inc, defer 시 dec.
+	// 운영자가 "silent vs hang" 을 즉답하기 위한 단일 source of truth.
+	busyCount atomic.Int32
+	// priority 는 heartbeat 로그에 포함될 pool 식별자 ("high"/"normal"/"low").
+	// 빈 문자열이면 heartbeat goroutine 자체가 시작되지 않음 (테스트 호환).
+	priority string
 }
 
 type jobItem struct {
@@ -214,6 +221,13 @@ func (p *KafkaConsumerPool) normalizeURL(rawURL string) string {
 	return normalized
 }
 
+// SetPriority 는 heartbeat 로그에 사용할 pool 식별자를 설정합니다 (이슈 #137).
+// 빈 문자열이면 heartbeat goroutine 이 시작되지 않아 기존 동작이 유지됩니다.
+// Start 호출 전에 설정해야 효과가 있습니다.
+func (p *KafkaConsumerPool) SetPriority(name string) {
+	p.priority = name
+}
+
 // Start는 worker goroutine들과 message polling goroutine을 시작합니다.
 // context가 cancel되면 polling이 중단되고 진행 중인 작업이 완료됩니다.
 func (p *KafkaConsumerPool) Start(ctx context.Context) {
@@ -228,6 +242,41 @@ func (p *KafkaConsumerPool) Start(ctx context.Context) {
 		defer close(p.pollDone)
 		p.pollMessages(ctx)
 	}()
+
+	// 이슈 #137 — heartbeat goroutine. priority 가 설정된 경우만 시작 (테스트 호환).
+	// silent vs hang 즉답을 위해 30초마다 worker pool status 를 DEBUG 로 출력.
+	// ctx cancel 시 자체 종료 — wg 등록 안 함 (관찰용 goroutine).
+	if p.priority != "" {
+		go p.heartbeatLoop(ctx)
+	}
+}
+
+// heartbeatLoop 는 30초마다 worker pool 의 현재 상태 (busy/total/buffered) 를 DEBUG 로
+// 출력합니다 (이슈 #137). 운영자가 LOG_LEVEL=debug 로 토글 시 silent 구간이 정상 idle
+// 인지 (busy=0, buffer=0) 또는 long-running 처리 중인지 (busy>0) 즉답할 수 있습니다.
+//
+// ctx cancel 시 자체 종료 — wg 미등록 (관찰용이라 셧다운을 차단할 책임 없음).
+func (p *KafkaConsumerPool) heartbeatLoop(ctx context.Context) {
+	const interval = 30 * time.Second
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+
+	log := logger.FromContext(ctx)
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			busy := int(p.busyCount.Load())
+			log.WithFields(map[string]interface{}{
+				"priority":      p.priority,
+				"busy_workers":  busy,
+				"total_workers": p.workerCount,
+				"jobs_buffered": len(p.jobs),
+			}).Debug("worker pool status")
+		}
+	}
 }
 
 // Stop은 pool을 정상 종료합니다.
@@ -335,10 +384,12 @@ func (p *KafkaConsumerPool) worker(ctx context.Context) {
 func (p *KafkaConsumerPool) processJob(ctx context.Context, item jobItem) (err error) {
 	log := logger.FromContext(ctx)
 
-	// 이슈 #137 — processJob 의 모든 return path 를 defer 로 wrap 하여 duration 측정.
-	// outcome 은 err 여부로 분기 (정상 종료/error). 세부 outcome 은 기존 path 별 로그가 표현.
+	// 이슈 #137 — processJob 의 모든 return path 를 defer 로 wrap 하여 duration 측정 +
+	// busyCount 증감 (heartbeat 가시성). outcome 은 err 여부로 분기.
+	p.busyCount.Add(1)
 	start := time.Now()
 	defer func() {
+		p.busyCount.Add(-1)
 		fields := map[string]interface{}{
 			"job_id":      item.job.ID,
 			"crawler":     item.job.CrawlerName,

--- a/internal/crawler/worker/pool.go
+++ b/internal/crawler/worker/pool.go
@@ -332,8 +332,25 @@ func (p *KafkaConsumerPool) worker(ctx context.Context) {
 	}
 }
 
-func (p *KafkaConsumerPool) processJob(ctx context.Context, item jobItem) error {
+func (p *KafkaConsumerPool) processJob(ctx context.Context, item jobItem) (err error) {
 	log := logger.FromContext(ctx)
+
+	// 이슈 #137 — processJob 의 모든 return path 를 defer 로 wrap 하여 duration 측정.
+	// outcome 은 err 여부로 분기 (정상 종료/error). 세부 outcome 은 기존 path 별 로그가 표현.
+	start := time.Now()
+	defer func() {
+		fields := map[string]interface{}{
+			"job_id":      item.job.ID,
+			"crawler":     item.job.CrawlerName,
+			"duration_ms": time.Since(start).Milliseconds(),
+		}
+		if err != nil {
+			fields["outcome"] = "error"
+		} else {
+			fields["outcome"] = "ok"
+		}
+		log.WithFields(fields).Debug("job processed")
+	}()
 
 	// URL 가드 (이슈 #119): processJob 진입 직후 차단 URL 을 즉시 거르고 commit
 	// → handler 호출·lock 획득·backoff 대기 등 모든 비용 회피

--- a/internal/crawler/worker/retry_scheduler.go
+++ b/internal/crawler/worker/retry_scheduler.go
@@ -237,6 +237,7 @@ func (s *RedisDelayedRetryScheduler) Stop() {
 // peek 단계에서는 ZSET 에서 제거하지 않으며, publish 성공 후에만 AckRetry 로 제거 —
 // at-least-once 보장 (peek-publish-ack 패턴, PR #128 피드백).
 func (s *RedisDelayedRetryScheduler) pollOnce(ctx context.Context) {
+	peekStart := time.Now()
 	due, err := s.client.PeekDueRetries(ctx, time.Now(), s.cfg.BatchSize)
 	if err != nil {
 		// ctx cancel 로 인한 에러는 정상 종료 흐름 — DEBUG 로 강등
@@ -246,6 +247,20 @@ func (s *RedisDelayedRetryScheduler) pollOnce(ctx context.Context) {
 		}
 		s.log.WithError(err).Warn("failed to peek due retries from redis")
 		return
+	}
+
+	// 이슈 #137 — peek 결과를 항상 DEBUG 로 노출 (count=0 이어도 한 줄).
+	// 운영자가 retry pipeline 이 살아있고 polling 중인지 즉답 가능.
+	if len(due) > 0 {
+		s.log.WithFields(map[string]interface{}{
+			"due_count":  len(due),
+			"peek_ms":    time.Since(peekStart).Milliseconds(),
+			"batch_size": s.cfg.BatchSize,
+		}).Debug("retry peek returned due items")
+	} else {
+		s.log.WithFields(map[string]interface{}{
+			"peek_ms": time.Since(peekStart).Milliseconds(),
+		}).Debug("retry peek returned no due items")
 	}
 
 	for _, item := range due {

--- a/test/internal/worker/circuit_breaker_test.go
+++ b/test/internal/worker/circuit_breaker_test.go
@@ -27,7 +27,7 @@ func newTestCBConfig(maxFailures int, openTimeout time.Duration) worker.CircuitB
 // TestCircuitBreaker_InitialState_AllowsRequests는
 // 초기 Closed 상태에서 요청을 허용하는지 검증합니다.
 func TestCircuitBreaker_InitialState_AllowsRequests(t *testing.T) {
-	registry := worker.NewCircuitBreakerRegistry(newTestCBConfig(3, time.Minute))
+	registry := worker.NewCircuitBreakerRegistry(newTestCBConfig(3, time.Minute), nil)
 	cb := registry.Get("cnn")
 
 	assert.True(t, cb.Allow())
@@ -37,7 +37,7 @@ func TestCircuitBreaker_InitialState_AllowsRequests(t *testing.T) {
 // TestCircuitBreaker_ExceedsMaxFailures_OpensCircuit는
 // MaxFailures 연속 실패 후 Open 상태로 전환되는지 검증합니다.
 func TestCircuitBreaker_ExceedsMaxFailures_OpensCircuit(t *testing.T) {
-	registry := worker.NewCircuitBreakerRegistry(newTestCBConfig(3, time.Minute))
+	registry := worker.NewCircuitBreakerRegistry(newTestCBConfig(3, time.Minute), nil)
 	cb := registry.Get("cnn")
 
 	cb.RecordFailure()
@@ -53,7 +53,7 @@ func TestCircuitBreaker_ExceedsMaxFailures_OpensCircuit(t *testing.T) {
 // TestCircuitBreaker_SuccessResetFailures_StaysClosed는
 // 성공 기록 시 실패 카운터가 초기화되는지 검증합니다.
 func TestCircuitBreaker_SuccessResetFailures_StaysClosed(t *testing.T) {
-	registry := worker.NewCircuitBreakerRegistry(newTestCBConfig(3, time.Minute))
+	registry := worker.NewCircuitBreakerRegistry(newTestCBConfig(3, time.Minute), nil)
 	cb := registry.Get("cnn")
 
 	cb.RecordFailure()
@@ -68,7 +68,7 @@ func TestCircuitBreaker_SuccessResetFailures_StaysClosed(t *testing.T) {
 // TestCircuitBreaker_OpenTimeout_TransitionsToHalfOpen는
 // OpenTimeout 경과 후 HalfOpen으로 전환되어 probe를 허용하는지 검증합니다.
 func TestCircuitBreaker_OpenTimeout_TransitionsToHalfOpen(t *testing.T) {
-	registry := worker.NewCircuitBreakerRegistry(newTestCBConfig(1, 10*time.Millisecond))
+	registry := worker.NewCircuitBreakerRegistry(newTestCBConfig(1, 10*time.Millisecond), nil)
 	cb := registry.Get("naver")
 
 	cb.RecordFailure() // 1회 실패 → Open
@@ -89,7 +89,7 @@ func TestCircuitBreaker_OpenTimeout_TransitionsToHalfOpen(t *testing.T) {
 // TestCircuitBreaker_HalfOpenProbeSuccess_ClosesCircuit는
 // HalfOpen probe 성공 시 Closed로 전환되는지 검증합니다.
 func TestCircuitBreaker_HalfOpenProbeSuccess_ClosesCircuit(t *testing.T) {
-	registry := worker.NewCircuitBreakerRegistry(newTestCBConfig(1, 10*time.Millisecond))
+	registry := worker.NewCircuitBreakerRegistry(newTestCBConfig(1, 10*time.Millisecond), nil)
 	cb := registry.Get("naver")
 
 	cb.RecordFailure()
@@ -103,7 +103,7 @@ func TestCircuitBreaker_HalfOpenProbeSuccess_ClosesCircuit(t *testing.T) {
 // TestCircuitBreaker_HalfOpenProbeFailure_ReopensCircuit는
 // HalfOpen probe 실패 시 다시 Open으로 전환되는지 검증합니다.
 func TestCircuitBreaker_HalfOpenProbeFailure_ReopensCircuit(t *testing.T) {
-	registry := worker.NewCircuitBreakerRegistry(newTestCBConfig(1, 10*time.Millisecond))
+	registry := worker.NewCircuitBreakerRegistry(newTestCBConfig(1, 10*time.Millisecond), nil)
 	cb := registry.Get("naver")
 
 	cb.RecordFailure()
@@ -117,7 +117,7 @@ func TestCircuitBreaker_HalfOpenProbeFailure_ReopensCircuit(t *testing.T) {
 // TestCircuitBreakerRegistry_IsolatesPerSource는
 // 소스별로 독립적인 circuit breaker가 관리되는지 검증합니다.
 func TestCircuitBreakerRegistry_IsolatesPerSource(t *testing.T) {
-	registry := worker.NewCircuitBreakerRegistry(newTestCBConfig(2, time.Minute))
+	registry := worker.NewCircuitBreakerRegistry(newTestCBConfig(2, time.Minute), nil)
 
 	cnn := registry.Get("cnn")
 	naver := registry.Get("naver")
@@ -137,7 +137,7 @@ func TestCircuitBreakerRegistry_IsolatesPerSource(t *testing.T) {
 // TestCircuitBreakerRegistry_GetReturnsSameInstance는
 // 동일 소스에 대해 동일 인스턴스를 반환하는지 검증합니다.
 func TestCircuitBreakerRegistry_GetReturnsSameInstance(t *testing.T) {
-	registry := worker.NewCircuitBreakerRegistry(worker.DefaultCircuitBreakerConfig)
+	registry := worker.NewCircuitBreakerRegistry(worker.DefaultCircuitBreakerConfig, nil)
 
 	cb1 := registry.Get("cnn")
 	cb2 := registry.Get("cnn")

--- a/test/internal/worker/job_locker_test.go
+++ b/test/internal/worker/job_locker_test.go
@@ -91,7 +91,7 @@ func TestKafkaConsumerPool_JobLocker_AlreadyAcquired_SkipsWithoutCommit(t *testi
 
 	pool := worker.NewKafkaConsumerPoolWithOptions(
 		consumer, producer, handler, contentSvc, 1,
-		worker.NewCircuitBreakerRegistry(worker.DefaultCircuitBreakerConfig),
+		worker.NewCircuitBreakerRegistry(worker.DefaultCircuitBreakerConfig, nil),
 		locker,
 		worker.NoopURLCache{},
 	)
@@ -122,7 +122,7 @@ func TestKafkaConsumerPool_JobLocker_Acquired_ReleasedAfterProcessing(t *testing
 
 	pool := worker.NewKafkaConsumerPoolWithOptions(
 		consumer, producer, handler, contentSvc, 1,
-		worker.NewCircuitBreakerRegistry(worker.DefaultCircuitBreakerConfig),
+		worker.NewCircuitBreakerRegistry(worker.DefaultCircuitBreakerConfig, nil),
 		locker,
 		worker.NoopURLCache{},
 	)
@@ -158,7 +158,7 @@ func TestKafkaConsumerPool_JobLocker_AcquireError_ProceedsWithoutLock(t *testing
 
 	pool := worker.NewKafkaConsumerPoolWithOptions(
 		consumer, producer, handler, contentSvc, 1,
-		worker.NewCircuitBreakerRegistry(worker.DefaultCircuitBreakerConfig),
+		worker.NewCircuitBreakerRegistry(worker.DefaultCircuitBreakerConfig, nil),
 		locker,
 		worker.NoopURLCache{},
 	)

--- a/test/internal/worker/pool_test.go
+++ b/test/internal/worker/pool_test.go
@@ -401,7 +401,7 @@ func TestKafkaConsumerPool_ProcessJob_CircuitOpen_SendsToDLQ(t *testing.T) {
 	cbRegistry := worker.NewCircuitBreakerRegistry(worker.CircuitBreakerConfig{
 		MaxFailures: 1,
 		OpenTimeout: time.Minute,
-	})
+	}, nil)
 	// 첫 번째 실패로 circuit을 미리 open 상태로 만듭니다.
 	cbRegistry.Get("test-crawler").RecordFailure()
 

--- a/test/internal/worker/url_cache_test.go
+++ b/test/internal/worker/url_cache_test.go
@@ -65,7 +65,7 @@ func TestKafkaConsumerPool_URLCache_Hit_SkipsWithCommit(t *testing.T) {
 
 	pool := worker.NewKafkaConsumerPoolWithOptions(
 		consumer, producer, handler, contentSvc, 1,
-		worker.NewCircuitBreakerRegistry(worker.DefaultCircuitBreakerConfig),
+		worker.NewCircuitBreakerRegistry(worker.DefaultCircuitBreakerConfig, nil),
 		worker.NoopJobLocker{},
 		urlCache,
 	)
@@ -97,7 +97,7 @@ func TestKafkaConsumerPool_URLCache_Miss_ProceedsAndSets(t *testing.T) {
 
 	pool := worker.NewKafkaConsumerPoolWithOptions(
 		consumer, producer, handler, contentSvc, 1,
-		worker.NewCircuitBreakerRegistry(worker.DefaultCircuitBreakerConfig),
+		worker.NewCircuitBreakerRegistry(worker.DefaultCircuitBreakerConfig, nil),
 		worker.NoopJobLocker{},
 		urlCache,
 	)
@@ -135,7 +135,7 @@ func TestKafkaConsumerPool_URLCache_ExistsError_ProceedsWithFetch(t *testing.T) 
 
 	pool := worker.NewKafkaConsumerPoolWithOptions(
 		consumer, producer, handler, contentSvc, 1,
-		worker.NewCircuitBreakerRegistry(worker.DefaultCircuitBreakerConfig),
+		worker.NewCircuitBreakerRegistry(worker.DefaultCircuitBreakerConfig, nil),
 		worker.NoopJobLocker{},
 		urlCache,
 	)
@@ -172,7 +172,7 @@ func TestKafkaConsumerPool_URLCache_CategoryPage_SkipsCache(t *testing.T) {
 
 	pool := worker.NewKafkaConsumerPoolWithOptions(
 		consumer, producer, handler, contentSvc, 1,
-		worker.NewCircuitBreakerRegistry(worker.DefaultCircuitBreakerConfig),
+		worker.NewCircuitBreakerRegistry(worker.DefaultCircuitBreakerConfig, nil),
 		worker.NoopJobLocker{},
 		urlCache,
 	)


### PR DESCRIPTION
## 연관 이슈
- Closes #137
- 기반: #133 (라이브 검증으로 silent vs hang 구분 도구 부재 확인)

<br>

## 구현 내용

#133 검증 결과 silent 구간을 SIGQUIT goroutine dump 없이는 진단 불가했다. 본 PR 은 운영자가 \`LOG_LEVEL=debug\` 로 토글했을 때 worker / lock / circuit breaker / retry pipeline 의 모든 결정 시점을 추적할 수 있도록 5개 영역 로그를 추가한다. 5개 논리적 커밋:

1. **`[FEAT]` JobLocker** — Acquire 성공 (`{job_id, ttl_ms}`) / Release 성공 (`{job_id}`) DEBUG. 기존 duplicate skip / error 메시지도 일관화 (\"being processed by another worker\" → \"lock already held by another worker\")
2. **`[FEAT]` CircuitBreaker state 전이** — logger 주입 (nil 허용). 4가지 전이 모두 구조화 로그:
   - Closed → Open: WARN `{source, failures, max_failures}`
   - Open → HalfOpen: INFO `{source, open_for_ms}`
   - HalfOpen → Closed: INFO `{source}`
   - HalfOpen → Open: WARN `{source}`
3. **`[FEAT]` processJob duration** — defer 패턴으로 모든 return path (gate/ctx/lock dup/circuit open/handler error/success) 를 wrap, `{duration_ms, outcome}` 일관 기록. named return value 사용
4. **`[FEAT]` RetryScheduler pollOnce** — peek 결과를 매 cycle DEBUG 로 노출 (`{due_count, peek_ms, batch_size}` / 0 cycle 도 \"no due items\")
5. **`[FEAT]` Worker pool heartbeat** — 가장 중요. 30초 주기로 priority 별 `{busy_workers, total_workers, jobs_buffered}` 출력. busyCount atomic.Int32 + SetPriority 주입 + heartbeatLoop goroutine

### 라이브 검증 (35초간 LOG_LEVEL=debug)

| 신규 로그 | 35s 카운트 | 비고 |
|---|---|---|
| job lock acquired | 59 | TTL 600,000 ms 표시 |
| job lock released | 59 | acquired 와 1:1 매칭 |
| job processed | 71 | duration_ms + outcome (ok/error) |
| retry peek returned | 매초 | due_count + peek_ms (0 cycle 포함) |
| worker pool status | 3 (high/normal/low) | 30s 주기 |
| circuit breaker state transition | 1 | open 발생 |

heartbeat 샘플 (운영자가 silent vs hang 즉답):
```json
{\"priority\":\"low\",\"busy_workers\":0,\"total_workers\":2,\"jobs_buffered\":0}
{\"priority\":\"normal\",\"busy_workers\":6,\"total_workers\":6,\"jobs_buffered\":12}
{\"priority\":\"high\",\"busy_workers\":0,\"total_workers\":3,\"jobs_buffered\":0}
```
→ normal 은 6 worker 모두 가동 + 12 job 대기 (backlog), low/high 는 정상 idle.

<br>

## CI / 머지 게이트 점검

### 변경 영향 범위
- 영향 패키지/모듈: `internal/crawler/worker/{pool,manager,job_locker,circuit_breaker,retry_scheduler}.go`, 4개 worker 테스트 파일 (signature 변경 호환)
- 위험도: `Low`
  - 신규 로그만 추가 (기존 path 동작 변화 없음)
  - heartbeat goroutine 은 `priority != \"\"` 조건이라 단순 헬퍼 / 테스트 경로 영향 없음
  - CB Registry 의 logger 인자가 nil 허용이라 기존 테스트 nil 추가만으로 호환
  - processJob 은 named return + defer — 기존 return path 동작 동일

### Required Status Checks
- 통과 확인 대상:
  - [ ] `Commit Lint`
  - [ ] `PR Title Lint`
  - [ ] `Linked Issue Check`
  - [ ] `Format Check`
  - [ ] `Build`
  - [ ] `Test`
  - [ ] `Lint`

로컬 검증:
- `go test -race -count=1 ./...` 전체 통과 (19 패키지)
- `gofmt -l .` clean
- `go build ./...` 통과
- 라이브 35초 instance 로 5개 신규 로그 모두 출력 확인

### 롤백 계획
- 단일 PR revert
- 호환성 보존: heartbeat 는 SetPriority 미주입 시 동작 안 함, CB logger 는 nil 허용 → revert 시 기존 동작 즉시 복원

<br>

## TODO
- (별도 PR) `net/http/pprof` admin endpoint — heartbeat 가 \"무엇을 wait 하는지\" 까지는 답하지 못하므로 pprof 가 보완재
- (별도 PR) `last_message_age_s` 필드 — heartbeat 에 \"마지막 message fetch 후 경과시간\" 추가하여 \"버퍼 비었지만 fetch 도 멈춤\" 케이스 (Kafka rebalance 의심) 즉답

<br>

## 논의 사항
- heartbeat 주기 30초 — production 로그량 vs 진단 즉시성 trade-off. 운영 후 조정 가능 (상수로 노출 검토)
- `circuit breaker state transition` 메시지를 단일 message 로 통합 (`from_state`, `to_state` 필드로 분기). grep 친화적 + structured logging 컨벤션 일치

🤖 Generated with [Claude Code](https://claude.com/claude-code)