### PR TITLE
[FEAT#140] LLM 모듈 추가 — Gemini / OpenAI ChatGPT / Anthropic Claude 공통 인터페이스

### DIFF
--- a/pkg/llm/anthropic/anthropic.go
+++ b/pkg/llm/anthropic/anthropic.go
@@ -22,6 +22,27 @@ const (
 	apiVersion       = "2023-06-01"
 )
 
+// init 은 factory (llm.New) 에서 본 provider 를 사용할 수 있게 등록합니다 (이슈 #140).
+//
+// "anthropic" 외 별칭 "claude" 도 함께 등록 — 사용자가 모델 이름으로 자연스럽게 호출 가능.
+func init() {
+	builder := func(cfg llm.Config) (llm.Provider, error) {
+		opts := []Option{}
+		if cfg.Model != "" {
+			opts = append(opts, WithModel(cfg.Model))
+		}
+		if cfg.BaseURL != "" {
+			opts = append(opts, WithBaseURL(cfg.BaseURL))
+		}
+		if cfg.Timeout > 0 {
+			opts = append(opts, WithTimeout(cfg.Timeout))
+		}
+		return New(cfg.APIKey, opts...), nil
+	}
+	llm.RegisterProvider(providerName, builder)
+	llm.RegisterProvider("claude", builder)
+}
+
 // Provider 는 llm.Provider 의 Anthropic 구현입니다.
 type Provider struct {
 	apiKey  string

--- a/pkg/llm/anthropic/anthropic.go
+++ b/pkg/llm/anthropic/anthropic.go
@@ -1,0 +1,231 @@
+// Package anthropic 는 Anthropic Claude API 의 llm.Provider 구현입니다 (이슈 #140).
+//
+// Package anthropic implements the llm.Provider interface against Anthropic's
+// Messages REST API.
+//
+// API 문서: https://docs.anthropic.com/en/api/messages
+package anthropic
+
+import (
+	"context"
+	"encoding/json"
+	"time"
+
+	"issuetracker/pkg/llm"
+)
+
+const (
+	providerName     = "anthropic"
+	defaultBaseURL   = "https://api.anthropic.com/v1"
+	defaultModel     = "claude-opus-4-7"
+	defaultMaxTokens = 4096 // Anthropic 은 max_tokens 가 필수 — 기본값 보장
+	apiVersion       = "2023-06-01"
+)
+
+// Provider 는 llm.Provider 의 Anthropic 구현입니다.
+type Provider struct {
+	apiKey  string
+	model   string
+	baseURL string
+	http    *llm.HTTPClient
+}
+
+// Option 은 Provider 생성 옵션입니다.
+type Option func(*Provider)
+
+// WithBaseURL 은 API base URL 을 override 합니다 (테스트의 mock server 용).
+func WithBaseURL(u string) Option { return func(p *Provider) { p.baseURL = u } }
+
+// WithModel 은 기본 모델을 override 합니다.
+func WithModel(m string) Option { return func(p *Provider) { p.model = m } }
+
+// WithTimeout 은 HTTP timeout 을 override 합니다.
+func WithTimeout(d time.Duration) Option {
+	return func(p *Provider) { p.http = llm.NewHTTPClient(d) }
+}
+
+// New 는 Anthropic Provider 를 생성합니다.
+func New(apiKey string, opts ...Option) *Provider {
+	p := &Provider{
+		apiKey:  apiKey,
+		model:   defaultModel,
+		baseURL: defaultBaseURL,
+		http:    llm.NewHTTPClient(0),
+	}
+	for _, o := range opts {
+		o(p)
+	}
+	return p
+}
+
+// Name 은 provider 식별자를 반환합니다.
+func (p *Provider) Name() string { return providerName }
+
+// Generate 는 단일 chat completion 을 수행합니다.
+//
+// Anthropic API 스키마 차이:
+//   - llm.Role(system) → 별도 top-level "system" 필드 (messages 배열에 안 들어감)
+//   - llm.Role(user) / RoleAssistant → messages 배열
+//   - max_tokens 는 필수 — 0 이면 defaultMaxTokens 사용
+//   - 인증 헤더: x-api-key + anthropic-version
+func (p *Provider) Generate(ctx context.Context, req llm.Request) (*llm.Response, error) {
+	if p.apiKey == "" {
+		return nil, &llm.Error{
+			Code:     llm.ErrCodeAuth,
+			Provider: providerName,
+			Message:  "missing API key",
+		}
+	}
+
+	model := req.Model
+	if model == "" {
+		model = p.model
+	}
+
+	body, err := buildAnthropicRequest(req, model)
+	if err != nil {
+		return nil, err
+	}
+
+	endpoint := p.baseURL + "/messages"
+	headers := map[string]string{
+		"x-api-key":         p.apiKey,
+		"anthropic-version": apiVersion,
+	}
+
+	respBytes, err := p.http.PostJSON(ctx, providerName, endpoint, headers, body)
+	if err != nil {
+		return nil, err
+	}
+
+	return parseAnthropicResponse(respBytes, model)
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Request / Response 스키마
+// ─────────────────────────────────────────────────────────────────────────────
+
+type anthropicMessage struct {
+	Role    string `json:"role"` // "user" | "assistant"
+	Content string `json:"content"`
+}
+
+type anthropicRequest struct {
+	Model       string             `json:"model"`
+	System      string             `json:"system,omitempty"`
+	Messages    []anthropicMessage `json:"messages"`
+	MaxTokens   int                `json:"max_tokens"`
+	Temperature *float32           `json:"temperature,omitempty"`
+}
+
+type anthropicContentBlock struct {
+	Type string `json:"type"` // "text" 등
+	Text string `json:"text"`
+}
+
+type anthropicUsage struct {
+	InputTokens  int `json:"input_tokens"`
+	OutputTokens int `json:"output_tokens"`
+}
+
+type anthropicResponse struct {
+	Model      string                  `json:"model"`
+	Content    []anthropicContentBlock `json:"content"`
+	StopReason string                  `json:"stop_reason"`
+	Usage      anthropicUsage          `json:"usage"`
+}
+
+// buildAnthropicRequest 는 llm.Request 를 Anthropic 요청 body 로 변환합니다.
+//
+// 다중 system 메시지는 줄바꿈으로 합쳐 단일 system 필드로 전송 (Anthropic 표준).
+func buildAnthropicRequest(req llm.Request, model string) (*anthropicRequest, error) {
+	if len(req.Messages) == 0 {
+		return nil, &llm.Error{
+			Code:     llm.ErrCodeBadRequest,
+			Provider: providerName,
+			Message:  "request has no messages",
+		}
+	}
+
+	maxTokens := req.MaxTokens
+	if maxTokens <= 0 {
+		maxTokens = defaultMaxTokens
+	}
+	out := &anthropicRequest{
+		Model:     model,
+		MaxTokens: maxTokens,
+		Messages:  make([]anthropicMessage, 0, len(req.Messages)),
+	}
+
+	var systemTexts []string
+	for _, m := range req.Messages {
+		switch m.Role {
+		case llm.RoleSystem:
+			systemTexts = append(systemTexts, m.Content)
+		case llm.RoleUser:
+			out.Messages = append(out.Messages, anthropicMessage{Role: "user", Content: m.Content})
+		case llm.RoleAssistant:
+			out.Messages = append(out.Messages, anthropicMessage{Role: "assistant", Content: m.Content})
+		default:
+			return nil, &llm.Error{
+				Code:     llm.ErrCodeBadRequest,
+				Provider: providerName,
+				Message:  "unsupported role " + string(m.Role),
+			}
+		}
+	}
+	if len(systemTexts) > 0 {
+		joined := systemTexts[0]
+		for i := 1; i < len(systemTexts); i++ {
+			joined += "\n\n" + systemTexts[i]
+		}
+		out.System = joined
+	}
+
+	if req.Temperature > 0 {
+		t := req.Temperature
+		out.Temperature = &t
+	}
+
+	return out, nil
+}
+
+// parseAnthropicResponse 는 Anthropic 응답을 llm.Response 로 정규화합니다.
+//
+// Anthropic 의 content 는 block 배열 — 모든 type="text" 블록의 text 를 합칩니다.
+// (다른 type 예: tool_use 는 본 모듈에서 다루지 않음)
+func parseAnthropicResponse(body []byte, requestedModel string) (*llm.Response, error) {
+	var raw anthropicResponse
+	if err := json.Unmarshal(body, &raw); err != nil {
+		return nil, &llm.Error{
+			Code:     llm.ErrCodeUnknown,
+			Provider: providerName,
+			Message:  "decode response",
+			Err:      err,
+		}
+	}
+	if len(raw.Content) == 0 {
+		return nil, &llm.Error{
+			Code:     llm.ErrCodeUnknown,
+			Provider: providerName,
+			Message:  "empty response (no content blocks)",
+		}
+	}
+	content := ""
+	for _, block := range raw.Content {
+		if block.Type == "text" {
+			content += block.Text
+		}
+	}
+	model := raw.Model
+	if model == "" {
+		model = requestedModel
+	}
+	return &llm.Response{
+		Content:      content,
+		Model:        model,
+		InputTokens:  raw.Usage.InputTokens,
+		OutputTokens: raw.Usage.OutputTokens,
+		StopReason:   raw.StopReason,
+	}, nil
+}

--- a/pkg/llm/errors.go
+++ b/pkg/llm/errors.go
@@ -1,6 +1,9 @@
 package llm
 
-import "fmt"
+import (
+	"errors"
+	"fmt"
+)
 
 // ErrorCode 는 LLM 호출 실패의 표준화된 분류입니다.
 //
@@ -65,6 +68,26 @@ func (e *Error) Unwrap() error {
 	return e.Err
 }
 
+// Is 는 errors.Is 호환을 위한 비교입니다 (Gemini code review 피드백).
+//
+// target 의 비어있지 않은 필드들에 대해 AND 비교를 수행합니다 — 즉 호출자가
+// "Code=='auth' 인 모든 *Error 와 매칭" 같은 부분 매칭을 표현할 수 있습니다.
+//
+// 예시:
+//
+//	if errors.Is(err, &llm.Error{Code: llm.ErrCodeAuth}) { ... }            // Code 만 비교
+//	if errors.Is(err, &llm.Error{Provider: "openai"}) { ... }               // Provider 만 비교
+//	if errors.Is(err, &llm.Error{Code: llm.ErrCodeRateLimit, Provider: "anthropic"}) { ... }  // 둘 다
+func (e *Error) Is(target error) bool {
+	t, ok := target.(*Error)
+	if !ok {
+		return false
+	}
+	return (t.Code == "" || e.Code == t.Code) &&
+		(t.Provider == "" || e.Provider == t.Provider) &&
+		(t.Message == "" || e.Message == t.Message)
+}
+
 // IsRetryable 은 에러가 retry 가치가 있는지 빠르게 판단하는 헬퍼입니다.
 //
 // IsRetryable returns true if the error is a *llm.Error with Retryable=true.
@@ -74,25 +97,8 @@ func IsRetryable(err error) bool {
 		return false
 	}
 	var lerr *Error
-	if !errorsAs(err, &lerr) {
+	if !errors.As(err, &lerr) {
 		return false
 	}
 	return lerr.Retryable
-}
-
-// errorsAs 는 errors.As 의 thin wrapper 입니다 (테스트 친화적, std lib import 회피).
-func errorsAs(err error, target **Error) bool {
-	for err != nil {
-		if e, ok := err.(*Error); ok {
-			*target = e
-			return true
-		}
-		type unwrapper interface{ Unwrap() error }
-		u, ok := err.(unwrapper)
-		if !ok {
-			return false
-		}
-		err = u.Unwrap()
-	}
-	return false
 }

--- a/pkg/llm/errors.go
+++ b/pkg/llm/errors.go
@@ -1,0 +1,98 @@
+package llm
+
+import "fmt"
+
+// ErrorCode 는 LLM 호출 실패의 표준화된 분류입니다.
+//
+// ErrorCode is the normalized failure category across providers.
+// Provider 마다 HTTP status / error body 가 다르지만, 호출자는 ErrorCode 만으로
+// 재시도 / fallback / 알림을 결정할 수 있습니다.
+type ErrorCode string
+
+const (
+	// ErrCodeAuth: API key 오류, 권한 부족 등 (HTTP 401/403). 재시도 무의미.
+	ErrCodeAuth ErrorCode = "auth"
+
+	// ErrCodeRateLimit: 분당/시간당 호출 한도 초과 (HTTP 429). 재시도 가치 있음 (backoff).
+	ErrCodeRateLimit ErrorCode = "rate_limit"
+
+	// ErrCodeServer: provider 측 일시 오류 (HTTP 5xx). 재시도 가치 있음.
+	ErrCodeServer ErrorCode = "server"
+
+	// ErrCodeBadRequest: 요청 형식 오류 / 유효하지 않은 파라미터 (HTTP 400). 재시도 무의미.
+	ErrCodeBadRequest ErrorCode = "bad_request"
+
+	// ErrCodeContextLimit: 입력이 모델 context window 초과. 재시도 무의미 — 입력 단축 필요.
+	ErrCodeContextLimit ErrorCode = "context_limit"
+
+	// ErrCodeNetwork: 연결 / DNS / 타임아웃 등 클라이언트 측 네트워크 오류. 재시도 가치 있음.
+	ErrCodeNetwork ErrorCode = "network"
+
+	// ErrCodeUnknown: 매핑되지 않은 오류. Retryable=false (보수적으로).
+	ErrCodeUnknown ErrorCode = "unknown"
+)
+
+// Error 는 LLM 호출 실패의 공통 표현입니다.
+//
+// Error is the common error type returned by all Provider implementations.
+// 호출자는 errors.As 로 추출하여 Code / Retryable 로 분기할 수 있습니다.
+type Error struct {
+	// Code 는 표준화된 실패 분류.
+	Code ErrorCode
+
+	// Provider 는 실패를 보고한 backend 이름 ("gemini" / "openai" / "anthropic").
+	Provider string
+
+	// Message 는 사람이 읽을 수 있는 설명 (provider raw message 가능).
+	Message string
+
+	// Retryable 은 동일 입력으로 재시도가 의미 있는지 여부.
+	Retryable bool
+
+	// Err 는 wrap 된 원본 에러 (network / json decode 실패 등). nil 가능.
+	Err error
+}
+
+func (e *Error) Error() string {
+	if e.Err != nil {
+		return fmt.Sprintf("[llm:%s:%s] %s: %v", e.Provider, e.Code, e.Message, e.Err)
+	}
+	return fmt.Sprintf("[llm:%s:%s] %s", e.Provider, e.Code, e.Message)
+}
+
+// Unwrap 은 errors.Is / errors.As 가 wrap chain 을 따라가도록 합니다.
+func (e *Error) Unwrap() error {
+	return e.Err
+}
+
+// IsRetryable 은 에러가 retry 가치가 있는지 빠르게 판단하는 헬퍼입니다.
+//
+// IsRetryable returns true if the error is a *llm.Error with Retryable=true.
+// 비-llm.Error 는 false 를 반환합니다 (보수적 정책 — 모르는 에러는 재시도하지 않음).
+func IsRetryable(err error) bool {
+	if err == nil {
+		return false
+	}
+	var lerr *Error
+	if !errorsAs(err, &lerr) {
+		return false
+	}
+	return lerr.Retryable
+}
+
+// errorsAs 는 errors.As 의 thin wrapper 입니다 (테스트 친화적, std lib import 회피).
+func errorsAs(err error, target **Error) bool {
+	for err != nil {
+		if e, ok := err.(*Error); ok {
+			*target = e
+			return true
+		}
+		type unwrapper interface{ Unwrap() error }
+		u, ok := err.(unwrapper)
+		if !ok {
+			return false
+		}
+		err = u.Unwrap()
+	}
+	return false
+}

--- a/pkg/llm/factory.go
+++ b/pkg/llm/factory.go
@@ -1,0 +1,76 @@
+package llm
+
+import (
+	"fmt"
+	"strings"
+	"time"
+)
+
+// Config 는 Provider 생성을 위한 설정입니다.
+//
+// Config drives Provider construction in a backend-agnostic way.
+// Provider 교체는 본 Config 의 Provider 필드 한 줄 변경으로 가능합니다.
+type Config struct {
+	// Provider 식별자: "gemini" / "openai" / "anthropic" (대소문자 무시).
+	Provider string
+
+	// APIKey — provider 별 API key. 비어있으면 호출 시 ErrCodeAuth.
+	APIKey string
+
+	// Model — 기본 모델 (선택). 비어있으면 provider 별 default 사용.
+	Model string
+
+	// BaseURL — REST endpoint root (선택, 보통 테스트의 mock server 주입용).
+	BaseURL string
+
+	// Timeout — HTTP timeout (선택, default 60s).
+	Timeout time.Duration
+}
+
+// providerFactories 는 등록된 provider 빌더 함수 맵입니다.
+// 신규 provider 추가는 init() 에서 RegisterProvider 호출로 확장 가능 (현재는 패키지 init 미사용,
+// llm/<provider>/<provider>.go 모두 본 패키지가 직접 의존하지 않도록 builder 함수만 등록).
+//
+// 본 맵은 New() 에서만 read 되므로 lock 불필요 — init 시점에만 채워짐.
+var providerFactories = map[string]func(Config) (Provider, error){}
+
+// RegisterProvider 는 외부 패키지가 자기 builder 를 등록할 수 있게 합니다.
+// 일반적으로 각 provider 패키지의 init() 에서 호출됩니다.
+//
+// 본 함수는 thread-safe 하지 않으며, 패키지 init 시점에만 호출되어야 합니다.
+func RegisterProvider(name string, builder func(Config) (Provider, error)) {
+	providerFactories[strings.ToLower(name)] = builder
+}
+
+// New 는 Config 에 따라 적절한 Provider 를 생성합니다.
+//
+// Provider 식별자는 대소문자 무시 ("Gemini" / "GEMINI" / "gemini" 모두 동일).
+// 미등록 provider 는 ErrCodeBadRequest 반환 (호출자가 등록 누락 인지 가능).
+func New(cfg Config) (Provider, error) {
+	name := strings.ToLower(strings.TrimSpace(cfg.Provider))
+	if name == "" {
+		return nil, &Error{
+			Code:     ErrCodeBadRequest,
+			Provider: "factory",
+			Message:  "Config.Provider is empty",
+		}
+	}
+	builder, ok := providerFactories[name]
+	if !ok {
+		return nil, &Error{
+			Code:     ErrCodeBadRequest,
+			Provider: "factory",
+			Message:  fmt.Sprintf("unknown provider %q (registered: %v)", cfg.Provider, registeredNames()),
+		}
+	}
+	return builder(cfg)
+}
+
+// registeredNames 는 디버깅용 — 현재 등록된 provider 이름 목록을 반환합니다.
+func registeredNames() []string {
+	names := make([]string, 0, len(providerFactories))
+	for n := range providerFactories {
+		names = append(names, n)
+	}
+	return names
+}

--- a/pkg/llm/gemini/gemini.go
+++ b/pkg/llm/gemini/gemini.go
@@ -27,6 +27,25 @@ const (
 	defaultModel = "gemini-2.5-flash"
 )
 
+// init 은 factory (llm.New) 에서 본 provider 를 사용할 수 있게 등록합니다 (이슈 #140).
+//
+// 사용자는 llm.Config{Provider: "gemini", APIKey: "...", Model: "..."} 으로 생성 가능.
+func init() {
+	llm.RegisterProvider(providerName, func(cfg llm.Config) (llm.Provider, error) {
+		opts := []Option{}
+		if cfg.Model != "" {
+			opts = append(opts, WithModel(cfg.Model))
+		}
+		if cfg.BaseURL != "" {
+			opts = append(opts, WithBaseURL(cfg.BaseURL))
+		}
+		if cfg.Timeout > 0 {
+			opts = append(opts, WithTimeout(cfg.Timeout))
+		}
+		return New(cfg.APIKey, opts...), nil
+	})
+}
+
 // Provider 는 llm.Provider 의 Gemini 구현입니다.
 type Provider struct {
 	apiKey  string

--- a/pkg/llm/gemini/gemini.go
+++ b/pkg/llm/gemini/gemini.go
@@ -1,0 +1,248 @@
+// Package gemini 는 Google Gemini API 의 llm.Provider 구현입니다 (이슈 #140).
+//
+// Package gemini implements the llm.Provider interface against Google's
+// Generative Language REST API.
+//
+// API 문서: https://ai.google.dev/api/rest/v1beta/models/generateContent
+package gemini
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"time"
+
+	"issuetracker/pkg/llm"
+)
+
+const (
+	// providerName 은 llm.Error / Provider.Name 에서 사용되는 식별자.
+	providerName = "gemini"
+
+	// defaultBaseURL 은 Gemini REST API root.
+	defaultBaseURL = "https://generativelanguage.googleapis.com/v1beta"
+
+	// defaultModel 은 Model 필드가 비어있을 때 사용되는 기본 모델.
+	defaultModel = "gemini-2.5-flash"
+)
+
+// Provider 는 llm.Provider 의 Gemini 구현입니다.
+type Provider struct {
+	apiKey  string
+	model   string
+	baseURL string
+	http    *llm.HTTPClient
+}
+
+// Option 은 Provider 생성 옵션입니다.
+type Option func(*Provider)
+
+// WithBaseURL 은 API base URL 을 override 합니다 (테스트의 mock server 용).
+func WithBaseURL(u string) Option { return func(p *Provider) { p.baseURL = u } }
+
+// WithModel 은 기본 모델을 override 합니다.
+func WithModel(m string) Option { return func(p *Provider) { p.model = m } }
+
+// WithTimeout 은 HTTP timeout 을 override 합니다 (default llm.DefaultTimeout).
+func WithTimeout(d time.Duration) Option {
+	return func(p *Provider) { p.http = llm.NewHTTPClient(d) }
+}
+
+// New 는 Gemini Provider 를 생성합니다. apiKey 가 비어있으면 panic 대신
+// 호출 시 ErrCodeAuth 를 반환합니다 (테스트 / dry-run 용).
+func New(apiKey string, opts ...Option) *Provider {
+	p := &Provider{
+		apiKey:  apiKey,
+		model:   defaultModel,
+		baseURL: defaultBaseURL,
+		http:    llm.NewHTTPClient(0),
+	}
+	for _, o := range opts {
+		o(p)
+	}
+	return p
+}
+
+// Name 은 provider 식별자를 반환합니다 (llm.Provider 구현).
+func (p *Provider) Name() string { return providerName }
+
+// Generate 는 단일 chat completion 을 수행합니다 (llm.Provider 구현).
+//
+// Gemini API 형식 변환:
+//   - llm.Role(system)      → systemInstruction (별도 필드)
+//   - llm.Role(user)        → contents[].role="user"
+//   - llm.Role(assistant)   → contents[].role="model"  (Gemini 명칭 차이)
+//
+// API key 는 query parameter 로 전달 (Gemini 표준).
+func (p *Provider) Generate(ctx context.Context, req llm.Request) (*llm.Response, error) {
+	if p.apiKey == "" {
+		return nil, &llm.Error{
+			Code:     llm.ErrCodeAuth,
+			Provider: providerName,
+			Message:  "missing API key",
+		}
+	}
+
+	model := req.Model
+	if model == "" {
+		model = p.model
+	}
+
+	body, err := buildGeminiRequest(req)
+	if err != nil {
+		return nil, err
+	}
+
+	endpoint := fmt.Sprintf("%s/models/%s:generateContent?key=%s",
+		p.baseURL, url.PathEscape(model), url.QueryEscape(p.apiKey))
+
+	respBytes, err := p.http.PostJSON(ctx, providerName, endpoint, nil, body)
+	if err != nil {
+		return nil, err
+	}
+
+	return parseGeminiResponse(respBytes, model)
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Request / Response 스키마 (Gemini REST 전용)
+// ─────────────────────────────────────────────────────────────────────────────
+
+type geminiPart struct {
+	Text string `json:"text"`
+}
+
+type geminiContent struct {
+	Role  string       `json:"role,omitempty"` // "user" | "model"
+	Parts []geminiPart `json:"parts"`
+}
+
+type geminiSystemInstruction struct {
+	Parts []geminiPart `json:"parts"`
+}
+
+type geminiGenerationConfig struct {
+	Temperature     *float32 `json:"temperature,omitempty"`
+	MaxOutputTokens *int     `json:"maxOutputTokens,omitempty"`
+}
+
+type geminiRequest struct {
+	Contents          []geminiContent          `json:"contents"`
+	SystemInstruction *geminiSystemInstruction `json:"systemInstruction,omitempty"`
+	GenerationConfig  *geminiGenerationConfig  `json:"generationConfig,omitempty"`
+}
+
+type geminiCandidate struct {
+	Content      geminiContent `json:"content"`
+	FinishReason string        `json:"finishReason"`
+}
+
+type geminiUsageMetadata struct {
+	PromptTokenCount     int `json:"promptTokenCount"`
+	CandidatesTokenCount int `json:"candidatesTokenCount"`
+}
+
+type geminiResponse struct {
+	Candidates    []geminiCandidate   `json:"candidates"`
+	UsageMetadata geminiUsageMetadata `json:"usageMetadata"`
+	ModelVersion  string              `json:"modelVersion"`
+}
+
+// buildGeminiRequest 는 llm.Request 를 Gemini API 요청 body 로 변환합니다.
+func buildGeminiRequest(req llm.Request) (*geminiRequest, error) {
+	if len(req.Messages) == 0 {
+		return nil, &llm.Error{
+			Code:     llm.ErrCodeBadRequest,
+			Provider: providerName,
+			Message:  "request has no messages",
+		}
+	}
+	out := &geminiRequest{}
+
+	var systemTexts []string
+	for _, m := range req.Messages {
+		switch m.Role {
+		case llm.RoleSystem:
+			systemTexts = append(systemTexts, m.Content)
+		case llm.RoleUser:
+			out.Contents = append(out.Contents, geminiContent{
+				Role:  "user",
+				Parts: []geminiPart{{Text: m.Content}},
+			})
+		case llm.RoleAssistant:
+			out.Contents = append(out.Contents, geminiContent{
+				Role:  "model",
+				Parts: []geminiPart{{Text: m.Content}},
+			})
+		default:
+			return nil, &llm.Error{
+				Code:     llm.ErrCodeBadRequest,
+				Provider: providerName,
+				Message:  fmt.Sprintf("unsupported role %q", m.Role),
+			}
+		}
+	}
+	if len(systemTexts) > 0 {
+		// 여러 system 메시지는 줄바꿈으로 합쳐 하나의 systemInstruction 으로 전송
+		// (Gemini 가 multi-system 을 직접 지원하지 않음).
+		joined := systemTexts[0]
+		for i := 1; i < len(systemTexts); i++ {
+			joined += "\n\n" + systemTexts[i]
+		}
+		out.SystemInstruction = &geminiSystemInstruction{
+			Parts: []geminiPart{{Text: joined}},
+		}
+	}
+
+	if req.Temperature > 0 || req.MaxTokens > 0 {
+		out.GenerationConfig = &geminiGenerationConfig{}
+		if req.Temperature > 0 {
+			t := req.Temperature
+			out.GenerationConfig.Temperature = &t
+		}
+		if req.MaxTokens > 0 {
+			n := req.MaxTokens
+			out.GenerationConfig.MaxOutputTokens = &n
+		}
+	}
+
+	return out, nil
+}
+
+// parseGeminiResponse 는 Gemini API 응답을 llm.Response 로 정규화합니다.
+func parseGeminiResponse(body []byte, requestedModel string) (*llm.Response, error) {
+	var raw geminiResponse
+	if err := json.Unmarshal(body, &raw); err != nil {
+		return nil, &llm.Error{
+			Code:     llm.ErrCodeUnknown,
+			Provider: providerName,
+			Message:  "decode response",
+			Err:      err,
+		}
+	}
+	if len(raw.Candidates) == 0 || len(raw.Candidates[0].Content.Parts) == 0 {
+		return nil, &llm.Error{
+			Code:     llm.ErrCodeUnknown,
+			Provider: providerName,
+			Message:  "empty response (no candidates)",
+		}
+	}
+	// Gemini 는 단일 candidate 안의 parts 가 여러 text chunk 일 수 있어 합칩니다.
+	cand := raw.Candidates[0]
+	content := ""
+	for _, part := range cand.Content.Parts {
+		content += part.Text
+	}
+	model := raw.ModelVersion
+	if model == "" {
+		model = requestedModel
+	}
+	return &llm.Response{
+		Content:      content,
+		Model:        model,
+		InputTokens:  raw.UsageMetadata.PromptTokenCount,
+		OutputTokens: raw.UsageMetadata.CandidatesTokenCount,
+		StopReason:   cand.FinishReason,
+	}, nil
+}

--- a/pkg/llm/http.go
+++ b/pkg/llm/http.go
@@ -1,0 +1,182 @@
+package llm
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+)
+
+// DefaultTimeout 은 LLM HTTP 호출의 기본 timeout 입니다.
+// 모델 응답이 길어지면 길어질 수 있으므로 호출자가 Config 또는 ctx 로 override 가능합니다.
+const DefaultTimeout = 60 * time.Second
+
+// httpDoer 는 net/http.Client 를 추상화하여 테스트에서 mock 으로 교체 가능하게 합니다.
+type httpDoer interface {
+	Do(req *http.Request) (*http.Response, error)
+}
+
+// HTTPClient 는 모든 provider 가 공유하는 HTTP 호출 헬퍼입니다.
+//
+// HTTPClient is the shared HTTP transport used by all provider adapters.
+// Provider 구현은 공통 timeout / 에러 매핑을 재사용하면서 자기 endpoint URL /
+// auth header / request·response 직렬화만 책임지면 됩니다.
+type HTTPClient struct {
+	doer    httpDoer
+	timeout time.Duration
+}
+
+// NewHTTPClient 는 HTTPClient 를 생성합니다. timeout=0 이면 DefaultTimeout 사용.
+func NewHTTPClient(timeout time.Duration) *HTTPClient {
+	if timeout <= 0 {
+		timeout = DefaultTimeout
+	}
+	return &HTTPClient{
+		doer:    &http.Client{Timeout: timeout},
+		timeout: timeout,
+	}
+}
+
+// PostJSON 은 url 에 JSON body 를 POST 하고 응답 body 를 raw bytes 로 반환합니다.
+//
+// providerName 은 에러 발생 시 *llm.Error.Provider 에 채워집니다.
+// headers 는 Content-Type: application/json 외 추가할 헤더 (예: Authorization).
+//
+// 응답 status 가 2xx 이 아니면 mapHTTPError 로 *llm.Error 를 만들어 반환합니다.
+// 호출자는 2xx 응답의 body 를 자기 schema 로 unmarshal 만 하면 됩니다.
+func (c *HTTPClient) PostJSON(ctx context.Context, providerName, endpoint string, headers map[string]string, body any) ([]byte, error) {
+	payload, err := json.Marshal(body)
+	if err != nil {
+		return nil, &Error{
+			Code:     ErrCodeBadRequest,
+			Provider: providerName,
+			Message:  "marshal request body",
+			Err:      err,
+		}
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, bytes.NewReader(payload))
+	if err != nil {
+		return nil, &Error{
+			Code:     ErrCodeBadRequest,
+			Provider: providerName,
+			Message:  "build http request",
+			Err:      err,
+		}
+	}
+	req.Header.Set("Content-Type", "application/json")
+	for k, v := range headers {
+		req.Header.Set(k, v)
+	}
+
+	resp, err := c.doer.Do(req)
+	if err != nil {
+		return nil, classifyTransportError(providerName, err)
+	}
+	defer resp.Body.Close()
+
+	respBody, readErr := io.ReadAll(resp.Body)
+	if readErr != nil {
+		return nil, &Error{
+			Code:      ErrCodeNetwork,
+			Provider:  providerName,
+			Message:   "read response body",
+			Retryable: true,
+			Err:       readErr,
+		}
+	}
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nil, mapHTTPError(providerName, resp.StatusCode, respBody)
+	}
+
+	return respBody, nil
+}
+
+// classifyTransportError 는 http.Client.Do 의 에러를 *llm.Error 로 정규화합니다.
+//
+// context 취소는 재시도 가치가 없는 호출자 의도이므로 Retryable=false.
+// 그 외 (DNS / connection refused / timeout) 는 일시적 가능성이 높아 Retryable=true.
+func classifyTransportError(providerName string, err error) *Error {
+	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		// DeadlineExceeded 도 ctx 의 timeout 이라면 호출자가 의도한 종료 — 재시도 무의미.
+		// 다만 실제로 server 가 늦은 케이스면 재시도 가치 있을 수 있어 운영자 판단에 맡김.
+		return &Error{
+			Code:     ErrCodeNetwork,
+			Provider: providerName,
+			Message:  "request canceled or timed out",
+			Err:      err,
+		}
+	}
+	var netErr net.Error
+	if errors.As(err, &netErr) && netErr.Timeout() {
+		return &Error{
+			Code:      ErrCodeNetwork,
+			Provider:  providerName,
+			Message:   "network timeout",
+			Retryable: true,
+			Err:       err,
+		}
+	}
+	var urlErr *url.Error
+	if errors.As(err, &urlErr) {
+		return &Error{
+			Code:      ErrCodeNetwork,
+			Provider:  providerName,
+			Message:   "transport error",
+			Retryable: true,
+			Err:       err,
+		}
+	}
+	return &Error{
+		Code:      ErrCodeNetwork,
+		Provider:  providerName,
+		Message:   "transport error",
+		Retryable: true,
+		Err:       err,
+	}
+}
+
+// mapHTTPError 는 HTTP status + body 를 *llm.Error 의 Code 로 매핑합니다.
+//
+// 매핑 규칙 (provider 별 미세 차이는 호출자가 추가 분류 가능):
+//   - 401 / 403       → ErrCodeAuth (Retryable=false)
+//   - 429             → ErrCodeRateLimit (Retryable=true)
+//   - 5xx             → ErrCodeServer (Retryable=true)
+//   - 400             → ErrCodeBadRequest 또는 ErrCodeContextLimit (body keyword)
+//   - 그 외 4xx       → ErrCodeBadRequest (Retryable=false)
+func mapHTTPError(providerName string, status int, body []byte) *Error {
+	msg := strings.TrimSpace(string(body))
+	if msg == "" {
+		msg = http.StatusText(status)
+	}
+	switch {
+	case status == http.StatusUnauthorized, status == http.StatusForbidden:
+		return &Error{Code: ErrCodeAuth, Provider: providerName, Message: msg}
+	case status == http.StatusTooManyRequests:
+		return &Error{Code: ErrCodeRateLimit, Provider: providerName, Message: msg, Retryable: true}
+	case status >= 500 && status < 600:
+		return &Error{Code: ErrCodeServer, Provider: providerName, Message: msg, Retryable: true}
+	case status == http.StatusBadRequest:
+		// context window 초과는 provider 별 keyword 로 별도 분류 — 호출자가 입력 단축 결정 가능.
+		lower := strings.ToLower(msg)
+		if strings.Contains(lower, "context length") ||
+			strings.Contains(lower, "maximum context") ||
+			strings.Contains(lower, "too many tokens") ||
+			strings.Contains(lower, "context window") {
+			return &Error{Code: ErrCodeContextLimit, Provider: providerName, Message: msg}
+		}
+		return &Error{Code: ErrCodeBadRequest, Provider: providerName, Message: msg}
+	case status >= 400 && status < 500:
+		return &Error{Code: ErrCodeBadRequest, Provider: providerName, Message: msg}
+	default:
+		return &Error{Code: ErrCodeUnknown, Provider: providerName, Message: fmt.Sprintf("HTTP %d: %s", status, msg)}
+	}
+}

--- a/pkg/llm/llm.go
+++ b/pkg/llm/llm.go
@@ -1,0 +1,101 @@
+// Package llm 은 외부 LLM API (Gemini / OpenAI ChatGPT / Anthropic Claude) 를
+// 동일한 추상 인터페이스로 호출할 수 있게 하는 generic client 패키지입니다 (이슈 #140).
+//
+// Package llm provides a unified interface for invoking external LLM APIs
+// (Google Gemini, OpenAI ChatGPT, Anthropic Claude). Provider-specific request /
+// response shapes are normalized into common types so that callers depend only on
+// the Provider interface.
+//
+// 호출자는 인터페이스 (llm.Provider) 와 공통 모델 (Message / Request / Response) 만
+// 알면 되며, provider 교체는 factory (llm.New) 의 Config 한 줄 변경만으로 가능합니다.
+//
+// 사용 예시:
+//
+//	cfg := llm.Config{Provider: "claude", APIKey: os.Getenv("ANTHROPIC_API_KEY"), Model: "claude-opus-4-7"}
+//	p, err := llm.New(cfg)
+//	if err != nil {
+//	    log.Fatal(err)
+//	}
+//	resp, err := p.Generate(ctx, llm.Request{
+//	    Messages: []llm.Message{{Role: llm.RoleUser, Content: "Hello"}},
+//	})
+package llm
+
+import "context"
+
+// Role 은 대화 메시지의 발화자 역할을 나타냅니다.
+//
+// Role represents the speaker role for a message in a chat-style request.
+// Provider 별 명칭이 다르므로 (예: Anthropic 은 system 을 별도 파라미터로 받음)
+// 어댑터에서 변환합니다.
+type Role string
+
+const (
+	// RoleSystem 은 모델 동작을 지시하는 system instruction 입니다.
+	// Anthropic 은 별도 system 파라미터로, OpenAI 는 system role 메시지로 매핑됩니다.
+	RoleSystem Role = "system"
+
+	// RoleUser 는 사용자 입력 메시지입니다.
+	RoleUser Role = "user"
+
+	// RoleAssistant 는 모델 응답 메시지입니다 (multi-turn 시 이전 응답을 다시 전달).
+	RoleAssistant Role = "assistant"
+)
+
+// Message 는 대화의 단일 메시지입니다 (chat-style API 의 공통 단위).
+//
+// Message represents a single message in a chat-style conversation.
+type Message struct {
+	Role    Role   `json:"role"`
+	Content string `json:"content"`
+}
+
+// Request 는 LLM 호출 입력입니다.
+//
+// Request is the input for an LLM call. Empty fields fall back to provider defaults
+// configured at construction time (e.g. Model, Temperature).
+type Request struct {
+	// Messages 는 대화 메시지 목록입니다. RoleSystem 메시지는 일반적으로 첫 항목으로 둡니다.
+	Messages []Message
+
+	// Model 이 비어있으면 Provider 생성 시 설정된 기본 모델을 사용합니다.
+	Model string
+
+	// Temperature 는 0.0 ~ 2.0 범위 (provider 별로 정규화). 0 이면 provider default.
+	Temperature float32
+
+	// MaxTokens 는 응답 생성 시 최대 토큰 수. 0 이면 provider default.
+	MaxTokens int
+}
+
+// Response 는 LLM 응답입니다.
+//
+// Response is the normalized LLM response. Token counts may be 0 if the provider
+// did not report them.
+type Response struct {
+	// Content 는 assistant 응답 본문 (단일 string 으로 합친 결과).
+	Content string
+
+	// Model 은 실제 응답을 생성한 모델 이름 (provider 가 보고한 값).
+	Model string
+
+	// InputTokens / OutputTokens 는 사용량 metric (없으면 0).
+	InputTokens  int
+	OutputTokens int
+
+	// StopReason 은 응답 종료 사유 (provider 별 raw 값을 그대로 보존).
+	// 예: "end_turn" (Anthropic), "stop" (OpenAI), "STOP" (Gemini).
+	StopReason string
+}
+
+// Provider 는 LLM 호출의 추상 인터페이스입니다.
+// 모든 구현체는 goroutine-safe 해야 합니다 (단일 인스턴스를 여러 worker 가 공유).
+//
+// Provider abstracts an LLM backend. Implementations must be safe for concurrent use.
+type Provider interface {
+	// Name 은 provider 식별자 ("gemini" / "openai" / "anthropic") 를 반환합니다.
+	Name() string
+
+	// Generate 는 단일 chat completion 을 수행합니다. 에러는 *llm.Error 로 정규화됩니다.
+	Generate(ctx context.Context, req Request) (*Response, error)
+}

--- a/pkg/llm/openai/openai.go
+++ b/pkg/llm/openai/openai.go
@@ -20,6 +20,23 @@ const (
 	defaultModel   = "gpt-4o-mini"
 )
 
+// init 은 factory (llm.New) 에서 본 provider 를 사용할 수 있게 등록합니다 (이슈 #140).
+func init() {
+	llm.RegisterProvider(providerName, func(cfg llm.Config) (llm.Provider, error) {
+		opts := []Option{}
+		if cfg.Model != "" {
+			opts = append(opts, WithModel(cfg.Model))
+		}
+		if cfg.BaseURL != "" {
+			opts = append(opts, WithBaseURL(cfg.BaseURL))
+		}
+		if cfg.Timeout > 0 {
+			opts = append(opts, WithTimeout(cfg.Timeout))
+		}
+		return New(cfg.APIKey, opts...), nil
+	})
+}
+
 // Provider 는 llm.Provider 의 OpenAI 구현입니다.
 type Provider struct {
 	apiKey  string

--- a/pkg/llm/openai/openai.go
+++ b/pkg/llm/openai/openai.go
@@ -1,0 +1,190 @@
+// Package openai 는 OpenAI ChatGPT API 의 llm.Provider 구현입니다 (이슈 #140).
+//
+// Package openai implements the llm.Provider interface against OpenAI's
+// chat completions REST API.
+//
+// API 문서: https://platform.openai.com/docs/api-reference/chat
+package openai
+
+import (
+	"context"
+	"encoding/json"
+	"time"
+
+	"issuetracker/pkg/llm"
+)
+
+const (
+	providerName   = "openai"
+	defaultBaseURL = "https://api.openai.com/v1"
+	defaultModel   = "gpt-4o-mini"
+)
+
+// Provider 는 llm.Provider 의 OpenAI 구현입니다.
+type Provider struct {
+	apiKey  string
+	model   string
+	baseURL string
+	http    *llm.HTTPClient
+}
+
+// Option 은 Provider 생성 옵션입니다.
+type Option func(*Provider)
+
+// WithBaseURL 은 API base URL 을 override 합니다 (테스트의 mock server 용).
+func WithBaseURL(u string) Option { return func(p *Provider) { p.baseURL = u } }
+
+// WithModel 은 기본 모델을 override 합니다.
+func WithModel(m string) Option { return func(p *Provider) { p.model = m } }
+
+// WithTimeout 은 HTTP timeout 을 override 합니다.
+func WithTimeout(d time.Duration) Option {
+	return func(p *Provider) { p.http = llm.NewHTTPClient(d) }
+}
+
+// New 는 OpenAI Provider 를 생성합니다.
+func New(apiKey string, opts ...Option) *Provider {
+	p := &Provider{
+		apiKey:  apiKey,
+		model:   defaultModel,
+		baseURL: defaultBaseURL,
+		http:    llm.NewHTTPClient(0),
+	}
+	for _, o := range opts {
+		o(p)
+	}
+	return p
+}
+
+// Name 은 provider 식별자를 반환합니다.
+func (p *Provider) Name() string { return providerName }
+
+// Generate 는 단일 chat completion 을 수행합니다.
+//
+// OpenAI API 는 모든 role (system / user / assistant) 을 messages 배열에 그대로
+// 전달하므로 변환이 가장 단순합니다. Authorization 헤더 + Bearer 토큰.
+func (p *Provider) Generate(ctx context.Context, req llm.Request) (*llm.Response, error) {
+	if p.apiKey == "" {
+		return nil, &llm.Error{
+			Code:     llm.ErrCodeAuth,
+			Provider: providerName,
+			Message:  "missing API key",
+		}
+	}
+
+	model := req.Model
+	if model == "" {
+		model = p.model
+	}
+
+	body, err := buildOpenAIRequest(req, model)
+	if err != nil {
+		return nil, err
+	}
+
+	endpoint := p.baseURL + "/chat/completions"
+	headers := map[string]string{
+		"Authorization": "Bearer " + p.apiKey,
+	}
+
+	respBytes, err := p.http.PostJSON(ctx, providerName, endpoint, headers, body)
+	if err != nil {
+		return nil, err
+	}
+
+	return parseOpenAIResponse(respBytes, model)
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Request / Response 스키마
+// ─────────────────────────────────────────────────────────────────────────────
+
+type openaiMessage struct {
+	Role    string `json:"role"`
+	Content string `json:"content"`
+}
+
+type openaiRequest struct {
+	Model       string          `json:"model"`
+	Messages    []openaiMessage `json:"messages"`
+	Temperature *float32        `json:"temperature,omitempty"`
+	MaxTokens   *int            `json:"max_tokens,omitempty"`
+}
+
+type openaiChoice struct {
+	Message      openaiMessage `json:"message"`
+	FinishReason string        `json:"finish_reason"`
+}
+
+type openaiUsage struct {
+	PromptTokens     int `json:"prompt_tokens"`
+	CompletionTokens int `json:"completion_tokens"`
+}
+
+type openaiResponse struct {
+	Model   string         `json:"model"`
+	Choices []openaiChoice `json:"choices"`
+	Usage   openaiUsage    `json:"usage"`
+}
+
+// buildOpenAIRequest 는 llm.Request 를 OpenAI 요청 body 로 변환합니다.
+func buildOpenAIRequest(req llm.Request, model string) (*openaiRequest, error) {
+	if len(req.Messages) == 0 {
+		return nil, &llm.Error{
+			Code:     llm.ErrCodeBadRequest,
+			Provider: providerName,
+			Message:  "request has no messages",
+		}
+	}
+	out := &openaiRequest{
+		Model:    model,
+		Messages: make([]openaiMessage, 0, len(req.Messages)),
+	}
+	for _, m := range req.Messages {
+		out.Messages = append(out.Messages, openaiMessage{
+			Role:    string(m.Role), // "system" / "user" / "assistant" 그대로 매핑
+			Content: m.Content,
+		})
+	}
+	if req.Temperature > 0 {
+		t := req.Temperature
+		out.Temperature = &t
+	}
+	if req.MaxTokens > 0 {
+		n := req.MaxTokens
+		out.MaxTokens = &n
+	}
+	return out, nil
+}
+
+// parseOpenAIResponse 는 OpenAI 응답을 llm.Response 로 정규화합니다.
+func parseOpenAIResponse(body []byte, requestedModel string) (*llm.Response, error) {
+	var raw openaiResponse
+	if err := json.Unmarshal(body, &raw); err != nil {
+		return nil, &llm.Error{
+			Code:     llm.ErrCodeUnknown,
+			Provider: providerName,
+			Message:  "decode response",
+			Err:      err,
+		}
+	}
+	if len(raw.Choices) == 0 {
+		return nil, &llm.Error{
+			Code:     llm.ErrCodeUnknown,
+			Provider: providerName,
+			Message:  "empty response (no choices)",
+		}
+	}
+	choice := raw.Choices[0]
+	model := raw.Model
+	if model == "" {
+		model = requestedModel
+	}
+	return &llm.Response{
+		Content:      choice.Message.Content,
+		Model:        model,
+		InputTokens:  raw.Usage.PromptTokens,
+		OutputTokens: raw.Usage.CompletionTokens,
+		StopReason:   choice.FinishReason,
+	}, nil
+}

--- a/pkg/llm/providers/providers.go
+++ b/pkg/llm/providers/providers.go
@@ -1,0 +1,15 @@
+// Package providers 는 모든 내장 provider 를 사이드 이펙트로 등록하는 편의 패키지입니다 (이슈 #140).
+//
+// 사용자는 호출처에서 다음 한 줄만 import 하면 모든 provider (gemini / openai / anthropic / claude) 가
+// llm.New 에 자동 등록됩니다:
+//
+//	import _ "issuetracker/pkg/llm/providers"
+//
+// 특정 provider 만 사용하고 싶다면 본 패키지 대신 해당 provider 패키지만 직접 import 하면 됩니다.
+package providers
+
+import (
+	_ "issuetracker/pkg/llm/anthropic"
+	_ "issuetracker/pkg/llm/gemini"
+	_ "issuetracker/pkg/llm/openai"
+)

--- a/test/pkg/llm/anthropic/anthropic_test.go
+++ b/test/pkg/llm/anthropic/anthropic_test.go
@@ -1,0 +1,161 @@
+package anthropic_test
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"issuetracker/pkg/llm"
+	"issuetracker/pkg/llm/anthropic"
+)
+
+const successResponse = `{
+  "id":"msg_01",
+  "model":"claude-opus-4-7",
+  "content":[
+    {"type":"text","text":"Hello"},
+    {"type":"text","text":", world"}
+  ],
+  "stop_reason":"end_turn",
+  "usage":{"input_tokens":20,"output_tokens":5}
+}`
+
+func TestAnthropic_Generate_Success_ConcatTextBlocks(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "test-key", r.Header.Get("x-api-key"))
+		assert.Equal(t, "2023-06-01", r.Header.Get("anthropic-version"))
+		assert.Equal(t, "/messages", r.URL.Path)
+
+		body, _ := io.ReadAll(r.Body)
+		var req map[string]any
+		_ = json.Unmarshal(body, &req)
+		// system 은 별도 top-level 필드
+		assert.Equal(t, "Be brief.", req["system"])
+		// messages 에는 user/assistant 만
+		msgs := req["messages"].([]any)
+		assert.Len(t, msgs, 2)
+		assert.Equal(t, "user", msgs[0].(map[string]any)["role"])
+		assert.Equal(t, "assistant", msgs[1].(map[string]any)["role"])
+		// max_tokens 필수 — 미지정 시 default 4096
+		assert.EqualValues(t, 4096, req["max_tokens"])
+
+		w.WriteHeader(200)
+		_, _ = w.Write([]byte(successResponse))
+	}))
+	defer srv.Close()
+
+	p := anthropic.New("test-key", anthropic.WithBaseURL(srv.URL))
+	resp, err := p.Generate(context.Background(), llm.Request{
+		Messages: []llm.Message{
+			{Role: llm.RoleSystem, Content: "Be brief."},
+			{Role: llm.RoleUser, Content: "Hi"},
+			{Role: llm.RoleAssistant, Content: "Hi back"},
+		},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "Hello, world", resp.Content, "다중 text 블록은 합쳐서 반환")
+	assert.Equal(t, "claude-opus-4-7", resp.Model)
+	assert.Equal(t, 20, resp.InputTokens)
+	assert.Equal(t, 5, resp.OutputTokens)
+	assert.Equal(t, "end_turn", resp.StopReason)
+}
+
+func TestAnthropic_Generate_MultipleSystem_Concatenated(t *testing.T) {
+	var seenSystem string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		var req map[string]any
+		_ = json.Unmarshal(body, &req)
+		seenSystem = req["system"].(string)
+		w.WriteHeader(200)
+		_, _ = w.Write([]byte(successResponse))
+	}))
+	defer srv.Close()
+
+	p := anthropic.New("k", anthropic.WithBaseURL(srv.URL))
+	_, err := p.Generate(context.Background(), llm.Request{
+		Messages: []llm.Message{
+			{Role: llm.RoleSystem, Content: "First instruction."},
+			{Role: llm.RoleSystem, Content: "Second instruction."},
+			{Role: llm.RoleUser, Content: "x"},
+		},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "First instruction.\n\nSecond instruction.", seenSystem)
+}
+
+func TestAnthropic_Generate_MaxTokensOverride(t *testing.T) {
+	var seen map[string]any
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(body, &seen)
+		w.WriteHeader(200)
+		_, _ = w.Write([]byte(successResponse))
+	}))
+	defer srv.Close()
+
+	p := anthropic.New("k", anthropic.WithBaseURL(srv.URL))
+	_, err := p.Generate(context.Background(), llm.Request{
+		Messages:  []llm.Message{{Role: llm.RoleUser, Content: "x"}},
+		MaxTokens: 1000,
+	})
+	require.NoError(t, err)
+	assert.EqualValues(t, 1000, seen["max_tokens"])
+}
+
+func TestAnthropic_Generate_NoAPIKey_Auth(t *testing.T) {
+	p := anthropic.New("")
+	_, err := p.Generate(context.Background(), llm.Request{
+		Messages: []llm.Message{{Role: llm.RoleUser, Content: "x"}},
+	})
+	require.Error(t, err)
+	var lerr *llm.Error
+	require.ErrorAs(t, err, &lerr)
+	assert.Equal(t, "anthropic", lerr.Provider)
+	assert.Equal(t, llm.ErrCodeAuth, lerr.Code)
+}
+
+func TestAnthropic_Generate_HTTP400_ContextLimit(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(400)
+		_, _ = w.Write([]byte(`{"error":"prompt exceeds maximum context length"}`))
+	}))
+	defer srv.Close()
+
+	p := anthropic.New("k", anthropic.WithBaseURL(srv.URL))
+	_, err := p.Generate(context.Background(), llm.Request{
+		Messages: []llm.Message{{Role: llm.RoleUser, Content: "x"}},
+	})
+	require.Error(t, err)
+	var lerr *llm.Error
+	require.ErrorAs(t, err, &lerr)
+	assert.Equal(t, llm.ErrCodeContextLimit, lerr.Code)
+	assert.False(t, llm.IsRetryable(err))
+}
+
+func TestAnthropic_Generate_EmptyContent_Unknown(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(200)
+		_, _ = w.Write([]byte(`{"content":[]}`))
+	}))
+	defer srv.Close()
+
+	p := anthropic.New("k", anthropic.WithBaseURL(srv.URL))
+	_, err := p.Generate(context.Background(), llm.Request{
+		Messages: []llm.Message{{Role: llm.RoleUser, Content: "x"}},
+	})
+	require.Error(t, err)
+	var lerr *llm.Error
+	require.ErrorAs(t, err, &lerr)
+	assert.Equal(t, llm.ErrCodeUnknown, lerr.Code)
+}
+
+func TestAnthropic_Name(t *testing.T) {
+	assert.Equal(t, "anthropic", anthropic.New("").Name())
+}

