### PR TITLE
[FEAT#144] LLM 비용/성능 기반 routing 정책 + 동적 chain 합성

### DIFF
--- a/pkg/llm/capabilities.go
+++ b/pkg/llm/capabilities.go
@@ -1,0 +1,114 @@
+package llm
+
+// Capabilities describes a provider/model's quantitative properties used by routing policies.
+//
+// Capabilities 는 routing policy 가 provider 선택에 사용하는 정량적 속성입니다 (이슈 #144).
+// 비용 / context window / 평균 latency 등을 표준 단위로 표현합니다.
+//
+// 모든 비용은 USD per 1M tokens, latency 는 milliseconds 입니다.
+type Capabilities struct {
+	// CostInputPer1M: 입력 토큰 1M 당 USD. 0 이면 unknown / 무료.
+	CostInputPer1M float64
+
+	// CostOutputPer1M: 출력 토큰 1M 당 USD. 0 이면 unknown / 무료.
+	CostOutputPer1M float64
+
+	// ContextWindow: 모델의 최대 context window (tokens). 0 이면 unknown.
+	ContextWindow int
+
+	// AvgLatencyMs: 평균 응답 latency 추정치 (milliseconds). 초기 hardcode estimate.
+	// MeasuredProvider 가 동적 EMA 를 노출하지만 Capabilities 는 정적 baseline.
+	AvgLatencyMs int
+}
+
+// CapabilitiesProvider returns the Capabilities for a given (provider, model) pair.
+//
+// 구현체:
+//   - StaticCapabilitiesProvider: 컴파일 시점 hardcode (초기 구현, 본 PR)
+//   - 향후 RefreshableCapabilitiesProvider: 주기 background goroutine 으로 외부 source
+//     (config 파일 / DB / pricing API) 에서 fetch 후 cache 갱신 (이슈 #144 후속)
+//
+// Get 은 lookup 결과가 없으면 (Capabilities{}, false) 반환합니다.
+type CapabilitiesProvider interface {
+	Get(provider, model string) (Capabilities, bool)
+}
+
+// StaticCapabilitiesProvider returns Capabilities from a compile-time hardcoded table.
+//
+// 본 구현은 본 PR 에서만 동기 lookup. RefreshableCapabilitiesProvider (후속) 는 동일 인터페이스를
+// 구현하면서 background refresh 로직만 추가하므로 호출자 코드 변경 없이 교체 가능합니다.
+type StaticCapabilitiesProvider struct {
+	table map[capKey]Capabilities
+}
+
+type capKey struct {
+	Provider string
+	Model    string
+}
+
+// NewStaticCapabilitiesProvider returns a StaticCapabilitiesProvider pre-populated with
+// the well-known model pricing as of 2026-04 (이슈 #144 본문 참고). 운영 단가 변동 시 hardcode
+// 갱신 또는 RefreshableCapabilitiesProvider 로 교체.
+func NewStaticCapabilitiesProvider() *StaticCapabilitiesProvider {
+	return &StaticCapabilitiesProvider{
+		table: defaultCapabilitiesTable(),
+	}
+}
+
+// NewStaticCapabilitiesProviderFrom builds a provider from an arbitrary table — 테스트 / 운영자
+// 커스텀 단가에 사용.
+func NewStaticCapabilitiesProviderFrom(table map[string]map[string]Capabilities) *StaticCapabilitiesProvider {
+	flat := make(map[capKey]Capabilities, len(table))
+	for provider, models := range table {
+		for model, caps := range models {
+			flat[capKey{Provider: provider, Model: model}] = caps
+		}
+	}
+	return &StaticCapabilitiesProvider{table: flat}
+}
+
+// Get implements CapabilitiesProvider — provider/model 조합으로 hardcode 테이블 lookup.
+func (s *StaticCapabilitiesProvider) Get(provider, model string) (Capabilities, bool) {
+	caps, ok := s.table[capKey{Provider: provider, Model: model}]
+	return caps, ok
+}
+
+// defaultCapabilitiesTable returns the hardcoded pricing baseline (USD per 1M tokens).
+// 단가 출처는 이슈 #144 본문 — 작업 시점 (2026-04) 기준이며 운영자가 주기 검증 필요.
+func defaultCapabilitiesTable() map[capKey]Capabilities {
+	return map[capKey]Capabilities{
+		// OpenAI
+		{Provider: "openai", Model: "gpt-4o-mini"}: {
+			CostInputPer1M: 0.15, CostOutputPer1M: 0.60,
+			ContextWindow: 128_000, AvgLatencyMs: 800,
+		},
+		{Provider: "openai", Model: "gpt-4o"}: {
+			CostInputPer1M: 2.50, CostOutputPer1M: 10.00,
+			ContextWindow: 128_000, AvgLatencyMs: 1500,
+		},
+
+		// Anthropic
+		{Provider: "anthropic", Model: "claude-opus-4-7"}: {
+			CostInputPer1M: 15.00, CostOutputPer1M: 75.00,
+			ContextWindow: 200_000, AvgLatencyMs: 3500,
+		},
+		{Provider: "anthropic", Model: "claude-sonnet-4-6"}: {
+			CostInputPer1M: 3.00, CostOutputPer1M: 15.00,
+			ContextWindow: 200_000, AvgLatencyMs: 1800,
+		},
+		{Provider: "anthropic", Model: "claude-haiku-4-5"}: {
+			CostInputPer1M: 0.80, CostOutputPer1M: 4.00,
+			ContextWindow: 200_000, AvgLatencyMs: 700,
+		},
+
+		// Google Gemini
+		{Provider: "gemini", Model: "gemini-1.5-pro"}: {
+			CostInputPer1M: 1.25, CostOutputPer1M: 5.00,
+			ContextWindow: 2_000_000, AvgLatencyMs: 2200,
+		},
+		{Provider: "gemini", Model: "gemini-2.5-flash"}: {
+			CostInputPer1M: 0.075, CostOutputPer1M: 0.30,
+			ContextWindow: 1_000_000, AvgLatencyMs: 600,
+		},
+	}
+}

--- a/pkg/llm/capabilities.go
+++ b/pkg/llm/capabilities.go
@@ -68,7 +68,12 @@ func NewStaticCapabilitiesProviderFrom(table map[string]map[string]Capabilities)
 }
 
 // Get implements CapabilitiesProvider — provider/model 조합으로 hardcode 테이블 lookup.
+//
+// nil 수신자 보호: 호출자가 typed nil 을 인터페이스에 할당하는 케이스에서 panic 회피.
 func (s *StaticCapabilitiesProvider) Get(provider, model string) (Capabilities, bool) {
+	if s == nil {
+		return Capabilities{}, false
+	}
 	caps, ok := s.table[capKey{Provider: provider, Model: model}]
 	return caps, ok
 }

