### PR TITLE
[FIX#154] kafka-init 사전 생성 토픽에 issuetracker.fetched 추가

### DIFF
--- a/deployments/docker/docker-compose.yml
+++ b/deployments/docker/docker-compose.yml
@@ -128,6 +128,9 @@ services:
         $$T --bootstrap-server $$KAFKA --create --if-not-exists --topic issuetracker.raw.us       --partitions 8 --replication-factor 1
         $$T --bootstrap-server $$KAFKA --create --if-not-exists --topic issuetracker.raw.kr       --partitions 8 --replication-factor 1
 
+        echo '[fetched ref topic — fetcher → parser claim check (이슈 #134)]'
+        $$T --bootstrap-server $$KAFKA --create --if-not-exists --topic issuetracker.fetched     --partitions 8 --replication-factor 1
+
         echo '[pipeline topics]'
         $$T --bootstrap-server $$KAFKA --create --if-not-exists --topic issuetracker.normalized   --partitions 8 --replication-factor 1
         $$T --bootstrap-server $$KAFKA --create --if-not-exists --topic issuetracker.validated    --partitions 8 --replication-factor 1

--- a/deployments/docker/docker-compose.yml
+++ b/deployments/docker/docker-compose.yml
@@ -128,7 +128,7 @@ services:
         $$T --bootstrap-server $$KAFKA --create --if-not-exists --topic issuetracker.raw.us       --partitions 8 --replication-factor 1
         $$T --bootstrap-server $$KAFKA --create --if-not-exists --topic issuetracker.raw.kr       --partitions 8 --replication-factor 1
 
-        echo '[fetched ref topic — fetcher → parser claim check (이슈 #134)]'
+        echo '[fetched topics]'
         $$T --bootstrap-server $$KAFKA --create --if-not-exists --topic issuetracker.fetched     --partitions 8 --replication-factor 1
 
         echo '[pipeline topics]'


### PR DESCRIPTION
## 연관 이슈

Closes #154

## 배경

이슈 #134 (PR #151) 에서 fetcher / parser worker 분리 시 신규 Kafka 토픽 `issuetracker.fetched` 를 도입했으나 (`pkg/queue/config.go` 의 `TopicFetched`), `deployments/docker/docker-compose.yml` 의 `kafka-init` 사전 생성 목록에는 누락되어 있었습니다.

`docker-compose.yml` line 88 에 `KAFKA_AUTO_CREATE_TOPICS_ENABLE: \"false\"` 가 설정되어 있어 auto-create 도 동작하지 않아, fetcher 가 publish 시도 시 발행이 실패하고 fetcher → parser 흐름이 전면 중단되는 운영 차단 버그였습니다.

## 구현 내용

- `[raw topics]` 그룹과 `[pipeline topics]` 그룹 사이에 `[fetched ref topic]` 항목 추가
- partition 수: 8 (raw 토픽과 동일 — fetcher → fetched → parser 흐름이 1:1)
- replication-factor: 1 (개발 단일 브로커 기준)

## CI / 머지 게이트 점검

- [x] gofmt / lint 영향 없음 (yaml only)
- [x] 빌드 영향 없음
- [x] 라이브 검증: 현 dev 환경 Kafka 에 토픽 수동 생성하여 8 partitions 로 정상 작동 확인

## 변경 영향 범위 + 위험도

- **영향**: 신규 환경 / \`docker compose down -v\` 후 재기동 시 즉시 fetched 토픽 사용 가능
- **위험도**: 낮음 — \`--if-not-exists\` 멱등 동작, 기존 토픽 영향 없음

## 롤백 계획

- 단일 라인 추가이므로 revert commit 으로 즉시 롤백 가능
- 이미 생성된 토픽은 그대로 유지됨 (kafka-init 은 멱등이므로 revert 가 토픽 삭제로 이어지지 않음)