--- a/test/pkg/llm/errors_test.go
+++ b/test/pkg/llm/errors_test.go
@@ -1,0 +1,59 @@
+package llm_test
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"issuetracker/pkg/llm"
+)
+
+func TestError_String_WithoutWrapped(t *testing.T) {
+	e := &llm.Error{Code: llm.ErrCodeAuth, Provider: "gemini", Message: "missing key"}
+	assert.Equal(t, "[llm:gemini:auth] missing key", e.Error())
+}
+
+func TestError_String_WithWrapped(t *testing.T) {
+	e := &llm.Error{
+		Code:     llm.ErrCodeNetwork,
+		Provider: "openai",
+		Message:  "transport error",
+		Err:      errors.New("dial tcp: connection refused"),
+	}
+	assert.Contains(t, e.Error(), "[llm:openai:network] transport error")
+	assert.Contains(t, e.Error(), "dial tcp: connection refused")
+}
+
+func TestError_Unwrap_PreservesChain(t *testing.T) {
+	root := errors.New("root cause")
+	e := &llm.Error{Code: llm.ErrCodeServer, Provider: "anthropic", Err: root}
+	assert.True(t, errors.Is(e, root))
+
+	var target *llm.Error
+	wrapped := fmt.Errorf("wrap: %w", e)
+	assert.True(t, errors.As(wrapped, &target))
+	assert.Equal(t, llm.ErrCodeServer, target.Code)
+}
+
+func TestIsRetryable_TrueForRetryableLLMError(t *testing.T) {
+	e := &llm.Error{Code: llm.ErrCodeRateLimit, Retryable: true}
+	assert.True(t, llm.IsRetryable(e))
+}
+
+func TestIsRetryable_FalseForNonRetryableLLMError(t *testing.T) {
+	e := &llm.Error{Code: llm.ErrCodeAuth, Retryable: false}
+	assert.False(t, llm.IsRetryable(e))
+}
+
+func TestIsRetryable_FalseForNonLLMError(t *testing.T) {
+	assert.False(t, llm.IsRetryable(errors.New("plain")))
+	assert.False(t, llm.IsRetryable(nil))
+}
+
+func TestIsRetryable_UnwrapsToFindLLMError(t *testing.T) {
+	inner := &llm.Error{Code: llm.ErrCodeServer, Retryable: true}
+	wrapped := fmt.Errorf("during call: %w", inner)
+	assert.True(t, llm.IsRetryable(wrapped))
+}

