### PR TITLE
[REFAC#148] LinkDiscovery ArticleURLPattern optional + 사이트 rule all-pass 전환

### DIFF
--- a/internal/crawler/parser/rule/discovery.go
+++ b/internal/crawler/parser/rule/discovery.go
@@ -2,6 +2,8 @@ package rule
 
 import (
 	"fmt"
+	"math/rand/v2"
+	"net/url"
 	"regexp"
 
 	"issuetracker/internal/crawler/core"
@@ -100,18 +102,52 @@ func (d *PageLinkDiscovery) Discover(raw *core.RawContent, cfg *storage.LinkDisc
 		}
 	}
 
+	// MaxLinksPerPage 우선순위 정책 (이슈 #148 후속):
+	//   1. same-origin (raw.URL 의 host 와 동일) 링크는 maxOut 무시하고 모두 통과
+	//   2. cross-origin 링크는 잔여 슬롯 (maxOut - len(same)) 만큼 무작위 sample
+	//   3. maxOut == 0 (무제한) 이면 cross 도 모두 통과
+	//
+	// 이유: 운영 사이트 자체 컨텐츠 (same-origin) 는 noise 가 적고 가치 높음 — 모두 발행.
+	// 외부 링크 (cross-origin) 는 광고/제휴 노이즈 비율 높으므로 cap 으로 통제하되,
+	// 무작위 sample 로 특정 영역 (예: 페이지 상단의 광고 슬롯) 에 편향되지 않도록.
 	maxOut := cfg.MaxLinksPerPage
-	out := make([]parser.LinkItem, 0, len(candidates))
+	pageHost := hostOf(raw.URL)
+
+	sameOrigin := make([]parser.LinkItem, 0, len(candidates))
+	crossOrigin := make([]parser.LinkItem, 0)
 	for _, l := range candidates {
 		if pattern != nil && !pattern.MatchString(l.URL) {
 			continue
 		}
-		out = append(out, parser.LinkItem{
-			URL:   l.URL,
-			Title: l.Text,
-		})
-		if maxOut > 0 && len(out) >= maxOut {
-			break
+		item := parser.LinkItem{URL: l.URL, Title: l.Text}
+		if pageHost != "" && hostOf(l.URL) == pageHost {
+			sameOrigin = append(sameOrigin, item)
+		} else {
+			crossOrigin = append(crossOrigin, item)
+		}
+	}
+
+	out := append(make([]parser.LinkItem, 0, len(sameOrigin)+len(crossOrigin)), sameOrigin...)
+
+	switch {
+	case len(crossOrigin) == 0:
+		// nothing to add
+	case maxOut <= 0:
+		// 무제한 — cross 도 모두 추가
+		out = append(out, crossOrigin...)
+	default:
+		remaining := maxOut - len(sameOrigin)
+		switch {
+		case remaining <= 0:
+			// same-origin 만으로 cap 초과 — cross 0건 (정책상 same 우선)
+		case remaining >= len(crossOrigin):
+			out = append(out, crossOrigin...)
+		default:
+			// remaining < len(crossOrigin) — 무작위로 remaining 개 sample
+			rand.Shuffle(len(crossOrigin), func(i, j int) {
+				crossOrigin[i], crossOrigin[j] = crossOrigin[j], crossOrigin[i]
+			})
+			out = append(out, crossOrigin[:remaining]...)
 		}
 	}
 
@@ -130,4 +166,14 @@ func (d *PageLinkDiscovery) Discover(raw *core.RawContent, cfg *storage.LinkDisc
 		}
 	}
 	return out, nil
+}
+
+// hostOf 는 URL 문자열에서 host 를 추출합니다 (parse 실패 시 빈 문자열).
+// 본 함수는 same-origin 분류 비교용 — 빈 문자열 비교는 항상 cross-origin 으로 취급되도록.
+func hostOf(rawURL string) string {
+	u, err := url.Parse(rawURL)
+	if err != nil || u == nil {
+		return ""
+	}
+	return u.Host
 }

--- a/internal/crawler/parser/rule/discovery.go
+++ b/internal/crawler/parser/rule/discovery.go
@@ -32,10 +32,15 @@ func NewPageLinkDiscovery() *PageLinkDiscovery { return &PageLinkDiscovery{} }
 // Discover 는 raw 의 HTML 에서 cfg 정책에 부합하는 링크들을 LinkItem 으로 반환합니다.
 //
 // 흐름:
-//  1. cfg.ArticleURLPattern compile (빈 문자열이면 ErrEmptySelector)
+//  1. cfg.ArticleURLPattern 이 비어있지 않으면 compile (빈 문자열이면 all-pass 모드 — 이슈 #148)
 //  2. pkg/links.Extractor 로 raw.HTML 의 모든 <a href> 추출
 //     (SameOriginOnly / PathPrefixes / ExcludePatterns / MaxLinksPerPage 적용)
-//  3. extractor 결과를 ArticleURLPattern regex 로 추가 필터링
+//  3. pattern 이 있으면 추가 regex 필터링, 없으면 extractor 결과 그대로
+//
+// All-pass 모드 (이슈 #148):
+//   - 본 시스템의 타겟은 \"뉴스 기사\" 만이 아닌 페이지 내 모든 의미 있는 글 (이슈 #100 도메인 일반화)
+//   - ArticleURLPattern 을 강제하면 사이트별 article URL regex 외 모든 컨텐츠가 누락됨
+//   - 빈 pattern 은 \"ExcludePatterns + SameOriginOnly + MaxLinksPerPage 만으로 필터\" 의도
 //
 // 반환 LinkItem 의 Title 은 anchor text 로 채움 (ItemContainer 모드 와 달리 별도 selector
 // 가 없음). Snippet 은 비워둠 — full-page discovery 는 list 페이지의 컨텍스트가 없으므로