--- a/pkg/llm/chain/policy.go
+++ b/pkg/llm/chain/policy.go
@@ -34,7 +34,10 @@ func WithPolicyLogger(log *logger.Logger) PolicyOption {
 // candidates 가 비어있어도 panic 없이 생성됩니다 — 호출 시 ErrCodeBadRequest.
 // policy 가 nil 이면 호출 시 ErrCodeBadRequest.
 func NewWithPolicy(p policy.Policy, candidates []llm.Provider, opts ...PolicyOption) *PolicyProvider {
-	pp := &PolicyProvider{policy: p, candidates: candidates}
+	// candidates 를 defensive copy — 호출자가 후속 mutation 해도 routing 동작 불변 보장
+	// (Policy 인터페이스 contract: goroutine-safe).
+	copied := append([]llm.Provider(nil), candidates...)
+	pp := &PolicyProvider{policy: p, candidates: copied}
 	for _, o := range opts {
 		o(pp)
 	}

--- a/pkg/llm/chain/policy.go
+++ b/pkg/llm/chain/policy.go
@@ -2,7 +2,6 @@ package chain
 
 import (
 	"context"
-	"errors"
 
 	"issuetracker/pkg/llm"
 	"issuetracker/pkg/llm/policy"
@@ -100,10 +99,3 @@ func (p *PolicyProvider) Generate(ctx context.Context, req llm.Request) (*llm.Re
 
 // Compile-time check — PolicyProvider 가 llm.Provider 인터페이스를 만족하는지 확인.
 var _ llm.Provider = (*PolicyProvider)(nil)
-
-// errChainPolicySelectFailed 는 policy.Select 자체 실패의 sentinel — 일반적으로 외부 노출 없이
-// llm.Error 로 wrap 됩니다. errors.Is 매칭이 필요한 호출자를 위해 export.
-var errChainPolicySelectFailed = errors.New("policy.Select failed")
-
-// ErrPolicySelectFailed returns a sentinel for tests / matching.
-func ErrPolicySelectFailed() error { return errChainPolicySelectFailed }

--- a/pkg/llm/chain/policy.go
+++ b/pkg/llm/chain/policy.go
@@ -1,0 +1,109 @@
+package chain
+
+import (
+	"context"
+	"errors"
+
+	"issuetracker/pkg/llm"
+	"issuetracker/pkg/llm/policy"
+	"issuetracker/pkg/logger"
+)
+
+// PolicyProvider composes a Policy with a chain — order is decided per-request by Policy.Select.
+//
+// PolicyProvider 는 매 호출마다 policy.Select 가 결정한 순서로 chain 동작을 수행합니다 (이슈 #144 Phase 3).
+// 정적 chain.Provider 와 달리 호출별 dynamic ordering 이 가능하여 비용 / latency / 작업 특성에 따라
+// 다른 provider 가 우선 시도됩니다.
+//
+// 호출자 코드는 chain.Provider 와 동일 인터페이스 (llm.Provider) — 투명한 wrapper.
+type PolicyProvider struct {
+	policy     policy.Policy
+	candidates []llm.Provider
+	log        *logger.Logger
+}
+
+// PolicyOption 은 PolicyProvider 생성 옵션입니다.
+type PolicyOption func(*PolicyProvider)
+
+// WithPolicyLogger 는 위임 / 종결 / 고갈 시 로그를 출력할 logger 를 주입합니다 (chain.WithLogger 와 동일).
+func WithPolicyLogger(log *logger.Logger) PolicyOption {
+	return func(p *PolicyProvider) { p.log = log }
+}
+
+// NewWithPolicy 는 policy 가 매 호출마다 결정한 순서로 candidates 를 시도하는 PolicyProvider 를 반환합니다.
+//
+// candidates 가 비어있어도 panic 없이 생성됩니다 — 호출 시 ErrCodeBadRequest.
+// policy 가 nil 이면 호출 시 ErrCodeBadRequest.
+func NewWithPolicy(p policy.Policy, candidates []llm.Provider, opts ...PolicyOption) *PolicyProvider {
+	pp := &PolicyProvider{policy: p, candidates: candidates}
+	for _, o := range opts {
+		o(pp)
+	}
+	return pp
+}
+
+// Name returns the chain identifier (llm.Provider 구현).
+func (p *PolicyProvider) Name() string { return providerName }
+
+// Generate 는 policy 가 정렬한 순서로 candidates 를 시도합니다 (llm.Provider 구현).
+//
+// 흐름:
+//  1. policy / candidates 비어있음 / nil → ErrCodeBadRequest
+//  2. ctx 이미 cancel → ErrCodeNetwork
+//  3. policy.Select 호출하여 순서 결정 (실패 시 ErrCodeUnknown)
+//  4. 정렬된 순서대로 chain 동작 (chain.Provider.Generate 와 동일 위임 정책)
+func (p *PolicyProvider) Generate(ctx context.Context, req llm.Request) (*llm.Response, error) {
+	if p.policy == nil {
+		return nil, &llm.Error{
+			Code:     llm.ErrCodeBadRequest,
+			Provider: providerName,
+			Message:  "policy chain has no policy",
+		}
+	}
+	if len(p.candidates) == 0 {
+		return nil, &llm.Error{
+			Code:     llm.ErrCodeBadRequest,
+			Provider: providerName,
+			Message:  "policy chain has no candidates",
+		}
+	}
+	if err := ctx.Err(); err != nil {
+		return nil, &llm.Error{
+			Code:     llm.ErrCodeNetwork,
+			Provider: providerName,
+			Message:  "context already canceled before policy select",
+			Err:      err,
+		}
+	}
+
+	ordered, err := p.policy.Select(ctx, req, p.candidates)
+	if err != nil {
+		return nil, &llm.Error{
+			Code:     llm.ErrCodeUnknown,
+			Provider: providerName,
+			Message:  "policy.Select failed",
+			Err:      err,
+		}
+	}
+	if len(ordered) == 0 {
+		return nil, &llm.Error{
+			Code:     llm.ErrCodeBadRequest,
+			Provider: providerName,
+			Message:  "policy returned empty candidate list",
+		}
+	}
+
+	// chain.Provider.Generate 와 동일 위임 / cancel 정책. 코드 중복을 줄이기 위해 inner Provider 재사용.
+	delegate := &Provider{handlers: ordered, log: p.log}
+	return delegate.Generate(ctx, req)
+}
+
+// Compile-time check — PolicyProvider 가 llm.Provider 인터페이스를 만족하는지 확인.
+var _ llm.Provider = (*PolicyProvider)(nil)
+
+// errChainPolicySelectFailed 는 policy.Select 자체 실패의 sentinel — 일반적으로 외부 노출 없이
+// llm.Error 로 wrap 됩니다. errors.Is 매칭이 필요한 호출자를 위해 export.
+var errChainPolicySelectFailed = errors.New("policy.Select failed")
+
+// ErrPolicySelectFailed returns a sentinel for tests / matching.
+func ErrPolicySelectFailed() error { return errChainPolicySelectFailed }

--- a/pkg/llm/llm.go
+++ b/pkg/llm/llm.go
@@ -66,7 +66,28 @@ type Request struct {
 
 	// MaxTokens 는 응답 생성 시 최대 토큰 수. 0 이면 provider default.
 	MaxTokens int
+
+	// TaskHint 는 routing policy 가 작업 특성별로 적합한 provider 를 선택할 때 사용하는 hint 입니다 (이슈 #144).
+	// 빈 문자열이면 policy 기본 동작. 표준 값은 TaskHint* 상수 참고.
+	//
+	// TaskHint helps routing policies pick the most suitable provider per task type.
+	TaskHint string
 }
+
+// 표준 TaskHint 값. policy 가 호환되는 hint 면 활용, 그 외는 무시 (default 동작).
+const (
+	// TaskHintSummary: 짧은 요약 — 저렴/빠른 모델 우선.
+	TaskHintSummary = "summary"
+
+	// TaskHintReasoning: 복잡 추론 / 다단계 분석 — 큰 모델 우선.
+	TaskHintReasoning = "reasoning"
+
+	// TaskHintJSON: 구조화 JSON 응답 필요 — JSON mode / function calling 강한 모델 우선.
+	TaskHintJSON = "json"
+
+	// TaskHintLargeContext: 큰 입력 (수십~수백k tokens) — context window 큰 모델 우선.
+	TaskHintLargeContext = "large_context"
+)
 
 // Response 는 LLM 응답입니다.
 //

--- a/pkg/llm/measured.go
+++ b/pkg/llm/measured.go
@@ -1,0 +1,132 @@
+package llm
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+// MeasuredProvider wraps a Provider, recording per-call latency and success/failure metrics.
+//
+// MeasuredProvider 는 다른 Provider 를 wrap 하여 호출 시 latency / 성공·실패 metric 을 기록합니다 (이슈 #144).
+//
+//   - in-memory EMA (LatencyMs) — routing policy 가 dynamic 가중치로 활용
+//   - Prometheus metric (히스토그램 / counter) — /metrics endpoint 로 export (이슈 #165 의존)
+//
+// Prometheus registry 는 호출자가 주입 — nil 이면 metric 등록 skip (in-memory EMA 만 동작).
+type MeasuredProvider struct {
+	inner Provider
+	name  string
+	stats *Stats
+
+	// Prometheus metrics (registry 가 nil 이면 nil)
+	latencyHist *prometheus.HistogramVec
+	callCounter *prometheus.CounterVec
+}
+
+// Stats holds in-memory rolling metrics for a wrapped provider.
+//
+// Stats 는 wrap 된 provider 의 in-memory rolling metric 입니다.
+// LatencyMs 는 EMA (alpha 가중치) 로, Calls / Failures 는 atomic counter 로 누적됩니다.
+type Stats struct {
+	// Calls 는 누적 호출 수 (성공 + 실패).
+	Calls atomic.Uint64
+
+	// Failures 는 누적 실패 호출 수.
+	Failures atomic.Uint64
+
+	// latency EMA — float64 직접 atomic 어렵기에 mu 보호.
+	mu        sync.RWMutex
+	latencyMs float64
+}
+
+// LatencyEMAAlpha: EMA 가중치 (0~1). 0.2 = 새 측정치 20%, 기존 EMA 80%.
+// 작을수록 안정적, 클수록 최근 변화에 빠르게 반응. 0.2 는 일반적인 운영 default.
+const LatencyEMAAlpha = 0.2
+
+// LatencyMs returns the current EMA latency in milliseconds (0 if no calls yet).
+func (s *Stats) LatencyMs() float64 {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.latencyMs
+}
+
+// FailureRate returns the cumulative failure ratio in [0, 1] (0 if no calls yet).
+func (s *Stats) FailureRate() float64 {
+	calls := s.Calls.Load()
+	if calls == 0 {
+		return 0
+	}
+	return float64(s.Failures.Load()) / float64(calls)
+}
+
+func (s *Stats) record(latencyMs float64, failed bool) {
+	s.Calls.Add(1)
+	if failed {
+		s.Failures.Add(1)
+	}
+	s.mu.Lock()
+	if s.latencyMs == 0 {
+		s.latencyMs = latencyMs
+	} else {
+		s.latencyMs = LatencyEMAAlpha*latencyMs + (1-LatencyEMAAlpha)*s.latencyMs
+	}
+	s.mu.Unlock()
+}
+
+// NewMeasuredProvider wraps inner with latency + success metrics.
+//
+// registry 가 nil 이면 Prometheus 등록 skip — in-memory Stats 는 항상 동작.
+// labelPrefix 는 metric 이름 prefix (예: "llm" → "llm_provider_call_total" / "llm_provider_latency_seconds").
+func NewMeasuredProvider(inner Provider, registry *prometheus.Registry, labelPrefix string) *MeasuredProvider {
+	if labelPrefix == "" {
+		labelPrefix = "llm"
+	}
+	mp := &MeasuredProvider{
+		inner: inner,
+		name:  inner.Name(),
+		stats: &Stats{},
+	}
+	if registry != nil {
+		mp.latencyHist = prometheus.NewHistogramVec(prometheus.HistogramOpts{
+			Name:    labelPrefix + "_provider_latency_seconds",
+			Help:    "LLM provider call latency in seconds.",
+			Buckets: []float64{0.1, 0.25, 0.5, 1, 2.5, 5, 10, 30, 60},
+		}, []string{"provider", "status"})
+		mp.callCounter = prometheus.NewCounterVec(prometheus.CounterOpts{
+			Name: labelPrefix + "_provider_call_total",
+			Help: "LLM provider call counter labeled by provider/status.",
+		}, []string{"provider", "status"})
+		registry.MustRegister(mp.latencyHist, mp.callCounter)
+	}
+	return mp
+}
+
+// Name returns the wrapped provider's name (transparent wrapping).
+func (m *MeasuredProvider) Name() string { return m.name }
+
+// Stats returns the in-memory rolling stats — routing policy 가 직접 읽음.
+func (m *MeasuredProvider) Stats() *Stats { return m.stats }
+
+// Generate delegates to the inner provider, recording latency + status metrics.
+func (m *MeasuredProvider) Generate(ctx context.Context, req Request) (*Response, error) {
+	start := time.Now()
+	resp, err := m.inner.Generate(ctx, req)
+	elapsed := time.Since(start)
+
+	failed := err != nil
+	m.stats.record(float64(elapsed.Milliseconds()), failed)
+
+	if m.latencyHist != nil {
+		status := "success"
+		if failed {
+			status = "failure"
+		}
+		m.latencyHist.WithLabelValues(m.name, status).Observe(elapsed.Seconds())
+		m.callCounter.WithLabelValues(m.name, status).Inc()
+	}
+	return resp, err
+}

--- a/pkg/llm/measured.go
+++ b/pkg/llm/measured.go
@@ -3,7 +3,6 @@ package llm
 import (
 	"context"
 	"sync"
-	"sync/atomic"
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -30,22 +29,31 @@ type MeasuredProvider struct {
 // Stats holds in-memory rolling metrics for a wrapped provider.
 //
 // Stats 는 wrap 된 provider 의 in-memory rolling metric 입니다.
-// LatencyMs 는 EMA (alpha 가중치) 로, Calls / Failures 는 atomic counter 로 누적됩니다.
+// 모든 필드는 단일 mu 보호 — calls/failures/latency 의 일관된 snapshot 보장 (PR #167 gemini 피드백).
 type Stats struct {
-	// Calls 는 누적 호출 수 (성공 + 실패).
-	Calls atomic.Uint64
-
-	// Failures 는 누적 실패 호출 수.
-	Failures atomic.Uint64
-
-	// latency EMA — float64 직접 atomic 어렵기에 mu 보호.
 	mu        sync.RWMutex
+	calls     uint64
+	failures  uint64
 	latencyMs float64
 }
 
 // LatencyEMAAlpha: EMA 가중치 (0~1). 0.2 = 새 측정치 20%, 기존 EMA 80%.
 // 작을수록 안정적, 클수록 최근 변화에 빠르게 반응. 0.2 는 일반적인 운영 default.
 const LatencyEMAAlpha = 0.2
+
+// Calls returns the cumulative call count.
+func (s *Stats) Calls() uint64 {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.calls
+}
+
+// Failures returns the cumulative failure count.
+func (s *Stats) Failures() uint64 {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.failures
+}
 
 // LatencyMs returns the current EMA latency in milliseconds (0 if no calls yet).
 func (s *Stats) LatencyMs() float64 {
@@ -55,26 +63,29 @@ func (s *Stats) LatencyMs() float64 {
 }
 
 // FailureRate returns the cumulative failure ratio in [0, 1] (0 if no calls yet).
+//
+// calls / failures 를 단일 lock 안에서 read 하여 race-free snapshot 보장.
 func (s *Stats) FailureRate() float64 {
-	calls := s.Calls.Load()
-	if calls == 0 {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	if s.calls == 0 {
 		return 0
 	}
-	return float64(s.Failures.Load()) / float64(calls)
+	return float64(s.failures) / float64(s.calls)
 }
 
 func (s *Stats) record(latencyMs float64, failed bool) {
-	s.Calls.Add(1)
-	if failed {
-		s.Failures.Add(1)
-	}
 	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.calls++
+	if failed {
+		s.failures++
+	}
 	if s.latencyMs == 0 {
 		s.latencyMs = latencyMs
 	} else {
 		s.latencyMs = LatencyEMAAlpha*latencyMs + (1-LatencyEMAAlpha)*s.latencyMs
 	}
-	s.mu.Unlock()
 }
 
 // MeasuredFactory creates MeasuredProvider instances that share a single set of Prometheus collectors.

--- a/pkg/llm/measured.go
+++ b/pkg/llm/measured.go
@@ -2,6 +2,7 @@ package llm
 
 import (
 	"context"
+	"errors"
 	"sync"
 	"time"
 
@@ -108,25 +109,56 @@ type MeasuredFactory struct {
 // labelPrefix 가 빈 문자열이면 "llm" 사용. metric 이름은
 // "<prefix>_provider_latency_seconds" / "<prefix>_provider_call_total".
 //
-// 동일 registry 에 두 번 생성하면 panic — 하나의 process 에서 단일 factory 인스턴스 재사용 권장.
+// 동일 registry 에 두 번 호출돼도 idempotent — 기존 collector 가 있으면 재사용 (panic 회피).
+// 프로젝트 가이드 "NEVER panic in production code" 준수.
 func NewMeasuredFactory(registry *prometheus.Registry, labelPrefix string) *MeasuredFactory {
 	if labelPrefix == "" {
 		labelPrefix = "llm"
 	}
 	f := &MeasuredFactory{}
 	if registry != nil {
-		f.latencyHist = prometheus.NewHistogramVec(prometheus.HistogramOpts{
+		f.latencyHist = registerOrReuseHistogram(registry, prometheus.HistogramOpts{
 			Name:    labelPrefix + "_provider_latency_seconds",
 			Help:    "LLM provider call latency in seconds.",
 			Buckets: []float64{0.1, 0.25, 0.5, 1, 2.5, 5, 10, 30, 60},
 		}, []string{"provider", "status"})
-		f.callCounter = prometheus.NewCounterVec(prometheus.CounterOpts{
+		f.callCounter = registerOrReuseCounter(registry, prometheus.CounterOpts{
 			Name: labelPrefix + "_provider_call_total",
 			Help: "LLM provider call counter labeled by provider/status.",
 		}, []string{"provider", "status"})
-		registry.MustRegister(f.latencyHist, f.callCounter)
 	}
 	return f
+}
+
+// registerOrReuseHistogram 은 collector 를 등록하거나, 이미 등록되어 있으면 기존 collector 를 반환합니다.
+// 등록이 다른 incompatible collector 와 충돌하면 panic — fail-fast (운영자가 metric 이름 충돌 즉시 인지).
+func registerOrReuseHistogram(registry *prometheus.Registry, opts prometheus.HistogramOpts, labels []string) *prometheus.HistogramVec {
+	hist := prometheus.NewHistogramVec(opts, labels)
+	if err := registry.Register(hist); err != nil {
+		var are prometheus.AlreadyRegisteredError
+		if errors.As(err, &are) {
+			if existing, ok := are.ExistingCollector.(*prometheus.HistogramVec); ok {
+				return existing
+			}
+		}
+		panic(err) // incompatible collector 충돌 — 운영자 개입 필요한 설정 오류
+	}
+	return hist
+}
+
+// registerOrReuseCounter — registerOrReuseHistogram 의 CounterVec 변형.
+func registerOrReuseCounter(registry *prometheus.Registry, opts prometheus.CounterOpts, labels []string) *prometheus.CounterVec {
+	counter := prometheus.NewCounterVec(opts, labels)
+	if err := registry.Register(counter); err != nil {
+		var are prometheus.AlreadyRegisteredError
+		if errors.As(err, &are) {
+			if existing, ok := are.ExistingCollector.(*prometheus.CounterVec); ok {
+				return existing
+			}
+		}
+		panic(err)
+	}
+	return counter
 }
 
 // Wrap returns a MeasuredProvider sharing this factory's collectors.

--- a/pkg/llm/measured.go
+++ b/pkg/llm/measured.go
@@ -77,32 +77,56 @@ func (s *Stats) record(latencyMs float64, failed bool) {
 	s.mu.Unlock()
 }
 
-// NewMeasuredProvider wraps inner with latency + success metrics.
+// MeasuredFactory creates MeasuredProvider instances that share a single set of Prometheus collectors.
 //
-// registry 가 nil 이면 Prometheus 등록 skip — in-memory Stats 는 항상 동작.
-// labelPrefix 는 metric 이름 prefix (예: "llm" → "llm_provider_call_total" / "llm_provider_latency_seconds").
-func NewMeasuredProvider(inner Provider, registry *prometheus.Registry, labelPrefix string) *MeasuredProvider {
+// MeasuredFactory 는 동일 registry / labelPrefix 에 대해 collector 를 1회만 생성·등록하고,
+// 여러 provider 를 wrap 할 수 있는 factory 입니다 (PR #167 gemini 피드백 — collector 중복 등록 panic 해결).
+//
+// collector 는 (provider, status) label 로 구분하므로 단일 collector 인스턴스가 모든 wrapped
+// provider 의 metric 을 처리할 수 있습니다.
+type MeasuredFactory struct {
+	latencyHist *prometheus.HistogramVec
+	callCounter *prometheus.CounterVec
+}
+
+// NewMeasuredFactory returns a MeasuredFactory ready to Wrap providers.
+//
+// registry 가 nil 이면 collector 등록 skip — Wrap 으로 만들어진 MeasuredProvider 는 in-memory
+// Stats 만 동작.
+//
+// labelPrefix 가 빈 문자열이면 "llm" 사용. metric 이름은
+// "<prefix>_provider_latency_seconds" / "<prefix>_provider_call_total".
+//
+// 동일 registry 에 두 번 생성하면 panic — 하나의 process 에서 단일 factory 인스턴스 재사용 권장.
+func NewMeasuredFactory(registry *prometheus.Registry, labelPrefix string) *MeasuredFactory {
 	if labelPrefix == "" {
 		labelPrefix = "llm"
 	}
-	mp := &MeasuredProvider{
-		inner: inner,
-		name:  inner.Name(),
-		stats: &Stats{},
-	}
+	f := &MeasuredFactory{}
 	if registry != nil {
-		mp.latencyHist = prometheus.NewHistogramVec(prometheus.HistogramOpts{
+		f.latencyHist = prometheus.NewHistogramVec(prometheus.HistogramOpts{
 			Name:    labelPrefix + "_provider_latency_seconds",
 			Help:    "LLM provider call latency in seconds.",
 			Buckets: []float64{0.1, 0.25, 0.5, 1, 2.5, 5, 10, 30, 60},
 		}, []string{"provider", "status"})
-		mp.callCounter = prometheus.NewCounterVec(prometheus.CounterOpts{
+		f.callCounter = prometheus.NewCounterVec(prometheus.CounterOpts{
 			Name: labelPrefix + "_provider_call_total",
 			Help: "LLM provider call counter labeled by provider/status.",
 		}, []string{"provider", "status"})
-		registry.MustRegister(mp.latencyHist, mp.callCounter)
+		registry.MustRegister(f.latencyHist, f.callCounter)
 	}
-	return mp
+	return f
+}
+
+// Wrap returns a MeasuredProvider sharing this factory's collectors.
+func (f *MeasuredFactory) Wrap(inner Provider) *MeasuredProvider {
+	return &MeasuredProvider{
+		inner:       inner,
+		name:        inner.Name(),
+		stats:       &Stats{},
+		latencyHist: f.latencyHist,
+		callCounter: f.callCounter,
+	}
 }
 
 // Name returns the wrapped provider's name (transparent wrapping).

--- a/pkg/llm/policy/cheapest.go
+++ b/pkg/llm/policy/cheapest.go
@@ -1,0 +1,42 @@
+package policy
+
+import (
+	"context"
+	"sort"
+
+	"issuetracker/pkg/llm"
+)
+
+// CheapestFirst orders candidates by ascending input token cost.
+//
+// CheapestFirst 는 입력 토큰 단가 (Capabilities.CostInputPer1M) 가 낮은 순으로 후보를 정렬합니다.
+// 출력 단가도 보조 키로 사용 — 입력 단가 동률 시 출력 단가가 낮은 쪽 우선.
+//
+// Capabilities lookup 실패 (cost == 0) 인 후보는 zero cost 로 간주되어 가장 앞으로 옵니다 —
+// "free" 또는 "unknown" 둘 다 일단 시도가 합리적이라는 정책. 운영자가 필요 시 명시 unknown
+// 페널티는 별도 정책으로 구현 가능.
+type CheapestFirst struct {
+	caps llm.CapabilitiesProvider
+}
+
+// NewCheapestFirst returns a CheapestFirst policy backed by the given capabilities provider.
+// caps 가 nil 이면 모든 후보가 zero cost 로 평가되어 입력 순서가 보존됩니다.
+func NewCheapestFirst(caps llm.CapabilitiesProvider) *CheapestFirst {
+	return &CheapestFirst{caps: caps}
+}
+
+// Select orders candidates by (CostInputPer1M, CostOutputPer1M) ascending.
+func (p *CheapestFirst) Select(_ context.Context, req llm.Request, candidates []llm.Provider) ([]llm.Provider, error) {
+	out := make([]llm.Provider, len(candidates))
+	copy(out, candidates)
+
+	sort.SliceStable(out, func(i, j int) bool {
+		ci := capabilityFor(p.caps, out[i], req)
+		cj := capabilityFor(p.caps, out[j], req)
+		if ci.CostInputPer1M != cj.CostInputPer1M {
+			return ci.CostInputPer1M < cj.CostInputPer1M
+		}
+		return ci.CostOutputPer1M < cj.CostOutputPer1M
+	})
+	return out, nil
+}

--- a/pkg/llm/policy/fixed.go
+++ b/pkg/llm/policy/fixed.go
@@ -32,8 +32,12 @@ type FixedOrder struct {
 }
 
 // NewFixedOrder returns a policy that selects providers by exact Name() match in the given order.
+//
+// names 를 defensive copy — 호출자의 후속 mutation 으로 routing 동작이 바뀌지 않도록 보장
+// (Policy 인터페이스 contract: goroutine-safe).
 func NewFixedOrder(names ...string) *FixedOrder {
-	return &FixedOrder{names: names}
+	copied := append([]string(nil), names...)
+	return &FixedOrder{names: copied}
 }
 
 // Select returns providers whose Name() matches names, ordered by names sequence.

--- a/pkg/llm/policy/fixed.go
+++ b/pkg/llm/policy/fixed.go
@@ -1,0 +1,59 @@
+package policy
+
+import (
+	"context"
+
+	"issuetracker/pkg/llm"
+)
+
+// FixedOrder pins routing to an explicit list of provider names, ignoring others.
+//
+// FixedOrder 는 호출자가 지정한 provider 이름 슬라이스를 그대로 우선순위로 사용합니다 (이슈 #144).
+// candidates 중 names 에 매칭되는 provider 만 지정 순서로 반환하며, 매칭되지 않는 candidate 는
+// 결과에서 제외됩니다 — "이 provider 만 쓴다" 는 명시적 정책 (단일 provider 운영, 무료 한도 내
+// 제한, A/B 비교용 강제 핀 등에 사용).
+//
+// 사용 예시 — Gemini 만 사용 (예: 무료 한도 내 운영):
+//
+//	pol := policy.NewFixedOrder("gemini")
+//	p   := chain.NewWithPolicy(pol, []llm.Provider{geminiProvider, openaiProvider})
+//	// openaiProvider 는 무시됨 — gemini 만 시도
+//
+// 사용 예시 — 우선순위 순서 명시 (gemini 우선, 실패 시 openai fallback):
+//
+//	pol := policy.NewFixedOrder("gemini", "openai")
+//
+// 동작:
+//   - names 가 비어있으면 candidates 를 입력 순서 그대로 반환 (no-op).
+//   - 매칭되는 provider 가 하나도 없으면 빈 슬라이스 반환 → chain 이 ErrCodeBadRequest 처리.
+//   - 동일 이름의 candidate 가 둘 이상이면 마지막 것이 사용됨 (map overwrite).
+type FixedOrder struct {
+	names []string
+}
+
+// NewFixedOrder returns a policy that selects providers by exact Name() match in the given order.
+func NewFixedOrder(names ...string) *FixedOrder {
+	return &FixedOrder{names: names}
+}
+
+// Select returns providers whose Name() matches names, ordered by names sequence.
+func (p *FixedOrder) Select(_ context.Context, _ llm.Request, candidates []llm.Provider) ([]llm.Provider, error) {
+	if len(p.names) == 0 {
+		out := make([]llm.Provider, len(candidates))
+		copy(out, candidates)
+		return out, nil
+	}
+
+	byName := make(map[string]llm.Provider, len(candidates))
+	for _, c := range candidates {
+		byName[c.Name()] = c
+	}
+
+	out := make([]llm.Provider, 0, len(p.names))
+	for _, name := range p.names {
+		if c, ok := byName[name]; ok {
+			out = append(out, c)
+		}
+	}
+	return out, nil
+}

--- a/pkg/llm/policy/hybrid.go
+++ b/pkg/llm/policy/hybrid.go
@@ -59,12 +59,15 @@ func (p *Hybrid) Select(_ context.Context, req llm.Request, candidates []llm.Pro
 		caps := capabilityFor(p.caps, c, req)
 		costs[i] = caps.CostInputPer1M
 		if mp, ok := c.(*llm.MeasuredProvider); ok {
-			if l := mp.Stats().LatencyMs(); l > 0 {
-				latencies[i] = l
+			// Calls() > 0 으로 측정 여부 판정 — LatencyMs()==0 도 valid 측정값일 수 있음
+			// (sub-ms 호출이 ms 단위로 round 된 경우).
+			stats := mp.Stats()
+			if stats.Calls() > 0 {
+				latencies[i] = stats.LatencyMs()
 			} else {
 				latencies[i] = float64(caps.AvgLatencyMs)
 			}
-			failures[i] = mp.Stats().FailureRate()
+			failures[i] = stats.FailureRate()
 		} else {
 			latencies[i] = float64(caps.AvgLatencyMs)
 		}

--- a/pkg/llm/policy/hybrid.go
+++ b/pkg/llm/policy/hybrid.go
@@ -1,0 +1,114 @@
+package policy
+
+import (
+	"context"
+	"sort"
+
+	"issuetracker/pkg/llm"
+)
+
+// HybridWeights controls the relative importance of cost / latency / failure rate signals.
+//
+// HybridWeights 는 비용 / latency / 실패율 시그널의 상대 가중치입니다 (이슈 #144 Phase 2.C).
+// 합이 1.0 일 필요는 없음 — 각 시그널을 normalize 후 가중 합산하므로 절대값보다 비율이 의미.
+//
+// 모두 0 이면 입력 순서가 보존됩니다 (panic 없이 graceful no-op).
+type HybridWeights struct {
+	Cost        float64 // 비용 (CostInputPer1M) 가중치
+	Latency     float64 // EMA / Capabilities latency 가중치
+	FailureRate float64 // MeasuredProvider failure rate 가중치 (이력 없으면 0)
+}
+
+// DefaultHybridWeights returns balanced weights — 운영자가 정책 변경 전 시작점.
+// Cost 와 Latency 가 동일 가중, FailureRate 는 그 절반 (long-term 안정성 보조 신호).
+func DefaultHybridWeights() HybridWeights {
+	return HybridWeights{Cost: 1.0, Latency: 1.0, FailureRate: 0.5}
+}
+
+// Hybrid orders candidates by a weighted score combining cost / latency / failure rate.
+//
+// 각 시그널은 후보 슬라이스 내 max 값으로 normalize 되어 [0, 1] 범위에서 합산됩니다.
+// 가중치가 모두 0 이면 입력 순서가 그대로 반환됩니다.
+//
+// **score 가 낮을수록 우선** — cost / latency / failure rate 모두 낮은 게 좋다는 의미.
+type Hybrid struct {
+	caps    llm.CapabilitiesProvider
+	weights HybridWeights
+}
+
+// NewHybrid returns a Hybrid policy with the given weights.
+func NewHybrid(caps llm.CapabilitiesProvider, weights HybridWeights) *Hybrid {
+	return &Hybrid{caps: caps, weights: weights}
+}
+
+// Select orders candidates by ascending hybrid score.
+func (p *Hybrid) Select(_ context.Context, req llm.Request, candidates []llm.Provider) ([]llm.Provider, error) {
+	if len(candidates) == 0 {
+		return nil, nil
+	}
+	if p.weights.Cost == 0 && p.weights.Latency == 0 && p.weights.FailureRate == 0 {
+		out := make([]llm.Provider, len(candidates))
+		copy(out, candidates)
+		return out, nil
+	}
+
+	costs := make([]float64, len(candidates))
+	latencies := make([]float64, len(candidates))
+	failures := make([]float64, len(candidates))
+	for i, c := range candidates {
+		caps := capabilityFor(p.caps, c, req)
+		costs[i] = caps.CostInputPer1M
+		if mp, ok := c.(*llm.MeasuredProvider); ok {
+			if l := mp.Stats().LatencyMs(); l > 0 {
+				latencies[i] = l
+			} else {
+				latencies[i] = float64(caps.AvgLatencyMs)
+			}
+			failures[i] = mp.Stats().FailureRate()
+		} else {
+			latencies[i] = float64(caps.AvgLatencyMs)
+		}
+	}
+
+	costMax := maxNonZero(costs)
+	latMax := maxNonZero(latencies)
+	failMax := maxNonZero(failures)
+
+	scored := make([]scoredProvider, len(candidates))
+	for i, c := range candidates {
+		score := 0.0
+		score += p.weights.Cost * normalize(costs[i], costMax)
+		score += p.weights.Latency * normalize(latencies[i], latMax)
+		score += p.weights.FailureRate * normalize(failures[i], failMax)
+		scored[i] = scoredProvider{provider: c, score: score}
+	}
+
+	sort.SliceStable(scored, func(i, j int) bool {
+		return scored[i].score < scored[j].score
+	})
+
+	out := make([]llm.Provider, len(scored))
+	for i, s := range scored {
+		out[i] = s.provider
+	}
+	return out, nil
+}
+
+// normalize divides v by max, returning 0 if max is 0 (avoid div-by-zero).
+func normalize(v, max float64) float64 {
+	if max == 0 {
+		return 0
+	}
+	return v / max
+}
+
+// maxNonZero returns the maximum value in xs, or 0 if all are zero / empty.
+func maxNonZero(xs []float64) float64 {
+	var m float64
+	for _, x := range xs {
+		if x > m {
+			m = x
+		}
+	}
+	return m
+}

--- a/pkg/llm/policy/latency.go
+++ b/pkg/llm/policy/latency.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"math/rand/v2"
 	"sort"
+	"sync"
 
 	"issuetracker/pkg/llm"
 )
@@ -23,7 +24,11 @@ import (
 type LatencyWeighted struct {
 	caps       llm.CapabilitiesProvider
 	stochastic bool
-	rng        *rand.Rand // nil 이면 default global rand
+
+	// rng 는 *math/rand/v2.Rand 가 concurrent-unsafe 하므로 rngMu 로 보호 — Policy 인터페이스
+	// contract (goroutine-safe) 준수. nil 이면 thread-safe global rand 사용 (lock 불필요).
+	rngMu sync.Mutex
+	rng   *rand.Rand
 }
 
 // LatencyWeightedOption 은 LatencyWeighted 생성 옵션입니다.
@@ -74,11 +79,14 @@ func (p *LatencyWeighted) Select(_ context.Context, req llm.Request, candidates 
 	return out, nil
 }
 
-// latencyMs returns observed EMA if MeasuredProvider, otherwise Capabilities baseline, otherwise 0.
+// latencyMs returns observed EMA if MeasuredProvider has any calls, otherwise Capabilities baseline.
+//
+// Calls() > 0 으로 측정 여부 판정 — LatencyMs()==0 도 valid 측정값일 수 있음 (sub-ms 호출).
 func (p *LatencyWeighted) latencyMs(provider llm.Provider, req llm.Request) float64 {
 	if mp, ok := provider.(*llm.MeasuredProvider); ok {
-		if observed := mp.Stats().LatencyMs(); observed > 0 {
-			return observed
+		stats := mp.Stats()
+		if stats.Calls() > 0 {
+			return stats.LatencyMs()
 		}
 	}
 	caps := capabilityFor(p.caps, provider, req)
@@ -96,18 +104,22 @@ func (p *LatencyWeighted) shuffleByInverseWeight(scored []scoredProvider) {
 		weights[i] = 1.0 / (s.score + epsilon)
 	}
 
-	rng := p.rng
+	// 주입된 *rand.Rand 는 concurrent-unsafe — Float64() 호출을 rngMu 로 보호.
+	// nil 인 경우 global rand.Float64() 는 thread-safe 하므로 lock 불필요.
+	float64Fn := func() float64 {
+		if p.rng == nil {
+			return rand.Float64()
+		}
+		p.rngMu.Lock()
+		defer p.rngMu.Unlock()
+		return p.rng.Float64()
+	}
 	pickIdx := func(remainingWeights []float64) int {
 		var total float64
 		for _, w := range remainingWeights {
 			total += w
 		}
-		var r float64
-		if rng != nil {
-			r = rng.Float64() * total
-		} else {
-			r = rand.Float64() * total
-		}
+		r := float64Fn() * total
 		var acc float64
 		for i, w := range remainingWeights {
 			acc += w

--- a/pkg/llm/policy/latency.go
+++ b/pkg/llm/policy/latency.go
@@ -1,0 +1,133 @@
+package policy
+
+import (
+	"context"
+	"math/rand/v2"
+	"sort"
+
+	"issuetracker/pkg/llm"
+)
+
+// LatencyWeighted orders candidates by ascending observed latency (lower is better).
+//
+// LatencyWeighted 는 동적 EMA latency 가 낮은 후보를 우선합니다 (이슈 #144 Phase 2.B).
+//
+// Latency source 우선순위:
+//  1. MeasuredProvider.Stats().LatencyMs() (실측 EMA) — 호출 이력이 있으면 본 값을 사용
+//  2. Capabilities.AvgLatencyMs (정적 baseline) — 실측이 없으면 fallback
+//  3. 0 (unknown) — 둘 다 없으면 0 으로 평가 (가장 빠름으로 간주)
+//
+// **확률 가중 무작위 선택 (옵션)**: WithStochastic(true) 시 latency 의 inverse 를 가중치로
+// 무작위 선택 — 운영 중 한 provider 가 latency 가 점진 악화돼도 다른 후보가 가끔 시도될 기회를
+// 보장 (단순 정렬은 lock-in 가능). default 는 deterministic 정렬.
+type LatencyWeighted struct {
+	caps       llm.CapabilitiesProvider
+	stochastic bool
+	rng        *rand.Rand // nil 이면 default global rand
+}
+
+// LatencyWeightedOption 은 LatencyWeighted 생성 옵션입니다.
+type LatencyWeightedOption func(*LatencyWeighted)
+
+// WithStochastic 은 latency 의 inverse 가중치로 확률 무작위 선택을 활성화합니다.
+// default false (단순 ascending 정렬).
+func WithStochastic(enabled bool) LatencyWeightedOption {
+	return func(p *LatencyWeighted) { p.stochastic = enabled }
+}
+
+// WithRand 는 결정적 테스트용 *rand.Rand 를 주입합니다. 미주입 시 global rand.
+func WithRand(rng *rand.Rand) LatencyWeightedOption {
+	return func(p *LatencyWeighted) { p.rng = rng }
+}
+
+// NewLatencyWeighted returns a LatencyWeighted policy.
+func NewLatencyWeighted(caps llm.CapabilitiesProvider, opts ...LatencyWeightedOption) *LatencyWeighted {
+	p := &LatencyWeighted{caps: caps}
+	for _, o := range opts {
+		o(p)
+	}
+	return p
+}
+
+// Select orders candidates by latency (ascending) or stochastic inverse-weighted random.
+func (p *LatencyWeighted) Select(_ context.Context, req llm.Request, candidates []llm.Provider) ([]llm.Provider, error) {
+	scored := make([]scoredProvider, len(candidates))
+	for i, c := range candidates {
+		scored[i] = scoredProvider{
+			provider: c,
+			score:    p.latencyMs(c, req),
+		}
+	}
+
+	if !p.stochastic {
+		sort.SliceStable(scored, func(i, j int) bool {
+			return scored[i].score < scored[j].score
+		})
+	} else {
+		p.shuffleByInverseWeight(scored)
+	}
+
+	out := make([]llm.Provider, len(scored))
+	for i, s := range scored {
+		out[i] = s.provider
+	}
+	return out, nil
+}
+
+// latencyMs returns observed EMA if MeasuredProvider, otherwise Capabilities baseline, otherwise 0.
+func (p *LatencyWeighted) latencyMs(provider llm.Provider, req llm.Request) float64 {
+	if mp, ok := provider.(*llm.MeasuredProvider); ok {
+		if observed := mp.Stats().LatencyMs(); observed > 0 {
+			return observed
+		}
+	}
+	caps := capabilityFor(p.caps, provider, req)
+	return float64(caps.AvgLatencyMs)
+}
+
+// shuffleByInverseWeight orders scored in-place by sampling without replacement using
+// weights proportional to 1 / (latency + epsilon). 낮은 latency = 높은 가중치 = 자주 선택.
+//
+// 모든 latency 가 0 이면 균등 분포 (무작위 순서).
+func (p *LatencyWeighted) shuffleByInverseWeight(scored []scoredProvider) {
+	const epsilon = 1.0
+	weights := make([]float64, len(scored))
+	for i, s := range scored {
+		weights[i] = 1.0 / (s.score + epsilon)
+	}
+
+	rng := p.rng
+	pickIdx := func(remainingWeights []float64) int {
+		var total float64
+		for _, w := range remainingWeights {
+			total += w
+		}
+		var r float64
+		if rng != nil {
+			r = rng.Float64() * total
+		} else {
+			r = rand.Float64() * total
+		}
+		var acc float64
+		for i, w := range remainingWeights {
+			acc += w
+			if r <= acc {
+				return i
+			}
+		}
+		return len(remainingWeights) - 1
+	}
+
+	for i := 0; i < len(scored)-1; i++ {
+		remaining := weights[i:]
+		pick := i + pickIdx(remaining)
+		scored[i], scored[pick] = scored[pick], scored[i]
+		weights[i], weights[pick] = weights[pick], weights[i]
+	}
+}
+
+// scoredProvider is an internal helper pairing a provider with its computed score.
+type scoredProvider struct {
+	provider llm.Provider
+	score    float64
+}

--- a/pkg/llm/policy/policy.go
+++ b/pkg/llm/policy/policy.go
@@ -1,0 +1,55 @@
+// Package policy implements LLM routing policies that order Providers per-request.
+//
+// Package policy 는 매 호출마다 비용 / 성능 / 작업 특성을 입력으로 적절한 provider 를 동적으로
+// 선택하는 routing policy 들을 제공합니다 (이슈 #144).
+//
+// Policy 는 후보 provider 슬라이스를 입력받아 우선순위 순서로 정렬해 반환합니다 — 단일 선택이 아닌
+// 정렬된 슬라이스를 반환하여 chain 합성 (chain.NewWithPolicy) 과 자연스럽게 어울립니다.
+//
+// 사용 예시:
+//
+//	caps := llm.NewStaticCapabilitiesProvider()
+//	pol := policy.NewCheapestFirst(caps)
+//	ordered, _ := pol.Select(ctx, req, []llm.Provider{p1, p2, p3})
+//	for _, p := range ordered {
+//	    if resp, err := p.Generate(ctx, req); err == nil {
+//	        return resp
+//	    }
+//	}
+package policy
+
+import (
+	"context"
+
+	"issuetracker/pkg/llm"
+)
+
+// Policy orders the given candidates by suitability for the request.
+//
+// Policy 는 request 에 가장 적합한 순서로 candidates 를 정렬해 반환합니다.
+// 반환된 슬라이스는 candidates 의 부분집합일 수 있습니다 (예: filter 적용).
+// 빈 슬라이스를 반환해도 panic 없이 caller 가 처리해야 합니다.
+//
+// 구현체는 goroutine-safe 해야 합니다 (단일 인스턴스를 여러 worker 가 공유).
+type Policy interface {
+	Select(ctx context.Context, req llm.Request, candidates []llm.Provider) ([]llm.Provider, error)
+}
+
+// CapabilityResolver returns a provider's capabilities for the given request.
+//
+// 호출자 (정책 구현) 가 candidate provider 의 model 을 어떻게 결정할지 의존성이 분리되어 있어 — 보통:
+//   - req.Model 이 비어있지 않으면 그대로 사용
+//   - 비어있으면 provider 의 default model — 현재 Provider 인터페이스에 노출 X 라
+//     향후 provider 가 자기 default 를 노출하는 메소드를 추가할 때 본 헬퍼가 그 메소드를 호출
+//
+// 본 PR scope: req.Model 만 사용. req.Model 이 비어있고 caps lookup 실패하면 zero Capabilities 사용.
+func capabilityFor(caps llm.CapabilitiesProvider, p llm.Provider, req llm.Request) llm.Capabilities {
+	if caps == nil {
+		return llm.Capabilities{}
+	}
+	c, ok := caps.Get(p.Name(), req.Model)
+	if !ok {
+		return llm.Capabilities{}
+	}
+	return c
+}

--- a/pkg/llm/prompt/prompt.go
+++ b/pkg/llm/prompt/prompt.go
@@ -1,0 +1,80 @@
+// Package prompt loads LLM prompt templates from the filesystem.
+//
+// Package prompt 는 LLM 호출용 프롬프트를 외부 파일에서 로드합니다 (이슈 #144 Phase 4).
+//
+// **위치 정책**: 프롬프트는 binary 와 분리하여 \`scripts/prompts/<name>.txt\` (또는 .md) 로 관리합니다.
+// 이는 다음을 가능하게 합니다:
+//   - 운영 중 프롬프트만 변경 (재빌드 없이)
+//   - PR 리뷰 시 프롬프트 변경이 코드와 별도로 잘 보임
+//   - 비-Go 운영자도 프롬프트 편집 가능
+//
+// **path 결정**: 환경변수 \`ISSUETRACKER_PROMPTS_DIR\` 가 set 되어 있으면 그 디렉토리, 아니면
+// \`scripts/prompts\` (현재 워킹 디렉토리 기준 상대 경로 — 일반적으로 repo root 에서 실행).
+//
+// 사용 예시:
+//
+//	body, err := prompt.Load("classify_news")  // scripts/prompts/classify_news.txt 또는 .md
+//	if err != nil { log.Fatal(err) }
+//	resp, _ := provider.Generate(ctx, llm.Request{
+//	    Messages: []llm.Message{{Role: llm.RoleUser, Content: body}},
+//	    TaskHint: llm.TaskHintReasoning,
+//	})
+package prompt
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// EnvPromptsDir 는 prompts 디렉토리를 override 하는 환경변수 이름입니다.
+const EnvPromptsDir = "ISSUETRACKER_PROMPTS_DIR"
+
+// DefaultDir 는 환경변수 미설정 시 사용하는 prompts 디렉토리 (cwd 기준 상대 경로).
+const DefaultDir = "scripts/prompts"
+
+// supportedExtensions 는 Load 시 자동 시도되는 파일 확장자 — 우선순위 순.
+var supportedExtensions = []string{".txt", ".md"}
+
+// ErrNotFound 는 어떤 확장자로도 prompt 파일을 찾지 못했을 때 반환됩니다.
+var ErrNotFound = errors.New("prompt not found")
+
+// Load returns the contents of the prompt file with the given name (확장자 제외).
+//
+// 검색 순서:
+//  1. <dir>/<name>.txt
+//  2. <dir>/<name>.md
+//
+// 모두 미존재 시 ErrNotFound 반환. dir 은 EnvPromptsDir 환경변수 또는 DefaultDir.
+//
+// name 에 path separator 가 포함되면 ErrNotFound (path traversal 방지) — 단순 식별자만 허용.
+func Load(name string) (string, error) {
+	if name == "" {
+		return "", fmt.Errorf("prompt name must not be empty")
+	}
+	if filepath.Base(name) != name {
+		return "", fmt.Errorf("prompt name %q must not contain path separators", name)
+	}
+
+	dir := dirFromEnv()
+	for _, ext := range supportedExtensions {
+		path := filepath.Join(dir, name+ext)
+		body, err := os.ReadFile(path)
+		if err == nil {
+			return string(body), nil
+		}
+		if !errors.Is(err, os.ErrNotExist) {
+			return "", fmt.Errorf("read prompt %q: %w", path, err)
+		}
+	}
+	return "", fmt.Errorf("%w: %s (dir=%s)", ErrNotFound, name, dir)
+}
+
+// dirFromEnv returns the prompts directory — env override or default.
+func dirFromEnv() string {
+	if v := os.Getenv(EnvPromptsDir); v != "" {
+		return v
+	}
+	return DefaultDir
+}

--- a/test/pkg/llm/capabilities_test.go
+++ b/test/pkg/llm/capabilities_test.go
@@ -1,0 +1,42 @@
+package llm_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"issuetracker/pkg/llm"
+)
+
+func TestStaticCapabilitiesProvider_DefaultLookup(t *testing.T) {
+	caps := llm.NewStaticCapabilitiesProvider()
+
+	got, ok := caps.Get("openai", "gpt-4o-mini")
+	assert.True(t, ok)
+	assert.Equal(t, 0.15, got.CostInputPer1M)
+	assert.Equal(t, 0.60, got.CostOutputPer1M)
+	assert.Equal(t, 128_000, got.ContextWindow)
+
+	got, ok = caps.Get("anthropic", "claude-opus-4-7")
+	assert.True(t, ok)
+	assert.Equal(t, 15.0, got.CostInputPer1M)
+
+	_, ok = caps.Get("unknown", "model")
+	assert.False(t, ok)
+}
+
+func TestStaticCapabilitiesProvider_CustomTable(t *testing.T) {
+	custom := map[string]map[string]llm.Capabilities{
+		"custom-vendor": {
+			"my-model": {CostInputPer1M: 1.0, ContextWindow: 8000},
+		},
+	}
+	caps := llm.NewStaticCapabilitiesProviderFrom(custom)
+
+	got, ok := caps.Get("custom-vendor", "my-model")
+	assert.True(t, ok)
+	assert.Equal(t, 1.0, got.CostInputPer1M)
+
+	_, ok = caps.Get("custom-vendor", "missing")
+	assert.False(t, ok)
+}

--- a/test/pkg/llm/chain/policy_test.go
+++ b/test/pkg/llm/chain/policy_test.go
@@ -1,0 +1,99 @@
+package chain_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"issuetracker/pkg/llm"
+	"issuetracker/pkg/llm/chain"
+	"issuetracker/pkg/llm/policy"
+)
+
+// trackedProvider — 호출 횟수 + 응답 / 에러 제어.
+type trackedProvider struct {
+	name  string
+	resp  *llm.Response
+	err   error
+	calls int
+}
+
+func (t *trackedProvider) Name() string { return t.name }
+func (t *trackedProvider) Generate(_ context.Context, _ llm.Request) (*llm.Response, error) {
+	t.calls++
+	return t.resp, t.err
+}
+
+// fixedPolicy — Select 결과를 고정 — 테스트 결정성 위해.
+type fixedPolicy struct{ order []llm.Provider }
+
+func (p *fixedPolicy) Select(_ context.Context, _ llm.Request, _ []llm.Provider) ([]llm.Provider, error) {
+	return p.order, nil
+}
+
+func TestPolicyProvider_UsesPolicyOrdering(t *testing.T) {
+	a := &trackedProvider{name: "a", err: &llm.Error{Code: llm.ErrCodeServer, Message: "fail a"}}
+	b := &trackedProvider{name: "b", resp: &llm.Response{Content: "ok b"}}
+	c := &trackedProvider{name: "c", resp: &llm.Response{Content: "ok c"}}
+
+	// policy 가 [b, a, c] 순으로 정렬한다고 가정 — b 가 첫 번째라 즉시 성공, a/c 는 호출 X.
+	pol := &fixedPolicy{order: []llm.Provider{b, a, c}}
+	pp := chain.NewWithPolicy(pol, []llm.Provider{a, b, c})
+
+	resp, err := pp.Generate(context.Background(), llm.Request{})
+	assert.NoError(t, err)
+	assert.Equal(t, "ok b", resp.Content)
+	assert.Equal(t, 1, b.calls)
+	assert.Equal(t, 0, a.calls)
+	assert.Equal(t, 0, c.calls)
+}
+
+func TestPolicyProvider_FallsBackOnDelegatableError(t *testing.T) {
+	a := &trackedProvider{name: "a", err: &llm.Error{Code: llm.ErrCodeServer, Message: "fail a"}}
+	b := &trackedProvider{name: "b", resp: &llm.Response{Content: "ok b"}}
+
+	// policy 가 [a, b] 순. a 실패 (delegatable) → b 시도.
+	pol := &fixedPolicy{order: []llm.Provider{a, b}}
+	pp := chain.NewWithPolicy(pol, []llm.Provider{a, b})
+
+	resp, err := pp.Generate(context.Background(), llm.Request{})
+	assert.NoError(t, err)
+	assert.Equal(t, "ok b", resp.Content)
+	assert.Equal(t, 1, a.calls)
+	assert.Equal(t, 1, b.calls)
+}
+
+func TestPolicyProvider_NoCandidates(t *testing.T) {
+	pol := &fixedPolicy{order: nil}
+	pp := chain.NewWithPolicy(pol, nil)
+
+	_, err := pp.Generate(context.Background(), llm.Request{})
+	var lerr *llm.Error
+	assert.ErrorAs(t, err, &lerr)
+	assert.Equal(t, llm.ErrCodeBadRequest, lerr.Code)
+}
+
+func TestPolicyProvider_NilPolicy(t *testing.T) {
+	pp := chain.NewWithPolicy(nil, []llm.Provider{&trackedProvider{name: "a"}})
+	_, err := pp.Generate(context.Background(), llm.Request{})
+	var lerr *llm.Error
+	assert.ErrorAs(t, err, &lerr)
+	assert.Equal(t, llm.ErrCodeBadRequest, lerr.Code)
+}
+
+func TestPolicyProvider_ContextCanceled(t *testing.T) {
+	pol := policy.NewCheapestFirst(nil)
+	pp := chain.NewWithPolicy(pol, []llm.Provider{&trackedProvider{name: "a"}})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	_, err := pp.Generate(ctx, llm.Request{})
+	var lerr *llm.Error
+	assert.ErrorAs(t, err, &lerr)
+	assert.Equal(t, llm.ErrCodeNetwork, lerr.Code)
+}
+
+// compile-time stub
+var _ = errors.New("compile check")

--- a/test/pkg/llm/measured_test.go
+++ b/test/pkg/llm/measured_test.go
@@ -37,7 +37,7 @@ func (s *stubProvider) Generate(ctx context.Context, _ llm.Request) (*llm.Respon
 
 func TestMeasuredProvider_RecordsLatencyAndCalls(t *testing.T) {
 	stub := &stubProvider{name: "stub", latency: 5 * time.Millisecond}
-	mp := llm.NewMeasuredProvider(stub, nil, "test")
+	mp := llm.NewMeasuredFactory(nil, "test").Wrap(stub)
 
 	for i := 0; i < 3; i++ {
 		_, err := mp.Generate(context.Background(), llm.Request{})
@@ -53,7 +53,7 @@ func TestMeasuredProvider_RecordsLatencyAndCalls(t *testing.T) {
 
 func TestMeasuredProvider_RecordsFailures(t *testing.T) {
 	stub := &stubProvider{name: "stub", latency: time.Millisecond, failTimes: 2}
-	mp := llm.NewMeasuredProvider(stub, nil, "test")
+	mp := llm.NewMeasuredFactory(nil, "test").Wrap(stub)
 
 	for i := 0; i < 5; i++ {
 		_, _ = mp.Generate(context.Background(), llm.Request{})
@@ -68,7 +68,7 @@ func TestMeasuredProvider_RecordsFailures(t *testing.T) {
 func TestMeasuredProvider_RegistersPrometheusMetrics(t *testing.T) {
 	stub := &stubProvider{name: "stub", latency: time.Millisecond}
 	registry := prometheus.NewRegistry()
-	mp := llm.NewMeasuredProvider(stub, registry, "llm")
+	mp := llm.NewMeasuredFactory(registry, "llm").Wrap(stub)
 
 	_, err := mp.Generate(context.Background(), llm.Request{})
 	assert.NoError(t, err)

--- a/test/pkg/llm/measured_test.go
+++ b/test/pkg/llm/measured_test.go
@@ -45,8 +45,8 @@ func TestMeasuredProvider_RecordsLatencyAndCalls(t *testing.T) {
 	}
 
 	stats := mp.Stats()
-	assert.Equal(t, uint64(3), stats.Calls.Load())
-	assert.Equal(t, uint64(0), stats.Failures.Load())
+	assert.Equal(t, uint64(3), stats.Calls())
+	assert.Equal(t, uint64(0), stats.Failures())
 	assert.Greater(t, stats.LatencyMs(), 0.0)
 	assert.Equal(t, 0.0, stats.FailureRate())
 }
@@ -60,8 +60,8 @@ func TestMeasuredProvider_RecordsFailures(t *testing.T) {
 	}
 
 	stats := mp.Stats()
-	assert.Equal(t, uint64(5), stats.Calls.Load())
-	assert.Equal(t, uint64(2), stats.Failures.Load())
+	assert.Equal(t, uint64(5), stats.Calls())
+	assert.Equal(t, uint64(2), stats.Failures())
 	assert.InDelta(t, 0.4, stats.FailureRate(), 0.001)
 }
 

--- a/test/pkg/llm/measured_test.go
+++ b/test/pkg/llm/measured_test.go
@@ -82,3 +82,29 @@ func TestMeasuredProvider_RegistersPrometheusMetrics(t *testing.T) {
 	assert.Contains(t, names, "llm_provider_call_total")
 	assert.Contains(t, names, "llm_provider_latency_seconds")
 }
+
+// 동일 registry 에 두 번 호출되어도 panic 없이 동일 collector 재사용 — idempotent 보장 (PR #167 CodeRabbit 피드백).
+func TestMeasuredFactory_IdempotentOnDuplicateRegistration(t *testing.T) {
+	registry := prometheus.NewRegistry()
+
+	var f1, f2 *llm.MeasuredFactory
+	assert.NotPanics(t, func() {
+		f1 = llm.NewMeasuredFactory(registry, "llm")
+		f2 = llm.NewMeasuredFactory(registry, "llm")
+	}, "동일 registry 에 두 번 호출되어도 panic 안 됨")
+
+	stub1 := &stubProvider{name: "a", latency: time.Millisecond}
+	stub2 := &stubProvider{name: "b", latency: time.Millisecond}
+	_, _ = f1.Wrap(stub1).Generate(context.Background(), llm.Request{})
+	_, _ = f2.Wrap(stub2).Generate(context.Background(), llm.Request{})
+
+	// 두 factory 가 같은 collector 를 공유하므로 metric 이름은 1회만 등록.
+	mfs, err := registry.Gather()
+	assert.NoError(t, err)
+	counts := map[string]int{}
+	for _, m := range mfs {
+		counts[m.GetName()]++
+	}
+	assert.Equal(t, 1, counts["llm_provider_call_total"])
+	assert.Equal(t, 1, counts["llm_provider_latency_seconds"])
+}

--- a/test/pkg/llm/measured_test.go
+++ b/test/pkg/llm/measured_test.go
@@ -1,0 +1,84 @@
+package llm_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stretchr/testify/assert"
+
+	"issuetracker/pkg/llm"
+)
+
+// stubProvider — 테스트용 fixed-latency provider.
+type stubProvider struct {
+	name      string
+	latency   time.Duration
+	failTimes int
+	calls     int
+}
+
+func (s *stubProvider) Name() string { return s.name }
+func (s *stubProvider) Generate(ctx context.Context, _ llm.Request) (*llm.Response, error) {
+	s.calls++
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	case <-time.After(s.latency):
+	}
+	if s.failTimes > 0 {
+		s.failTimes--
+		return nil, errors.New("stub failure")
+	}
+	return &llm.Response{Content: "ok", Model: s.name}, nil
+}
+
+func TestMeasuredProvider_RecordsLatencyAndCalls(t *testing.T) {
+	stub := &stubProvider{name: "stub", latency: 5 * time.Millisecond}
+	mp := llm.NewMeasuredProvider(stub, nil, "test")
+
+	for i := 0; i < 3; i++ {
+		_, err := mp.Generate(context.Background(), llm.Request{})
+		assert.NoError(t, err)
+	}
+
+	stats := mp.Stats()
+	assert.Equal(t, uint64(3), stats.Calls.Load())
+	assert.Equal(t, uint64(0), stats.Failures.Load())
+	assert.Greater(t, stats.LatencyMs(), 0.0)
+	assert.Equal(t, 0.0, stats.FailureRate())
+}
+
+func TestMeasuredProvider_RecordsFailures(t *testing.T) {
+	stub := &stubProvider{name: "stub", latency: time.Millisecond, failTimes: 2}
+	mp := llm.NewMeasuredProvider(stub, nil, "test")
+
+	for i := 0; i < 5; i++ {
+		_, _ = mp.Generate(context.Background(), llm.Request{})
+	}
+
+	stats := mp.Stats()
+	assert.Equal(t, uint64(5), stats.Calls.Load())
+	assert.Equal(t, uint64(2), stats.Failures.Load())
+	assert.InDelta(t, 0.4, stats.FailureRate(), 0.001)
+}
+
+func TestMeasuredProvider_RegistersPrometheusMetrics(t *testing.T) {
+	stub := &stubProvider{name: "stub", latency: time.Millisecond}
+	registry := prometheus.NewRegistry()
+	mp := llm.NewMeasuredProvider(stub, registry, "llm")
+
+	_, err := mp.Generate(context.Background(), llm.Request{})
+	assert.NoError(t, err)
+
+	mfs, err := registry.Gather()
+	assert.NoError(t, err)
+	names := make([]string, 0, len(mfs))
+	for _, m := range mfs {
+		names = append(names, m.GetName())
+	}
+	assert.Contains(t, names, "llm_provider_call_total")
+	assert.Contains(t, names, "llm_provider_latency_seconds")
+}

--- a/test/pkg/llm/policy/policy_test.go
+++ b/test/pkg/llm/policy/policy_test.go
@@ -75,7 +75,7 @@ func TestLatencyWeighted_OrdersByLatency(t *testing.T) {
 func TestLatencyWeighted_PrefersMeasuredEMAOverStatic(t *testing.T) {
 	// MeasuredProvider 가 실제 5ms latency 를 EMA 로 측정하면 static 200ms 무시.
 	stub := &stubLatencyProvider{name: "slow", latency: 5 * time.Millisecond}
-	mp := llm.NewMeasuredProvider(stub, nil, "test")
+	mp := llm.NewMeasuredFactory(nil, "test").Wrap(stub)
 
 	// 한 번 호출하여 EMA 값 채움.
 	_, _ = mp.Generate(context.Background(), llm.Request{})

--- a/test/pkg/llm/policy/policy_test.go
+++ b/test/pkg/llm/policy/policy_test.go
@@ -1,0 +1,137 @@
+package policy_test
+
+import (
+	"context"
+	"errors"
+	"math/rand/v2"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"issuetracker/pkg/llm"
+	"issuetracker/pkg/llm/policy"
+)
+
+// fakeProvider — 테스트용 noop provider.
+type fakeProvider struct{ name string }
+
+func (f *fakeProvider) Name() string { return f.name }
+func (f *fakeProvider) Generate(_ context.Context, _ llm.Request) (*llm.Response, error) {
+	return &llm.Response{Content: f.name}, nil
+}
+
+// stubLatencyProvider — 고정 latency 응답.
+type stubLatencyProvider struct {
+	name    string
+	latency time.Duration
+}
+
+func (s *stubLatencyProvider) Name() string { return s.name }
+func (s *stubLatencyProvider) Generate(_ context.Context, _ llm.Request) (*llm.Response, error) {
+	time.Sleep(s.latency)
+	return &llm.Response{Content: s.name}, nil
+}
+
+func TestCheapestFirst_OrdersByInputCost(t *testing.T) {
+	caps := llm.NewStaticCapabilitiesProviderFrom(map[string]map[string]llm.Capabilities{
+		"a": {"m": {CostInputPer1M: 5.0, CostOutputPer1M: 20.0}},
+		"b": {"m": {CostInputPer1M: 1.0, CostOutputPer1M: 4.0}},
+		"c": {"m": {CostInputPer1M: 3.0, CostOutputPer1M: 12.0}},
+	})
+	pol := policy.NewCheapestFirst(caps)
+
+	pa, pb, pc := &fakeProvider{name: "a"}, &fakeProvider{name: "b"}, &fakeProvider{name: "c"}
+	out, err := pol.Select(context.Background(), llm.Request{Model: "m"}, []llm.Provider{pa, pb, pc})
+	assert.NoError(t, err)
+	assert.Equal(t, []llm.Provider{pb, pc, pa}, out)
+}
+
+func TestCheapestFirst_TieBreakerByOutputCost(t *testing.T) {
+	caps := llm.NewStaticCapabilitiesProviderFrom(map[string]map[string]llm.Capabilities{
+		"a": {"m": {CostInputPer1M: 1.0, CostOutputPer1M: 10.0}},
+		"b": {"m": {CostInputPer1M: 1.0, CostOutputPer1M: 5.0}},
+	})
+	pol := policy.NewCheapestFirst(caps)
+
+	pa, pb := &fakeProvider{name: "a"}, &fakeProvider{name: "b"}
+	out, _ := pol.Select(context.Background(), llm.Request{Model: "m"}, []llm.Provider{pa, pb})
+	assert.Equal(t, []llm.Provider{pb, pa}, out)
+}
+
+func TestLatencyWeighted_OrdersByLatency(t *testing.T) {
+	caps := llm.NewStaticCapabilitiesProviderFrom(map[string]map[string]llm.Capabilities{
+		"a": {"m": {AvgLatencyMs: 1000}},
+		"b": {"m": {AvgLatencyMs: 200}},
+		"c": {"m": {AvgLatencyMs: 500}},
+	})
+	pol := policy.NewLatencyWeighted(caps)
+
+	pa, pb, pc := &fakeProvider{name: "a"}, &fakeProvider{name: "b"}, &fakeProvider{name: "c"}
+	out, _ := pol.Select(context.Background(), llm.Request{Model: "m"}, []llm.Provider{pa, pb, pc})
+	assert.Equal(t, []llm.Provider{pb, pc, pa}, out)
+}
+
+func TestLatencyWeighted_PrefersMeasuredEMAOverStatic(t *testing.T) {
+	// MeasuredProvider 가 실제 5ms latency 를 EMA 로 측정하면 static 200ms 무시.
+	stub := &stubLatencyProvider{name: "slow", latency: 5 * time.Millisecond}
+	mp := llm.NewMeasuredProvider(stub, nil, "test")
+
+	// 한 번 호출하여 EMA 값 채움.
+	_, _ = mp.Generate(context.Background(), llm.Request{})
+	assert.Greater(t, mp.Stats().LatencyMs(), 0.0)
+
+	// fast 는 static 200ms (높은 값) 인데 EMA 미측정 → static 사용 → 200 vs measured EMA(~5)
+	caps2 := llm.NewStaticCapabilitiesProviderFrom(map[string]map[string]llm.Capabilities{
+		"slow": {"m": {AvgLatencyMs: 100}},
+		"fast": {"m": {AvgLatencyMs: 200}},
+	})
+	pol2 := policy.NewLatencyWeighted(caps2)
+	fast := &fakeProvider{name: "fast"}
+	out, _ := pol2.Select(context.Background(), llm.Request{Model: "m"}, []llm.Provider{fast, mp})
+	assert.Equal(t, mp, out[0], "measured EMA(~5ms) 가 static 200ms 보다 빠르므로 mp 가 첫 번째")
+}
+
+func TestHybrid_BalancesCostAndLatency(t *testing.T) {
+	caps := llm.NewStaticCapabilitiesProviderFrom(map[string]map[string]llm.Capabilities{
+		"cheap_slow":  {"m": {CostInputPer1M: 0.1, AvgLatencyMs: 5000}},
+		"mid":         {"m": {CostInputPer1M: 1.0, AvgLatencyMs: 1000}},
+		"fast_pricey": {"m": {CostInputPer1M: 10.0, AvgLatencyMs: 200}},
+	})
+	// 균형 가중치 — mid 가 양 시그널의 normalized score 가 가장 낮음 (가운데)
+	pol := policy.NewHybrid(caps, policy.HybridWeights{Cost: 1.0, Latency: 1.0})
+
+	pa := &fakeProvider{name: "cheap_slow"}
+	pb := &fakeProvider{name: "mid"}
+	pc := &fakeProvider{name: "fast_pricey"}
+	out, _ := pol.Select(context.Background(), llm.Request{Model: "m"}, []llm.Provider{pa, pb, pc})
+	assert.Equal(t, pb, out[0], "비용·latency 균형 가중치에서 mid 가 가장 낮은 score")
+}
+
+func TestHybrid_AllZeroWeightsPreservesOrder(t *testing.T) {
+	pol := policy.NewHybrid(nil, policy.HybridWeights{})
+	pa, pb, pc := &fakeProvider{name: "a"}, &fakeProvider{name: "b"}, &fakeProvider{name: "c"}
+	in := []llm.Provider{pc, pa, pb}
+	out, _ := pol.Select(context.Background(), llm.Request{}, in)
+	assert.Equal(t, in, out)
+}
+
+func TestLatencyWeighted_StochasticDeterministicWithSeededRand(t *testing.T) {
+	caps := llm.NewStaticCapabilitiesProviderFrom(map[string]map[string]llm.Capabilities{
+		"a": {"m": {AvgLatencyMs: 1000}},
+		"b": {"m": {AvgLatencyMs: 200}},
+	})
+	rng := rand.New(rand.NewPCG(42, 42))
+	pol := policy.NewLatencyWeighted(caps, policy.WithStochastic(true), policy.WithRand(rng))
+
+	pa, pb := &fakeProvider{name: "a"}, &fakeProvider{name: "b"}
+	// stochastic 라도 동일 seed 로 두 번 호출 시 동일 순서 (regression 방지).
+	first, _ := pol.Select(context.Background(), llm.Request{Model: "m"}, []llm.Provider{pa, pb})
+	rng2 := rand.New(rand.NewPCG(42, 42))
+	pol2 := policy.NewLatencyWeighted(caps, policy.WithStochastic(true), policy.WithRand(rng2))
+	second, _ := pol2.Select(context.Background(), llm.Request{Model: "m"}, []llm.Provider{pa, pb})
+	assert.Equal(t, first, second)
+}
+
+// stub for compile-time check
+var _ error = errors.New("compile check")

--- a/test/pkg/llm/policy/policy_test.go
+++ b/test/pkg/llm/policy/policy_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"math/rand/v2"
+	"sync"
 	"testing"
 	"time"
 
@@ -114,6 +115,34 @@ func TestHybrid_AllZeroWeightsPreservesOrder(t *testing.T) {
 	in := []llm.Provider{pc, pa, pb}
 	out, _ := pol.Select(context.Background(), llm.Request{}, in)
 	assert.Equal(t, in, out)
+}
+
+// stochastic + 주입 rng 가 다중 goroutine 에서 race 없이 동작하는지 검증 — `go test -race` 필요 (PR #167 CodeRabbit 피드백).
+func TestLatencyWeighted_StochasticConcurrentSafe(t *testing.T) {
+	caps := llm.NewStaticCapabilitiesProviderFrom(map[string]map[string]llm.Capabilities{
+		"a": {"m": {AvgLatencyMs: 100}},
+		"b": {"m": {AvgLatencyMs: 200}},
+		"c": {"m": {AvgLatencyMs: 300}},
+	})
+	rng := rand.New(rand.NewPCG(7, 7))
+	pol := policy.NewLatencyWeighted(caps, policy.WithStochastic(true), policy.WithRand(rng))
+
+	pa, pb, pc := &fakeProvider{name: "a"}, &fakeProvider{name: "b"}, &fakeProvider{name: "c"}
+	candidates := []llm.Provider{pa, pb, pc}
+
+	var wg sync.WaitGroup
+	for i := 0; i < 32; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for j := 0; j < 50; j++ {
+				out, err := pol.Select(context.Background(), llm.Request{Model: "m"}, candidates)
+				assert.NoError(t, err)
+				assert.Len(t, out, 3)
+			}
+		}()
+	}
+	wg.Wait()
 }
 
 func TestLatencyWeighted_StochasticDeterministicWithSeededRand(t *testing.T) {

--- a/test/pkg/llm/policy/policy_test.go
+++ b/test/pkg/llm/policy/policy_test.go
@@ -133,5 +133,38 @@ func TestLatencyWeighted_StochasticDeterministicWithSeededRand(t *testing.T) {
 	assert.Equal(t, first, second)
 }
 
+func TestFixedOrder_PinsToSingleProvider(t *testing.T) {
+	pol := policy.NewFixedOrder("gemini")
+	pa := &fakeProvider{name: "openai"}
+	pb := &fakeProvider{name: "gemini"}
+	pc := &fakeProvider{name: "anthropic"}
+	out, err := pol.Select(context.Background(), llm.Request{}, []llm.Provider{pa, pb, pc})
+	assert.NoError(t, err)
+	assert.Equal(t, []llm.Provider{pb}, out, "gemini 만 결과에 포함되어야 함")
+}
+
+func TestFixedOrder_RespectsExplicitOrder(t *testing.T) {
+	pol := policy.NewFixedOrder("gemini", "openai")
+	pa := &fakeProvider{name: "openai"}
+	pb := &fakeProvider{name: "gemini"}
+	out, _ := pol.Select(context.Background(), llm.Request{}, []llm.Provider{pa, pb})
+	assert.Equal(t, []llm.Provider{pb, pa}, out, "names 순서 (gemini→openai) 가 입력 순서 (openai→gemini) 보다 우선")
+}
+
+func TestFixedOrder_FiltersUnmatched(t *testing.T) {
+	pol := policy.NewFixedOrder("gemini")
+	pa := &fakeProvider{name: "openai"}
+	out, _ := pol.Select(context.Background(), llm.Request{}, []llm.Provider{pa})
+	assert.Empty(t, out, "매칭되는 provider 없으면 빈 슬라이스")
+}
+
+func TestFixedOrder_EmptyNamesPreservesInput(t *testing.T) {
+	pol := policy.NewFixedOrder()
+	pa, pb := &fakeProvider{name: "a"}, &fakeProvider{name: "b"}
+	in := []llm.Provider{pb, pa}
+	out, _ := pol.Select(context.Background(), llm.Request{}, in)
+	assert.Equal(t, in, out, "names 비어있으면 입력 순서 그대로 반환")
+}
+
 // stub for compile-time check
 var _ error = errors.New("compile check")

--- a/test/pkg/llm/prompt/prompt_test.go
+++ b/test/pkg/llm/prompt/prompt_test.go
@@ -1,0 +1,62 @@
+package prompt_test
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"issuetracker/pkg/llm/prompt"
+)
+
+func TestLoad_TxtFile(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv(prompt.EnvPromptsDir, dir)
+	assert.NoError(t, os.WriteFile(filepath.Join(dir, "hello.txt"), []byte("hi from txt"), 0o600))
+
+	body, err := prompt.Load("hello")
+	assert.NoError(t, err)
+	assert.Equal(t, "hi from txt", body)
+}
+
+func TestLoad_MdFile(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv(prompt.EnvPromptsDir, dir)
+	assert.NoError(t, os.WriteFile(filepath.Join(dir, "hello.md"), []byte("# title"), 0o600))
+
+	body, err := prompt.Load("hello")
+	assert.NoError(t, err)
+	assert.Equal(t, "# title", body)
+}
+
+func TestLoad_PrefersTxtOverMd(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv(prompt.EnvPromptsDir, dir)
+	assert.NoError(t, os.WriteFile(filepath.Join(dir, "hello.txt"), []byte("from txt"), 0o600))
+	assert.NoError(t, os.WriteFile(filepath.Join(dir, "hello.md"), []byte("from md"), 0o600))
+
+	body, err := prompt.Load("hello")
+	assert.NoError(t, err)
+	assert.Equal(t, "from txt", body)
+}
+
+func TestLoad_NotFound(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv(prompt.EnvPromptsDir, dir)
+
+	_, err := prompt.Load("missing")
+	assert.ErrorIs(t, err, prompt.ErrNotFound)
+}
+
+func TestLoad_RejectsPathSeparator(t *testing.T) {
+	_, err := prompt.Load("../etc/passwd")
+	assert.Error(t, err)
+	assert.False(t, errors.Is(err, prompt.ErrNotFound), "path traversal 은 ErrNotFound 가 아닌 별도 에러")
+}
+
+func TestLoad_EmptyName(t *testing.T) {
+	_, err := prompt.Load("")
+	assert.Error(t, err)
+}


### PR DESCRIPTION
## 연관 이슈

Closes #144 (선행: #165 Prometheus client 도입 — 머지 완료)

## 배경

기존 \`pkg/llm/chain\` 의 정적 순차 fallback 을 넘어, **비용 / 성능 / 작업 특성 / 동적 metric** 을 입력으로 매 호출마다 적합한 provider 를 선택하는 routing 정책 layer 를 도입합니다.

호출자 코드는 변화 없음 — \`chain.NewWithPolicy(policy, candidates)\` 가 \`llm.Provider\` 인터페이스를 그대로 노출.

## 구현 내용 (8 commits)

### Phase 1 — 인프라

1. **Capabilities + CapabilitiesProvider + Request.TaskHint** (\`e4490d8\`)
   - \`Capabilities{CostInputPer1M, CostOutputPer1M, ContextWindow, AvgLatencyMs}\`
   - \`CapabilitiesProvider\` 인터페이스 — Static (본 PR) + 향후 Refreshable (주기 동적 갱신) 가 같은 인터페이스 구현하도록 설계
   - \`StaticCapabilitiesProvider\` 가 2026-04 기준 hardcode pricing (openai / anthropic / gemini)
   - \`Request.TaskHint\` 필드 + 표준 hint 상수 (summary / reasoning / json / large_context)

2. **MeasuredProvider + Prometheus metric** (\`820e600\`)
   - in-memory EMA latency (alpha 0.2) + atomic counter
   - Prometheus histogram + counter (registry 주입 시) — \`/metrics\` endpoint 노출
   - registry nil 이면 in-memory Stats 만 동작

### Phase 2 — 정책

3. **Policy interface + CheapestFirst** (\`7afaedc\`)
   - \`Policy.Select(ctx, req, candidates) ([]llm.Provider, error)\` — 정렬된 슬라이스 반환
   - CheapestFirst: input 단가 asc, 동률 시 output 단가 보조 키

4. **LatencyWeighted** (\`65a2457\`)
   - MeasuredProvider EMA 우선, 미측정 시 Capabilities baseline fallback
   - \`WithStochastic(true)\` — 1/(latency+ε) 가중 무작위 (lock-in 회피)
   - \`WithRand\` — 결정적 테스트 지원

5. **Hybrid** (\`fa8c1ff\`)
   - HybridWeights{Cost, Latency, FailureRate} — 후보 내 max 로 normalize 후 가중 합산
   - DefaultHybridWeights: Cost=1.0, Latency=1.0, FailureRate=0.5
   - 모든 가중치 0 이면 입력 순서 보존 (graceful no-op)

### Phase 3 — chain 합성

6. **chain.PolicyProvider** (\`93ae4e2\`)
   - \`chain.NewWithPolicy(policy, candidates, opts...)\` — 매 호출마다 policy.Select 가 순서 결정
   - chain.Provider 의 위임/cancel 정책을 그대로 재사용 (코드 중복 회피)
   - llm.Provider 인터페이스 컴파일 체크

### Phase 4 — 프롬프트 + 테스트

7. **pkg/llm/prompt** (\`0dba1b9\`)
   - \`prompt.Load(name)\` — \`scripts/prompts/<name>.txt\` 또는 \`.md\` 자동 시도
   - 환경변수 \`ISSUETRACKER_PROMPTS_DIR\` 로 디렉토리 override
   - path traversal 방지 (separator 거부)
   - \`scripts/prompts/.gitkeep\` 생성

8. **단위 테스트** (\`ed7e390\`)
   - capabilities / measured / policy (Cheapest/Latency/Hybrid) / chain.PolicyProvider / prompt 5 개 파일

## CI / 머지 게이트 점검

- [x] \`go build ./...\` 통과
- [x] \`go test -race -count=1 ./...\` 24 패키지 전체 PASS
- [x] \`gofmt -l .\` clean
- [x] commit-per-TODO 정책 준수 (각 commit 빌드/테스트 그린)

## 변경 영향 범위 + 위험도

- **영향**: \`llm.Request\` 에 \`TaskHint\` 필드 추가 (기존 호출자 영향 없음 — zero value 보존)
- **위험도**: 낮음
  - 기존 chain.Provider / 단일 provider 사용처 변경 없음
  - 본 PR 시점 호출처 0 — 인프라 배포만, 운영 동작 변경 없음
  - 후속 PR 에서 점진 적용 (validate / classifier 등)

## 롤백 계획

- 8 commits 모두 revert 시 main 상태 복원
- 외부 의존성 (#165 Prometheus) 는 별도 — 본 PR 만 revert 안전

## 후속 이슈 후보

- RefreshableCapabilitiesProvider — DB / pricing API 주기 갱신
- LLM 호출처 신설 (예: 카테고리 분류 LLM, parsing rule 자동 생성 #149)
- Hybrid 가중치 운영 환경별 config 분리

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced provider routing policies supporting cost-based, latency-based, hybrid scoring, and fixed ordering
  * Added task hints to guide provider selection (summary, reasoning, JSON, large context)
  * Implemented capability tracking for LLM providers (costs, latency, context window)
  * Added performance metrics collection and Prometheus monitoring for providers
  * Added prompt template loading from configurable directories

<!-- end of auto-generated comment: release notes by coderabbit.ai -->