--- a/test/pkg/llm/factory_test.go
+++ b/test/pkg/llm/factory_test.go
@@ -1,0 +1,64 @@
+package llm_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"issuetracker/pkg/llm"
+	_ "issuetracker/pkg/llm/providers"
+)
+
+func TestNew_KnownProviders_ReturnNonNil(t *testing.T) {
+	tests := []struct {
+		name     string
+		provider string
+	}{
+		{"gemini lowercase", "gemini"},
+		{"gemini uppercase", "GEMINI"},
+		{"openai", "openai"},
+		{"anthropic", "anthropic"},
+		{"claude alias", "claude"},
+		{"with whitespace", "  openai  "},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			p, err := llm.New(llm.Config{Provider: tc.provider, APIKey: "dummy"})
+			require.NoError(t, err)
+			assert.NotNil(t, p)
+		})
+	}
+}
+
+func TestNew_EmptyProvider_ReturnsBadRequest(t *testing.T) {
+	_, err := llm.New(llm.Config{APIKey: "x"})
+	require.Error(t, err)
+	var lerr *llm.Error
+	require.True(t, errors.As(err, &lerr))
+	assert.Equal(t, llm.ErrCodeBadRequest, lerr.Code)
+}
+
+func TestNew_UnknownProvider_ReturnsBadRequestWithRegisteredList(t *testing.T) {
+	_, err := llm.New(llm.Config{Provider: "no-such-provider", APIKey: "x"})
+	require.Error(t, err)
+	var lerr *llm.Error
+	require.True(t, errors.As(err, &lerr))
+	assert.Equal(t, llm.ErrCodeBadRequest, lerr.Code)
+	// 디버깅 친화: 등록된 이름이 메시지에 포함됨
+	assert.Contains(t, lerr.Message, "registered:")
+}
+
+func TestNew_ProviderNameAsExpected(t *testing.T) {
+	for name, want := range map[string]string{
+		"gemini":    "gemini",
+		"openai":    "openai",
+		"anthropic": "anthropic",
+		"claude":    "anthropic", // 별칭이라도 Provider.Name() 은 raw provider 이름
+	} {
+		p, err := llm.New(llm.Config{Provider: name, APIKey: "x"})
+		require.NoError(t, err)
+		assert.Equal(t, want, p.Name(), "config provider %q", name)
+	}
+}

