### PR TITLE
[FEAT#173] parsing_rules URI 매칭 인프라 — path_pattern 컬럼 + Resolver 후보 슬라이스 + regex cache (단계 1)

### DIFF
--- a/cmd/issuetracker/main.go
+++ b/cmd/issuetracker/main.go
@@ -352,7 +352,8 @@ func verifyParsingRulesSeeded(ctx context.Context, resolver *rule.Resolver) erro
 		{"edition.cnn.com", storage.TargetTypeList},
 	}
 	for _, r := range required {
-		if _, err := resolver.Resolve(ctx, r.host, r.typ); err != nil {
+		// "/" path 로 catch-all (path_pattern='') 매칭 검증 — seed 된 host-only rule 확인 (이슈 #173).
+		if _, err := resolver.Resolve(ctx, r.host, "/", r.typ); err != nil {
 			return fmt.Errorf("missing rule for (%s, %s): %w", r.host, r.typ, err)
 		}
 	}

--- a/internal/crawler/parser/rule/resolver.go
+++ b/internal/crawler/parser/rule/resolver.go
@@ -203,11 +203,9 @@ func (r *Resolver) compileRegex(pattern string) *compiledPattern {
 	if v, ok := r.regexCache.Load(pattern); ok {
 		return v.(*compiledPattern)
 	}
+	// regexp.Compile 은 에러 시 re=nil 반환 — 별도 nil 처리 불필요 (PR #181 gemini 피드백).
 	re, err := regexp.Compile(pattern)
 	cp := &compiledPattern{re: re, err: err}
-	if err != nil {
-		cp.re = nil
-	}
 	// LoadOrStore 로 race 시 첫 winner 의 결과를 보존 — 같은 패턴 두 goroutine 동시 컴파일도 안전.
 	actual, _ := r.regexCache.LoadOrStore(pattern, cp)
 	return actual.(*compiledPattern)

--- a/internal/crawler/parser/rule/resolver.go
+++ b/internal/crawler/parser/rule/resolver.go
@@ -7,9 +7,9 @@ package rule
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"net/url"
+	"regexp"
 	"strings"
 	"sync"
 	"time"
@@ -38,7 +38,11 @@ const DefaultMaxCacheEntries = 10_000
 // In-memory cache (TTL based) 로 DB roundtrip 을 줄입니다 — 운영자는 새 rule enabled 후
 // 최대 DefaultCacheTTL 만큼 지연을 감수합니다.
 //
-// goroutine-safe — sync.RWMutex 로 cache 보호.
+// 이슈 #173 단계 1: cache value 가 단일 rule → rule 슬라이스 (host 매칭 후보들) 로 변경.
+// ResolveByURL 이 슬라이스를 받아 application 측에서 URL path 와 path_pattern regex 매칭.
+// path_pattern=” 인 row 는 catch-all 로 마지막에 위치 (LENGTH DESC 정렬).
+//
+// goroutine-safe — sync.RWMutex 로 cache 보호. regex compile cache 는 sync.Map.
 type Resolver struct {
 	repo             storage.ParsingRuleRepository
 	cacheTTL         time.Duration
@@ -48,18 +52,33 @@ type Resolver struct {
 	mu    sync.RWMutex
 	cache map[cacheKey]cacheEntry
 	now   func() time.Time // 테스트 주입 (실시각 → fake clock)
+
+	// regexCache 는 path_pattern 별 compile 결과를 보관합니다 (이슈 #173).
+	// 같은 패턴의 재컴파일을 회피 — 운영 중 동일 host 의 후보 슬라이스가 cache 만료 시마다
+	// 다시 fetch 되어도 regex 객체는 재사용. sync.Map 으로 lock-free read.
+	regexCache sync.Map // map[string]*compiledPattern
 }
 
-// cacheKey 는 (host, target_type) 튜플입니다 — DB FindActive 인자와 1:1 매칭.
+// compiledPattern 은 path_pattern 의 컴파일 결과 (또는 컴파일 실패) 를 보관합니다.
+// 실패한 패턴은 err 를 보관하여 매번 재컴파일을 시도하지 않도록 negative cache 역할.
+type compiledPattern struct {
+	re  *regexp.Regexp // 컴파일 실패 또는 빈 패턴이면 nil
+	err error
+}
+
+// cacheKey 는 (host, target_type) 튜플입니다 — DB FindActiveCandidates 인자와 1:1 매칭.
 type cacheKey struct {
 	host       string
 	targetType storage.TargetType
 }
 
-// cacheEntry 는 lookup 결과를 캐싱합니다. rule==nil 이면 negative cache.
+// cacheEntry 는 lookup 결과를 캐싱합니다.
+//
+// 이슈 #173: 후보 슬라이스를 통째로 보관 — application 측 path 매칭은 매 호출마다 실행
+// (cache hit path 안에서 수행). 매칭 비용은 ms 미만 (regex 컴파일은 regexCache 로 분리).
 type cacheEntry struct {
-	rule      *storage.ParsingRuleRecord
-	expiresAt time.Time
+	candidates []*storage.ParsingRuleRecord // 빈 슬라이스 = negative cache
+	expiresAt  time.Time
 }
 
 // Option 은 Resolver 생성 옵션입니다.
@@ -105,46 +124,93 @@ func NewResolver(repo storage.ParsingRuleRepository, opts ...Option) *Resolver {
 	return r
 }
 
-// ResolveByURL 은 URL 에서 host 를 추출해 매칭 활성 규칙을 반환합니다.
+// ResolveByURL 은 URL 에서 host + path 를 추출해 매칭 활성 규칙을 반환합니다.
 //
-// 흐름:
+// 흐름 (이슈 #173):
 //  1. URL parse 실패 → ErrInvalidURL
-//  2. cache hit (양성) → 즉시 반환
-//  3. cache hit (negative, 미만료) → ErrNoRule (DB roundtrip 회피)
-//  4. cache miss → repo.FindActive → 결과를 cache 후 반환
+//  2. cache hit → 후보 슬라이스에서 path 매칭, 첫 매칭 rule 반환
+//  3. cache miss → repo.FindActiveCandidates → cache 후 path 매칭
+//
+// 후보 슬라이스 안에서 path 매칭:
+//   - path_pattern=” (catch-all) 은 모든 path 매칭, LENGTH DESC 정렬상 가장 마지막
+//   - 더 구체적인 (긴) path_pattern 이 먼저 평가되어 우선 채택
+//   - 매칭 없음 → ErrNoRule
 //
 // 매칭 없음은 storage.ErrNotFound 가 아닌 rule.ErrNoRule 로 정규화 — 호출자가 errors.Is
 // 로 분기 가능 (예: LLM 자동 생성 fallback 트리거).
 func (r *Resolver) ResolveByURL(ctx context.Context, rawURL string, targetType storage.TargetType) (*storage.ParsingRuleRecord, error) {
-	host, err := extractHost(rawURL)
+	host, path, err := extractHostPath(rawURL)
 	if err != nil {
 		return nil, &Error{Code: ErrInvalidURL, Message: err.Error(), URL: rawURL}
 	}
-	return r.Resolve(ctx, host, targetType)
+	return r.Resolve(ctx, host, path, targetType)
 }
 
-// Resolve 는 host 를 직접 받아 매칭 활성 규칙을 반환합니다 (host 가 이미 추출된 경우).
-func (r *Resolver) Resolve(ctx context.Context, host string, targetType storage.TargetType) (*storage.ParsingRuleRecord, error) {
+// Resolve 는 host + path 를 직접 받아 매칭 활성 규칙을 반환합니다 (이슈 #173).
+//
+// host 는 정규화 (lowercase, 포트 제외) 된 상태로 전달 권장. path 는 URL.Path (rawpath 아님) —
+// 정규화는 호출자 책임.
+func (r *Resolver) Resolve(ctx context.Context, host, path string, targetType storage.TargetType) (*storage.ParsingRuleRecord, error) {
 	host = strings.ToLower(host)
 	key := cacheKey{host: host, targetType: targetType}
 
-	if rule, hit, negative := r.lookupCache(key); hit {
-		if negative {
-			return nil, &Error{Code: ErrNoRule, Message: "no active rule (cached)", Host: host, TargetType: string(targetType)}
+	candidates, hit := r.lookupCache(key)
+	if !hit {
+		fetched, err := r.repo.FindActiveCandidates(ctx, host, targetType)
+		if err != nil {
+			return nil, fmt.Errorf("find active candidates (%s, %s): %w", host, targetType, err)
 		}
-		return rule, nil
+		ttl := r.cacheTTL
+		if len(fetched) == 0 {
+			ttl = r.negativeCacheTTL
+		}
+		r.storeCache(key, fetched, ttl)
+		candidates = fetched
 	}
 
-	rule, err := r.repo.FindActive(ctx, host, targetType)
-	if err != nil {
-		if errors.Is(err, storage.ErrNotFound) {
-			r.storeCache(key, nil, r.negativeCacheTTL)
-			return nil, &Error{Code: ErrNoRule, Message: "no active rule", Host: host, TargetType: string(targetType)}
-		}
-		return nil, fmt.Errorf("find active rule (%s, %s): %w", host, targetType, err)
+	if len(candidates) == 0 {
+		return nil, &Error{Code: ErrNoRule, Message: "no active rule (cached)", Host: host, TargetType: string(targetType)}
 	}
-	r.storeCache(key, rule, r.cacheTTL)
-	return rule, nil
+
+	// 후보 슬라이스는 LENGTH(path_pattern) DESC 로 정렬됨 — 더 구체적인 패턴부터 평가.
+	for _, c := range candidates {
+		if r.pathMatches(c.PathPattern, path) {
+			return c, nil
+		}
+	}
+	return nil, &Error{Code: ErrNoRule, Message: "no rule matched url path", Host: host, URL: path, TargetType: string(targetType)}
+}
+
+// pathMatches 는 path_pattern 이 path 와 매칭되는지 확인합니다 (이슈 #173).
+//
+//   - pattern=” → 모든 path 매칭 (catch-all)
+//   - pattern 컴파일 결과를 regexCache 에 보관 — 같은 패턴 재컴파일 회피
+//   - 컴파일 실패한 패턴은 매칭 안 됨으로 간주 (negative cache 로 보관)
+func (r *Resolver) pathMatches(pattern, path string) bool {
+	if pattern == "" {
+		return true
+	}
+	cp := r.compileRegex(pattern)
+	if cp.re == nil {
+		return false
+	}
+	return cp.re.MatchString(path)
+}
+
+// compileRegex 는 path_pattern 을 컴파일하고 결과를 sync.Map 에 캐시합니다 (이슈 #173).
+// 같은 패턴이 여러 host 또는 cache 만료 후 재fetch 되어도 컴파일은 1회만 발생.
+func (r *Resolver) compileRegex(pattern string) *compiledPattern {
+	if v, ok := r.regexCache.Load(pattern); ok {
+		return v.(*compiledPattern)
+	}
+	re, err := regexp.Compile(pattern)
+	cp := &compiledPattern{re: re, err: err}
+	if err != nil {
+		cp.re = nil
+	}
+	// LoadOrStore 로 race 시 첫 winner 의 결과를 보존 — 같은 패턴 두 goroutine 동시 컴파일도 안전.
+	actual, _ := r.regexCache.LoadOrStore(pattern, cp)
+	return actual.(*compiledPattern)
 }
 
 // Invalidate 는 (host, type) 의 cache entry 를 즉시 제거합니다 — 운영자가 rule 변경 직후 호출.
@@ -162,16 +228,16 @@ func (r *Resolver) InvalidateAll() {
 	r.mu.Unlock()
 }
 
-// lookupCache 는 캐시 조회 결과를 반환합니다.
-// 반환값: (rule, hit, negative) — hit=true 이면 캐시 적용, negative=true 이면 미매칭 캐시.
-func (r *Resolver) lookupCache(key cacheKey) (*storage.ParsingRuleRecord, bool, bool) {
+// lookupCache 는 캐시 조회 결과를 반환합니다 (이슈 #173).
+// 반환값: (candidates, hit) — hit=true 이면 캐시 적용 (negative cache 는 빈 슬라이스).
+func (r *Resolver) lookupCache(key cacheKey) ([]*storage.ParsingRuleRecord, bool) {
 	r.mu.RLock()
 	entry, ok := r.cache[key]
 	r.mu.RUnlock()
 	if !ok || r.now().After(entry.expiresAt) {
-		return nil, false, false
+		return nil, false
 	}
-	return entry.rule, true, entry.rule == nil
+	return entry.candidates, true
 }
 
 // evictExpiringSoon 은 cache 가 maxEntries 초과 시 가장 만료 임박한 entry 를 제거합니다.
@@ -198,26 +264,33 @@ func (r *Resolver) evictExpiringSoon() {
 	}
 }
 
-// storeCache 는 entry 를 저장합니다 (rule==nil 이면 negative cache).
+// storeCache 는 후보 슬라이스를 저장합니다 (이슈 #173 — 빈 슬라이스 = negative cache).
 // maxEntries 초과 시 evictExpiringSoon 으로 가장 만료 임박 entry 제거 후 저장.
-func (r *Resolver) storeCache(key cacheKey, rule *storage.ParsingRuleRecord, ttl time.Duration) {
+func (r *Resolver) storeCache(key cacheKey, candidates []*storage.ParsingRuleRecord, ttl time.Duration) {
 	r.mu.Lock()
 	r.evictExpiringSoon()
-	r.cache[key] = cacheEntry{rule: rule, expiresAt: r.now().Add(ttl)}
+	r.cache[key] = cacheEntry{candidates: candidates, expiresAt: r.now().Add(ttl)}
 	r.mu.Unlock()
 }
 
-// extractHost 는 URL 문자열에서 host (소문자) 를 추출합니다.
-func extractHost(rawURL string) (string, error) {
+// extractHostPath 는 URL 문자열에서 host (소문자) + path 를 추출합니다 (이슈 #173).
+//
+// host: 포트 제거 + 소문자.
+// path: URL.Path (raw path 아님 — percent-decoded 표현). 빈 path 는 "/" 로 정규화.
+func extractHostPath(rawURL string) (string, string, error) {
 	u, err := url.Parse(rawURL)
 	if err != nil {
-		return "", fmt.Errorf("parse url: %w", err)
+		return "", "", fmt.Errorf("parse url: %w", err)
 	}
 	// u.Hostname() — 포트 부분 ":8080" 을 제거 (Gemini code review 피드백).
 	// DB 의 host_pattern 이 순수 호스트네임이라 포트 포함 매칭 실패 회피.
 	host := u.Hostname()
 	if host == "" {
-		return "", fmt.Errorf("empty host in url %q", rawURL)
+		return "", "", fmt.Errorf("empty host in url %q", rawURL)
 	}
-	return strings.ToLower(host), nil
+	path := u.Path
+	if path == "" {
+		path = "/"
+	}
+	return strings.ToLower(host), path, nil
 }

--- a/internal/storage/errors.go
+++ b/internal/storage/errors.go
@@ -9,3 +9,7 @@ var ErrNotFound = errors.New("record not found")
 
 // ErrDuplicate는 유일성 제약 위반(예: URL 중복) 시 반환됩니다.
 var ErrDuplicate = errors.New("duplicate record")
+
+// ErrInvalid 는 record 의 형식이 유효하지 않을 때 반환됩니다 (이슈 #173).
+// 예: parsing_rules.path_pattern 이 RE2 컴파일 실패 — Repository 가 DB write 전 거부.
+var ErrInvalid = errors.New("invalid record")

--- a/internal/storage/parsing_rule.go
+++ b/internal/storage/parsing_rule.go
@@ -131,8 +131,9 @@ type ParsingRuleRecord struct {
 	ID          int64
 	SourceName  string     // "naver" / "cnn"
 	HostPattern string     // URL host 매칭 (예: "n.news.naver.com")
+	PathPattern string     // URL path regex (RE2). "" 면 모든 path 매칭 (이슈 #173 단계 1).
 	TargetType  TargetType // "page" | "list"
-	Version     int        // 활성 row 안에서 같은 (source, host, type) 의 최신 버전
+	Version     int        // 활성 row 안에서 같은 (source, host, path, type) 의 최신 버전
 	Enabled     bool
 	Selectors   SelectorMap // JSONB — application 측 struct 로 직렬화
 	Description string
@@ -169,7 +170,20 @@ type ParsingRuleRepository interface {
 	// FindActive 는 host + target_type 에 매칭되는 활성 규칙을 반환합니다 (RuleResolver 핫패스).
 	// 같은 (host, type) 에 여러 활성 row 가 있다면 version DESC 순으로 첫 항목 반환.
 	// 매칭 없으면 ErrNotFound.
+	//
+	// Deprecated (이슈 #173): path_pattern 도입 후 후보 슬라이스를 한꺼번에 받아 application 측에서
+	// 매칭하는 FindActiveCandidates 사용 권장. 본 메소드는 후방 호환을 위해 유지 — 내부적으로
+	// FindActiveCandidates 의 첫 항목 (length DESC 정렬, '' 포함) 을 반환합니다.
 	FindActive(ctx context.Context, host string, targetType TargetType) (*ParsingRuleRecord, error)
+
+	// FindActiveCandidates 는 host + target_type 매칭 활성 rule 들을 LENGTH(path_pattern) DESC,
+	// version DESC 정렬로 반환합니다 (이슈 #173 단계 1).
+	//
+	// Resolver 가 반환된 슬라이스를 application 측에서 URL path 와 regex 매칭 — 첫 매칭 rule 채택.
+	// path_pattern='' 인 row 는 길이 0 으로 가장 마지막에 위치 (catch-all).
+	//
+	// 매칭 없으면 빈 슬라이스 + nil 에러 (ErrNotFound 아님 — 호출자가 빈 슬라이스로 분기).
+	FindActiveCandidates(ctx context.Context, host string, targetType TargetType) ([]*ParsingRuleRecord, error)
 
 	// List 는 필터 조건에 맞는 규칙들을 반환합니다 (운영 대시보드용).
 	List(ctx context.Context, filter ParsingRuleFilter) ([]*ParsingRuleRecord, error)

--- a/internal/storage/postgres/parsing_rule.go
+++ b/internal/storage/postgres/parsing_rule.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"regexp"
 
 	"github.com/jackc/pgerrcode"
 	"github.com/jackc/pgx/v5"
@@ -32,16 +33,27 @@ func NewParsingRuleRepository(pool *pgxpool.Pool, log *logger.Logger) storage.Pa
 
 const sqlInsertParsingRule = `
 INSERT INTO parsing_rules (
-  source_name, host_pattern, target_type, version, enabled, selectors, description
+  source_name, host_pattern, path_pattern, target_type, version, enabled, selectors, description
 ) VALUES (
-  $1, $2, $3, $4, $5, $6, $7
+  $1, $2, $3, $4, $5, $6, $7, $8
 )
 RETURNING id, created_at, updated_at
 `
 
-// Insert 는 새 규칙을 저장합니다. 자연키 (source_name, host_pattern, target_type, version) 충돌 시
-// storage.ErrDuplicate 를 반환합니다. 성공 시 r.ID / CreatedAt / UpdatedAt 가 채워집니다.
+// Insert 는 새 규칙을 저장합니다. 자연키 (source_name, host_pattern, path_pattern, target_type, version)
+// 충돌 시 storage.ErrDuplicate 를 반환합니다.
+//
+// path_pattern 이 비어있지 않으면 RE2 컴파일 검증 — 실패 시 storage.ErrInvalid (이슈 #173).
+// DB write 전 마지막 방어선 — Resolver 가 매 호출마다 컴파일 실패한 패턴을 스킵하도록 두기보다,
+// INSERT 시점에 거부하는 것이 운영 가시성 ↑ + DB 에 잘못된 row 진입 차단.
+//
+// 성공 시 r.ID / CreatedAt / UpdatedAt 가 채워집니다.
 func (r *pgParsingRuleRepository) Insert(ctx context.Context, rec *storage.ParsingRuleRecord) error {
+	if rec.PathPattern != "" {
+		if _, reErr := regexp.Compile(rec.PathPattern); reErr != nil {
+			return fmt.Errorf("%w: path_pattern %q is not a valid regex: %v", storage.ErrInvalid, rec.PathPattern, reErr)
+		}
+	}
 	selectors, err := json.Marshal(rec.Selectors)
 	if err != nil {
 		return fmt.Errorf("marshal selectors: %w", err)
@@ -50,7 +62,7 @@ func (r *pgParsingRuleRepository) Insert(ctx context.Context, rec *storage.Parsi
 		rec.Version = 1
 	}
 	row := r.pool.QueryRow(ctx, sqlInsertParsingRule,
-		rec.SourceName, rec.HostPattern, string(rec.TargetType), rec.Version,
+		rec.SourceName, rec.HostPattern, rec.PathPattern, string(rec.TargetType), rec.Version,
 		rec.Enabled, selectors, rec.Description,
 	)
 	if err := row.Scan(&rec.ID, &rec.CreatedAt, &rec.UpdatedAt); err != nil {
@@ -70,7 +82,7 @@ WHERE id = $1
 RETURNING updated_at
 `
 
-// Update 는 ID 로 규칙을 갱신합니다. 자연키 (source/host/type/version) 는 변경 불가 —
+// Update 는 ID 로 규칙을 갱신합니다. 자연키 (source/host/path/type/version) 는 변경 불가 —
 // 규칙 진화는 새 row 를 INSERT 후 enabled flip 으로 표현 권장.
 func (r *pgParsingRuleRepository) Update(ctx context.Context, rec *storage.ParsingRuleRecord) error {
 	selectors, err := json.Marshal(rec.Selectors)
@@ -88,7 +100,7 @@ func (r *pgParsingRuleRepository) Update(ctx context.Context, rec *storage.Parsi
 }
 
 const sqlGetParsingRuleByID = `
-SELECT id, source_name, host_pattern, target_type, version, enabled, selectors, description, created_at, updated_at
+SELECT id, source_name, host_pattern, path_pattern, target_type, version, enabled, selectors, description, created_at, updated_at
 FROM parsing_rules
 WHERE id = $1
 `
@@ -106,28 +118,59 @@ func (r *pgParsingRuleRepository) GetByID(ctx context.Context, id int64) (*stora
 	return rec, nil
 }
 
-const sqlFindActiveParsingRule = `
-SELECT id, source_name, host_pattern, target_type, version, enabled, selectors, description, created_at, updated_at
+// sqlFindActiveCandidates 는 host + target_type 매칭 활성 rule 들을 후보 슬라이스로 반환합니다 (이슈 #173).
+//
+// 정렬:
+//   - LENGTH(path_pattern) DESC : 더 구체적인 (긴) regex 패턴 우선 (path_pattern=” 은 길이 0 으로 마지막)
+//   - version DESC             : 같은 패턴 안에서 최신 버전 우선
+const sqlFindActiveCandidates = `
+SELECT id, source_name, host_pattern, path_pattern, target_type, version, enabled, selectors, description, created_at, updated_at
 FROM parsing_rules
 WHERE host_pattern = $1
   AND target_type  = $2
   AND enabled      = TRUE
-ORDER BY version DESC
-LIMIT 1
+ORDER BY LENGTH(path_pattern) DESC, version DESC
 `
 
-// FindActive 는 host + target_type 매칭 활성 규칙을 반환합니다 (RuleResolver 핫패스).
-// 같은 (host, type) 에 여러 활성 row 가 있다면 version DESC 순으로 첫 항목.
+// FindActive 는 host + target_type 매칭 활성 규칙 1건을 반환합니다 (후방 호환).
+//
+// Deprecated (이슈 #173): path_pattern 도입 후 후보 슬라이스를 받아 application 측에서 path 매칭하는
+// FindActiveCandidates 사용 권장. 본 메소드는 호출자 호환을 위해 유지 — 내부적으로 후보 슬라이스의
+// 첫 항목 (가장 구체적 또는 최신) 을 반환. ErrNotFound 시 storage.ErrNotFound.
 func (r *pgParsingRuleRepository) FindActive(ctx context.Context, host string, targetType storage.TargetType) (*storage.ParsingRuleRecord, error) {
-	row := r.pool.QueryRow(ctx, sqlFindActiveParsingRule, host, string(targetType))
-	rec, err := scanParsingRule(row)
+	candidates, err := r.FindActiveCandidates(ctx, host, targetType)
 	if err != nil {
-		if errors.Is(err, pgx.ErrNoRows) {
-			return nil, storage.ErrNotFound
-		}
-		return nil, fmt.Errorf("find active parsing rule (%s, %s): %w", host, targetType, err)
+		return nil, err
 	}
-	return rec, nil
+	if len(candidates) == 0 {
+		return nil, storage.ErrNotFound
+	}
+	return candidates[0], nil
+}
+
+// FindActiveCandidates 는 host + target_type 매칭 활성 rule 들을 LENGTH(path_pattern) DESC,
+// version DESC 정렬로 반환합니다 (이슈 #173).
+//
+// 매칭 없으면 빈 슬라이스 + nil 에러 (호출자가 빈 슬라이스로 분기).
+func (r *pgParsingRuleRepository) FindActiveCandidates(ctx context.Context, host string, targetType storage.TargetType) ([]*storage.ParsingRuleRecord, error) {
+	rows, err := r.pool.Query(ctx, sqlFindActiveCandidates, host, string(targetType))
+	if err != nil {
+		return nil, fmt.Errorf("find active candidates (%s, %s): %w", host, targetType, err)
+	}
+	defer rows.Close()
+
+	var out []*storage.ParsingRuleRecord
+	for rows.Next() {
+		rec, scanErr := scanParsingRule(rows)
+		if scanErr != nil {
+			return nil, fmt.Errorf("scan candidate: %w", scanErr)
+		}
+		out = append(out, rec)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate candidates: %w", err)
+	}
+	return out, nil
 }
 
 // List 는 필터 조건에 맞는 규칙들을 반환합니다.
@@ -138,7 +181,7 @@ func (r *pgParsingRuleRepository) List(ctx context.Context, f storage.ParsingRul
 	}
 
 	query := `
-SELECT id, source_name, host_pattern, target_type, version, enabled, selectors, description, created_at, updated_at
+SELECT id, source_name, host_pattern, path_pattern, target_type, version, enabled, selectors, description, created_at, updated_at
 FROM parsing_rules
 WHERE 1=1`
 	args := make([]any, 0, 4)
@@ -203,7 +246,7 @@ func scanParsingRule(s scanner) (*storage.ParsingRuleRecord, error) {
 	var selectorsRaw []byte
 	var targetType string
 	if err := s.Scan(
-		&rec.ID, &rec.SourceName, &rec.HostPattern, &targetType, &rec.Version,
+		&rec.ID, &rec.SourceName, &rec.HostPattern, &rec.PathPattern, &targetType, &rec.Version,
 		&rec.Enabled, &selectorsRaw, &rec.Description, &rec.CreatedAt, &rec.UpdatedAt,
 	); err != nil {
 		return nil, err

--- a/migrations/down/011_parsing_rules_path_pattern.sql
+++ b/migrations/down/011_parsing_rules_path_pattern.sql
@@ -1,0 +1,16 @@
+-- 011_parsing_rules_path_pattern (down): path_pattern 컬럼 제거 + 기존 자연키 복원
+--
+-- 주의:
+--   동일 (host_pattern, target_type, version) 에 path_pattern 만 다른 row 가 두 개 이상 존재하면
+--   복원된 UNIQUE constraint 위반으로 ADD 가 실패한다. 운영자는 down 적용 전 중복 row 를 정리해야 한다
+--   (예: path_pattern='' 인 row 만 남기거나, 가장 우선순위 높은 row 만 enabled 로 두고 나머지 삭제).
+
+ALTER TABLE parsing_rules
+  DROP CONSTRAINT IF EXISTS parsing_rules_lookup_key_unique;
+
+ALTER TABLE parsing_rules
+  ADD CONSTRAINT parsing_rules_lookup_key_unique
+    UNIQUE (host_pattern, target_type, version);
+
+ALTER TABLE parsing_rules
+  DROP COLUMN IF EXISTS path_pattern;

--- a/migrations/up/011_parsing_rules_path_pattern.sql
+++ b/migrations/up/011_parsing_rules_path_pattern.sql
@@ -1,0 +1,32 @@
+-- 011_parsing_rules_path_pattern: parsing_rules 에 path_pattern 컬럼 추가 (이슈 #173 단계 1)
+--
+-- 배경:
+--   기존 lookup 키 (host_pattern, target_type) 는 같은 호스트의 모든 페이지를 단일 rule 로
+--   처리. SPA / 다양한 페이지 종류가 섞인 사이트는 표현 불가. 본 migration 은 path 기반 정밀
+--   매칭을 위한 인프라 (컬럼 + UNIQUE + 검증) 를 추가한다.
+--
+-- 호환성:
+--   - path_pattern DEFAULT '' (모든 path 매칭) — 기존 모든 row 의 동작 100% 보존
+--   - 신규 운영자/LLM 자동 생성 rule 만 path_pattern 명시 가능
+--   - application 측 (Resolver) 가 host 매칭 후보 슬라이스를 받아 regex 매칭
+--
+-- 매칭 정책:
+--   - SQL 단계: host_pattern + target_type + enabled 로 후보 슬라이스 fetch
+--     (application 측 옵션 B — DB regex 평가 회피, index 활용)
+--   - application 단계: path_pattern regex 길이 DESC 정렬, 길이 긴 (구체적) 패턴 우선
+--   - path_pattern='' 은 모든 path 매칭 (length 0 이라 가장 마지막 후보)
+
+ALTER TABLE parsing_rules
+  ADD COLUMN IF NOT EXISTS path_pattern TEXT NOT NULL DEFAULT '';
+
+-- 자연키 변경: (host_pattern, target_type, version) → (host_pattern, path_pattern, target_type, version)
+-- 같은 host 의 다른 path_pattern 은 별개 rule 로 운영 가능 (예: /article/.* 와 /sports/.* 가 다른 selector).
+ALTER TABLE parsing_rules
+  DROP CONSTRAINT IF EXISTS parsing_rules_lookup_key_unique;
+
+ALTER TABLE parsing_rules
+  ADD CONSTRAINT parsing_rules_lookup_key_unique
+    UNIQUE (host_pattern, path_pattern, target_type, version);
+
+-- idx_parsing_rules_lookup 은 그대로 유지 — Resolver 가 host_pattern + target_type 으로 후보 slice 를
+-- fetch 하고 application 측에서 path_pattern regex 매칭. SQL 레벨엔 path_pattern 필터 없음.

--- a/test/internal/parser/rule/resolver_test.go
+++ b/test/internal/parser/rule/resolver_test.go
@@ -3,6 +3,7 @@ package rule_test
 import (
 	"context"
 	"errors"
+	"sort"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -63,20 +64,15 @@ func (r *fakeRepo) FindActiveCandidates(_ context.Context, host string, t storag
 
 func (r *fakeRepo) calls() int { return int(atomic.LoadInt64(&r.findActiveCalls)) }
 
-// sortByPathPatternLengthDesc 는 stable insertion sort — LENGTH(path_pattern) DESC.
-// postgres 의 ORDER BY LENGTH(path_pattern) DESC, version DESC 와 동일 동작.
+// sortByPathPatternLengthDesc 는 LENGTH(path_pattern) DESC, version DESC 정렬을 수행합니다.
+// postgres 의 ORDER BY LENGTH(path_pattern) DESC, version DESC 와 동일 동작 (PR #181 gemini 피드백).
 func sortByPathPatternLengthDesc(s []*storage.ParsingRuleRecord) {
-	for i := 1; i < len(s); i++ {
-		for j := i; j > 0; j-- {
-			ai, aj := s[j], s[j-1]
-			if len(ai.PathPattern) > len(aj.PathPattern) ||
-				(len(ai.PathPattern) == len(aj.PathPattern) && ai.Version > aj.Version) {
-				s[j], s[j-1] = s[j-1], s[j]
-			} else {
-				break
-			}
+	sort.SliceStable(s, func(i, j int) bool {
+		if len(s[i].PathPattern) != len(s[j].PathPattern) {
+			return len(s[i].PathPattern) > len(s[j].PathPattern)
 		}
-	}
+		return s[i].Version > s[j].Version
+	})
 }
 
 func samplePageRule(host string) *storage.ParsingRuleRecord {

--- a/test/internal/parser/rule/resolver_test.go
+++ b/test/internal/parser/rule/resolver_test.go
@@ -15,10 +15,10 @@ import (
 )
 
 // fakeRepo 는 in-memory ParsingRuleRepository 구현입니다.
-// FindActive 호출 횟수를 atomic 으로 추적하여 cache 동작을 검증합니다.
+// FindActiveCandidates 호출 횟수를 atomic 으로 추적하여 cache 동작을 검증합니다.
 type fakeRepo struct {
-	rules           []*storage.ParsingRuleRecord // FindActive 매칭 후보
-	notFound        bool                         // true 면 항상 ErrNotFound
+	rules           []*storage.ParsingRuleRecord // FindActiveCandidates 매칭 후보
+	notFound        bool                         // true 면 항상 빈 슬라이스 (negative cache 시뮬레이션)
 	findActiveCalls int64
 }
 
@@ -32,20 +32,52 @@ func (r *fakeRepo) List(_ context.Context, _ storage.ParsingRuleFilter) ([]*stor
 }
 func (r *fakeRepo) Delete(_ context.Context, _ int64) error { return nil }
 
-func (r *fakeRepo) FindActive(_ context.Context, host string, t storage.TargetType) (*storage.ParsingRuleRecord, error) {
-	atomic.AddInt64(&r.findActiveCalls, 1)
-	if r.notFound {
+// FindActive 는 FindActiveCandidates 의 첫 항목을 반환 (이슈 #173 후방 호환).
+func (r *fakeRepo) FindActive(ctx context.Context, host string, t storage.TargetType) (*storage.ParsingRuleRecord, error) {
+	candidates, err := r.FindActiveCandidates(ctx, host, t)
+	if err != nil {
+		return nil, err
+	}
+	if len(candidates) == 0 {
 		return nil, storage.ErrNotFound
 	}
+	return candidates[0], nil
+}
+
+// FindActiveCandidates 는 host + target_type 매칭 슬라이스 반환. LENGTH(path_pattern) DESC 정렬 시뮬레이션.
+func (r *fakeRepo) FindActiveCandidates(_ context.Context, host string, t storage.TargetType) ([]*storage.ParsingRuleRecord, error) {
+	atomic.AddInt64(&r.findActiveCalls, 1)
+	if r.notFound {
+		return nil, nil
+	}
+	out := make([]*storage.ParsingRuleRecord, 0)
 	for _, rec := range r.rules {
-		if rec.HostPattern == host && rec.TargetType == t {
-			return rec, nil
+		if rec.HostPattern == host && rec.TargetType == t && rec.Enabled {
+			out = append(out, rec)
 		}
 	}
-	return nil, storage.ErrNotFound
+	// LENGTH(path_pattern) DESC stable sort (postgres 의 정렬과 동일)
+	sortByPathPatternLengthDesc(out)
+	return out, nil
 }
 
 func (r *fakeRepo) calls() int { return int(atomic.LoadInt64(&r.findActiveCalls)) }
+
+// sortByPathPatternLengthDesc 는 stable insertion sort — LENGTH(path_pattern) DESC.
+// postgres 의 ORDER BY LENGTH(path_pattern) DESC, version DESC 와 동일 동작.
+func sortByPathPatternLengthDesc(s []*storage.ParsingRuleRecord) {
+	for i := 1; i < len(s); i++ {
+		for j := i; j > 0; j-- {
+			ai, aj := s[j], s[j-1]
+			if len(ai.PathPattern) > len(aj.PathPattern) ||
+				(len(ai.PathPattern) == len(aj.PathPattern) && ai.Version > aj.Version) {
+				s[j], s[j-1] = s[j-1], s[j]
+			} else {
+				break
+			}
+		}
+	}
+}
 
 func samplePageRule(host string) *storage.ParsingRuleRecord {
 	return &storage.ParsingRuleRecord{
@@ -101,7 +133,7 @@ func TestResolver_NoMatch_ReturnsErrNoRule(t *testing.T) {
 	repo := &fakeRepo{notFound: true}
 	r := rule.NewResolver(repo)
 
-	_, err := r.Resolve(context.Background(), "no-rule.example.com", storage.TargetTypePage)
+	_, err := r.Resolve(context.Background(), "no-rule.example.com", "/", storage.TargetTypePage)
 	require.Error(t, err)
 	assert.True(t, errors.Is(err, &rule.Error{Code: rule.ErrNoRule}))
 }
@@ -115,13 +147,13 @@ func TestResolver_Cache_HitsAvoidRepoCall(t *testing.T) {
 	r := rule.NewResolver(repo)
 
 	// 첫 호출 → repo 1
-	_, err := r.Resolve(context.Background(), "news.example.com", storage.TargetTypePage)
+	_, err := r.Resolve(context.Background(), "news.example.com", "/", storage.TargetTypePage)
 	require.NoError(t, err)
 	assert.Equal(t, 1, repo.calls())
 
 	// 후속 호출 → cache hit, repo 호출 X
 	for i := 0; i < 5; i++ {
-		_, err := r.Resolve(context.Background(), "news.example.com", storage.TargetTypePage)
+		_, err := r.Resolve(context.Background(), "news.example.com", "/", storage.TargetTypePage)
 		require.NoError(t, err)
 	}
 	assert.Equal(t, 1, repo.calls(), "양성 cache hit — 추가 repo 호출 없어야 함")
@@ -132,7 +164,7 @@ func TestResolver_NegativeCache_AvoidRepoCallForMissingHost(t *testing.T) {
 	r := rule.NewResolver(repo)
 
 	for i := 0; i < 5; i++ {
-		_, err := r.Resolve(context.Background(), "missing.example.com", storage.TargetTypePage)
+		_, err := r.Resolve(context.Background(), "missing.example.com", "/", storage.TargetTypePage)
 		require.Error(t, err)
 	}
 	assert.Equal(t, 1, repo.calls(), "negative cache 도 repo 폭주 회피")
@@ -142,15 +174,15 @@ func TestResolver_Invalidate_ForcesRepoCall(t *testing.T) {
 	repo := &fakeRepo{rules: []*storage.ParsingRuleRecord{samplePageRule("news.example.com")}}
 	r := rule.NewResolver(repo)
 
-	_, err := r.Resolve(context.Background(), "news.example.com", storage.TargetTypePage)
+	_, err := r.Resolve(context.Background(), "news.example.com", "/", storage.TargetTypePage)
 	require.NoError(t, err)
-	_, err = r.Resolve(context.Background(), "news.example.com", storage.TargetTypePage)
+	_, err = r.Resolve(context.Background(), "news.example.com", "/", storage.TargetTypePage)
 	require.NoError(t, err)
 	assert.Equal(t, 1, repo.calls())
 
 	r.Invalidate("news.example.com", storage.TargetTypePage)
 
-	_, err = r.Resolve(context.Background(), "news.example.com", storage.TargetTypePage)
+	_, err = r.Resolve(context.Background(), "news.example.com", "/", storage.TargetTypePage)
 	require.NoError(t, err)
 	assert.Equal(t, 2, repo.calls(), "Invalidate 후 다음 호출은 repo 다시 도달")
 }
@@ -162,17 +194,17 @@ func TestResolver_InvalidateAll_ClearsAllEntries(t *testing.T) {
 	}}
 	r := rule.NewResolver(repo)
 
-	_, err := r.Resolve(context.Background(), "a.example.com", storage.TargetTypePage)
+	_, err := r.Resolve(context.Background(), "a.example.com", "/", storage.TargetTypePage)
 	require.NoError(t, err)
-	_, err = r.Resolve(context.Background(), "b.example.com", storage.TargetTypePage)
+	_, err = r.Resolve(context.Background(), "b.example.com", "/", storage.TargetTypePage)
 	require.NoError(t, err)
 	assert.Equal(t, 2, repo.calls())
 
 	r.InvalidateAll()
 
-	_, err = r.Resolve(context.Background(), "a.example.com", storage.TargetTypePage)
+	_, err = r.Resolve(context.Background(), "a.example.com", "/", storage.TargetTypePage)
 	require.NoError(t, err)
-	_, err = r.Resolve(context.Background(), "b.example.com", storage.TargetTypePage)
+	_, err = r.Resolve(context.Background(), "b.example.com", "/", storage.TargetTypePage)
 	require.NoError(t, err)
 	assert.Equal(t, 4, repo.calls())
 }
@@ -182,13 +214,13 @@ func TestResolver_CacheTTL_ExpiresAfterDuration(t *testing.T) {
 	// TTL 50ms — 테스트 친화적 짧은 시간
 	r := rule.NewResolver(repo, rule.WithCacheTTL(50*time.Millisecond))
 
-	_, err := r.Resolve(context.Background(), "news.example.com", storage.TargetTypePage)
+	_, err := r.Resolve(context.Background(), "news.example.com", "/", storage.TargetTypePage)
 	require.NoError(t, err)
 	assert.Equal(t, 1, repo.calls())
 
 	time.Sleep(80 * time.Millisecond)
 
-	_, err = r.Resolve(context.Background(), "news.example.com", storage.TargetTypePage)
+	_, err = r.Resolve(context.Background(), "news.example.com", "/", storage.TargetTypePage)
 	require.NoError(t, err)
 	assert.Equal(t, 2, repo.calls(), "TTL 만료 후 repo 다시 호출")
 }
@@ -197,4 +229,113 @@ func TestNewResolver_NilRepo_Panics(t *testing.T) {
 	assert.PanicsWithValue(t, "rule: NewResolver requires non-nil repo", func() {
 		rule.NewResolver(nil)
 	})
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Path pattern 매칭 (이슈 #173 단계 1)
+// ─────────────────────────────────────────────────────────────────────────────
+
+// path_pattern=” (catch-all) rule 만 있을 때 어떤 path 든 매칭됨 — 기존 동작 보존.
+func TestResolver_PathPattern_EmptyMatchesAnyPath(t *testing.T) {
+	repo := &fakeRepo{rules: []*storage.ParsingRuleRecord{samplePageRule("news.example.com")}}
+	r := rule.NewResolver(repo)
+
+	for _, path := range []string{"/", "/article/1", "/sports/breaking-news", "/about"} {
+		got, err := r.Resolve(context.Background(), "news.example.com", path, storage.TargetTypePage)
+		require.NoError(t, err, "path=%s", path)
+		assert.Equal(t, "news.example.com", got.HostPattern, "path=%s", path)
+	}
+}
+
+// 같은 host 에 path_pattern 이 여러 개일 때 더 구체적인 (긴) 패턴이 우선 매칭됨.
+func TestResolver_PathPattern_LongerPatternWinsOverCatchAll(t *testing.T) {
+	specific := samplePageRule("news.example.com")
+	specific.ID = 2
+	specific.Version = 2
+	specific.PathPattern = "^/sports/.*$"
+	specific.Selectors.Title = &storage.FieldSelector{CSS: "h1.sports-headline"}
+
+	catchAll := samplePageRule("news.example.com") // PathPattern="" 기본
+	catchAll.Selectors.Title = &storage.FieldSelector{CSS: "h1.default"}
+
+	repo := &fakeRepo{rules: []*storage.ParsingRuleRecord{specific, catchAll}}
+	r := rule.NewResolver(repo)
+
+	// /sports/* path 는 specific rule 매칭 (LENGTH DESC 정렬상 우선)
+	got, err := r.Resolve(context.Background(), "news.example.com", "/sports/breaking", storage.TargetTypePage)
+	require.NoError(t, err)
+	assert.Equal(t, "h1.sports-headline", got.Selectors.Title.CSS, "더 구체적인 path_pattern 우선")
+
+	// /article/* path 는 catch-all 매칭
+	got, err = r.Resolve(context.Background(), "news.example.com", "/article/123", storage.TargetTypePage)
+	require.NoError(t, err)
+	assert.Equal(t, "h1.default", got.Selectors.Title.CSS, "specific 미매칭 시 catch-all fallback")
+}
+
+// path_pattern 이 모두 매칭 안 되고 catch-all 도 없으면 ErrNoRule.
+func TestResolver_PathPattern_NoMatchReturnsErrNoRule(t *testing.T) {
+	specific := samplePageRule("news.example.com")
+	specific.PathPattern = "^/sports/.*$"
+
+	repo := &fakeRepo{rules: []*storage.ParsingRuleRecord{specific}}
+	r := rule.NewResolver(repo)
+
+	_, err := r.Resolve(context.Background(), "news.example.com", "/about", storage.TargetTypePage)
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, &rule.Error{Code: rule.ErrNoRule}))
+}
+
+// 잘못된 regex 패턴은 매칭 실패로 간주 (compileRegex negative cache).
+// Resolver 가 panic 하지 않고 다음 후보로 넘어감.
+func TestResolver_PathPattern_InvalidRegexFallsThrough(t *testing.T) {
+	bad := samplePageRule("news.example.com")
+	bad.ID = 2
+	bad.Version = 2
+	bad.PathPattern = "[unclosed-bracket" // 컴파일 실패
+
+	catchAll := samplePageRule("news.example.com") // PathPattern=""
+	catchAll.Selectors.Title = &storage.FieldSelector{CSS: "h1.default"}
+
+	repo := &fakeRepo{rules: []*storage.ParsingRuleRecord{bad, catchAll}}
+	r := rule.NewResolver(repo)
+
+	got, err := r.Resolve(context.Background(), "news.example.com", "/article/1", storage.TargetTypePage)
+	require.NoError(t, err)
+	assert.Equal(t, "h1.default", got.Selectors.Title.CSS, "잘못된 regex 는 skip 되고 catch-all fallback")
+}
+
+// 같은 패턴 여러 host 에 사용해도 컴파일은 1회 (regexCache 동작).
+// 직접 카운터 노출 안 됨 — 동일 패턴으로 다중 lookup 시 정상 동작 + 회귀 없음 검증.
+func TestResolver_PathPattern_RegexCacheReuseAcrossHosts(t *testing.T) {
+	pattern := "^/news/[0-9]+$"
+
+	a := samplePageRule("a.example.com")
+	a.PathPattern = pattern
+	b := samplePageRule("b.example.com")
+	b.PathPattern = pattern
+
+	repo := &fakeRepo{rules: []*storage.ParsingRuleRecord{a, b}}
+	r := rule.NewResolver(repo)
+
+	got, err := r.Resolve(context.Background(), "a.example.com", "/news/123", storage.TargetTypePage)
+	require.NoError(t, err)
+	assert.Equal(t, "a.example.com", got.HostPattern)
+
+	got, err = r.Resolve(context.Background(), "b.example.com", "/news/456", storage.TargetTypePage)
+	require.NoError(t, err)
+	assert.Equal(t, "b.example.com", got.HostPattern)
+}
+
+// ResolveByURL 이 host + path 모두 추출 + 매칭.
+func TestResolver_ResolveByURL_PathPatternMatching(t *testing.T) {
+	specific := samplePageRule("news.example.com")
+	specific.PathPattern = "^/article/[0-9]+$"
+	specific.Selectors.Title = &storage.FieldSelector{CSS: "h1.article"}
+
+	repo := &fakeRepo{rules: []*storage.ParsingRuleRecord{specific}}
+	r := rule.NewResolver(repo)
+
+	got, err := r.ResolveByURL(context.Background(), "https://news.example.com/article/12345?utm=x", storage.TargetTypePage)
+	require.NoError(t, err)
+	assert.Equal(t, "h1.article", got.Selectors.Title.CSS, "URL.Path 가 path_pattern 매칭")
 }


### PR DESCRIPTION
## 연관 이슈
- Closes #173 의 **단계 1 (URI 매칭 인프라)**.
- 단계 2~4 는 본 PR 머지 후 별도 sub-issue + PR 로 추적 (운영 단순성 + CI Linked Issue Check 정책 일관).

<br>

## 구현 내용

이슈 #173 의 사전 합의된 정책 (이슈 본문 \"결정된 정책\" 표) 그대로 구현 — 본 PR 은 단계 1 만.

| 항목 | 정책 | 본 PR 적용 |
|---|---|---|
| 매칭 위치 | Application 측 | ✅ |
| Cache | host 단위 유지 (rule 슬라이스 보관) | ✅ |
| 우선순위 | `LENGTH(path_pattern) DESC, version DESC` | ✅ |
| 호환성 | `path_pattern=''` (catch-all) default | ✅ — 기존 row 동작 100% 보존 |

### Commit 분할 (2개)

1. `[FEAT]: parsing_rules path_pattern 컬럼 + FindActiveCandidates 도입`
   - migration 011: `path_pattern TEXT NOT NULL DEFAULT ''` + UNIQUE 자연키 갱신 (host_pattern, path_pattern, target_type, version)
   - storage.ParsingRuleRecord 에 PathPattern 필드
   - 신규 메소드 `FindActiveCandidates(host, type) []*Record` — `LENGTH(path_pattern) DESC, version DESC` 정렬
   - 기존 `FindActive` 는 deprecated 표기 + 후방 호환 shim
   - **INSERT 안전 가드**: PathPattern 비어있지 않으면 RE2 컴파일 검증 → `storage.ErrInvalid` (DB write 전 차단)
   - 신규 `storage.ErrInvalid` sentinel

2. `[FEAT]: Resolver 에 path 매칭 + regex compile cache 도입`
   - cacheEntry: 단일 rule → `[]*ParsingRuleRecord` 슬라이스
   - `Resolve(host, path, type)`: URL.Path 인자 추가 — application 측 regex 매칭
   - `ResolveByURL`: host + path 동시 추출 (빈 path 는 \"/\" 정규화)
   - `pathMatches`: `''` (catch-all) 또는 RE2 매칭. **컴파일 실패 패턴은 skip 후 다음 후보로 fall-through**
   - `compileRegex`: `sync.Map` 기반 lock-free regex compile cache + LoadOrStore race 안전
   - main.go `verifyParsingRulesSeeded` 호출에 `\"/\"` 인자 추가
   - 단위 테스트 5건 신규 (catch-all / 길이 우선 / 매칭 없음 / 잘못된 regex skip / 다중 host regex 재사용 / ResolveByURL 종단간)

### 보호 효과

- 같은 host 의 페이지 종류별 selector 표현 가능 (예: `/article/.*` vs `/sports/.*` 가 다른 selector)
- 운영자가 직접 path_pattern 작성 가능 (단계 2/3 의 자동 생성 없이도 활용)
- 더 구체적인 패턴이 catch-all 보다 우선 매칭 — 점진 정밀화의 기반

### 호환성

- `path_pattern=''` default → 기존 모든 row 의 동작 변경 0
- 기존 `FindActive` 메소드 호출자 모두 동일하게 동작 (shim 으로 첫 후보 반환)
- migration up/down 모두 작성 — 운영 환경 rollback 가능 (단 down 시 `path_pattern != ''` row 가 두 개 이상이면 UNIQUE 충돌 — 운영 매뉴얼 명시)

<br>

## CI / 머지 게이트 점검

### 변경 영향 범위
- 영향 패키지/모듈:
  - `migrations/` (011 신규)
  - `internal/storage` (PathPattern 필드 + FindActiveCandidates + ErrInvalid)
  - `internal/storage/postgres` (SQL + RE2 검증)
  - `internal/crawler/parser/rule` (Resolver 시그니처 + path 매칭 + regex cache)
  - `cmd/issuetracker` (verifyParsingRulesSeeded 호출 1줄 변경)
- 위험도: **Medium**
  - **`Resolve(host, type)` → `Resolve(host, path, type)` 시그니처 변경** — 호출처는 main.go + 내부 (parser.go) 만, 모두 갱신
  - DB UNIQUE 변경 — DEFAULT '' 라 기존 row 충돌 없음
  - `FindActive` 후방 호환 shim 으로 외부 영향 0

### Required Status Checks
- 통과 확인 대상:
  - [ ] `Commit Lint`
  - [ ] `PR Title Lint`
  - [ ] `Linked Issue Check`
  - [ ] `Format Check`
  - [ ] `Build`
  - [ ] `Test`
  - [ ] `Lint`

### 롤백 계획
- 환경 영향 없음 — `path_pattern=''` default 라 기존 운영 동작 유지
- 코드 롤백: 본 PR revert
- DB 롤백: `migrations/down/011` — `path_pattern` 컬럼 drop + UNIQUE 복원
  - 주의: `path_pattern != ''` 인 row 가 두 개 이상 누적되면 down 적용 시 UNIQUE 충돌 (운영 매뉴얼에 명시)

<br>

## TODO (이슈 #173 의 후속 단계 — 본 PR 머지 후 별도 sub-issue 생성 예정)

- [ ] **단계 2** — 알고리즘 기반 path 패턴 추출 (numeric/UUID/slug heuristic)
- [ ] **단계 3** — LLM 기반 path 패턴 추출 + 검증 (positive/negative 매칭)
- [ ] **단계 4** — 점진적 정밀화 워크플로 (sample 누적 → path 갱신 트리거)
- [ ] **PoC 권장** (단계 3 진입 전): 5개 호스트 \* sample 5+5 으로 LLM regex 생성 품질 측정

<br>

## 논의 사항

- **Resolver 의 path 매칭은 매 호출마다 실행** — cache hit path 안에서 regex 매칭. 비용은 ms 미만 (regex 컴파일은 별도 sync.Map cache). 호스트 당 rule 수가 수십 개로 폭증하면 P99 latency 영향 가능 — 운영 metric 으로 추적 후 단계 4 의 \"host 당 rule 수 cap\" 정책 검토 권장.
- **잘못된 regex 의 처리 정책**: INSERT 시 거부 + Resolver 도 skip + fall-through (방어 다중화). 운영자가 잘못된 패턴을 직접 SQL UPDATE 로 주입한 경우에도 방어 — 시스템은 catch-all 으로 fallback 후 정상 동작.