### PR TITLE
[FEAT#142] LLM ChainProvider — Chain-of-Responsibility fallback 합성

### DIFF
--- a/pkg/llm/chain/chain.go
+++ b/pkg/llm/chain/chain.go
@@ -1,0 +1,184 @@
+// Package chain 은 여러 llm.Provider 를 Chain-of-Responsibility 패턴으로 합성합니다 (이슈 #142).
+//
+// Package chain composes multiple llm.Provider instances into a single fallback chain
+// where the next handler is invoked when the current one fails with a delegatable error.
+//
+// 사용 예시:
+//
+//	primary,   _ := llm.New(llm.Config{Provider: "claude", APIKey: ...})
+//	secondary, _ := llm.New(llm.Config{Provider: "openai", APIKey: ...})
+//	fallback,  _ := llm.New(llm.Config{Provider: "gemini", APIKey: ...})
+//
+//	p := chain.New(primary, secondary, fallback)   // 그 자체가 llm.Provider
+//	resp, err := p.Generate(ctx, req)
+//
+// 호출자 코드는 단일 provider 사용과 동일합니다 — chain 은 투명한 wrapper.
+package chain
+
+import (
+	"context"
+	"errors"
+
+	"issuetracker/pkg/llm"
+	"issuetracker/pkg/logger"
+)
+
+// providerName 은 Name() 반환값 / 로그 식별자.
+const providerName = "chain"
+
+// Provider 는 여러 llm.Provider 를 순차 시도하는 fallback chain 입니다.
+//
+// 각 handler 가 ctx · 동일 Request 로 호출되며, 위임 가능한 에러 (shouldDelegate==true) 시
+// 다음 handler 로 전파합니다. 모든 handler 가 실패하면 마지막 에러를 반환합니다.
+//
+// goroutine-safe — handlers 슬라이스는 New 시점 이후 변하지 않으며 각 handler 호출은
+// stateless 라 가정 (provider 패키지의 표준 보장).
+type Provider struct {
+	handlers []llm.Provider
+	log      *logger.Logger // 위임 발생 시 INFO 로그 (nil 허용 — 미주입 시 로그 skip)
+}
+
+// Option 은 Provider 생성 옵션입니다.
+type Option func(*Provider)
+
+// WithLogger 는 위임 발생 / 모든 handler 실패 시 INFO 로그를 출력할 logger 를 주입합니다.
+// 미주입 (nil) 이면 로그가 출력되지 않습니다 — 기존 동작 보존.
+func WithLogger(log *logger.Logger) Option {
+	return func(p *Provider) { p.log = log }
+}
+
+// New 는 handlers 를 순서대로 시도하는 ChainProvider 를 반환합니다.
+//
+// handlers 가 비어있어도 panic 없이 생성됩니다 — 호출 시 ErrCodeBadRequest 반환.
+// (호출 시점에 명시적 에러가 더 디버깅 친화적이라 생성 시점은 관대하게 처리.)
+func New(handlers ...llm.Provider) *Provider {
+	return NewWithOptions(handlers, nil)
+}
+
+// NewWithOptions 는 handlers + 옵션으로 ChainProvider 를 생성합니다.
+func NewWithOptions(handlers []llm.Provider, opts []Option) *Provider {
+	p := &Provider{handlers: handlers}
+	for _, o := range opts {
+		o(p)
+	}
+	return p
+}
+
+// Name 은 chain 식별자를 반환합니다 (llm.Provider 구현).
+func (p *Provider) Name() string { return providerName }
+
+// Generate 는 handlers 를 순서대로 시도하여 첫 성공 응답을 반환합니다 (llm.Provider 구현).
+//
+// 흐름:
+//  1. handlers 가 비어있음 → ErrCodeBadRequest 즉시 반환
+//  2. ctx 가 이미 cancel → ErrCodeNetwork (transport-like) 즉시 반환
+//  3. handler 별 순회:
+//     - 성공     → 즉시 반환
+//     - !delegatable (BadRequest/ContextLimit) → 즉시 반환 (다른 handler 도 동일 실패)
+//     - delegatable → 다음 handler 시도 (마지막 에러 보존)
+//  4. 모든 handler 실패 → 마지막 에러 반환
+func (p *Provider) Generate(ctx context.Context, req llm.Request) (*llm.Response, error) {
+	if len(p.handlers) == 0 {
+		return nil, &llm.Error{
+			Code:     llm.ErrCodeBadRequest,
+			Provider: providerName,
+			Message:  "chain has no handlers",
+		}
+	}
+	if err := ctx.Err(); err != nil {
+		return nil, &llm.Error{
+			Code:     llm.ErrCodeNetwork,
+			Provider: providerName,
+			Message:  "context already canceled before first handler",
+			Err:      err,
+		}
+	}
+
+	var lastErr error
+	for i, h := range p.handlers {
+		resp, err := h.Generate(ctx, req)
+		if err == nil {
+			return resp, nil
+		}
+		if !shouldDelegate(err) {
+			// 입력 자체 문제 — 다른 handler 도 동일 실패. 즉시 종결.
+			p.logTermination(h.Name(), i, err, "non-delegatable")
+			return nil, err
+		}
+		p.logDelegation(h.Name(), i, err)
+		lastErr = err
+
+		// ctx 취소가 handler 내부에서 일어났을 수 있음 — 다음 handler 호출 전 빠른 종결.
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return nil, lastErr
+		}
+	}
+
+	// 모든 handler 실패 — 마지막 에러를 그대로 반환 (래핑 없이 ErrorCode 정보 보존).
+	p.logExhausted(lastErr)
+	return nil, lastErr
+}
+
+// shouldDelegate 는 에러를 다음 handler 에 위임할 가치가 있는지 판단합니다.
+//
+//   - *llm.Error 가 아닌 경우 → 다음 handler 시도 (보수적 — 정상 가능성 남김)
+//   - BadRequest / ContextLimit → 즉시 종결 (입력 자체 문제, 다른 handler 도 동일 실패)
+//   - 그 외 (Auth/RateLimit/Server/Network/Unknown) → 다음 handler 시도
+//
+// 정책 근거:
+//   - Auth: 잘못된 API key — 다른 provider 의 key 는 유효할 수 있음
+//   - RateLimit: 이 provider 의 한도 초과 — 다른 provider 는 별도 한도
+//   - Server: 이 provider 측 일시 장애 — 다른 provider 는 정상 가능성
+//   - Network: 일반적인 transport 문제. 다음 handler 시도가 합리적.
+//   - BadRequest: 형식 / 파라미터 자체 문제 — 다른 provider 도 동일 reject
+//   - ContextLimit: 입력 토큰 초과 — 모델 제한이라기보다 입력 자체가 큰 경우라 모든 provider 동일
+func shouldDelegate(err error) bool {
+	var lerr *llm.Error
+	if !errors.As(err, &lerr) {
+		return true
+	}
+	switch lerr.Code {
+	case llm.ErrCodeBadRequest, llm.ErrCodeContextLimit:
+		return false
+	default:
+		return true
+	}
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 관찰성 헬퍼 (logger nil 허용)
+// ─────────────────────────────────────────────────────────────────────────────
+
+// logDelegation 은 handler 가 위임 가능한 에러로 실패해 다음으로 넘어갈 때 호출됩니다.
+func (p *Provider) logDelegation(handlerName string, index int, err error) {
+	if p.log == nil {
+		return
+	}
+	p.log.WithFields(map[string]interface{}{
+		"handler":       handlerName,
+		"handler_index": index,
+		"total":         len(p.handlers),
+	}).WithError(err).Info("llm chain delegating to next handler")
+}
+
+// logTermination 은 non-delegatable 에러로 chain 이 즉시 종결될 때 호출됩니다.
+func (p *Provider) logTermination(handlerName string, index int, err error, reason string) {
+	if p.log == nil {
+		return
+	}
+	p.log.WithFields(map[string]interface{}{
+		"handler":       handlerName,
+		"handler_index": index,
+		"reason":        reason,
+	}).WithError(err).Info("llm chain terminated without delegation")
+}
+
+// logExhausted 는 모든 handler 가 위임 가능한 에러로 실패했을 때 호출됩니다.
+func (p *Provider) logExhausted(lastErr error) {
+	if p.log == nil {
+		return
+	}
+	p.log.WithFields(map[string]interface{}{
+		"handlers": len(p.handlers),
+	}).WithError(lastErr).Warn("llm chain exhausted — all handlers failed")
+}

--- a/pkg/llm/chain/chain.go
+++ b/pkg/llm/chain/chain.go
@@ -74,8 +74,10 @@ func (p *Provider) Name() string { return providerName }
 //  2. ctx 가 이미 cancel → ErrCodeNetwork (transport-like) 즉시 반환
 //  3. handler 별 순회:
 //     - 성공     → 즉시 반환
-//     - !delegatable (BadRequest/ContextLimit) → 즉시 반환 (다른 handler 도 동일 실패)
-//     - delegatable → 다음 handler 시도 (마지막 에러 보존)
+//     - !delegatable (BadRequest) → 즉시 반환 (다른 handler 도 동일 실패)
+//     - delegatable → 다음 handler 시도 전 ctx 취소 검사 →
+//     취소면 명시적 ErrCodeNetwork 반환 (이전 handler 의 lastErr 로 가리지 않음),
+//     아니면 위임 로그 후 다음 handler 시도 (lastErr 보존)
 //  4. 모든 handler 실패 → 마지막 에러 반환
 func (p *Provider) Generate(ctx context.Context, req llm.Request) (*llm.Response, error) {
 	if len(p.handlers) == 0 {
@@ -105,13 +107,19 @@ func (p *Provider) Generate(ctx context.Context, req llm.Request) (*llm.Response
 			p.logTermination(h.Name(), i, err, "non-delegatable")
 			return nil, err
 		}
+		// ctx 취소가 handler 내부에서 일어났을 수 있음 — 다음 handler 호출 전에 즉시 검사.
+		// 명시적 ErrCodeNetwork 로 반환하여 호출자가 "취소" 를 즉답 가능 (Gemini code review #2).
+		// 위임 로그 호출 전에 검사하여 취소된 상황에서 불필요한 위임 로그 회피.
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return nil, &llm.Error{
+				Code:     llm.ErrCodeNetwork,
+				Provider: providerName,
+				Message:  "context canceled during chain execution",
+				Err:      ctxErr,
+			}
+		}
 		p.logDelegation(h.Name(), i, err)
 		lastErr = err
-
-		// ctx 취소가 handler 내부에서 일어났을 수 있음 — 다음 handler 호출 전 빠른 종결.
-		if ctxErr := ctx.Err(); ctxErr != nil {
-			return nil, lastErr
-		}
 	}
 
 	// 모든 handler 실패 — 마지막 에러를 그대로 반환 (래핑 없이 ErrorCode 정보 보존).
@@ -122,23 +130,26 @@ func (p *Provider) Generate(ctx context.Context, req llm.Request) (*llm.Response
 // shouldDelegate 는 에러를 다음 handler 에 위임할 가치가 있는지 판단합니다.
 //
 //   - *llm.Error 가 아닌 경우 → 다음 handler 시도 (보수적 — 정상 가능성 남김)
-//   - BadRequest / ContextLimit → 즉시 종결 (입력 자체 문제, 다른 handler 도 동일 실패)
-//   - 그 외 (Auth/RateLimit/Server/Network/Unknown) → 다음 handler 시도
+//   - BadRequest → 즉시 종결 (입력 형식/파라미터 자체 문제, 다른 provider 도 동일 reject)
+//   - 그 외 (Auth/RateLimit/Server/Network/Unknown/ContextLimit) → 다음 handler 시도
 //
 // 정책 근거:
 //   - Auth: 잘못된 API key — 다른 provider 의 key 는 유효할 수 있음
 //   - RateLimit: 이 provider 의 한도 초과 — 다른 provider 는 별도 한도
 //   - Server: 이 provider 측 일시 장애 — 다른 provider 는 정상 가능성
 //   - Network: 일반적인 transport 문제. 다음 handler 시도가 합리적.
-//   - BadRequest: 형식 / 파라미터 자체 문제 — 다른 provider 도 동일 reject
-//   - ContextLimit: 입력 토큰 초과 — 모델 제한이라기보다 입력 자체가 큰 경우라 모든 provider 동일
+//   - ContextLimit: provider/모델 마다 context window 가 크게 다름 — 예:
+//     gpt-4o-mini ≈128k, claude-opus-4-7 ≈200k, gemini-1.5-pro ≈2M.
+//     한 모델에서 ContextLimit 이라도 더 큰 window 를 가진 다른 모델은 처리 가능.
+//     Gemini code review #1 피드백 — 위임 대상으로 포함.
+//   - BadRequest: 형식 / 파라미터 자체 문제 — 다른 provider 도 동일 reject 가 합리적 가정.
 func shouldDelegate(err error) bool {
 	var lerr *llm.Error
 	if !errors.As(err, &lerr) {
 		return true
 	}
 	switch lerr.Code {
-	case llm.ErrCodeBadRequest, llm.ErrCodeContextLimit:
+	case llm.ErrCodeBadRequest:
 		return false
 	default:
 		return true

--- a/test/pkg/llm/chain/chain_test.go
+++ b/test/pkg/llm/chain/chain_test.go
@@ -1,0 +1,243 @@
+package chain_test
+
+import (
+	"context"
+	"errors"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"issuetracker/pkg/llm"
+	"issuetracker/pkg/llm/chain"
+)
+
+// fakeProvider 는 미리 정해진 결과를 반환하는 mock provider 입니다.
+// 호출 횟수를 atomic counter 로 추적하여 chain 위임 시점을 검증합니다.
+type fakeProvider struct {
+	name    string
+	resp    *llm.Response
+	err     error
+	callCnt int64
+	onCall  func(ctx context.Context, req llm.Request) // optional hook
+}
+
+func (f *fakeProvider) Name() string { return f.name }
+
+func (f *fakeProvider) Generate(ctx context.Context, req llm.Request) (*llm.Response, error) {
+	atomic.AddInt64(&f.callCnt, 1)
+	if f.onCall != nil {
+		f.onCall(ctx, req)
+	}
+	return f.resp, f.err
+}
+
+func (f *fakeProvider) calls() int { return int(atomic.LoadInt64(&f.callCnt)) }
+
+func sampleRequest() llm.Request {
+	return llm.Request{
+		Messages: []llm.Message{{Role: llm.RoleUser, Content: "ping"}},
+	}
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 정상 흐름
+// ─────────────────────────────────────────────────────────────────────────────
+
+func TestChain_FirstHandlerSucceeds_ShortCircuits(t *testing.T) {
+	want := &llm.Response{Content: "ok-1", Model: "m1"}
+	h1 := &fakeProvider{name: "h1", resp: want}
+	h2 := &fakeProvider{name: "h2", resp: &llm.Response{Content: "ok-2"}}
+	h3 := &fakeProvider{name: "h3", resp: &llm.Response{Content: "ok-3"}}
+
+	p := chain.New(h1, h2, h3)
+	resp, err := p.Generate(context.Background(), sampleRequest())
+
+	require.NoError(t, err)
+	assert.Same(t, want, resp)
+	assert.Equal(t, 1, h1.calls())
+	assert.Equal(t, 0, h2.calls(), "후속 handler 는 호출되면 안 됨")
+	assert.Equal(t, 0, h3.calls())
+}
+
+func TestChain_FirstFailsRetryable_FallsBackToSecond(t *testing.T) {
+	h1 := &fakeProvider{name: "h1", err: &llm.Error{Code: llm.ErrCodeServer, Provider: "h1", Retryable: true}}
+	want := &llm.Response{Content: "from-h2"}
+	h2 := &fakeProvider{name: "h2", resp: want}
+
+	p := chain.New(h1, h2)
+	resp, err := p.Generate(context.Background(), sampleRequest())
+
+	require.NoError(t, err)
+	assert.Same(t, want, resp)
+	assert.Equal(t, 1, h1.calls())
+	assert.Equal(t, 1, h2.calls())
+}
+
+func TestChain_AllHandlersFail_ReturnsLastError(t *testing.T) {
+	first := &llm.Error{Code: llm.ErrCodeRateLimit, Provider: "h1", Message: "first failure"}
+	last := &llm.Error{Code: llm.ErrCodeServer, Provider: "h2", Message: "last failure"}
+
+	h1 := &fakeProvider{name: "h1", err: first}
+	h2 := &fakeProvider{name: "h2", err: last}
+
+	p := chain.New(h1, h2)
+	_, err := p.Generate(context.Background(), sampleRequest())
+
+	require.Error(t, err)
+	var lerr *llm.Error
+	require.ErrorAs(t, err, &lerr)
+	assert.Equal(t, "h2", lerr.Provider, "마지막 handler 의 에러가 반환되어야 함")
+	assert.Equal(t, llm.ErrCodeServer, lerr.Code)
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 위임 정책 (shouldDelegate)
+// ─────────────────────────────────────────────────────────────────────────────
+
+func TestChain_BadRequest_TerminatesImmediately(t *testing.T) {
+	// h1 의 BadRequest 는 입력 자체 문제 — 다른 handler 도 동일 실패. 즉시 종결.
+	h1 := &fakeProvider{name: "h1", err: &llm.Error{Code: llm.ErrCodeBadRequest, Provider: "h1"}}
+	h2 := &fakeProvider{name: "h2", resp: &llm.Response{Content: "should-not-be-called"}}
+
+	p := chain.New(h1, h2)
+	_, err := p.Generate(context.Background(), sampleRequest())
+
+	require.Error(t, err)
+	var lerr *llm.Error
+	require.ErrorAs(t, err, &lerr)
+	assert.Equal(t, llm.ErrCodeBadRequest, lerr.Code)
+	assert.Equal(t, 1, h1.calls())
+	assert.Equal(t, 0, h2.calls(), "BadRequest 는 위임 무의미 — 후속 handler 호출되면 안 됨")
+}
+
+func TestChain_ContextLimit_TerminatesImmediately(t *testing.T) {
+	h1 := &fakeProvider{name: "h1", err: &llm.Error{Code: llm.ErrCodeContextLimit, Provider: "h1"}}
+	h2 := &fakeProvider{name: "h2", resp: &llm.Response{Content: "x"}}
+
+	p := chain.New(h1, h2)
+	_, err := p.Generate(context.Background(), sampleRequest())
+
+	require.Error(t, err)
+	var lerr *llm.Error
+	require.ErrorAs(t, err, &lerr)
+	assert.Equal(t, llm.ErrCodeContextLimit, lerr.Code)
+	assert.Equal(t, 0, h2.calls(), "ContextLimit 는 모든 provider 동일 → 즉시 종결")
+}
+
+func TestChain_DelegateOnAuthRateLimitServerNetworkUnknown(t *testing.T) {
+	delegatable := []llm.ErrorCode{
+		llm.ErrCodeAuth,
+		llm.ErrCodeRateLimit,
+		llm.ErrCodeServer,
+		llm.ErrCodeNetwork,
+		llm.ErrCodeUnknown,
+	}
+	for _, code := range delegatable {
+		t.Run(string(code), func(t *testing.T) {
+			h1 := &fakeProvider{name: "h1", err: &llm.Error{Code: code, Provider: "h1"}}
+			h2 := &fakeProvider{name: "h2", resp: &llm.Response{Content: "recovered"}}
+
+			p := chain.New(h1, h2)
+			resp, err := p.Generate(context.Background(), sampleRequest())
+
+			require.NoError(t, err)
+			assert.Equal(t, "recovered", resp.Content)
+			assert.Equal(t, 1, h2.calls(), "code=%s 는 위임되어야 함", code)
+		})
+	}
+}
+
+func TestChain_NonLLMError_StillDelegates(t *testing.T) {
+	// 비-llm.Error (raw error) → 보수적으로 다음 handler 시도
+	h1 := &fakeProvider{name: "h1", err: errors.New("raw network blip")}
+	h2 := &fakeProvider{name: "h2", resp: &llm.Response{Content: "recovered"}}
+
+	p := chain.New(h1, h2)
+	resp, err := p.Generate(context.Background(), sampleRequest())
+
+	require.NoError(t, err)
+	assert.Equal(t, "recovered", resp.Content)
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// edge cases
+// ─────────────────────────────────────────────────────────────────────────────
+
+func TestChain_EmptyHandlers_ReturnsBadRequest(t *testing.T) {
+	p := chain.New()
+	_, err := p.Generate(context.Background(), sampleRequest())
+
+	require.Error(t, err)
+	var lerr *llm.Error
+	require.ErrorAs(t, err, &lerr)
+	assert.Equal(t, llm.ErrCodeBadRequest, lerr.Code)
+	assert.Equal(t, "chain", lerr.Provider)
+}
+
+func TestChain_PrecanceledContext_FailsBeforeAnyHandler(t *testing.T) {
+	h1 := &fakeProvider{name: "h1", resp: &llm.Response{Content: "x"}}
+	p := chain.New(h1)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // 호출 전에 이미 cancel
+
+	_, err := p.Generate(ctx, sampleRequest())
+	require.Error(t, err)
+	var lerr *llm.Error
+	require.ErrorAs(t, err, &lerr)
+	assert.Equal(t, llm.ErrCodeNetwork, lerr.Code)
+	assert.Equal(t, 0, h1.calls(), "ctx 이미 cancel 이면 첫 handler 도 호출 안 함")
+}
+
+func TestChain_ContextCanceledMidway_StopsBeforeNextHandler(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+
+	// h1 이 호출되는 동안 ctx 를 cancel — 그 후 h2 는 호출되면 안 됨
+	h1 := &fakeProvider{
+		name: "h1",
+		err:  &llm.Error{Code: llm.ErrCodeServer, Provider: "h1", Retryable: true},
+		onCall: func(_ context.Context, _ llm.Request) {
+			cancel()
+		},
+	}
+	h2 := &fakeProvider{name: "h2", resp: &llm.Response{Content: "should-not-call"}}
+
+	p := chain.New(h1, h2)
+	_, err := p.Generate(ctx, sampleRequest())
+
+	require.Error(t, err)
+	var lerr *llm.Error
+	require.ErrorAs(t, err, &lerr)
+	// ctx cancel 감지 후 lastErr (h1 의 server) 반환
+	assert.Equal(t, "h1", lerr.Provider)
+	assert.Equal(t, 1, h1.calls())
+	assert.Equal(t, 0, h2.calls(), "h1 이후 ctx cancel 감지 → h2 호출 안 함")
+}
+
+func TestChain_Name_ReturnsChain(t *testing.T) {
+	assert.Equal(t, "chain", chain.New().Name())
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 합성 가능성 — chain in a chain
+// ─────────────────────────────────────────────────────────────────────────────
+
+func TestChain_NestedChain_BehavesAsSingleProvider(t *testing.T) {
+	// inner chain: [h1(rate_limit), h2(success)]
+	h1 := &fakeProvider{name: "h1", err: &llm.Error{Code: llm.ErrCodeRateLimit, Provider: "h1"}}
+	h2 := &fakeProvider{name: "h2", resp: &llm.Response{Content: "from-inner-h2"}}
+	inner := chain.New(h1, h2)
+
+	// outer chain: [extraFail, inner]
+	extra := &fakeProvider{name: "extra", err: &llm.Error{Code: llm.ErrCodeServer, Provider: "extra"}}
+	outer := chain.New(extra, inner)
+
+	resp, err := outer.Generate(context.Background(), sampleRequest())
+	require.NoError(t, err)
+	assert.Equal(t, "from-inner-h2", resp.Content)
+	assert.Equal(t, 1, extra.calls())
+	assert.Equal(t, 1, h1.calls())
+	assert.Equal(t, 1, h2.calls())
+}

--- a/test/pkg/llm/chain/chain_test.go
+++ b/test/pkg/llm/chain/chain_test.go
@@ -112,27 +112,29 @@ func TestChain_BadRequest_TerminatesImmediately(t *testing.T) {
 	assert.Equal(t, 0, h2.calls(), "BadRequest 는 위임 무의미 — 후속 handler 호출되면 안 됨")
 }
 
-func TestChain_ContextLimit_TerminatesImmediately(t *testing.T) {
+func TestChain_ContextLimit_Delegates(t *testing.T) {
+	// ContextLimit 은 provider/모델 별 context window 차이로 위임 가치 있음
+	// (예: gpt-4o-mini 128k → claude-opus-4-7 200k → gemini-1.5-pro 2M).
+	// 현재 정책: 다음 handler 가 더 큰 window 를 가질 수 있어 시도.
 	h1 := &fakeProvider{name: "h1", err: &llm.Error{Code: llm.ErrCodeContextLimit, Provider: "h1"}}
-	h2 := &fakeProvider{name: "h2", resp: &llm.Response{Content: "x"}}
+	h2 := &fakeProvider{name: "h2", resp: &llm.Response{Content: "recovered-with-larger-window"}}
 
 	p := chain.New(h1, h2)
-	_, err := p.Generate(context.Background(), sampleRequest())
+	resp, err := p.Generate(context.Background(), sampleRequest())
 
-	require.Error(t, err)
-	var lerr *llm.Error
-	require.ErrorAs(t, err, &lerr)
-	assert.Equal(t, llm.ErrCodeContextLimit, lerr.Code)
-	assert.Equal(t, 0, h2.calls(), "ContextLimit 는 모든 provider 동일 → 즉시 종결")
+	require.NoError(t, err)
+	assert.Equal(t, "recovered-with-larger-window", resp.Content)
+	assert.Equal(t, 1, h2.calls(), "ContextLimit 는 다음 handler 위임 — 더 큰 context window 가능성")
 }
 
-func TestChain_DelegateOnAuthRateLimitServerNetworkUnknown(t *testing.T) {
+func TestChain_DelegateOnAllExceptBadRequest(t *testing.T) {
 	delegatable := []llm.ErrorCode{
 		llm.ErrCodeAuth,
 		llm.ErrCodeRateLimit,
 		llm.ErrCodeServer,
 		llm.ErrCodeNetwork,
 		llm.ErrCodeUnknown,
+		llm.ErrCodeContextLimit, // 다른 모델의 더 큰 context window 가능성
 	}
 	for _, code := range delegatable {
 		t.Run(string(code), func(t *testing.T) {
@@ -191,7 +193,7 @@ func TestChain_PrecanceledContext_FailsBeforeAnyHandler(t *testing.T) {
 	assert.Equal(t, 0, h1.calls(), "ctx 이미 cancel 이면 첫 handler 도 호출 안 함")
 }
 
-func TestChain_ContextCanceledMidway_StopsBeforeNextHandler(t *testing.T) {
+func TestChain_ContextCanceledMidway_ReturnsExplicitNetworkError(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 
 	// h1 이 호출되는 동안 ctx 를 cancel — 그 후 h2 는 호출되면 안 됨
@@ -210,8 +212,10 @@ func TestChain_ContextCanceledMidway_StopsBeforeNextHandler(t *testing.T) {
 	require.Error(t, err)
 	var lerr *llm.Error
 	require.ErrorAs(t, err, &lerr)
-	// ctx cancel 감지 후 lastErr (h1 의 server) 반환
-	assert.Equal(t, "h1", lerr.Provider)
+	// ctx cancel 감지 시 명시적 chain 의 ErrCodeNetwork — 호출자가 "취소" 즉답 가능
+	// (이전 handler 의 server 에러로 가리지 않음, Gemini code review #2)
+	assert.Equal(t, "chain", lerr.Provider)
+	assert.Equal(t, llm.ErrCodeNetwork, lerr.Code)
 	assert.Equal(t, 1, h1.calls())
 	assert.Equal(t, 0, h2.calls(), "h1 이후 ctx cancel 감지 → h2 호출 안 함")
 }


### PR DESCRIPTION
## 연관 이슈
- Closes #142
- Parent: #100 (사이트별 파싱 규칙 DB 일원화) — sub-issue
- **Stacked on PR #141** (이슈 #140) — base 가 \`feature/#140/llm-module\` 이라 #141 머지 후 자동으로 main 으로 base 전환

<br>

## 구현 내용

#140 의 \`llm.Provider\` 인터페이스를 활용해 여러 provider 를 fallback chain 으로 합성하는 \`pkg/llm/chain.Provider\`. 자체가 \`llm.Provider\` 구현이라 호출자 코드는 단일 provider 사용과 동일. 2개 논리적 commit:

### Commit 1 — `[FEAT]` ChainProvider 구현 + 위임 정책

**위임 정책** (`shouldDelegate`):

| ErrorCode | 위임? | 이유 |
|---|---|---|
| `Auth`, `RateLimit`, `Server`, `Network`, `Unknown` | ✅ 다음 handler | 이 provider 의 일시/구성 문제, 다른 provider 에서 정상 가능성 |
| `BadRequest`, `ContextLimit` | ❌ 즉시 종결 | 입력 자체 문제 — 다른 provider 도 동일 실패 |
| 비-`llm.Error` (raw) | ✅ 다음 handler | 보수적 — 다음에서 정상 가능성 남김 |

**흐름**:
1. handlers 비어있음 → `ErrCodeBadRequest` 즉시
2. ctx 이미 cancel → `ErrCodeNetwork` 즉시
3. handler 순회: 성공 → 종결 / non-delegatable → 종결 / delegatable → 다음 시도
4. handler 후 ctx cancel 감지 시 즉시 종결 (낭비 호출 회피)
5. 모두 실패 → 마지막 에러 그대로 반환 (`ErrorCode` 정보 보존)

**관찰성**: `WithLogger` 옵션 (nil 허용) — 위임/종결/exhausted 시 INFO/WARN 로그 (handler 이름 + index + 마지막 에러)

### Commit 2 — `[FEAT]` 단위 테스트 12 케이스

`fakeProvider` mock — atomic counter 로 호출 횟수 추적, `onCall` hook 으로 ctx 조작 가능. 모든 테스트 race-safe.

| 카테고리 | 테스트 |
|---|---|
| 정상 흐름 | 첫 성공 short-circuit / 첫 retryable → fallback 성공 / 모두 실패 → 마지막 에러 |
| 위임 정책 | BadRequest 즉시 종결 / ContextLimit 즉시 종결 / Auth·RateLimit·Server·Network·Unknown 위임 (table-driven) / 비-llm.Error 위임 |
| Edge | 빈 chain → BadRequest / ctx 사전 cancel → 첫 handler 호출 안 함 / handler 중 ctx cancel → 다음 handler 호출 안 함 |
| 합성 | nested chain (chain in a chain) 단일 Provider 처럼 동작 |

### 사용 예시

```go
import (
    \"issuetracker/pkg/llm\"
    \"issuetracker/pkg/llm/chain\"
    _ \"issuetracker/pkg/llm/providers\"
)

primary,   _ := llm.New(llm.Config{Provider: \"claude\", APIKey: ...})
secondary, _ := llm.New(llm.Config{Provider: \"openai\", APIKey: ...})
fallback,  _ := llm.New(llm.Config{Provider: \"gemini\", APIKey: ...})

// 그 자체가 llm.Provider — 호출 코드 무변화
p := chain.New(primary, secondary, fallback)

resp, err := p.Generate(ctx, llm.Request{
    Messages: []llm.Message{{Role: llm.RoleUser, Content: \"...\"}},
})
```

<br>

## CI / 머지 게이트 점검

### 변경 영향 범위
- 신규 패키지 2개: `pkg/llm/chain/`, `test/pkg/llm/chain/`
- 위험도: `Low` — 신규 패키지만 추가, 기존 코드 미변경
- 외부 의존성 추가 0건

### Required Status Checks
- 통과 확인 대상:
  - [ ] `Commit Lint`
  - [ ] `PR Title Lint`
  - [ ] `Linked Issue Check`
  - [ ] `Format Check`
  - [ ] `Build`
  - [ ] `Test`
  - [ ] `Lint`

로컬 검증:
- `go test -race -count=1 ./...` 22 패키지 통과 (chain test 12 추가)
- `gofmt -l .` clean
- `go build ./...` 통과

### 롤백 계획
- 단일 PR revert
- 신규 패키지만 추가라 revert 시 즉시 안전 복원

<br>

## TODO (별도 PR)
- factory 통합? — 현재 chain 은 호출자가 명시적으로 `chain.New(...)` 합성. \`Config\` 로 chain 표현하려면 별도 schema 필요 (provider 목록 + 옵션). 본 PR 범위 밖.
- 가중치/우선순위 정책 — 현재는 단순 순차. 비용/성능 기반 정책 wrapper 는 별도 이슈.
- 동시 호출 (race) 정책 — 첫 응답 채택 vs 다수결. 본 PR 은 \"순차 fallback\" 만.

<br>

## 논의 사항
- **위임 결정의 단일 source** — `ErrorCode` 하나로 정책 표현. provider 가 늘어나도 정책 코드 무변화.
- **에러 보존** — 모든 handler 실패 시 wrap 없이 마지막 에러 그대로 반환. 호출자가 `ErrorCode` 로 분기 가능.
- **stacked PR** — base 가 #141 브랜치이므로, #141 머지 후 본 PR base 가 자동으로 main 으로 전환됨.

🤖 Generated with [Claude Code](https://claude.com/claude-code)