--- a/test/pkg/llm/gemini/gemini_test.go
+++ b/test/pkg/llm/gemini/gemini_test.go
@@ -1,0 +1,177 @@
+package gemini_test
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"issuetracker/pkg/llm"
+	"issuetracker/pkg/llm/gemini"
+)
+
+// gemini API 응답 mock — usageMetadata + candidates 1개 (text part 1개).
+const successResponse = `{
+  "candidates": [{
+    "content": {"role":"model","parts":[{"text":"Hello, world!"}]},
+    "finishReason": "STOP"
+  }],
+  "usageMetadata": {"promptTokenCount":12,"candidatesTokenCount":3},
+  "modelVersion": "gemini-2.5-flash-001"
+}`
+
+func TestGemini_Generate_Success_NormalizesResponse(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Gemini 는 query param 으로 API key 전달
+		assert.Equal(t, "test-api-key", r.URL.Query().Get("key"))
+		// path 에 model 포함
+		assert.Contains(t, r.URL.Path, "/models/gemini-2.5-flash:generateContent")
+		// 요청 body 검사 — system 분리, role 매핑
+		body, _ := io.ReadAll(r.Body)
+		var req map[string]any
+		require.NoError(t, json.Unmarshal(body, &req))
+		assert.NotNil(t, req["systemInstruction"])
+		contents, _ := req["contents"].([]any)
+		assert.Len(t, contents, 1)
+		c0 := contents[0].(map[string]any)
+		assert.Equal(t, "user", c0["role"])
+
+		w.WriteHeader(200)
+		_, _ = w.Write([]byte(successResponse))
+	}))
+	defer srv.Close()
+
+	p := gemini.New("test-api-key", gemini.WithBaseURL(srv.URL))
+	resp, err := p.Generate(context.Background(), llm.Request{
+		Messages: []llm.Message{
+			{Role: llm.RoleSystem, Content: "You are a helpful assistant."},
+			{Role: llm.RoleUser, Content: "Hi"},
+		},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "Hello, world!", resp.Content)
+	assert.Equal(t, "gemini-2.5-flash-001", resp.Model)
+	assert.Equal(t, 12, resp.InputTokens)
+	assert.Equal(t, 3, resp.OutputTokens)
+	assert.Equal(t, "STOP", resp.StopReason)
+}
+
+func TestGemini_Generate_AssistantRoleMapsToModel(t *testing.T) {
+	var seenContents []map[string]any
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		var req map[string]any
+		_ = json.Unmarshal(body, &req)
+		for _, c := range req["contents"].([]any) {
+			seenContents = append(seenContents, c.(map[string]any))
+		}
+		w.WriteHeader(200)
+		_, _ = w.Write([]byte(successResponse))
+	}))
+	defer srv.Close()
+
+	p := gemini.New("k", gemini.WithBaseURL(srv.URL))
+	_, err := p.Generate(context.Background(), llm.Request{
+		Messages: []llm.Message{
+			{Role: llm.RoleUser, Content: "Q1"},
+			{Role: llm.RoleAssistant, Content: "A1"},
+			{Role: llm.RoleUser, Content: "Q2"},
+		},
+	})
+	require.NoError(t, err)
+	require.Len(t, seenContents, 3)
+	assert.Equal(t, "user", seenContents[0]["role"])
+	assert.Equal(t, "model", seenContents[1]["role"], "assistant 는 Gemini 의 'model' 로 매핑")
+	assert.Equal(t, "user", seenContents[2]["role"])
+}
+
+func TestGemini_Generate_NoAPIKey_ReturnsAuthError(t *testing.T) {
+	p := gemini.New("")
+	_, err := p.Generate(context.Background(), llm.Request{
+		Messages: []llm.Message{{Role: llm.RoleUser, Content: "x"}},
+	})
+	require.Error(t, err)
+	assertLLMError(t, err, "gemini", llm.ErrCodeAuth)
+}
+
+func TestGemini_Generate_EmptyMessages_BadRequest(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Error("server should not be called when request is invalid")
+	}))
+	defer srv.Close()
+
+	p := gemini.New("k", gemini.WithBaseURL(srv.URL))
+	_, err := p.Generate(context.Background(), llm.Request{})
+	require.Error(t, err)
+	assertLLMError(t, err, "gemini", llm.ErrCodeBadRequest)
+}
+
+func TestGemini_Generate_EmptyCandidates_Unknown(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(200)
+		_, _ = w.Write([]byte(`{"candidates":[]}`))
+	}))
+	defer srv.Close()
+
+	p := gemini.New("k", gemini.WithBaseURL(srv.URL))
+	_, err := p.Generate(context.Background(), llm.Request{
+		Messages: []llm.Message{{Role: llm.RoleUser, Content: "x"}},
+	})
+	require.Error(t, err)
+	assertLLMError(t, err, "gemini", llm.ErrCodeUnknown)
+}
+
+func TestGemini_Generate_HTTP429_RateLimit(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(429)
+		_, _ = w.Write([]byte(`{"error":"quota exceeded"}`))
+	}))
+	defer srv.Close()
+
+	p := gemini.New("k", gemini.WithBaseURL(srv.URL))
+	_, err := p.Generate(context.Background(), llm.Request{
+		Messages: []llm.Message{{Role: llm.RoleUser, Content: "x"}},
+	})
+	require.Error(t, err)
+	assertLLMError(t, err, "gemini", llm.ErrCodeRateLimit)
+	assert.True(t, llm.IsRetryable(err))
+}
+
+func TestGemini_Name_ReturnsGemini(t *testing.T) {
+	assert.Equal(t, "gemini", gemini.New("").Name())
+}
+
+// assertLLMError 는 모든 provider 테스트에서 공유하는 헬퍼 — *llm.Error 검증.
+func assertLLMError(t *testing.T, err error, wantProvider string, wantCode llm.ErrorCode) {
+	t.Helper()
+	var lerr *llm.Error
+	require.True(t, errorsAs(err, &lerr), "want *llm.Error, got %T: %v", err, err)
+	assert.Equal(t, wantProvider, lerr.Provider)
+	assert.Equal(t, wantCode, lerr.Code)
+}
+
+// errorsAs 는 std errors.As 를 그대로 사용 (testify 의존 회피).
+func errorsAs(err error, target **llm.Error) bool {
+	for err != nil {
+		if e, ok := err.(*llm.Error); ok {
+			*target = e
+			return true
+		}
+		type unwrapper interface{ Unwrap() error }
+		u, ok := err.(unwrapper)
+		if !ok {
+			return false
+		}
+		err = u.Unwrap()
+	}
+	return false
+}
+
+// 컴파일 사용 — strings 가 unused 없도록 (다른 import 가 필요할 때 쓸 placeholder)
+var _ = strings.Contains

