### PR TITLE
[REFAC#134] Fetcher/Parser worker 분리 + raw_contents Claim Check

### DIFF
--- a/cmd/issuetracker/main.go
+++ b/cmd/issuetracker/main.go
@@ -209,6 +209,11 @@ func main() {
 	)
 	pw.Start(ctx)
 
+	// Cleanup cron — parser worker 가 처리하지 못한 채 잔존한 raw_contents row 정리.
+	// 정상 흐름에서는 거의 동작 안 함. crash / rule.Error 잔존 / LLM 재처리 윈도우 만료된 row 만 대상.
+	cleaner := parserWorker.NewRawContentCleaner(rawSvc, parserWorker.CleanupConfig{}, log)
+	cleaner.Start(ctx)
+
 	// ── Scheduler (시드 Job 발행) ─────────────────────────────────────────────
 	schedulerCfg, err := config.LoadScheduler()
 	if err != nil {
@@ -305,6 +310,7 @@ func main() {
 	if err := pw.Stop(shutdownCtx); err != nil {
 		log.WithError(err).Error("error during parser worker shutdown")
 	}
+	cleaner.Stop()
 	if err := validateWorker.Stop(shutdownCtx); err != nil {
 		log.WithError(err).Error("error during validate worker shutdown")
 	}

--- a/cmd/issuetracker/main.go
+++ b/cmd/issuetracker/main.go
@@ -14,6 +14,7 @@ import (
 	"issuetracker/internal/crawler/handler"
 	"issuetracker/internal/crawler/parser/rule"
 	crawlerWorker "issuetracker/internal/crawler/worker"
+	parserWorker "issuetracker/internal/parser/worker"
 	"issuetracker/internal/processor/validate"
 	"issuetracker/internal/publisher"
 	"issuetracker/internal/scheduler"
@@ -26,7 +27,12 @@ import (
 	"issuetracker/pkg/redis"
 )
 
-const validateWorkerCount = 8
+const (
+	validateWorkerCount = 8
+	// parserWorkerCount: TopicFetched consumer group (issuetracker-parsers) 의 worker 수.
+	// fetcher worker 와 독립 — chromedp/LLM 등으로 parser 가 무거워질 때 별도 스케일 (이슈 #134).
+	parserWorkerCount = 6
+)
 
 func main() {
 	log := logger.New(logger.DefaultConfig())
@@ -90,22 +96,27 @@ func main() {
 	ruleResolver := rule.NewResolver(parsingRuleRepo)
 	ruleParser := rule.NewParser(ruleResolver)
 
-	// Readiness check: 사이트 등록 전 parsing_rules 가 seed 됐는지 검증 (Coderabbit 피드백).
+	// Readiness check: 사이트 등록 전 parsing_rules 가 seed 됐는지 검증.
 	// 부재 시 fail-fast — 실행 중 모든 ParsePage/ParseLinks 가 ErrNoRule 로 죽는 것보다 즉시 종료.
 	// migration 007 (또는 동등한 운영자 seed) 가 적용되어야 통과.
 	if err := verifyParsingRulesSeeded(ctx, ruleResolver); err != nil {
 		log.WithError(err).Fatal("parsing_rules seed missing — apply migration 007 before deploy")
 	}
 
-	if err := kr.Register(registry, core.DefaultConfig(), ruleParser, newsRepo, jobPublisher, log); err != nil {
-		log.WithError(err).Fatal("failed to register kr crawlers")
-	}
-	if err := us.Register(registry, core.DefaultConfig(), ruleParser, newsRepo, jobPublisher, log); err != nil {
-		log.WithError(err).Fatal("failed to register us crawlers")
-	}
+	// raw_contents 서비스 — fetcher 측 Claim Check 저장 + parser 측 로드/삭제 (이슈 #134).
+	rawRepo := pgstore.NewRawContentRepository(pool, log)
+	rawSvc := service.NewRawContentService(rawRepo, log)
 
 	contentRepo := pgstore.NewContentRepository(pool, log)
 	contentSvc := service.NewContentService(contentRepo, log)
+
+	// fetcher 측 등록 (이슈 #134 분리 후): chain handler 가 raw_contents 저장 + RawContentRef 발행만 수행.
+	if err := kr.Register(registry, core.DefaultConfig(), rawSvc, crawlerProducer, log); err != nil {
+		log.WithError(err).Fatal("failed to register kr crawlers")
+	}
+	if err := us.Register(registry, core.DefaultConfig(), rawSvc, crawlerProducer, log); err != nil {
+		log.WithError(err).Fatal("failed to register us crawlers")
+	}
 
 	// Redis 기반 JobLocker: 동일 job_id가 여러 worker/인스턴스에서 중복 처리되는 것을 방지합니다.
 	// worker/manager가 JobLocker nil을 NoopJobLocker로 fallback 처리하는 설계와 일관되게,
@@ -177,6 +188,26 @@ func main() {
 		"normal_workers": managerCfg.Normal.WorkerCount,
 		"low_workers":    managerCfg.Low.WorkerCount,
 	}).Info("crawler pool manager started")
+
+	// ── Parser worker (이슈 #134) ──────────────────────────────────────────────
+	// fetcher 와 분리된 별도 consumer group (issuetracker-parsers) 으로 동작 — 인스턴스 수 독립 스케일.
+	// TopicFetched 의 RawContentRef 를 consume 하여 raw 로드 + 파싱 + content 저장 + raw 삭제.
+	// 파싱 실패 (rule.Error) 시 raw 잔존 → LLM 재처리 윈도우 (이슈 #149).
+	parserKafkaCfg := queue.DefaultConfig()
+	parserKafkaCfg.GroupID = queue.GroupParsers
+	parserConsumer := queue.NewConsumer(parserKafkaCfg, queue.TopicFetched)
+	pw := parserWorker.NewParserWorker(
+		parserConsumer,
+		crawlerProducer, // normalized 토픽 발행 + chained article jobs 발행 시 publisher 가 동일 producer 사용
+		rawSvc,
+		contentSvc,
+		newsRepo,
+		jobPublisher,
+		ruleParser,
+		parserWorkerCount,
+		log,
+	)
+	pw.Start(ctx)
 
 	// ── Scheduler (시드 Job 발행) ─────────────────────────────────────────────
 	schedulerCfg, err := config.LoadScheduler()
@@ -270,6 +301,9 @@ func main() {
 
 	if err := manager.Stop(shutdownCtx); err != nil {
 		log.WithError(err).Error("error during crawler shutdown")
+	}
+	if err := pw.Stop(shutdownCtx); err != nil {
+		log.WithError(err).Error("error during parser worker shutdown")
 	}
 	if err := validateWorker.Stop(shutdownCtx); err != nil {
 		log.WithError(err).Error("error during validate worker shutdown")

--- a/internal/crawler/domain/general/chain_handler.go
+++ b/internal/crawler/domain/general/chain_handler.go
@@ -2,66 +2,63 @@ package general
 
 import (
 	"context"
-	"errors"
+	"encoding/json"
 	"fmt"
 
 	"issuetracker/internal/crawler/core"
-	"issuetracker/internal/crawler/parser"
-	"issuetracker/internal/crawler/parser/rule"
-	"issuetracker/internal/storage"
+	"issuetracker/internal/storage/service"
 	"issuetracker/pkg/logger"
+	"issuetracker/pkg/queue"
 )
 
-const (
-	// maxChainedURLs: 단일 카테고리 페이지에서 발행할 수 있는 최대 기사 URL 수.
-	// 광고/외부 링크 혼재 시 Kafka 토픽 폭증 방지. parsing_rules.LinkDiscovery.MaxLinksPerPage
-	// 이 추가 cap 으로 동작하지만 본 상수는 ItemContainer 모드도 보호.
-	maxChainedURLs = 200
-)
-
-// ChainHandler 는 fetch chain + DB 기반 파싱 (rule.Parser) + DB 저장을 결합한
-// handler.Handler 어댑터입니다 (이슈 #100 / #139 통합).
+// ChainHandler 는 fetcher worker 의 책임을 담당하는 handler.Handler 어댑터입니다 (이슈 #134).
 //
-// ChainHandler combines fetch chain + DB-driven parsing + DB persistence.
-// 사이트별 NaverParser/CNNParser/... 가 사라진 자리 — 모든 사이트가 단일 rule.Parser 를 공유하며,
-// parsing_rules 테이블의 row 가 사이트 동작을 결정합니다.
+// 분리 후 책임 (Claim Check 패턴):
+//  1. Chain (RSS / GoQuery / Browser) 으로 raw HTML fetch
+//  2. RawContentService.Store 로 raw_contents 테이블에 저장 → raw_id
+//  3. RawContentRef (raw_id + url + source_info) 를 queue.TopicFetched 로 publish
 //
-// 동작 분기:
-//  1. RSS (fetch_strategy=rss): ConvertRSSPages 로 다건 변환 반환
-//  2. 카테고리/목록 (TargetTypeCategory): rule.Parser.ParseLinks → publisher.Publish → nil 반환
-//  3. 기사 페이지 (TargetTypeArticle): rule.Parser.ParsePage → ConvertPage → 단건 반환
+// 파싱 / DB 저장 / 다음 단계 chained job 발행은 별도 parser worker (issuetracker-parsers
+// consumer group) 의 책임으로 이전됨. 본 핸들러는 nil Content slice 를 반환하여 worker pool 의
+// publishNormalized 단계를 스킵하도록 함.
+//
+// 본 분리의 핵심 가치:
+//   - parser 가 무거워져도 (chromedp 가 큰 HTML 처리, LLM 호출 등) fetcher worker 슬롯 점유 X
+//   - parser worker 인스턴스 수를 fetcher 와 독립으로 스케일 가능
+//   - raw HTML 이 DB 에 보존되어 worker crash 시에도 복구 가능
+//   - 파싱 실패한 raw 가 잔존 → LLM 으로 새 rule 생성 (이슈 #149) 후 재처리 가능
 type ChainHandler struct {
-	Crawler   SourceCrawler
-	Chain     Handler
-	Parser    *rule.Parser                  // nil 허용 — nil 이면 ParsePage / ParseLinks 건너뜀
-	Publisher JobPublisher                  // nil 허용 — nil 이면 카테고리 체이닝 건너뜀
-	Repo      storage.NewsArticleRepository // nil 허용 — nil 이면 DB 저장 건너뜀
-	Log       *logger.Logger
+	Crawler  SourceCrawler
+	Chain    Handler
+	RawSvc   service.RawContentService
+	Producer queue.Producer
+	Log      *logger.Logger
 }
 
-// NewChainHandler 는 새 ChainHandler 를 생성합니다. chain 과 log 는 비-nil 필수.
+// NewChainHandler 는 새 ChainHandler 를 생성합니다.
+// Chain / RawSvc / Producer / Log 모두 비-nil 필수.
 func NewChainHandler(
 	crawler SourceCrawler,
 	chain Handler,
-	parser *rule.Parser,
-	publisher JobPublisher,
-	repo storage.NewsArticleRepository,
+	rawSvc service.RawContentService,
+	producer queue.Producer,
 	log *logger.Logger,
 ) *ChainHandler {
 	return &ChainHandler{
-		Crawler:   crawler,
-		Chain:     chain,
-		Parser:    parser,
-		Publisher: publisher,
-		Repo:      repo,
-		Log:       log,
+		Crawler:  crawler,
+		Chain:    chain,
+		RawSvc:   rawSvc,
+		Producer: producer,
+		Log:      log,
 	}
 }
 
-// Handle 은 CrawlJob 을 chain 통과시키고 파싱된 Content(s) 반환.
+// Handle 은 chain 통과로 raw HTML 을 fetch 하고 raw_contents 저장 + RawContentRef 발행을 수행합니다.
+//
+// 항상 nil Content slice 를 반환 — 파싱은 parser worker 가 TopicFetched 를 consume 하여 처리.
 func (h *ChainHandler) Handle(ctx context.Context, job *core.CrawlJob) ([]*core.Content, error) {
-	if h.Chain == nil || h.Log == nil {
-		return nil, fmt.Errorf("chain handler is not properly initialized: chain or log is nil")
+	if h.Chain == nil || h.Log == nil || h.RawSvc == nil || h.Producer == nil {
+		return nil, fmt.Errorf("chain handler is not properly initialized")
 	}
 
 	raw, err := h.Chain.Handle(ctx, job)
@@ -72,121 +69,62 @@ func (h *ChainHandler) Handle(ctx context.Context, job *core.CrawlJob) ([]*core.
 		return nil, fmt.Errorf("chain returned nil raw content for %s", job.Target.URL)
 	}
 
-	// 1. RSS 결과
-	if strategy, ok := raw.Metadata["fetch_strategy"].(string); ok && strategy == "rss" {
-		return ConvertRSSPages(raw), nil
-	}
-
-	// 2. 카테고리/목록 페이지
-	if job.Target.Type == core.TargetTypeCategory {
-		if h.Parser == nil || h.Publisher == nil {
-			h.Log.WithFields(map[string]interface{}{
-				"crawler":    job.CrawlerName,
-				"url":        job.Target.URL,
-				"has_parser": h.Parser != nil,
-				"has_pub":    h.Publisher != nil,
-			}).Debug("category job skipped: parser or publisher not configured")
-			return nil, nil
-		}
-		return nil, h.publishArticleJobs(ctx, job, raw)
-	}
-
-	// 3. 기사 페이지
-	isArticle := job.Target.Type == core.TargetTypeArticle
-	canParse := raw.HTML != "" && h.Parser != nil
-	if !isArticle || !canParse {
-		h.Log.WithFields(map[string]interface{}{
-			"is_article": isArticle,
-			"has_html":   raw.HTML != "",
-			"has_parser": h.Parser != nil,
-		}).Debug("skipping parse: conditions not met")
-		return nil, nil
-	}
-
-	page, err := h.Parser.ParsePage(ctx, raw)
+	// raw_contents 저장 (중복 시 기존 ID 재사용 — RawContentService 책임)
+	rawID, dup, err := h.RawSvc.Store(ctx, raw)
 	if err != nil {
-		h.Log.WithError(err).Warn("page parse failed, skipping")
-		return nil, nil
+		return nil, fmt.Errorf("store raw content for %s: %w", job.Target.URL, err)
 	}
-
-	if h.Repo != nil {
-		if err := h.Repo.Insert(ctx, PageToRecord(page, raw)); err != nil {
-			h.Log.WithError(err).Warn("failed to save parsed page to news_articles")
-		}
-	}
-
-	return []*core.Content{ConvertPage(page, raw)}, nil
-}
-
-// publishArticleJobs 는 카테고리/목록 페이지에서 기사 URL 추출 후 CrawlJob 발행.
-// rule.Parser.ParseLinks 가 LinkDiscovery (full-page) 또는 ItemContainer 경로 자동 선택.
-//
-// 에러 처리 정책 (Coderabbit 피드백):
-//   - rule 진단 에러 (ErrParseFailure / ErrEmptySelector / ErrNoRule) 는 terminal —
-//     warn + nil 반환. 카테고리 페이지가 비거나 rule 이 stale 한 경우 재시도해도
-//     같은 결과 → DLQ/재시도 churn 회피. article ParsePage 의 동일 정책 (105-108) 과 정렬.
-//   - 그 외 에러 (예: ctx 취소) 만 재시도/DLQ 진입을 위해 전파.
-func (h *ChainHandler) publishArticleJobs(ctx context.Context, job *core.CrawlJob, raw *core.RawContent) error {
-	items, err := h.Parser.ParseLinks(ctx, raw)
-	if err != nil {
-		var rerr *rule.Error
-		if errors.As(err, &rerr) {
-			h.Log.WithFields(map[string]interface{}{
-				"crawler":    job.CrawlerName,
-				"url":        job.Target.URL,
-				"error_code": string(rerr.Code),
-			}).WithError(err).Warn("link parse failed (rule stale or no matches), skipping category")
-			return nil
-		}
-		return fmt.Errorf("parse links for %s: %w", job.Target.URL, err)
-	}
-	if len(items) == 0 {
+	if dup {
+		// 동일 URL 의 이전 raw 가 이미 존재 — 새 fetch 가 의미 없음 (parser 가 이전 raw 를 처리 중이거나 처리 완료).
+		// 단, dedup 정책상 publisher 가 URL cache 로 사전 차단해야 정상 — 여기 도달은 race condition.
+		// 정상 흐름이라 가정하고 ref 만 다시 발행 (idempotent — JobLocker 가 parser 측 중복 흡수).
 		h.Log.WithFields(map[string]interface{}{
-			"crawler": job.CrawlerName,
-			"url":     job.Target.URL,
-		}).Debug("no article links found in category page")
-		return nil
+			"crawler":     job.CrawlerName,
+			"url":         raw.URL,
+			"existing_id": rawID,
+		}).Debug("raw content already exists for url, republishing ref")
 	}
 
-	urls := uniqueURLs(items, maxChainedURLs)
-
-	if err := h.Publisher.Publish(ctx, job.CrawlerName, urls, core.TargetTypeArticle, job.Timeout); err != nil {
-		return fmt.Errorf("publish chained jobs for %s: %w", job.Target.URL, err)
+	if err := h.publishFetchedRef(ctx, job, raw, rawID); err != nil {
+		return nil, fmt.Errorf("publish fetched ref for %s: %w", job.Target.URL, err)
 	}
 
 	h.Log.WithFields(map[string]interface{}{
 		"crawler":     job.CrawlerName,
-		"url":         job.Target.URL,
-		"url_count":   len(urls),
-		"target_type": string(core.TargetTypeArticle),
-	}).Info("chained article jobs published from category page")
-	return nil
+		"url":         raw.URL,
+		"raw_id":      rawID,
+		"target_type": string(job.Target.Type),
+	}).Debug("raw content stored, fetched ref published")
+
+	return nil, nil
 }
 
-// uniqueURLs 는 LinkItem 슬라이스에서 빈 URL 을 제거하고 limit 까지의 unique URL 반환.
-func uniqueURLs(items []parser.LinkItem, limit int) []string {
-	seen := make(map[string]struct{}, len(items))
-	urls := make([]string, 0, min(len(items), limit))
-
-	for _, item := range items {
-		if item.URL == "" {
-			continue
-		}
-		if _, dup := seen[item.URL]; dup {
-			continue
-		}
-		seen[item.URL] = struct{}{}
-		urls = append(urls, item.URL)
-		if len(urls) >= limit {
-			break
-		}
+// publishFetchedRef 는 RawContentRef 를 TopicFetched 에 발행합니다.
+// 헤더에 target_type 을 포함하여 parser worker 가 RSS/Article/Category 분기에 사용.
+func (h *ChainHandler) publishFetchedRef(ctx context.Context, job *core.CrawlJob, raw *core.RawContent, rawID string) error {
+	ref := core.RawContentRef{
+		ID:         rawID,
+		URL:        raw.URL,
+		FetchedAt:  raw.FetchedAt,
+		SourceInfo: raw.SourceInfo,
 	}
-	return urls
-}
-
-func min(a, b int) int {
-	if a < b {
-		return a
+	payload, err := json.Marshal(ref)
+	if err != nil {
+		return fmt.Errorf("marshal raw content ref: %w", err)
 	}
-	return b
+
+	msg := queue.Message{
+		Topic: queue.TopicFetched,
+		Key:   []byte(rawID),
+		Value: payload,
+		Headers: map[string]string{
+			"source":      raw.SourceInfo.Name,
+			"country":     raw.SourceInfo.Country,
+			"crawler":     job.CrawlerName,
+			"job_id":      job.ID,
+			"target_type": string(job.Target.Type),
+			"timeout_ms":  fmt.Sprintf("%d", job.Timeout.Milliseconds()),
+		},
+	}
+	return h.Producer.Publish(ctx, msg)
 }

--- a/internal/crawler/domain/general/sources/kr/registry.go
+++ b/internal/crawler/domain/general/sources/kr/registry.go
@@ -16,50 +16,47 @@ import (
 	"issuetracker/internal/crawler/handler"
 	cdp "issuetracker/internal/crawler/implementation/chromedp"
 	"issuetracker/internal/crawler/implementation/goquery"
-	"issuetracker/internal/crawler/parser/rule"
-	"issuetracker/internal/storage"
+	"issuetracker/internal/storage/service"
 	"issuetracker/pkg/logger"
+	"issuetracker/pkg/queue"
 )
 
-// Register 는 모든 한국 사이트 크롤러를 registry 에 등록합니다.
-// repo 가 nil 이면 DB 저장 건너뜀, publisher 가 nil 이면 카테고리 체이닝 건너뜀.
-// parser 는 rule 기반 단일 인스턴스 — 모든 사이트가 공유 (parsing_rules row 가 사이트 동작 결정).
+// Register 는 모든 한국 사이트 크롤러를 registry 에 등록합니다 (이슈 #134 — fetcher/parser 분리 후).
+//
+// rawSvc + producer 는 ChainHandler (fetcher 측) 가 raw_contents 저장 + RawContentRef 발행에 사용.
+// parser worker 는 본 함수 외부에서 별도 wiring (cmd/issuetracker/main.go).
 //
 // 등록 중 wiring 실패 (BuildChain misconfig 등) 시 error 반환 — 호출자가 fail-fast 결정.
 func Register(
 	registry *handler.Registry,
 	config core.Config,
-	parser *rule.Parser,
-	repo storage.NewsArticleRepository,
-	publisher general.JobPublisher,
+	rawSvc service.RawContentService,
+	producer queue.Producer,
 	log *logger.Logger,
 ) error {
-	if err := registerNaver(registry, config, parser, repo, publisher, log); err != nil {
+	if err := registerNaver(registry, config, rawSvc, producer, log); err != nil {
 		return err
 	}
-	if err := registerYonhap(registry, config, parser, repo, publisher, log); err != nil {
+	if err := registerYonhap(registry, config, rawSvc, producer, log); err != nil {
 		return err
 	}
-	if err := registerDaum(registry, config, parser, repo, publisher, log); err != nil {
+	if err := registerDaum(registry, config, rawSvc, producer, log); err != nil {
 		return err
 	}
 	return nil
 }
 
-// 사이트별 등록의 공통 패턴:
+// 사이트별 등록의 공통 패턴 (이슈 #134 분리 후):
 //   - cfg := xxx.Default() 로 사이트 기본값 (RequestsPerHour 등) 보유
-//   - 호출자가 넘긴 config 는 사용하지 않음 (사이트별 디테일을 덮어쓰는 버그 회피 — Gemini 피드백)
-//   - chromedp/goquery 등 모든 컴포넌트가 cfg.CrawlerConfig 를 참조하여 사이트별 설정 일관 적용
-//
-// 호출자가 넘긴 config 의 의미: 향후 전역 default 가 필요할 때를 위한 시그니처 보존 — 현재는 무시.
+//   - 호출자가 넘긴 config 는 사용하지 않음 (사이트별 디테일 덮어쓰기 회피)
+//   - ChainHandler 는 fetch + raw store + RawContentRef publish 만 수행 — 파싱은 parser worker 책임
 
-func registerNaver(registry *handler.Registry, _ core.Config, parser *rule.Parser, repo storage.NewsArticleRepository, publisher general.JobPublisher, log *logger.Logger) error {
+func registerNaver(registry *handler.Registry, _ core.Config, rawSvc service.RawContentService, producer queue.Producer, log *logger.Logger) error {
 	cfg := naver.Default()
 
 	gqCrawler := goquery.NewGoqueryCrawler("naver-goquery", cfg.CrawlerConfig.SourceInfo, cfg.CrawlerConfig)
 	gqFetcher := fetcher.NewGoqueryFetcher(gqCrawler)
 
-	// chromedp 인스턴스 식별자만 "naver-browser" — SourceInfo.Name 은 "naver" 그대로 (source_name 일관성, Coderabbit 피드백)
 	cdpCrawler := cdp.NewChromedpCrawlerWithOptions("naver-browser", cfg.CrawlerConfig.SourceInfo, cfg.CrawlerConfig, cdp.DefaultRemoteOptions())
 	brFetcher := fetcher.NewBrowserFetcher(cdpCrawler, cfg.CrawlerConfig)
 
@@ -71,12 +68,12 @@ func registerNaver(registry *handler.Registry, _ core.Config, parser *rule.Parse
 		return fmt.Errorf("naver chain wiring: %w", err)
 	}
 
-	registry.Register("naver", general.NewChainHandler(crawler, chain, parser, publisher, repo, log))
+	registry.Register("naver", general.NewChainHandler(crawler, chain, rawSvc, producer, log))
 	log.WithField("crawler", "naver").Info("naver crawler registered")
 	return nil
 }
 
-func registerYonhap(registry *handler.Registry, _ core.Config, parser *rule.Parser, repo storage.NewsArticleRepository, publisher general.JobPublisher, log *logger.Logger) error {
+func registerYonhap(registry *handler.Registry, _ core.Config, rawSvc service.RawContentService, producer queue.Producer, log *logger.Logger) error {
 	cfg := yonhap.Default()
 
 	gqCrawler := goquery.NewGoqueryCrawler("yonhap-goquery", cfg.CrawlerConfig.SourceInfo, cfg.CrawlerConfig)
@@ -88,12 +85,12 @@ func registerYonhap(registry *handler.Registry, _ core.Config, parser *rule.Pars
 		return fmt.Errorf("yonhap chain wiring: %w", err)
 	}
 
-	registry.Register("yonhap", general.NewChainHandler(crawler, chain, parser, publisher, repo, log))
+	registry.Register("yonhap", general.NewChainHandler(crawler, chain, rawSvc, producer, log))
 	log.WithField("crawler", "yonhap").Info("yonhap crawler registered")
 	return nil
 }
 
-func registerDaum(registry *handler.Registry, _ core.Config, parser *rule.Parser, repo storage.NewsArticleRepository, publisher general.JobPublisher, log *logger.Logger) error {
+func registerDaum(registry *handler.Registry, _ core.Config, rawSvc service.RawContentService, producer queue.Producer, log *logger.Logger) error {
 	cfg := daum.Default()
 
 	gqCrawler := goquery.NewGoqueryCrawler("daum-goquery", cfg.CrawlerConfig.SourceInfo, cfg.CrawlerConfig)
@@ -110,7 +107,7 @@ func registerDaum(registry *handler.Registry, _ core.Config, parser *rule.Parser
 		return fmt.Errorf("daum chain wiring: %w", err)
 	}
 
-	registry.Register("daum", general.NewChainHandler(crawler, chain, parser, publisher, repo, log))
+	registry.Register("daum", general.NewChainHandler(crawler, chain, rawSvc, producer, log))
 	log.WithField("crawler", "daum").Info("daum crawler registered")
 	return nil
 }

--- a/internal/crawler/domain/general/sources/us/registry.go
+++ b/internal/crawler/domain/general/sources/us/registry.go
@@ -13,26 +13,25 @@ import (
 	"issuetracker/internal/crawler/handler"
 	cdp "issuetracker/internal/crawler/implementation/chromedp"
 	"issuetracker/internal/crawler/implementation/goquery"
-	"issuetracker/internal/crawler/parser/rule"
-	"issuetracker/internal/storage"
+	"issuetracker/internal/storage/service"
 	"issuetracker/pkg/logger"
+	"issuetracker/pkg/queue"
 )
 
-// Register 는 모든 미국 사이트 크롤러를 registry 에 등록합니다.
-// 등록 중 wiring 실패 (BuildChain misconfig 등) 시 error 반환 — 호출자가 fail-fast 결정.
+// Register 는 모든 미국 사이트 크롤러를 registry 에 등록합니다 (이슈 #134 — fetcher/parser 분리 후).
+// 등록 중 wiring 실패 시 error 반환 — 호출자가 fail-fast 결정.
 func Register(
 	registry *handler.Registry,
 	config core.Config,
-	parser *rule.Parser,
-	repo storage.NewsArticleRepository,
-	publisher general.JobPublisher,
+	rawSvc service.RawContentService,
+	producer queue.Producer,
 	log *logger.Logger,
 ) error {
-	return registerCNN(registry, config, parser, repo, publisher, log)
+	return registerCNN(registry, config, rawSvc, producer, log)
 }
 
-// 사이트별 등록 패턴은 kr/registry.go 와 동일 — cfg.CrawlerConfig 보존, 호출자 config 무시.
-func registerCNN(registry *handler.Registry, _ core.Config, parser *rule.Parser, repo storage.NewsArticleRepository, publisher general.JobPublisher, log *logger.Logger) error {
+// 사이트별 등록 패턴은 kr/registry.go 와 동일.
+func registerCNN(registry *handler.Registry, _ core.Config, rawSvc service.RawContentService, producer queue.Producer, log *logger.Logger) error {
 	cfg := cnn.Default()
 
 	gqCrawler := goquery.NewGoqueryCrawler("cnn-goquery", cfg.CrawlerConfig.SourceInfo, cfg.CrawlerConfig)
@@ -49,7 +48,7 @@ func registerCNN(registry *handler.Registry, _ core.Config, parser *rule.Parser,
 		return fmt.Errorf("cnn chain wiring: %w", err)
 	}
 
-	registry.Register("cnn", general.NewChainHandler(crawler, chain, parser, publisher, repo, log))
+	registry.Register("cnn", general.NewChainHandler(crawler, chain, rawSvc, producer, log))
 	log.WithField("crawler", "cnn").Info("cnn crawler registered")
 	return nil
 }

--- a/internal/parser/worker/cleanup.go
+++ b/internal/parser/worker/cleanup.go
@@ -1,0 +1,116 @@
+package worker
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"issuetracker/internal/storage/service"
+	"issuetracker/pkg/logger"
+)
+
+const (
+	// DefaultCleanupInterval: cleanup 루프 주기.
+	DefaultCleanupInterval = 30 * time.Minute
+
+	// DefaultStaleRawTTL: parser worker 가 처리하지 못한 채 남은 raw_contents row 의 보존 기간.
+	//
+	// 정책 의도 (이슈 #134):
+	//   - 정상 흐름에서는 parser worker 가 즉시 Delete 하므로 raw 가 누적되지 않음
+	//   - 잔존하는 row 는 (1) parser crash, (2) rule.Error 로 잔존, (3) LLM 재처리 대기 윈도우
+	//   - LLM 자동 rule 생성 (이슈 #149) 후 cleanup 이전에 reprocess 가능해야 의미 있음
+	//   - 기본 1시간 — LLM rule 생성 + 재처리에 충분, 폭주 시 디스크 보호
+	DefaultStaleRawTTL = 1 * time.Hour
+)
+
+// CleanupConfig 는 RawContentCleaner 의 동작을 제어합니다.
+type CleanupConfig struct {
+	// Interval: 루프 polling 주기. 0 이면 DefaultCleanupInterval 사용.
+	Interval time.Duration
+	// StaleTTL: cutoff = now - StaleTTL. 0 이면 DefaultStaleRawTTL 사용.
+	StaleTTL time.Duration
+}
+
+// RawContentCleaner 는 parser worker 가 처리하지 못한 채 잔존한 raw_contents row 를
+// 주기적으로 정리하는 안전망 goroutine 입니다 (이슈 #134).
+//
+// 정상 흐름에서는 parser worker 가 처리 직후 raw 를 삭제하므로 본 cleaner 의 동작은 거의 없음.
+// row 가 남는 케이스:
+//   - parser worker crash (Delete 호출 전)
+//   - rule.Error 로 raw 잔존 (LLM 재처리 윈도우 — 이슈 #149)
+//   - 일시적 DB 에러로 Delete 실패
+//
+// StaleTTL 보다 오래된 row 는 LLM 재처리에 더 이상 의미 없다고 판단하여 정리.
+type RawContentCleaner struct {
+	rawSvc service.RawContentService
+	cfg    CleanupConfig
+	log    *logger.Logger
+	wg     sync.WaitGroup
+}
+
+// NewRawContentCleaner 는 RawContentCleaner 를 생성합니다.
+// cfg 의 0 값 필드는 default 로 보정.
+func NewRawContentCleaner(rawSvc service.RawContentService, cfg CleanupConfig, log *logger.Logger) *RawContentCleaner {
+	if cfg.Interval <= 0 {
+		cfg.Interval = DefaultCleanupInterval
+	}
+	if cfg.StaleTTL <= 0 {
+		cfg.StaleTTL = DefaultStaleRawTTL
+	}
+	return &RawContentCleaner{
+		rawSvc: rawSvc,
+		cfg:    cfg,
+		log:    log,
+	}
+}
+
+// Start 는 cleanup 루프를 별도 goroutine 으로 시작합니다 (non-blocking).
+func (c *RawContentCleaner) Start(ctx context.Context) {
+	c.wg.Add(1)
+	go c.run(ctx)
+	c.log.WithFields(map[string]interface{}{
+		"interval_ms": c.cfg.Interval.Milliseconds(),
+		"ttl_ms":      c.cfg.StaleTTL.Milliseconds(),
+	}).Info("raw content cleaner started")
+}
+
+// Stop 은 goroutine 종료 대기 (ctx cancel 후 호출).
+func (c *RawContentCleaner) Stop() {
+	c.wg.Wait()
+	c.log.Info("raw content cleaner stopped")
+}
+
+func (c *RawContentCleaner) run(ctx context.Context) {
+	defer c.wg.Done()
+	ticker := time.NewTicker(c.cfg.Interval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			c.purgeOnce(ctx)
+		}
+	}
+}
+
+func (c *RawContentCleaner) purgeOnce(ctx context.Context) {
+	cutoff := time.Now().Add(-c.cfg.StaleTTL)
+	n, err := c.rawSvc.PurgeOlderThan(ctx, cutoff)
+	if err != nil {
+		// ctx cancel 로 인한 에러는 정상 종료 흐름 — DEBUG 강등
+		if ctx.Err() != nil {
+			c.log.WithError(err).Debug("raw content purge interrupted by shutdown")
+			return
+		}
+		c.log.WithError(err).Warn("raw content purge failed")
+		return
+	}
+	if n > 0 {
+		c.log.WithFields(map[string]interface{}{
+			"deleted_count": n,
+			"cutoff":        cutoff.Format(time.RFC3339),
+		}).Info("raw content cleanup removed stale rows")
+	}
+}

--- a/internal/parser/worker/parser_worker.go
+++ b/internal/parser/worker/parser_worker.go
@@ -1,0 +1,400 @@
+// Package worker 는 fetcher 와 분리된 parser worker 를 제공합니다 (이슈 #134).
+//
+// Package worker provides a parser worker decoupled from fetcher workers.
+//
+// 흐름 (Claim Check 패턴):
+//  1. queue.TopicFetched 에서 RawContentRef consume
+//  2. RawContentService.GetByID 로 raw HTML 로드
+//  3. target_type 분기:
+//     - RSS (raw.Metadata["fetch_strategy"] == "rss"): ConvertRSSPages → 다건 content store + publish normalized
+//     - Category (TargetTypeCategory): rule.Parser.ParseLinks → publisher.Publish (chained jobs)
+//     - Article (TargetTypeArticle): rule.Parser.ParsePage → ConvertPage → content store + publish normalized
+//  4. 정상 처리 후 RawContentService.Delete (raw_contents 정리)
+//
+// 실패 정책:
+//   - rule.Error (parse_failure / empty_selector / no_rule): raw 잔존 + Kafka commit (재시도 X)
+//     → LLM 으로 새 rule 생성 (이슈 #149) 후 cleanup cron 이전에 재처리 가능
+//   - 기타 transient 에러: commit 안 함 → Kafka 재배달 → 재시도
+package worker
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strconv"
+	"sync"
+	"time"
+
+	"issuetracker/internal/crawler/core"
+	"issuetracker/internal/crawler/domain/general"
+	"issuetracker/internal/crawler/parser"
+	"issuetracker/internal/crawler/parser/rule"
+	"issuetracker/internal/storage"
+	"issuetracker/internal/storage/service"
+	"issuetracker/pkg/logger"
+	"issuetracker/pkg/queue"
+)
+
+const (
+	// maxChainedURLs: 카테고리 페이지에서 발행할 chained article CrawlJob 의 상한.
+	// LinkDiscovery 의 MaxLinksPerPage 외 2중 안전장치.
+	maxChainedURLs = 200
+
+	// defaultJobTimeout: 헤더에 timeout_ms 가 없을 때 chained job 이 사용할 기본 timeout.
+	defaultJobTimeout = 30 * time.Second
+)
+
+// ParserWorker 는 TopicFetched consumer group 의 worker pool 입니다.
+type ParserWorker struct {
+	consumer    *queue.KafkaConsumer
+	producer    queue.Producer
+	rawSvc      service.RawContentService
+	contentSvc  service.ContentService
+	newsRepo    storage.NewsArticleRepository
+	publisher   general.JobPublisher
+	parser      *rule.Parser
+	workerCount int
+	log         *logger.Logger
+
+	wg sync.WaitGroup
+}
+
+// NewParserWorker 는 ParserWorker 를 생성합니다.
+//
+//   - newsRepo 는 nil 허용 — nil 이면 news_articles 보존 건너뜀 (contents 만 저장)
+//   - publisher 는 nil 허용 — nil 이면 카테고리 chained jobs 발행 건너뜀 (이런 모드는 보통 운영 금지)
+func NewParserWorker(
+	consumer *queue.KafkaConsumer,
+	producer queue.Producer,
+	rawSvc service.RawContentService,
+	contentSvc service.ContentService,
+	newsRepo storage.NewsArticleRepository,
+	publisher general.JobPublisher,
+	parser *rule.Parser,
+	workerCount int,
+	log *logger.Logger,
+) *ParserWorker {
+	if workerCount <= 0 {
+		workerCount = 1
+	}
+	return &ParserWorker{
+		consumer:    consumer,
+		producer:    producer,
+		rawSvc:      rawSvc,
+		contentSvc:  contentSvc,
+		newsRepo:    newsRepo,
+		publisher:   publisher,
+		parser:      parser,
+		workerCount: workerCount,
+		log:         log,
+	}
+}
+
+// Start 는 worker goroutines 를 기동합니다 (non-blocking).
+// 호출자는 ctx cancel + Stop 으로 graceful shutdown 수행.
+func (w *ParserWorker) Start(ctx context.Context) {
+	w.log.WithFields(map[string]interface{}{
+		"worker_count": w.workerCount,
+		"input_topic":  queue.TopicFetched,
+		"output_topic": queue.TopicNormalized,
+	}).Info("parser worker started")
+
+	for i := 0; i < w.workerCount; i++ {
+		w.wg.Add(1)
+		go w.runWorker(ctx, i)
+	}
+}
+
+// Stop 은 모든 worker goroutine 의 종료를 대기합니다.
+// 호출 전 ctx 가 cancel 되어야 함 (외부 책임).
+func (w *ParserWorker) Stop(ctx context.Context) error {
+	done := make(chan struct{})
+	go func() {
+		w.wg.Wait()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		w.log.Info("parser worker stopped")
+	case <-ctx.Done():
+		w.log.Warn("parser worker stop timeout")
+	}
+	return w.consumer.Close()
+}
+
+func (w *ParserWorker) runWorker(ctx context.Context, idx int) {
+	defer w.wg.Done()
+	wlog := w.log.WithField("parser_worker_id", idx)
+
+	for {
+		if ctx.Err() != nil {
+			return
+		}
+
+		msg, err := w.consumer.FetchMessage(ctx)
+		if err != nil {
+			if ctx.Err() != nil {
+				return
+			}
+			wlog.WithError(err).Warn("fetch message failed")
+			continue
+		}
+
+		if err := w.processMessage(ctx, msg); err != nil {
+			// processMessage 가 commit 안 한 경우 — 재시도 위해 commit skip (Kafka 가 redeliver).
+			wlog.WithError(err).WithField("offset", msg.Offset).Warn("process message failed, will be redelivered")
+			continue
+		}
+
+		if commitErr := w.consumer.CommitMessages(ctx, msg); commitErr != nil {
+			if ctx.Err() == nil {
+				wlog.WithError(commitErr).Warn("commit failed after success")
+			}
+		}
+	}
+}
+
+// processMessage 는 단일 메시지 처리 흐름. 성공 시 nil, 재시도 필요 시 error 반환.
+//
+// Commit 정책:
+//   - 정상 처리 → 호출자가 commit
+//   - rule.Error (parse 실패) → commit (raw 잔존, 재시도 X)
+//   - payload 손상 → commit (DLQ 발행 후, 재시도 무의미)
+//   - 기타 transient → commit 안 함 (재시도)
+func (w *ParserWorker) processMessage(ctx context.Context, msg *queue.Message) error {
+	var ref core.RawContentRef
+	if err := json.Unmarshal(msg.Value, &ref); err != nil {
+		w.log.WithError(err).Error("malformed RawContentRef payload, dropping")
+		// commit 을 호출자가 하도록 nil 반환 — payload 손상은 재시도 의미 없음
+		return nil
+	}
+
+	mlog := w.log.WithFields(map[string]interface{}{
+		"raw_id": ref.ID,
+		"url":    ref.URL,
+	})
+
+	raw, err := w.rawSvc.GetByID(ctx, ref.ID)
+	if err != nil {
+		// raw 가 이미 삭제 (다른 worker 가 먼저 처리했거나 cleanup 발생) — 정상 종료
+		if isNotFound(err) {
+			mlog.Debug("raw content not found, skipping (already processed or cleaned up)")
+			return nil
+		}
+		// transient — 재시도
+		return fmt.Errorf("get raw by id: %w", err)
+	}
+
+	crawlerName := msg.Headers["crawler"]
+	if crawlerName == "" {
+		crawlerName = raw.SourceInfo.Name
+	}
+	targetType := core.TargetType(msg.Headers["target_type"])
+	jobTimeout := parseTimeoutHeader(msg.Headers["timeout_ms"])
+
+	// RSS strategy 분기 — chain handler 가 buildRSSRawContent 로 만든 raw
+	if strategy, ok := raw.Metadata["fetch_strategy"].(string); ok && strategy == "rss" {
+		contents := general.ConvertRSSPages(raw)
+		if err := w.publishContents(ctx, contents, crawlerName); err != nil {
+			return fmt.Errorf("publish rss contents: %w", err)
+		}
+		w.deleteRaw(ctx, ref.ID, mlog)
+		return nil
+	}
+
+	// 카테고리 페이지 — ParseLinks 후 chained article jobs 발행
+	if targetType == core.TargetTypeCategory {
+		return w.processCategoryPage(ctx, raw, ref.ID, crawlerName, jobTimeout, mlog)
+	}
+
+	// article 페이지 — ParsePage → ConvertPage → publish normalized
+	return w.processArticlePage(ctx, raw, ref.ID, crawlerName, mlog)
+}
+
+func (w *ParserWorker) processCategoryPage(ctx context.Context, raw *core.RawContent, rawID, crawlerName string, jobTimeout time.Duration, mlog *logger.Logger) error {
+	if w.parser == nil || w.publisher == nil {
+		mlog.Debug("parser or publisher not configured, skipping category job")
+		w.deleteRaw(ctx, rawID, mlog)
+		return nil
+	}
+
+	items, err := w.parser.ParseLinks(ctx, raw)
+	if err != nil {
+		return w.handleRuleError(ctx, rawID, "parse_links", err, mlog)
+	}
+	if len(items) == 0 {
+		mlog.Debug("no article links found in category page")
+		w.deleteRaw(ctx, rawID, mlog)
+		return nil
+	}
+
+	urls := uniqueURLs(items, maxChainedURLs)
+	if err := w.publisher.Publish(ctx, crawlerName, urls, core.TargetTypeArticle, jobTimeout); err != nil {
+		return fmt.Errorf("publish chained article jobs: %w", err)
+	}
+
+	mlog.WithFields(map[string]interface{}{
+		"crawler":   crawlerName,
+		"url_count": len(urls),
+	}).Info("chained article jobs published from category page")
+
+	// 카테고리 페이지는 contents/news_articles 에 저장하지 않음 — raw 즉시 정리
+	w.deleteRaw(ctx, rawID, mlog)
+	return nil
+}
+
+func (w *ParserWorker) processArticlePage(ctx context.Context, raw *core.RawContent, rawID, crawlerName string, mlog *logger.Logger) error {
+	if w.parser == nil {
+		mlog.Debug("parser not configured, skipping article")
+		w.deleteRaw(ctx, rawID, mlog)
+		return nil
+	}
+
+	page, err := w.parser.ParsePage(ctx, raw)
+	if err != nil {
+		return w.handleRuleError(ctx, rawID, "parse_page", err, mlog)
+	}
+
+	// news_articles 보존 (옵셔널)
+	if w.newsRepo != nil {
+		if insErr := w.newsRepo.Insert(ctx, general.PageToRecord(page, raw)); insErr != nil {
+			mlog.WithError(insErr).Warn("news_articles insert failed (non-fatal)")
+		}
+	}
+
+	content := general.ConvertPage(page, raw)
+	if err := w.publishContents(ctx, []*core.Content{content}, crawlerName); err != nil {
+		return fmt.Errorf("publish article content: %w", err)
+	}
+
+	w.deleteRaw(ctx, rawID, mlog)
+	return nil
+}
+
+// handleRuleError 는 rule.Error (parse 실패) 와 그 외 에러를 구분합니다.
+//
+//   - rule.Error → raw 잔존 + commit (warn 로그) — LLM 재처리 윈도우
+//   - 기타 → 호출자에게 error 전파 → commit 안 함 → 재시도
+func (w *ParserWorker) handleRuleError(ctx context.Context, rawID, stage string, err error, mlog *logger.Logger) error {
+	_ = ctx // ctx 는 향후 LLM 비동기 enqueue 시 활용 (이슈 #149)
+	var rerr *rule.Error
+	if errors.As(err, &rerr) {
+		mlog.WithFields(map[string]interface{}{
+			"stage":      stage,
+			"error_code": string(rerr.Code),
+		}).WithError(err).Warn("rule-based parse failed, raw retained for LLM retry")
+		// raw 는 의도적으로 잔존 — cleanup cron 이 TTL (default 1h) 후 정리
+		// 또는 이슈 #149 LLM 자동 rule 생성 후 reprocess 가능
+		return nil
+	}
+	return fmt.Errorf("%s: %w", stage, err)
+}
+
+// publishContents 는 *core.Content 슬라이스를 contents 저장 + ContentRef 발행 (TopicNormalized).
+func (w *ParserWorker) publishContents(ctx context.Context, contents []*core.Content, crawlerName string) error {
+	for _, c := range contents {
+		storedID, _, err := w.contentSvc.Store(ctx, c)
+		if err != nil {
+			return fmt.Errorf("store content: %w", err)
+		}
+
+		ref := core.ContentRef{
+			ID:      storedID,
+			URL:     c.URL,
+			Country: c.Country,
+			SourceInfo: core.SourceInfo{
+				Country:  c.Country,
+				Type:     c.SourceType,
+				Name:     c.SourceID,
+				Language: c.Language,
+			},
+		}
+		refData, err := json.Marshal(ref)
+		if err != nil {
+			return fmt.Errorf("marshal content ref: %w", err)
+		}
+
+		pm := core.ProcessingMessage{
+			ID:        storedID,
+			Timestamp: time.Now(),
+			Country:   c.Country,
+			Stage:     "normalized",
+			Data:      refData,
+			Metadata: map[string]interface{}{
+				"crawler": crawlerName,
+			},
+		}
+		pmBytes, err := json.Marshal(pm)
+		if err != nil {
+			return fmt.Errorf("marshal processing message: %w", err)
+		}
+
+		partitionKey := c.CanonicalURL
+		if partitionKey == "" {
+			partitionKey = c.URL
+		}
+
+		msg := queue.Message{
+			Topic: queue.TopicNormalized,
+			Key:   []byte(partitionKey),
+			Value: pmBytes,
+			Headers: map[string]string{
+				"source":  c.SourceID,
+				"country": c.Country,
+				"crawler": crawlerName,
+			},
+		}
+		if err := w.producer.Publish(ctx, msg); err != nil {
+			return fmt.Errorf("publish normalized: %w", err)
+		}
+	}
+	return nil
+}
+
+// deleteRaw 는 처리 완료된 raw_contents row 를 즉시 정리합니다.
+// 실패는 non-fatal — cleanup cron 이 안전망으로 동작.
+func (w *ParserWorker) deleteRaw(ctx context.Context, rawID string, mlog *logger.Logger) {
+	if err := w.rawSvc.Delete(ctx, rawID); err != nil {
+		mlog.WithError(err).Warn("raw delete failed (non-fatal — cleanup cron will catch)")
+	}
+}
+
+// uniqueURLs 는 LinkItem 슬라이스에서 빈 URL 제거 + limit 까지의 unique URL 반환.
+func uniqueURLs(items []parser.LinkItem, limit int) []string {
+	seen := make(map[string]struct{}, len(items))
+	urls := make([]string, 0)
+	for _, item := range items {
+		if item.URL == "" {
+			continue
+		}
+		if _, dup := seen[item.URL]; dup {
+			continue
+		}
+		seen[item.URL] = struct{}{}
+		urls = append(urls, item.URL)
+		if len(urls) >= limit {
+			break
+		}
+	}
+	return urls
+}
+
+// parseTimeoutHeader 는 timeout_ms 헤더를 time.Duration 으로 파싱합니다.
+// 실패 시 defaultJobTimeout 반환.
+func parseTimeoutHeader(s string) time.Duration {
+	if s == "" {
+		return defaultJobTimeout
+	}
+	ms, err := strconv.ParseInt(s, 10, 64)
+	if err != nil || ms <= 0 {
+		return defaultJobTimeout
+	}
+	return time.Duration(ms) * time.Millisecond
+}
+
+// isNotFound 는 storage 의 NotFound 에러 여부를 판별합니다.
+func isNotFound(err error) bool {
+	return errors.Is(err, storage.ErrNotFound)
+}

--- a/internal/storage/service/raw_content.go
+++ b/internal/storage/service/raw_content.go
@@ -22,6 +22,10 @@ type RawContentService interface {
 	// GetByID는 ID로 RawContent를 조회합니다.
 	GetByID(ctx context.Context, id string) (*core.RawContent, error)
 
+	// Delete는 ID로 RawContent를 삭제합니다 (idempotent — 미존재여도 nil).
+	// parser worker (이슈 #134) 가 파싱 완료된 raw_contents row 를 즉시 정리할 때 사용 (Claim Check 패턴).
+	Delete(ctx context.Context, id string) error
+
 	// List는 필터 조건에 맞는 RawContent 목록을 반환합니다.
 	List(ctx context.Context, filter storage.RawContentFilter) ([]*core.RawContent, error)
 
@@ -80,6 +84,14 @@ func (s *rawContentService) GetByID(ctx context.Context, id string) (*core.RawCo
 	}
 
 	return raw, nil
+}
+
+// Delete는 ID로 RawContent를 삭제합니다 (idempotent — 미존재여도 nil).
+func (s *rawContentService) Delete(ctx context.Context, id string) error {
+	if err := s.repo.Delete(ctx, id); err != nil {
+		return core.NewStorageError(core.CodeStorageDelete, "delete raw content", true, err)
+	}
+	return nil
 }
 
 // List는 RawContentFilter 조건으로 RawContent를 조회합니다.

--- a/pkg/queue/config.go
+++ b/pkg/queue/config.go
@@ -13,6 +13,11 @@ const (
 	TopicRawUS = "issuetracker.raw.us"
 	TopicRawKR = "issuetracker.raw.kr"
 
+	// TopicFetched: fetcher worker 가 RawContent 저장 후 RawContentRef 발행하는 토픽 (이슈 #134).
+	// payload 는 raw_id + url + source_info 만 포함 (HTML 본문 미포함, < 1KB).
+	// parser worker (GroupParsers) 가 consume 하여 raw_contents 에서 본문 로드 + 파싱.
+	TopicFetched = "issuetracker.fetched"
+
 	// 처리 파이프라인 토픽
 	TopicNormalized = "issuetracker.normalized"
 	TopicValidated  = "issuetracker.validated"
@@ -27,11 +32,13 @@ const (
 // Consumer group 상수
 const (
 	GroupCrawlerWorkers = "issuetracker-crawler-workers"
-	GroupNormalizers    = "issuetracker-normalizers"
-	GroupValidators     = "issuetracker-validators"
-	GroupEnrichers      = "issuetracker-enrichers"
-	GroupEmbedders      = "issuetracker-embedders"
-	GroupClusterers     = "issuetracker-clusterers"
+	// GroupParsers: TopicFetched 를 consume 하여 raw 로드 + 파싱 + content 저장 + raw 삭제 (이슈 #134).
+	GroupParsers     = "issuetracker-parsers"
+	GroupNormalizers = "issuetracker-normalizers"
+	GroupValidators  = "issuetracker-validators"
+	GroupEnrichers   = "issuetracker-enrichers"
+	GroupEmbedders   = "issuetracker-embedders"
+	GroupClusterers  = "issuetracker-clusterers"
 )
 
 // Config는 Kafka 연결 설정을 나타냅니다.

--- a/test/internal/parser/worker/cleanup_test.go
+++ b/test/internal/parser/worker/cleanup_test.go
@@ -1,0 +1,105 @@
+package worker_test
+
+import (
+	"context"
+	"errors"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"issuetracker/internal/crawler/core"
+	parserWorker "issuetracker/internal/parser/worker"
+	"issuetracker/internal/storage"
+	"issuetracker/pkg/logger"
+)
+
+// fakeRawSvc 는 RawContentService 의 in-memory mock 입니다.
+// Purge / Delete / Get 호출 횟수를 atomic 으로 추적.
+type fakeRawSvc struct {
+	purgeCalls   int64
+	deleteCalls  int64
+	getCalls     int64
+	purgeReturns int64
+	purgeErr     error
+}
+
+func (s *fakeRawSvc) Store(_ context.Context, _ *core.RawContent) (string, bool, error) {
+	return "", false, nil
+}
+func (s *fakeRawSvc) GetByID(_ context.Context, _ string) (*core.RawContent, error) {
+	atomic.AddInt64(&s.getCalls, 1)
+	return nil, storage.ErrNotFound
+}
+func (s *fakeRawSvc) Delete(_ context.Context, _ string) error {
+	atomic.AddInt64(&s.deleteCalls, 1)
+	return nil
+}
+func (s *fakeRawSvc) List(_ context.Context, _ storage.RawContentFilter) ([]*core.RawContent, error) {
+	return nil, nil
+}
+func (s *fakeRawSvc) PurgeOlderThan(_ context.Context, _ time.Time) (int64, error) {
+	atomic.AddInt64(&s.purgeCalls, 1)
+	if s.purgeErr != nil {
+		return 0, s.purgeErr
+	}
+	return s.purgeReturns, nil
+}
+
+func TestRawContentCleaner_PurgesPeriodically(t *testing.T) {
+	svc := &fakeRawSvc{purgeReturns: 3}
+	cleaner := parserWorker.NewRawContentCleaner(svc, parserWorker.CleanupConfig{
+		Interval: 50 * time.Millisecond,
+		StaleTTL: 100 * time.Millisecond,
+	}, logger.New(logger.DefaultConfig()))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cleaner.Start(ctx)
+
+	// 3 ticks 정도 흐를 시간
+	time.Sleep(180 * time.Millisecond)
+	cancel()
+	cleaner.Stop()
+
+	calls := atomic.LoadInt64(&svc.purgeCalls)
+	assert.GreaterOrEqual(t, calls, int64(2), "30ms 마다 ticker → 180ms 동안 최소 2회 purge")
+}
+
+func TestRawContentCleaner_HonorsContextCancel(t *testing.T) {
+	svc := &fakeRawSvc{purgeErr: errors.New("simulated db error")}
+	cleaner := parserWorker.NewRawContentCleaner(svc, parserWorker.CleanupConfig{
+		Interval: 30 * time.Millisecond,
+	}, logger.New(logger.DefaultConfig()))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cleaner.Start(ctx)
+	time.Sleep(50 * time.Millisecond)
+	cancel()
+
+	// Stop 이 무한 대기 안 하는지 검증
+	done := make(chan struct{})
+	go func() {
+		cleaner.Stop()
+		close(done)
+	}()
+	select {
+	case <-done:
+		// ok
+	case <-time.After(1 * time.Second):
+		t.Fatal("cleaner.Stop did not return after ctx cancel")
+	}
+}
+
+func TestRawContentCleaner_DefaultsApplied(t *testing.T) {
+	svc := &fakeRawSvc{}
+	cleaner := parserWorker.NewRawContentCleaner(svc, parserWorker.CleanupConfig{}, logger.New(logger.DefaultConfig()))
+	require.NotNil(t, cleaner, "default config 로도 정상 생성")
+
+	// 즉시 종료 — defaults 가 적용된 상태로 leak 없이 stop
+	ctx, cancel := context.WithCancel(context.Background())
+	cleaner.Start(ctx)
+	cancel()
+	cleaner.Stop()
+}


### PR DESCRIPTION
## 연관 이슈
- Closes #134

이슈 #100 / #139 / #150 후속 — 사용자 추가 의도: **이전에 실패했던 타겟들을 LLM 으로 새 rule 생성 후 재처리하는 프로세스를 윤택하게 하기 위한 분리**.

<br>

## 구현 내용

### 분리 후 데이터 흐름

```
CrawlJob → fetcher worker (KafkaConsumerPool, GroupCrawlerWorkers)
  └─► ChainHandler.Handle:
        chain.Fetch (RSS/GoQuery/Browser) → core.RawContent
          └─► rawSvc.Store(raw) → raw_id
              └─► Kafka publish (TopicFetched, RawContentRef)

RawContentRef → parser worker (ParserWorker, GroupParsers, NEW)
  └─► raw load (rawSvc.GetByID)
      └─► target_type 분기:
            - RSS:      ConvertRSSPages       → 다건 content store + publish normalized
            - Category: rule.Parser.ParseLinks → publisher.Publish (chained article jobs)
            - Article:  rule.Parser.ParsePage  → ConvertPage → content store + publish normalized
      └─► 정상 처리 후 rawSvc.Delete (Claim Check)
```

### 1. Kafka topic + consumer group ([pkg/queue/config.go](pkg/queue/config.go))
- `TopicFetched = \"issuetracker.fetched\"` — RawContentRef 발행 토픽
- `GroupParsers = \"issuetracker-parsers\"` — parser worker consumer group

### 2. ChainHandler 단순화 ([internal/crawler/domain/general/chain_handler.go](internal/crawler/domain/general/chain_handler.go))
- 기존 책임: fetch + parse + content store + chained jobs publish + news_articles INSERT
- **새 책임: fetch + raw store + RawContentRef publish 만** (`Handle` 항상 nil contents 반환)
- 파싱 / DB 저장 / 다음 단계 chained job 모두 parser worker 로 이전

### 3. ParserWorker 신규 ([internal/parser/worker/parser_worker.go](internal/parser/worker/parser_worker.go))
- TopicFetched consumer + N goroutines (기본 6, fetcher 와 독립 스케일)
- target_type 분기로 RSS / Category / Article 처리
- contents 저장 + ContentRef → TopicNormalized publish
- 정상 처리 후 rawSvc.Delete (raw_contents 즉시 정리)

### 4. 실패 타겟 raw 잔존 정책 — **사용자 강조 의도 반영**
- `rule.Error` (parse_failure / empty_selector / no_rule) → **raw 잔존 + commit (재시도 X)**
- → LLM 으로 새 rule 생성 (이슈 #149) 후 cleanup 이전에 재처리 가능
- transient 에러 (network/timeout) → commit 안 함 → Kafka 재배달 → 재시도
- payload 손상 → commit (재시도 무의미)

### 5. RawContentCleaner ([internal/parser/worker/cleanup.go](internal/parser/worker/cleanup.go))
- 잔존 raw_contents row 의 안전망 정리
- `DefaultStaleRawTTL = 1h` — LLM rule 생성 + 재처리 윈도우 보장
- `DefaultCleanupInterval = 30m` — 부담 적은 background 주기
- 정상 흐름에서는 거의 동작 안 함 (parser 가 즉시 Delete)

### 6. 부수 변경
- `service.RawContentService.Delete` 메서드 추가 (parser 가 호출)
- `kr/us.Register` 시그니처 변경: `(parser/repo/publisher)` → `(rawSvc/producer)`
- `cmd/issuetracker/main.go`: `parserWorker.NewParserWorker.Start` + `RawContentCleaner.Start` + shutdown 시 Stop
- 단위 테스트 (RawContentCleaner 3 케이스)

<br>

## CI / 머지 게이트 점검

### 변경 영향 범위
- 영향 패키지/모듈:
  - 신규: `internal/parser/worker/{parser_worker,cleanup}.go`
  - 변경: `internal/crawler/domain/general/chain_handler.go`, `internal/crawler/domain/general/sources/{kr,us}/registry.go`, `cmd/issuetracker/main.go`, `pkg/queue/config.go`, `internal/storage/service/raw_content.go`
  - 신규 테스트: `test/internal/parser/worker/cleanup_test.go`
- 위험도: `High` — 운영 fetch+parse pipeline 의 핵심 분리. 신규 토픽 + consumer group 운영 인입 필요.

### Required Status Checks
- [ ] `Commit Lint`
- [ ] `PR Title Lint`
- [ ] `Linked Issue Check`
- [ ] `Format Check`
- [ ] `Build`
- [ ] `Test`
- [ ] `Lint`

### 배포 순서 (운영)
1. **Kafka 토픽 사전 생성** (production 운영 시): `kafka-topics.sh --create --topic issuetracker.fetched --partitions 16 --replication-factor 3`
   (개발 환경은 auto.create.topics.enable=true 면 자동 생성)
2. 코드 deploy
3. 라이브 모니터링:
   - `raw content stored, fetched ref published` 로그 (fetcher 측)
   - `chained article jobs published` / 정상 content store 로그 (parser 측)
   - `raw_contents` 테이블 row 수 — 정상 시 거의 0, 누적 시 parser 정체 신호
   - `rule-based parse failed, raw retained for LLM retry` (rule.Error 잔존 — LLM 재처리 후보)

### 롤백 계획
1. 코드 revert: 본 PR 의 6 commits 역순 `git revert`
2. raw_contents 테이블 잔존 row 는 `RawContentService.PurgeOlderThan` 으로 정리 (또는 그대로 두고 90일 TTL 적용)
3. 신규 Kafka 토픽은 미사용 상태로 두면 됨 (옵션: 삭제)

### 후속 작업 (별도 PR)
- 이슈 #149: LLM 자동 rule 생성 — 본 PR 의 잔존 raw 를 활용한 재처리 진입점 구현
- ParserWorker 통합 테스트 (Kafka in-memory mock 사용)
- 운영 metric (`raw_contents` row count gauge / parser worker lag)

<br>