@@ -44,24 +49,29 @@ func (d *PageLinkDiscovery) Discover(raw *core.RawContent, cfg *storage.LinkDisc
 	if err := validateRaw(raw); err != nil {
 		return nil, err
 	}
-	if cfg == nil || cfg.ArticleURLPattern == "" {
+	if cfg == nil {
 		return nil, &Error{
 			Code:       ErrEmptySelector,
-			Message:    "link discovery requires non-empty ArticleURLPattern",
+			Message:    "link discovery requires non-nil LinkDiscoveryConfig",
 			URL:        raw.URL,
 			TargetType: string(storage.TargetTypeList),
 		}
 	}
 
-	pattern, err := regexp.Compile(cfg.ArticleURLPattern)
-	if err != nil {
-		return nil, &Error{
-			Code:       ErrEmptySelector,
-			Message:    fmt.Sprintf("invalid ArticleURLPattern regex: %q", cfg.ArticleURLPattern),
-			URL:        raw.URL,
-			TargetType: string(storage.TargetTypeList),
-			Err:        err,
+	// pattern 이 비어있으면 all-pass — 이슈 #148. Extractor 의 다른 옵션만으로 필터링.
+	var pattern *regexp.Regexp
+	if cfg.ArticleURLPattern != "" {
+		compiled, err := regexp.Compile(cfg.ArticleURLPattern)
+		if err != nil {
+			return nil, &Error{
+				Code:       ErrEmptySelector,
+				Message:    fmt.Sprintf("invalid ArticleURLPattern regex: %q", cfg.ArticleURLPattern),
+				URL:        raw.URL,
+				TargetType: string(storage.TargetTypeList),
+				Err:        err,
+			}
 		}
+		pattern = compiled
 	}
 
 	opts := []links.Option{}
@@ -93,7 +103,7 @@ func (d *PageLinkDiscovery) Discover(raw *core.RawContent, cfg *storage.LinkDisc
 	maxOut := cfg.MaxLinksPerPage
 	out := make([]parser.LinkItem, 0, len(candidates))
 	for _, l := range candidates {
-		if !pattern.MatchString(l.URL) {
+		if pattern != nil && !pattern.MatchString(l.URL) {
 			continue
 		}
 		out = append(out, parser.LinkItem{
@@ -106,11 +116,15 @@ func (d *PageLinkDiscovery) Discover(raw *core.RawContent, cfg *storage.LinkDisc
 	}
 
 	if len(out) == 0 {
-		// 매칭 0건 — pattern stale 이거나 페이지에 article URL 자체가 없음.
-		// ItemContainer 경로의 0건 진단과 동일한 메시지 패턴.
+		// 매칭 0건 — pattern 모드면 stale, all-pass 모드면 페이지 자체에 통과 가능 링크 없음.
+		// 진단 메시지는 모드별로 분기하여 운영자가 원인 추적하기 쉽게.
+		msg := "all <a href> filtered out (page has no eligible links)"
+		if pattern != nil {
+			msg = "ArticleURLPattern matched 0 links on page (pattern may be stale or page empty)"
+		}
 		return nil, &Error{
 			Code:       ErrParseFailure,
-			Message:    "ArticleURLPattern matched 0 links on page (pattern may be stale or page empty)",
+			Message:    msg,
 			URL:        raw.URL,
 			TargetType: string(storage.TargetTypeList),
 		}

--- a/internal/crawler/parser/rule/parser.go
+++ b/internal/crawler/parser/rule/parser.go
@@ -153,8 +153,10 @@ func (p *Parser) ParseLinks(ctx context.Context, raw *core.RawContent) ([]parser
 		return nil, err
 	}
 
-	// LinkDiscovery 모드 (이슈 #139) — opt-in. ArticleURLPattern 비어있으면 ItemContainer fallback.
-	if cfg := rule.Selectors.LinkDiscovery; cfg != nil && cfg.ArticleURLPattern != "" {
+	// LinkDiscovery 모드 (이슈 #139, #148) — opt-in.
+	// LinkDiscovery 객체 자체가 채워져 있으면 discovery 경로 (ArticleURLPattern 빈 문자열도 허용 — all-pass).
+	// LinkDiscovery 가 nil 일 때만 ItemContainer fallback.
+	if cfg := rule.Selectors.LinkDiscovery; cfg != nil {
 		return p.discovery.Discover(raw, cfg)
 	}
 

--- a/internal/storage/parsing_rule.go
+++ b/internal/storage/parsing_rule.go
@@ -72,28 +72,29 @@ type SelectorMap struct {
 	ItemTitle     *FieldSelector `json:"item_title,omitempty"`
 	ItemSnippet   *FieldSelector `json:"item_snippet,omitempty"` // 짧은 요약/설명 (있을 때)
 
-	// LinkDiscovery (이슈 #139): 페이지 전체 <a href> 스캔 + URL 패턴 필터 모드.
+	// LinkDiscovery (이슈 #139, #148): 페이지 전체 <a href> 스캔 + 정책 기반 필터 모드.
 	//
 	// 설정 시 ParseLinks 가 ItemContainer 경로 대신 full-page discovery 로 동작합니다 —
 	// 사이드바 / 추천 / 관련 기사 / 카테고리 메뉴 등 ItemContainer 가 놓치는 영역까지
-	// 같은 fetch 비용으로 발견. nil 또는 비어있으면 기존 ItemContainer 경로 사용 (opt-in).
+	// 같은 fetch 비용으로 발견. **nil 일 때만** 기존 ItemContainer 경로로 fallback —
+	// 객체가 채워져 있으면 ArticleURLPattern 이 빈 문자열이어도 discovery 모드 (all-pass).
 	//
-	// 권장 활용: 사이트 전체 article URL 이 일관된 path 패턴을 가질 때
-	//   (예: cnn = "^/\d{4}/\d{2}/\d{2}/", naver-news = "^/article/\d+/\d+").
+	// 권장 활용: 사이트 전체에서 모든 의미 있는 글을 발견하고자 할 때 (이슈 #100 도메인 일반화).
 	// noise 는 ExcludePatterns + MaxLinksPerPage + 다운스트림 URL dedup / rate limiter 가 흡수.
 	LinkDiscovery *LinkDiscoveryConfig `json:"link_discovery,omitempty"`
 }
 
-// LinkDiscoveryConfig 는 full-page link discovery 모드의 설정입니다 (이슈 #139).
+// LinkDiscoveryConfig 는 full-page link discovery 모드의 설정입니다 (이슈 #139, #148).
 //
 // LinkDiscoveryConfig drives the rule-based full-page <a href> discovery, replacing
-// site-specific ItemContainer extraction with a generic URL-pattern filter.
+// site-specific ItemContainer extraction with a generic policy-based filter.
 //
-// 모든 필드는 optional 이지만 ArticleURLPattern 이 비어있으면 discovery 모드 자체가 비활성화됩니다
-// (= 기존 ItemContainer 경로로 fallback). pattern 만 채우면 최소 동작 가능.
+// 모든 필드는 optional. 본 객체가 SelectorMap.LinkDiscovery 에 채워져 있으면 ParseLinks 는
+// discovery 모드로 동작합니다 — ArticleURLPattern 이 빈 문자열이어도 all-pass 모드로 진입.
+// ItemContainer fallback 은 LinkDiscovery 자체가 nil 일 때만.
 type LinkDiscoveryConfig struct {
 	// ArticleURLPattern: 통과 조건 (regex, RE2). 매칭되는 절대 URL 만 발행.
-	// 빈 문자열이면 LinkDiscovery 자체가 disabled — 호출자는 ItemContainer 경로 사용.
+	// 빈 문자열이면 all-pass 모드 — ExcludePatterns / SameOriginOnly / MaxLinksPerPage 만으로 필터링.
 	ArticleURLPattern string `json:"article_url_pattern"`
 
 	// ExcludePatterns: 제외 조건 (substring, 대소문자 무시). 기본 제외 (javascript:/mailto:/login 등)
@@ -109,8 +110,17 @@ type LinkDiscoveryConfig struct {
 	SameOriginOnly bool `json:"same_origin_only,omitempty"`
 
 	// MaxLinksPerPage: 한 페이지에서 발행할 최대 링크 수 (0 = 무제한).
-	// publish 폭증 방지 — backlog throttle (#124) 와 함께 2중 안전장치.
-	// 권장 기본 200.
+	//
+	// 우선순위 정책 (이슈 #148):
+	//   1. same-origin (raw.URL host 와 동일) 링크는 cap 무시하고 모두 통과
+	//   2. cross-origin 은 잔여 슬롯 (cap - len(same)) 만큼 무작위 sample
+	//   3. 0 (무제한) 이면 same + cross 모두 통과
+	//
+	// 사이트 자체 컨텐츠 (same) 는 noise 적고 가치 높음 — 모두 발행 가치.
+	// 외부 링크 (cross) 는 광고/제휴 noise 많음 — cap 통제 + 무작위 sample 로
+	// 페이지 상단 sponsored slot 등 특정 영역 편향 회피.
+	//
+	// publish 폭증 방지 — backlog throttle (#124) 와 함께 2중 안전장치. 권장 기본 200.
 	MaxLinksPerPage int `json:"max_links_per_page,omitempty"`
 }
 

--- a/migrations/down/008_relax_link_discovery_patterns.sql
+++ b/migrations/down/008_relax_link_discovery_patterns.sql
@@ -1,0 +1,53 @@
+-- 008_relax_link_discovery_patterns (down): migration 007 의 좁은 ArticleURLPattern 으로 복원.
+
+UPDATE parsing_rules
+SET selectors = jsonb_set(
+  selectors,
+  '{link_discovery}',
+  '{
+    "article_url_pattern": "^https?://n\\.news\\.naver\\.com/(?:mnews/)?article/\\d+/\\d+",
+    "same_origin_only":    false,
+    "max_links_per_page":  200,
+    "exclude_patterns":    ["/comment/", "/photo/", "/tv/"]
+  }'::jsonb
+)
+WHERE source_name = 'naver' AND host_pattern = 'news.naver.com' AND target_type = 'list';
+
+UPDATE parsing_rules
+SET selectors = jsonb_set(
+  selectors,
+  '{link_discovery}',
+  '{
+    "article_url_pattern": "^https?://v\\.daum\\.net/v/\\d+",
+    "same_origin_only":    false,
+    "max_links_per_page":  200,
+    "exclude_patterns":    ["/cp/", "/cafe/", "/photo/"]
+  }'::jsonb
+)
+WHERE source_name = 'daum' AND host_pattern = 'news.daum.net' AND target_type = 'list';
+
+UPDATE parsing_rules
+SET selectors = jsonb_set(
+  selectors,
+  '{link_discovery}',
+  '{
+    "article_url_pattern": "^https?://www\\.yna\\.co\\.kr/view/[A-Z]+\\d+",
+    "same_origin_only":    true,
+    "max_links_per_page":  200,
+    "exclude_patterns":    ["/photo/", "/video/"]
+  }'::jsonb
+)
+WHERE source_name = 'yonhap' AND host_pattern = 'www.yna.co.kr' AND target_type = 'list';
+
+UPDATE parsing_rules
+SET selectors = jsonb_set(
+  selectors,
+  '{link_discovery}',
+  '{
+    "article_url_pattern": "^https?://edition\\.cnn\\.com/\\d{4}/\\d{2}/\\d{2}/",
+    "same_origin_only":    false,
+    "max_links_per_page":  200,
+    "exclude_patterns":    ["/videos/", "/gallery/", "/live-news/"]
+  }'::jsonb
+)
+WHERE source_name = 'cnn' AND host_pattern = 'edition.cnn.com' AND target_type = 'list';

--- a/migrations/up/008_relax_link_discovery_patterns.sql
+++ b/migrations/up/008_relax_link_discovery_patterns.sql
@@ -8,7 +8,7 @@
 --
 --   - article_url_pattern: \"\" (빈 문자열) → all-pass discovery
 --   - exclude_patterns: 사이트별 광고/네비/공유/미디어 등 노이즈 패턴
---   - same_origin_only: true (외부 도메인 차단)
+--   - same_origin_only: site profile 유지 (yonhap=true / naver/daum/cnn=false — 기존 설정값 보존)
 --   - max_links_per_page: 200 유지 (publish 폭증 방지)
 --
 -- 후속 노이즈 컷 정밀화는 운영자가 라이브 모니터링 후 ExcludePatterns 를 점진 추가.

--- a/migrations/up/008_relax_link_discovery_patterns.sql
+++ b/migrations/up/008_relax_link_discovery_patterns.sql
@@ -1,0 +1,66 @@
+-- 008_relax_link_discovery_patterns: 사이트별 list rule 의 ArticleURLPattern 을 빈 문자열로 변경
+-- + ExcludePatterns 를 사이트별 노이즈 컷 패턴으로 강화 (이슈 #148).
+--
+-- 배경:
+--   migration 007 에서 시드한 list rule 들은 좁은 ArticleURLPattern regex 를 사용하여
+--   사이트별 \"기사 URL\" 만 통과시킴. 그러나 본 시스템 타겟은 article 만이 아닌 페이지 내
+--   모든 의미 있는 글 (이슈 #100 도메인 일반화). 본 migration 으로 all-pass 모드 전환:
+--
+--   - article_url_pattern: \"\" (빈 문자열) → all-pass discovery
+--   - exclude_patterns: 사이트별 광고/네비/공유/미디어 등 노이즈 패턴
+--   - same_origin_only: true (외부 도메인 차단)
+--   - max_links_per_page: 200 유지 (publish 폭증 방지)
+--
+-- 후속 노이즈 컷 정밀화는 운영자가 라이브 모니터링 후 ExcludePatterns 를 점진 추가.
+
+UPDATE parsing_rules
+SET selectors = jsonb_set(
+  selectors,
+  '{link_discovery}',
+  '{
+    "article_url_pattern": "",
+    "same_origin_only":    false,
+    "max_links_per_page":  200,
+    "exclude_patterns":    ["/comment/", "/photo/", "/tv/", "/about", "/help", "/login", "/sitemap"]
+  }'::jsonb
+)
+WHERE source_name = 'naver' AND host_pattern = 'news.naver.com' AND target_type = 'list';
+
+UPDATE parsing_rules
+SET selectors = jsonb_set(
+  selectors,
+  '{link_discovery}',
+  '{
+    "article_url_pattern": "",
+    "same_origin_only":    false,
+    "max_links_per_page":  200,
+    "exclude_patterns":    ["/cp/", "/cafe/", "/photo/", "/about", "/help", "/login"]
+  }'::jsonb
+)
+WHERE source_name = 'daum' AND host_pattern = 'news.daum.net' AND target_type = 'list';
+
+UPDATE parsing_rules
+SET selectors = jsonb_set(
+  selectors,
+  '{link_discovery}',
+  '{
+    "article_url_pattern": "",
+    "same_origin_only":    true,
+    "max_links_per_page":  200,
+    "exclude_patterns":    ["/photo/", "/video/", "/about", "/help", "/login", "/sitemap"]
+  }'::jsonb
+)
+WHERE source_name = 'yonhap' AND host_pattern = 'www.yna.co.kr' AND target_type = 'list';
+
+UPDATE parsing_rules
+SET selectors = jsonb_set(
+  selectors,
+  '{link_discovery}',
+  '{
+    "article_url_pattern": "",
+    "same_origin_only":    false,
+    "max_links_per_page":  200,
+    "exclude_patterns":    ["/videos/", "/gallery/", "/live-news/", "/about", "/help"]
+  }'::jsonb
+)
+WHERE source_name = 'cnn' AND host_pattern = 'edition.cnn.com' AND target_type = 'list';

--- a/test/internal/parser/rule/discovery_test.go
+++ b/test/internal/parser/rule/discovery_test.go
@@ -156,7 +156,72 @@ func TestPageLinkDiscovery_ExcludePatterns(t *testing.T) {
 	}
 }
 
-func TestPageLinkDiscovery_MaxLinksPerPage(t *testing.T) {
+// MaxLinksPerPage 정책 (이슈 #148 후속):
+//   - same-origin 링크는 cap 무시하고 모두 통과
+//   - cross-origin 링크는 잔여 슬롯 (maxOut - len(same)) 만큼 무작위 sample
+//   - maxOut == 0 (무제한) 이면 cross 도 모두 통과
+
+// fullPageHTML 매칭 분석 (raw.URL = https://news.example.com/category/politics):
+//   - same-origin (news.example.com): /article/2026/04/29/headline-one, .../headline-two,
+//     .../related-one, .../related-two, https://news.example.com/article/2026/04/27/cross = 5건
+//   - cross-origin: https://other.example.com/article/2026/04/27/external = 1건
+
+// SameOriginOnly=false, maxOut=2 — same-origin 5건은 cap 무시 통과, cross 0건 (이미 cap 초과).
+func TestPageLinkDiscovery_MaxLinksPerPage_SameOriginUnlimited(t *testing.T) {
+	d := rule.NewPageLinkDiscovery()
+	cfg := &storage.LinkDiscoveryConfig{
+		ArticleURLPattern: `/article/`,
+		SameOriginOnly:    false,
+		MaxLinksPerPage:   2,
+	}
+
+	items, err := d.Discover(makeRaw("https://news.example.com/category/politics", fullPageHTML), cfg)
+	require.NoError(t, err)
+	assert.Len(t, items, 5, "same-origin 5건은 maxOut=2 무시하고 모두 통과")
+
+	for _, it := range items {
+		assert.NotContains(t, it.URL, "other.example.com", "cap 초과로 cross-origin 0건")
+	}
+}
+
+// maxOut 이 same-origin 보다 크면 잔여 슬롯에 cross 가 채워짐.
+func TestPageLinkDiscovery_MaxLinksPerPage_CrossOriginFillsRemaining(t *testing.T) {
+	d := rule.NewPageLinkDiscovery()
+	cfg := &storage.LinkDiscoveryConfig{
+		ArticleURLPattern: `/article/`,
+		SameOriginOnly:    false,
+		MaxLinksPerPage:   10, // same 5 + cross 1 = 6 ≤ 10 → 모두 통과
+	}
+
+	items, err := d.Discover(makeRaw("https://news.example.com/category/politics", fullPageHTML), cfg)
+	require.NoError(t, err)
+	assert.Len(t, items, 6, "same 5 + cross 1 모두 통과 (cap 여유 있음)")
+
+	hasExternal := false
+	for _, it := range items {
+		if it.URL == "https://other.example.com/article/2026/04/27/external" {
+			hasExternal = true
+		}
+	}
+	assert.True(t, hasExternal, "잔여 슬롯에 cross-origin 채워짐")
+}
+
+// maxOut == 0 (무제한) — same + cross 모두 통과.
+func TestPageLinkDiscovery_MaxLinksPerPage_Unlimited(t *testing.T) {
+	d := rule.NewPageLinkDiscovery()
+	cfg := &storage.LinkDiscoveryConfig{
+		ArticleURLPattern: `/article/`,
+		SameOriginOnly:    false,
+		MaxLinksPerPage:   0,
+	}
+
+	items, err := d.Discover(makeRaw("https://news.example.com/category/politics", fullPageHTML), cfg)
+	require.NoError(t, err)
+	assert.Len(t, items, 6, "maxOut=0 무제한 — same + cross 모두 통과")
+}
+
+// SameOriginOnly=true 일 때 cross 자체가 candidates 에 안 들어옴 — same-origin 모두 통과.
+func TestPageLinkDiscovery_MaxLinksPerPage_SameOriginOnlyMode(t *testing.T) {
 	d := rule.NewPageLinkDiscovery()
 	cfg := &storage.LinkDiscoveryConfig{
 		ArticleURLPattern: `/article/`,
@@ -166,7 +231,54 @@ func TestPageLinkDiscovery_MaxLinksPerPage(t *testing.T) {
 
 	items, err := d.Discover(makeRaw("https://news.example.com/category/politics", fullPageHTML), cfg)
 	require.NoError(t, err)
-	assert.Len(t, items, 2, "MaxLinksPerPage cap 적용")
+	assert.Len(t, items, 5, "SameOriginOnly=true 면 cross 사전 제거 + same 5건 모두 통과 (cap 무시)")
+}
+
+// cross-origin 풀이 잔여 슬롯보다 클 때 무작위 sample 검증.
+// 다수의 cross-origin 링크가 들어있는 별도 HTML 사용.
+func TestPageLinkDiscovery_MaxLinksPerPage_CrossOriginRandomSample(t *testing.T) {
+	d := rule.NewPageLinkDiscovery()
+
+	// same-origin 1개 + cross-origin 5개. maxOut=3 이면 same 1 + cross 무작위 2.
+	html := `
+<html><body>
+  <a href="/article/local">Local</a>
+  <a href="https://ext1.example.com/article/a">Ext A</a>
+  <a href="https://ext2.example.com/article/b">Ext B</a>
+  <a href="https://ext3.example.com/article/c">Ext C</a>
+  <a href="https://ext4.example.com/article/d">Ext D</a>
+  <a href="https://ext5.example.com/article/e">Ext E</a>
+</body></html>
+`
+	cfg := &storage.LinkDiscoveryConfig{
+		ArticleURLPattern: `/article/`,
+		SameOriginOnly:    false,
+		MaxLinksPerPage:   3,
+	}
+
+	items, err := d.Discover(makeRaw("https://news.example.com/", html), cfg)
+	require.NoError(t, err)
+	require.Len(t, items, 3, "same 1 + cross random 2 = 3")
+
+	// 첫 항목은 same-origin 이어야 함 (정책상 same 우선)
+	assert.Contains(t, items[0].URL, "news.example.com", "same-origin 우선 추가")
+
+	crossCount := 0
+	for _, it := range items {
+		if !contains(it.URL, "news.example.com") {
+			crossCount++
+		}
+	}
+	assert.Equal(t, 2, crossCount, "cross-origin 잔여 슬롯 2건만 sample")
+}
+
+func contains(s, substr string) bool {
+	for i := 0; i+len(substr) <= len(s); i++ {
+		if s[i:i+len(substr)] == substr {
+			return true
+		}
+	}
+	return false
 }
 
 func TestPageLinkDiscovery_NoMatch_ReturnsParseFailure(t *testing.T) {

--- a/test/internal/parser/rule/discovery_test.go
+++ b/test/internal/parser/rule/discovery_test.go
@@ -340,6 +340,25 @@ func TestPageLinkDiscovery_EmptyPattern_ExcludeStillApplies(t *testing.T) {
 	}
 }
 
+// TestPageLinkDiscovery_EmptyPattern_PathPrefixesStillApply 는 all-pass 모드에서도
+// PathPrefixes 가 path 기반 cutoff 로 동작함을 검증합니다 (Coderabbit 피드백).
+func TestPageLinkDiscovery_EmptyPattern_PathPrefixesStillApply(t *testing.T) {
+	d := rule.NewPageLinkDiscovery()
+	cfg := &storage.LinkDiscoveryConfig{
+		ArticleURLPattern: "",
+		SameOriginOnly:    true,
+		PathPrefixes:      []string{"/article/"}, // /, /category/, /about, /login 모두 차단
+	}
+
+	items, err := d.Discover(makeRaw("https://news.example.com/category/politics", fullPageHTML), cfg)
+	require.NoError(t, err)
+	require.NotEmpty(t, items, "/article/ prefix 매칭은 통과")
+
+	for _, it := range items {
+		assert.Contains(t, it.URL, "/article/", "all-pass 모드에서도 PathPrefixes 1차 cutoff 적용")
+	}
+}
+
 func TestPageLinkDiscovery_NilConfig_ReturnsEmptySelector(t *testing.T) {
 	d := rule.NewPageLinkDiscovery()
 
@@ -420,17 +439,22 @@ func TestParser_ParseLinks_FallsBackToItemContainerWhenPatternEmpty(t *testing.T
 // TestParser_ParseLinks_LinkDiscoveryWithEmptyPattern_AllPassDiscovery 는 이슈 #148 변경 검증:
 // LinkDiscovery 객체가 채워져 있으면 ArticleURLPattern 이 빈 문자열이어도 discovery 모드 진입.
 // ItemContainer fallback 은 LinkDiscovery 자체가 nil 일 때만.
+//
+// discovery vs fallback 명확 구분 (Coderabbit 피드백):
+//   - ItemContainer 를 매칭 0건 selector 로 설정 — fallback 경로 진입 시 ErrParseFailure
+//   - 그래도 3건 반환 → discovery 경로가 동작했다는 명백한 증거
 func TestParser_ParseLinks_LinkDiscoveryWithEmptyPattern_AllPassDiscovery(t *testing.T) {
-	// LinkDiscovery 객체는 있지만 pattern 비어있음 → all-pass discovery (ItemContainer 사용 안 함)
 	r := listRule()
 	r.Selectors.LinkDiscovery = &storage.LinkDiscoveryConfig{
 		ArticleURLPattern: "",
 		SameOriginOnly:    true,
 	}
+	// ItemContainer 를 매칭 0건 selector 로 변경 — fallback 진입 시 ErrParseFailure 보장
+	r.Selectors.ItemContainer = &storage.FieldSelector{CSS: "div.no-such-class-anywhere"}
 	repo := &fakeRepo{rules: []*storage.ParsingRuleRecord{r}}
 	p := rule.NewParser(rule.NewResolver(repo))
 
 	items, err := p.ParseLinks(context.Background(), makeRaw("https://news.example.com/category", listHTML))
-	require.NoError(t, err)
-	require.Len(t, items, 3, "all-pass 모드 — listHTML 의 a href 3개 모두 통과")
+	require.NoError(t, err, "discovery 경로가 동작 — fallback 진입 시 stale selector 로 에러였을 것")
+	require.Len(t, items, 3, "all-pass discovery — listHTML 의 a href 3개 모두 통과")
 }

--- a/test/internal/parser/rule/discovery_test.go
+++ b/test/internal/parser/rule/discovery_test.go
@@ -183,15 +183,49 @@ func TestPageLinkDiscovery_NoMatch_ReturnsParseFailure(t *testing.T) {
 	assert.Equal(t, rule.ErrParseFailure, rerr.Code, "0건 매칭 = pattern stale 진단")
 }
 
-func TestPageLinkDiscovery_EmptyPattern_ReturnsEmptySelector(t *testing.T) {
+// TestPageLinkDiscovery_EmptyPattern_AllPass 는 빈 ArticleURLPattern 이 all-pass 모드로
+// 동작함을 검증합니다 (이슈 #148). pkg/links.Extractor 의 기본 제외 패턴 (javascript:/mailto:/tel:/login 등)
+// 만 적용되고 그 외 모든 (a href) 가 통과.
+func TestPageLinkDiscovery_EmptyPattern_AllPass(t *testing.T) {
 	d := rule.NewPageLinkDiscovery()
-	cfg := &storage.LinkDiscoveryConfig{ArticleURLPattern: ""}
+	cfg := &storage.LinkDiscoveryConfig{
+		ArticleURLPattern: "",
+		SameOriginOnly:    true,
+	}
 
-	_, err := d.Discover(makeRaw("https://news.example.com/x", fullPageHTML), cfg)
-	require.Error(t, err)
-	var rerr *rule.Error
-	require.ErrorAs(t, err, &rerr)
-	assert.Equal(t, rule.ErrEmptySelector, rerr.Code)
+	items, err := d.Discover(makeRaw("https://news.example.com/category/politics", fullPageHTML), cfg)
+	require.NoError(t, err, "all-pass 모드는 정상 통과")
+
+	// nav, /category/politics, main article × 2, sidebar × 2 = 6 (footer/external/login/mailto/javascript 제외)
+	require.GreaterOrEqual(t, len(items), 6, "fullPageHTML 의 same-origin 통과 가능 링크 모두 포함")
+
+	// 명시적으로 article 만 외 nav/category 도 포함됐는지 확인
+	urls := make(map[string]bool)
+	for _, it := range items {
+		urls[it.URL] = true
+	}
+	assert.True(t, urls["https://news.example.com/category/politics"], "category 링크 포함")
+	assert.True(t, urls["https://news.example.com/article/2026/04/29/headline-one"], "article 링크 포함")
+	assert.False(t, urls["https://news.example.com/login"], "기본 제외 패턴 (/login) 은 차단")
+}
+
+// TestPageLinkDiscovery_EmptyPattern_ExcludeStillApplies 는 all-pass 모드에서도
+// ExcludePatterns 가 정상 동작함을 검증합니다.
+func TestPageLinkDiscovery_EmptyPattern_ExcludeStillApplies(t *testing.T) {
+	d := rule.NewPageLinkDiscovery()
+	cfg := &storage.LinkDiscoveryConfig{
+		ArticleURLPattern: "",
+		SameOriginOnly:    true,
+		ExcludePatterns:   []string{"/category/", "/about"},
+	}
+
+	items, err := d.Discover(makeRaw("https://news.example.com/category/politics", fullPageHTML), cfg)
+	require.NoError(t, err)
+
+	for _, it := range items {
+		assert.NotContains(t, it.URL, "/category/", "all-pass 모드에서도 ExcludePatterns 적용")
+		assert.NotContains(t, it.URL, "/about", "운영자 정의 제외 패턴 적용")
+	}
 }
 
 func TestPageLinkDiscovery_NilConfig_ReturnsEmptySelector(t *testing.T) {
@@ -271,14 +305,20 @@ func TestParser_ParseLinks_FallsBackToItemContainerWhenPatternEmpty(t *testing.T
 	assert.Len(t, items, 3, "ItemContainer 경로로 3개 추출 (기존 동작 회귀 없음)")
 }
 
-func TestParser_ParseLinks_LinkDiscoveryWithEmptyPattern_FallsBackToItemContainer(t *testing.T) {
-	// LinkDiscovery 객체는 있지만 pattern 비어있음 → ItemContainer fallback
+// TestParser_ParseLinks_LinkDiscoveryWithEmptyPattern_AllPassDiscovery 는 이슈 #148 변경 검증:
+// LinkDiscovery 객체가 채워져 있으면 ArticleURLPattern 이 빈 문자열이어도 discovery 모드 진입.
+// ItemContainer fallback 은 LinkDiscovery 자체가 nil 일 때만.
+func TestParser_ParseLinks_LinkDiscoveryWithEmptyPattern_AllPassDiscovery(t *testing.T) {
+	// LinkDiscovery 객체는 있지만 pattern 비어있음 → all-pass discovery (ItemContainer 사용 안 함)
 	r := listRule()
-	r.Selectors.LinkDiscovery = &storage.LinkDiscoveryConfig{ArticleURLPattern: ""}
+	r.Selectors.LinkDiscovery = &storage.LinkDiscoveryConfig{
+		ArticleURLPattern: "",
+		SameOriginOnly:    true,
+	}
 	repo := &fakeRepo{rules: []*storage.ParsingRuleRecord{r}}
 	p := rule.NewParser(rule.NewResolver(repo))
 
 	items, err := p.ParseLinks(context.Background(), makeRaw("https://news.example.com/category", listHTML))
 	require.NoError(t, err)
-	assert.Len(t, items, 3, "빈 pattern 은 disabled 와 동일 — ItemContainer fallback")
+	require.Len(t, items, 3, "all-pass 모드 — listHTML 의 a href 3개 모두 통과")
 }


### PR DESCRIPTION
## 연관 이슈
- Closes #148

이슈 #100 / #139 후속. 사이트별 \"기사 URL\" regex 강제로 인해 누락되던 비-article 컨텐츠
(공지/이벤트/시리즈/오피니언/멀티미디어 등) 를 모두 수집하도록 LinkDiscovery 의 pattern 을 optional 로 강등.

<br>

## 구현 내용

### 1. PageLinkDiscovery 컴포넌트 — pattern optional
- `internal/crawler/parser/rule/discovery.go`
- `cfg.ArticleURLPattern` 빈 문자열 시 regex compile/매칭 단계 skip
- `pkg/links.Extractor` 의 SameOriginOnly / PathPrefixes / ExcludePatterns / MaxLinksPerPage 만으로 필터
- 0건 매칭 메시지를 모드별 분기 (pattern stale vs page-empty)

### 2. rule.Parser ParseLinks 분기 완화
- `internal/crawler/parser/rule/parser.go`
- 기존: `cfg != nil && cfg.ArticleURLPattern != \"\"` → discovery
- 신규: `cfg != nil` → discovery (빈 pattern 도 all-pass 모드)
- ItemContainer fallback 은 LinkDiscovery 객체 자체가 nil 일 때만

### 3. Migration 008 — 운영 사이트 rules all-pass 전환
- naver/daum/yonhap/cnn × list rule = 4 rows UPDATE
- `article_url_pattern` 빈 문자열로 갱신
- `exclude_patterns` 강화 — 사이트별 광고/공유/네비/미디어/about/login 등 노이즈 컷
- `max_links_per_page=200`, `same_origin_only` site profile 유지

### 5. MaxLinksPerPage 우선순위 정책 (추가 commit)

사용자 피드백 반영 — `same-origin` 우선 + `cross-origin` random sample 로 변경:

1. **same-origin** (raw.URL host 와 동일) 링크는 `maxOut` 무시하고 모두 통과
2. **cross-origin** 은 잔여 슬롯 (`maxOut - len(same)`) 만큼 `math/rand/v2.Shuffle` 로 무작위 sample
3. `maxOut == 0` (무제한) 이면 cross 도 모두 통과

이유:
- 사이트 자체 컨텐츠 (same) 는 noise 적고 가치 높음 — 모두 발행
- 외부 링크 (cross) 는 광고/제휴 noise 많음 — cap 통제 + 무작위 sample 로 특정 영역 (페이지 상단 sponsored slot 등) 편향 회피

### 4. 테스트 갱신 (3건)
- `TestPageLinkDiscovery_EmptyPattern_AllPass` — 빈 pattern 으로 모든 same-origin 링크 통과 + 기본 제외 (login 등) 차단 검증
- `TestPageLinkDiscovery_EmptyPattern_ExcludeStillApplies` — all-pass 모드에서 ExcludePatterns 동작
- `TestParser_ParseLinks_LinkDiscoveryWithEmptyPattern_AllPassDiscovery` — 객체만 있고 pattern 비었을 때 all-pass discovery 진입 (ItemContainer fallback X)
- 기존 `TestPageLinkDiscovery_EmptyPattern_ReturnsEmptySelector` 는 의미 변경에 따라 위 케이스로 대체

<br>

## CI / 머지 게이트 점검

### 변경 영향 범위
- 영향 패키지/모듈:
  - 변경: `internal/crawler/parser/rule/{discovery.go, parser.go}`
  - 신규: `migrations/{up,down}/008_*.sql`
  - 테스트 변경: `test/internal/parser/rule/discovery_test.go`
- 위험도: `Medium`
  - 코드 변경은 작지만 라이브 동작이 \"매칭 가능 article 만\" → \"모든 의미 있는 링크\" 로 확장됨
  - publish 수가 사이트별 2~5배 증가 가능 → backlog throttle (#124) / URL cache (#127) / JobLocker (#126) 가 흡수
  - validator reject 비율 증가 가능 — 라이브 모니터링 후 ExcludePatterns 점진 정밀화

### Required Status Checks
- [ ] `Commit Lint`
- [ ] `PR Title Lint`
- [ ] `Linked Issue Check`
- [ ] `Format Check`
- [ ] `Build`
- [ ] `Test`
- [ ] `Lint`

### 배포 순서
1. **migration 008 적용** (production DB 의 4개 list rule UPDATE)
2. 코드 deploy
3. 라이브 모니터링:
   - 카테고리 페이지의 `chained article jobs published` 에서 `url_count` 증가 추이
   - validator reject 비율 — noise 흡수 여부
   - Kafka backlog — `issuetracker.crawl.normal` 토픽 lag

### 롤백 계획
1. 코드 revert: `git revert` (4 commits, 역순)
2. migration 008 down 적용 — 007 의 좁은 ArticleURLPattern 으로 복원
3. 즉시 이전 동작 회귀 (rule cache TTL 5분 이내 자동 적용)

### 후속 작업 (별도 PR)
- 라이브 측정 후 사이트별 ExcludePatterns 추가 정밀화
- LLM (#149) 도입 시 noise 분류기 정확도 측정

<br>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved link discovery mechanism to support all-pass filtering mode, allowing exclusion patterns to work independently of URL pattern matching.

* **Chores**
  * Updated parsing rules for Naver, Daum, Yonhap, and CNN to use relaxed link discovery patterns with enhanced exclusion-based filtering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->