--- a/test/pkg/llm/gemini/gemini_test.go
+++ b/test/pkg/llm/gemini/gemini_test.go
@@ -6,7 +6,6 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
-	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -151,27 +150,7 @@ func TestGemini_Name_ReturnsGemini(t *testing.T) {
 func assertLLMError(t *testing.T, err error, wantProvider string, wantCode llm.ErrorCode) {
 	t.Helper()
 	var lerr *llm.Error
-	require.True(t, errorsAs(err, &lerr), "want *llm.Error, got %T: %v", err, err)
+	require.ErrorAs(t, err, &lerr)
 	assert.Equal(t, wantProvider, lerr.Provider)
 	assert.Equal(t, wantCode, lerr.Code)
 }
-
-// errorsAs 는 std errors.As 를 그대로 사용 (testify 의존 회피).
-func errorsAs(err error, target **llm.Error) bool {
-	for err != nil {
-		if e, ok := err.(*llm.Error); ok {
-			*target = e
-			return true
-		}
-		type unwrapper interface{ Unwrap() error }
-		u, ok := err.(unwrapper)
-		if !ok {
-			return false
-		}
-		err = u.Unwrap()
-	}
-	return false
-}
-
-// 컴파일 사용 — strings 가 unused 없도록 (다른 import 가 필요할 때 쓸 placeholder)
-var _ = strings.Contains

--- a/test/pkg/llm/http_test.go
+++ b/test/pkg/llm/http_test.go
@@ -1,0 +1,131 @@
+package llm_test
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"issuetracker/pkg/llm"
+)
+
+// TestHTTPClient_PostJSON_Success 는 2xx 응답이 raw bytes 로 반환됨을 검증합니다.
+func TestHTTPClient_PostJSON_Success(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "application/json", r.Header.Get("Content-Type"))
+		w.WriteHeader(200)
+		_, _ = w.Write([]byte(`{"ok":true}`))
+	}))
+	defer srv.Close()
+
+	c := llm.NewHTTPClient(5 * time.Second)
+	body, err := c.PostJSON(context.Background(), "test", srv.URL, nil, map[string]string{"hello": "world"})
+	require.NoError(t, err)
+	assert.JSONEq(t, `{"ok":true}`, string(body))
+}
+
+func TestHTTPClient_PostJSON_HeadersForwarded(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "Bearer xyz", r.Header.Get("Authorization"))
+		w.WriteHeader(200)
+		_, _ = w.Write([]byte(`{}`))
+	}))
+	defer srv.Close()
+
+	c := llm.NewHTTPClient(5 * time.Second)
+	_, err := c.PostJSON(context.Background(), "test", srv.URL,
+		map[string]string{"Authorization": "Bearer xyz"}, struct{}{})
+	require.NoError(t, err)
+}
+
+// TestHTTPClient_PostJSON_StatusMappings 는 status → ErrorCode 매핑을 모두 검증합니다.
+func TestHTTPClient_PostJSON_StatusMappings(t *testing.T) {
+	tests := []struct {
+		name      string
+		status    int
+		body      string
+		wantCode  llm.ErrorCode
+		wantRetry bool
+	}{
+		{"401 → auth", 401, `{"error":"unauthorized"}`, llm.ErrCodeAuth, false},
+		{"403 → auth", 403, "forbidden", llm.ErrCodeAuth, false},
+		{"429 → rate_limit retryable", 429, `{"error":"rate limit"}`, llm.ErrCodeRateLimit, true},
+		{"500 → server retryable", 500, "internal", llm.ErrCodeServer, true},
+		{"503 → server retryable", 503, "unavailable", llm.ErrCodeServer, true},
+		{"400 generic → bad_request", 400, `{"error":"invalid"}`, llm.ErrCodeBadRequest, false},
+		{"400 context window keyword → context_limit", 400, `{"error":"maximum context length 8000 tokens"}`, llm.ErrCodeContextLimit, false},
+		{"404 → bad_request", 404, "not found", llm.ErrCodeBadRequest, false},
+		{"418 → unknown? actually bad_request 4xx", 418, "teapot", llm.ErrCodeBadRequest, false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(tc.status)
+				_, _ = w.Write([]byte(tc.body))
+			}))
+			defer srv.Close()
+
+			c := llm.NewHTTPClient(5 * time.Second)
+			_, err := c.PostJSON(context.Background(), "test-provider", srv.URL, nil, struct{}{})
+			require.Error(t, err)
+
+			var lerr *llm.Error
+			require.True(t, errors.As(err, &lerr))
+			assert.Equal(t, tc.wantCode, lerr.Code, "status %d", tc.status)
+			assert.Equal(t, "test-provider", lerr.Provider)
+			assert.Equal(t, tc.wantRetry, lerr.Retryable, "status %d retryable", tc.status)
+		})
+	}
+}
+
+// TestHTTPClient_PostJSON_ContextCancelled 는 ctx 취소 시 network 에러 반환을 검증합니다.
+func TestHTTPClient_PostJSON_ContextCancelled(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// 응답을 일부러 지연시켜 ctx 취소가 먼저 발화하도록.
+		select {
+		case <-r.Context().Done():
+		case <-time.After(2 * time.Second):
+			w.WriteHeader(200)
+		}
+	}))
+	defer srv.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(50 * time.Millisecond)
+		cancel()
+	}()
+
+	c := llm.NewHTTPClient(5 * time.Second)
+	_, err := c.PostJSON(ctx, "test", srv.URL, nil, struct{}{})
+	require.Error(t, err)
+	var lerr *llm.Error
+	require.True(t, errors.As(err, &lerr))
+	assert.Equal(t, llm.ErrCodeNetwork, lerr.Code)
+}
+
+// TestHTTPClient_PostJSON_BadResponseEncoding 은 marshal 실패 케이스 — function value (JSON 비호환) 전달.
+func TestHTTPClient_PostJSON_BadEncodingBody(t *testing.T) {
+	c := llm.NewHTTPClient(5 * time.Second)
+	// JSON 인코딩 불가능한 값 (function) 으로 marshal 실패 유도
+	badBody := func() {}
+	_, err := c.PostJSON(context.Background(), "test", "http://localhost:1", nil, badBody)
+	require.Error(t, err)
+	var lerr *llm.Error
+	require.True(t, errors.As(err, &lerr))
+	assert.Equal(t, llm.ErrCodeBadRequest, lerr.Code)
+}
+
+// 이하 helper — 다른 provider test 들이 mock JSON 작성 시 사용
+func mustJSON(t *testing.T, v any) []byte {
+	t.Helper()
+	b, err := json.Marshal(v)
+	require.NoError(t, err)
+	return b
+}

--- a/test/pkg/llm/http_test.go
+++ b/test/pkg/llm/http_test.go
@@ -2,7 +2,6 @@ package llm_test
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"net/http"
 	"net/http/httptest"
@@ -120,12 +119,4 @@ func TestHTTPClient_PostJSON_BadEncodingBody(t *testing.T) {
 	var lerr *llm.Error
 	require.True(t, errors.As(err, &lerr))
 	assert.Equal(t, llm.ErrCodeBadRequest, lerr.Code)
-}
-
-// 이하 helper — 다른 provider test 들이 mock JSON 작성 시 사용
-func mustJSON(t *testing.T, v any) []byte {
-	t.Helper()
-	b, err := json.Marshal(v)
-	require.NoError(t, err)
-	return b
 }

--- a/test/pkg/llm/openai/openai_test.go
+++ b/test/pkg/llm/openai/openai_test.go
@@ -1,0 +1,132 @@
+package openai_test
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"issuetracker/pkg/llm"
+	"issuetracker/pkg/llm/openai"
+)
+
+const successResponse = `{
+  "id":"chatcmpl-1",
+  "model":"gpt-4o-mini-2024-07-18",
+  "choices":[{
+    "message":{"role":"assistant","content":"Hello there"},
+    "finish_reason":"stop"
+  }],
+  "usage":{"prompt_tokens":15,"completion_tokens":4}
+}`
+
+func TestOpenAI_Generate_Success(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "Bearer sk-test", r.Header.Get("Authorization"))
+		assert.Equal(t, "/chat/completions", r.URL.Path)
+
+		body, _ := io.ReadAll(r.Body)
+		var req map[string]any
+		_ = json.Unmarshal(body, &req)
+		// system / user / assistant 모두 messages 배열에 그대로
+		msgs := req["messages"].([]any)
+		assert.Len(t, msgs, 3)
+		assert.Equal(t, "system", msgs[0].(map[string]any)["role"])
+		assert.Equal(t, "user", msgs[1].(map[string]any)["role"])
+		assert.Equal(t, "assistant", msgs[2].(map[string]any)["role"])
+		assert.Equal(t, "gpt-4o-mini", req["model"])
+
+		w.WriteHeader(200)
+		_, _ = w.Write([]byte(successResponse))
+	}))
+	defer srv.Close()
+
+	p := openai.New("sk-test", openai.WithBaseURL(srv.URL))
+	resp, err := p.Generate(context.Background(), llm.Request{
+		Messages: []llm.Message{
+			{Role: llm.RoleSystem, Content: "Be brief."},
+			{Role: llm.RoleUser, Content: "Hi"},
+			{Role: llm.RoleAssistant, Content: "Hi back"},
+		},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "Hello there", resp.Content)
+	assert.Equal(t, "gpt-4o-mini-2024-07-18", resp.Model)
+	assert.Equal(t, 15, resp.InputTokens)
+	assert.Equal(t, 4, resp.OutputTokens)
+	assert.Equal(t, "stop", resp.StopReason)
+}
+
+func TestOpenAI_Generate_NoAPIKey_Auth(t *testing.T) {
+	p := openai.New("")
+	_, err := p.Generate(context.Background(), llm.Request{
+		Messages: []llm.Message{{Role: llm.RoleUser, Content: "x"}},
+	})
+	require.Error(t, err)
+	var lerr *llm.Error
+	require.ErrorAs(t, err, &lerr)
+	assert.Equal(t, "openai", lerr.Provider)
+	assert.Equal(t, llm.ErrCodeAuth, lerr.Code)
+}
+
+func TestOpenAI_Generate_EmptyChoices_Unknown(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(200)
+		_, _ = w.Write([]byte(`{"choices":[]}`))
+	}))
+	defer srv.Close()
+
+	p := openai.New("k", openai.WithBaseURL(srv.URL))
+	_, err := p.Generate(context.Background(), llm.Request{
+		Messages: []llm.Message{{Role: llm.RoleUser, Content: "x"}},
+	})
+	require.Error(t, err)
+	var lerr *llm.Error
+	require.ErrorAs(t, err, &lerr)
+	assert.Equal(t, llm.ErrCodeUnknown, lerr.Code)
+}
+
+func TestOpenAI_Generate_HTTP500_Server_Retryable(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(500)
+		_, _ = w.Write([]byte("server overload"))
+	}))
+	defer srv.Close()
+
+	p := openai.New("k", openai.WithBaseURL(srv.URL))
+	_, err := p.Generate(context.Background(), llm.Request{
+		Messages: []llm.Message{{Role: llm.RoleUser, Content: "x"}},
+	})
+	require.Error(t, err)
+	assert.True(t, llm.IsRetryable(err))
+}
+
+func TestOpenAI_Generate_TemperatureAndMaxTokens_Forwarded(t *testing.T) {
+	var seen map[string]any
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(body, &seen)
+		w.WriteHeader(200)
+		_, _ = w.Write([]byte(successResponse))
+	}))
+	defer srv.Close()
+
+	p := openai.New("k", openai.WithBaseURL(srv.URL))
+	_, err := p.Generate(context.Background(), llm.Request{
+		Messages:    []llm.Message{{Role: llm.RoleUser, Content: "x"}},
+		Temperature: 0.7,
+		MaxTokens:   200,
+	})
+	require.NoError(t, err)
+	assert.InDelta(t, 0.7, seen["temperature"], 0.001)
+	assert.EqualValues(t, 200, seen["max_tokens"])
+}
+
+func TestOpenAI_Name(t *testing.T) {
+	assert.Equal(t, "openai", openai.New("").Name())
+}


### PR DESCRIPTION
## 연관 이슈
- Closes #140
- Parent: #100 (사이트별 파싱 규칙 DB 일원화) — 본 모듈은 #100 의 \"미지원 페이지 LLM 자동 생성\" 단계에서 활용

<br>

## 구현 내용

#100 의 LLM 활용 단계를 위한 generic LLM client 패키지. 외부 API 3종 (Gemini / OpenAI ChatGPT / Anthropic Claude) 을 동일 인터페이스로 호출할 수 있게 하여, provider 교체가 \`llm.Config{Provider: \"...\"}\` 한 줄 변경으로 가능하도록 구현. 7개 논리적 commit:

1. **`[FEAT]` 공통 인터페이스 + 에러 타입** (`pkg/llm/llm.go`, `errors.go`)
   - `Provider interface { Name(), Generate(ctx, Request) (*Response, error) }`
   - 공통 모델: `Role` (system/user/assistant), `Message`, `Request`, `Response`
   - `Error` (Code / Provider / Retryable / Err) — 7가지 ErrorCode 표준화
   - `IsRetryable(err)` 헬퍼

2. **`[FEAT]` HTTPClient + 상태 매핑** (`pkg/llm/http.go`)
   - 공통 timeout (default 60s) + JSON encode/decode
   - `mapHTTPError`: 401/403→Auth, 429→RateLimit, 5xx→Server, 400+context keyword→ContextLimit
   - `classifyTransportError`: ctx cancel / timeout / DNS / connection
   - `httpDoer` 인터페이스로 테스트 mock 가능

3. **`[FEAT]` Gemini provider** (`pkg/llm/gemini/`)
   - `generativelanguage.googleapis.com/v1beta/models/{model}:generateContent`
   - role 매핑: `assistant→model` (Gemini 명칭 차이), `system→systemInstruction` 별도 필드
   - API key 는 query parameter
   - default model: `gemini-2.5-flash`

4. **`[FEAT]` OpenAI provider** (`pkg/llm/openai/`)
   - `api.openai.com/v1/chat/completions`
   - role 1:1 매핑 (가장 단순), Authorization Bearer 헤더
   - default model: `gpt-4o-mini`

5. **`[FEAT]` Anthropic provider** (`pkg/llm/anthropic/`)
   - `api.anthropic.com/v1/messages`
   - role 매핑: `system→top-level system 필드`
   - max_tokens 필수 — 0 이면 default 4096
   - 헤더: `x-api-key` + `anthropic-version: 2023-06-01`
   - default model: `claude-opus-4-7`
   - 응답 content 가 block 배열 — type=\"text\" 블록의 text 합쳐서 반환

6. **`[FEAT]` factory + providers 통합** (`pkg/llm/factory.go`, `pkg/llm/providers/`)
   - `llm.Config{Provider, APIKey, Model, BaseURL, Timeout}` + `llm.New(cfg) (Provider, error)`
   - `RegisterProvider` — 각 provider 패키지의 `init()` 에서 자기 builder 등록 (lock-free)
   - `pkg/llm/providers` 패키지 — `_` import 한 줄로 모든 내장 provider 자동 등록
   - anthropic 은 `\"anthropic\"` + `\"claude\"` 두 별칭 등록
   - 미등록 provider 시 등록된 이름 목록을 에러 메시지에 포함 (디버깅 친화)

7. **`[FEAT]` 단위 테스트** (`test/pkg/llm/`)
   - errors / factory / http base + provider 별 (gemini/openai/anthropic)
   - `httptest` mock server 로 외부 네트워크 없이 모든 경로 검증
   - 성공 응답 정규화, role 매핑, 에러 매핑 (Auth/RateLimit/Server/ContextLimit/Unknown), API key 누락
   - **race 테스트 22 패키지 모두 통과**

### 사용 예시

```go
import (
    \"issuetracker/pkg/llm\"
    _ \"issuetracker/pkg/llm/providers\"  // 모든 내장 provider 자동 등록
)

p, err := llm.New(llm.Config{
    Provider: \"claude\",  // \"gemini\" / \"openai\" 로 교체만 하면 다른 backend
    APIKey:   os.Getenv(\"ANTHROPIC_API_KEY\"),
    Model:    \"claude-opus-4-7\",
})
if err != nil { ... }

resp, err := p.Generate(ctx, llm.Request{
    Messages: []llm.Message{
        {Role: llm.RoleSystem, Content: \"You are a parsing rule generator.\"},
        {Role: llm.RoleUser, Content: \"Generate selectors for this HTML: ...\"},
    },
    MaxTokens: 2000,
})

// 에러 처리
var lerr *llm.Error
if errors.As(err, &lerr) {
    if llm.IsRetryable(err) {
        // backoff + retry
    }
}
```

<br>

## CI / 머지 게이트 점검

### 변경 영향 범위
- 신규 패키지 7개: `pkg/llm/`, `pkg/llm/{gemini,openai,anthropic,providers}/`, `test/pkg/llm/{,gemini,openai,anthropic}/`
- 위험도: `Low` — 신규 패키지만 추가, 기존 코드 미변경. 외부 의존성 추가 없음 (표준 라이브러리만 사용)

### Required Status Checks
- 통과 확인 대상:
  - [ ] `Commit Lint`
  - [ ] `PR Title Lint`
  - [ ] `Linked Issue Check`
  - [ ] `Format Check`
  - [ ] `Build`
  - [ ] `Test`
  - [ ] `Lint`

로컬 검증:
- `go test -race -count=1 ./...` 전체 통과 (22 패키지, llm 4 + 기존 18)
- `gofmt -l .` clean
- `go build ./...` 통과
- 외부 SDK 의존성 추가 0건 (`go.mod` 변경 없음)

### 롤백 계획
- 단일 PR revert
- 기존 코드 변경 없으므로 즉시 안전 revert

<br>

## TODO (별도 PR / 후속 작업)
- pkg/config 에 `LLMConfig` 추가 — `LoadLLM()` 으로 환경변수 (`LLM_PROVIDER`, `<PROVIDER>_API_KEY`, `LLM_MODEL`) 로드 표준화
- 재시도 wrapper — `Retryable(err)==true` 일 때 backoff 자동 재시도하는 decorator provider
- streaming 응답 지원 — `GenerateStream(ctx, req) (<-chan ResponseChunk, error)` (현재는 단일 응답만)
- function calling / tool use — Anthropic / OpenAI 의 native 지원, Gemini 동일 추상화

<br>

## 논의 사항
- **외부 SDK 미사용** — provider 별 공식 SDK (anthropic-sdk-go 등) 대신 net/http 직접 호출. 의존성 폭증 / 버전 충돌 회피, 우리가 노출하는 표면이 작아 유지 부담 적음. SDK 의 fancy feature (streaming / tool call) 가 필요해지면 그때 도입.
- **default 모델 선택** — 각 provider 의 가장 최신 안정/저비용 모델 (gemini-2.5-flash / gpt-4o-mini / claude-opus-4-7). 호출자가 \`Config.Model\` 로 override 가능.
- **다중 system 메시지** — Anthropic / Gemini 가 단일 system 만 받으므로 줄바꿈으로 합침. OpenAI 는 multi-system 그대로 전달.

🤖 Generated with [Claude Code](https://claude.com/claude-code)