### PR TITLE
[FEAT#182] pathinfer 알고리즘 모듈 — sample URL 기반 path_pattern 추론 (이슈 #173 단계 2)

### DIFF
--- a/internal/crawler/parser/rule/pathinfer/pathinfer.go
+++ b/internal/crawler/parser/rule/pathinfer/pathinfer.go
@@ -27,10 +27,36 @@ import (
 	"strings"
 )
 
-// minSamplesForInference 는 휴리스틱이 의미 있는 패턴을 추출하기 위한 최소 sample 수입니다.
+// DefaultMinSamples 는 휴리스틱이 의미 있는 패턴을 추출하기 위한 최소 sample 수의 default 입니다.
 // 1-2 개로는 \"공통 prefix vs 변수 부분\" 구분이 의미 없음 (모든 segment 가 \"공통\" 으로 보임).
 // 3+ 개면 변수 부분의 다양성을 검출 가능.
-const minSamplesForInference = 3
+//
+// 호출자는 WithMinSamples 옵션으로 override 가능 — 운영자가 환경변수로 조정 가능하도록
+// (예: pkg/config.LoadPathInfer 에서 PATHINFER_MIN_SAMPLES 읽어 InferHeuristic 에 전달).
+const DefaultMinSamples = 3
+
+// Option 은 InferHeuristic 의 동작을 변경하는 함수형 옵션입니다.
+type Option func(*config)
+
+// config 는 InferHeuristic 의 내부 설정입니다.
+// 외부에서 직접 변경할 수 없으며 Option 함수를 통해서만 구성됩니다.
+type config struct {
+	minSamples int
+}
+
+// WithMinSamples 는 추론에 필요한 최소 sample 수를 override 합니다.
+// n <= 0 은 무시되고 default (DefaultMinSamples) 가 유지됩니다.
+//
+// 운영 권장: 너무 낮은 값 (1-2) 은 \"공통 vs 변수\" 구분이 의미 없어 추론 품질 저하.
+// 너무 높은 값 (10+) 은 sample 수집 시간이 길어 정밀화 트리거 지연.
+// default 3 이 균형점.
+func WithMinSamples(n int) Option {
+	return func(c *config) {
+		if n > 0 {
+			c.minSamples = n
+		}
+	}
+}
 
 // PathSamples 는 휴리스틱 추론에 사용할 입력입니다.
 //
@@ -42,17 +68,24 @@ type PathSamples struct {
 
 // InferHeuristic 은 PathSamples 로부터 path_pattern regex 를 추론합니다 (이슈 #173 단계 2).
 //
+// opts 로 동작 override 가능 — WithMinSamples 등 (운영자 환경변수 주입용).
+// 미지정 시 default config (DefaultMinSamples = 3) 적용.
+//
 // 반환값:
 //   - regex string: 결과 RE2 패턴 (^...$ 앵커 포함). ok=false 면 빈 문자열.
 //   - ok bool     : 신뢰도. 다음 조건 중 하나라도 만족하지 않으면 false:
-//     1. samples 가 minSamplesForInference 미만
+//     1. samples 가 cfg.minSamples 미만
 //     2. samples 의 segment 길이가 일정하지 않음
 //     3. 변수 부분 segment 에서 공통 패턴을 찾지 못함
 //     4. 결과 regex 가 입력 samples 전체를 매칭하지 못함
 //
-// 결정성: 동일 입력 → 동일 출력. test 친화 + 운영 디버깅 용이.
-func InferHeuristic(samples PathSamples) (string, bool) {
-	if len(samples.Articles) < minSamplesForInference {
+// 결정성: 동일 입력 + 동일 옵션 → 동일 출력. test 친화 + 운영 디버깅 용이.
+func InferHeuristic(samples PathSamples, opts ...Option) (string, bool) {
+	cfg := config{minSamples: DefaultMinSamples}
+	for _, o := range opts {
+		o(&cfg)
+	}
+	if len(samples.Articles) < cfg.minSamples {
 		return "", false
 	}
 

--- a/internal/crawler/parser/rule/pathinfer/pathinfer.go
+++ b/internal/crawler/parser/rule/pathinfer/pathinfer.go
@@ -1,0 +1,199 @@
+// Package pathinfer 는 같은 호스트의 sample URL 들로부터 path_pattern regex 를
+// 알고리즘 기반으로 추론합니다 (이슈 #173 단계 2).
+//
+// 본 패키지는 **LLM 의존 없는 결정적 휴리스틱** 만 다룹니다 — 70-80% 의 단순 ID
+// 패턴 (numeric/UUID/slug/연도-월) 케이스를 cover. 모호한 케이스는 ok=false 로
+// 반환하여 호출자가 LLM 기반 추론 (단계 3) 또는 host-only catch-all 유지로 분기.
+//
+// 위치 결정 (이슈 본문은 llmgen/pathinfer 제안):
+//
+//	본 패키지는 LLM 무관 — llmgen 패키지 아래 두면 의존 분리 깨짐.
+//	단계 3 (LLM 추론) 이 도입되면 llmgen 측에서 본 패키지를 import 하여 알고리즘 우선
+//	시도 + 실패 시 LLM fallback 으로 합성하는 hybrid 흐름 구성.
+//
+// Algorithm 개요 (InferHeuristic 참조):
+//  1. 입력 sample URL path 들을 segment 슬라이스로 분리 ("/article/123" → ["article", "123"]).
+//  2. segment 길이가 모두 같지 않으면 ok=false (구조적 변형 — 휴리스틱으로 처리 어려움).
+//  3. 각 segment index 별로:
+//     - 모든 sample 에서 동일 텍스트 → 정적 prefix (정규식 escape 후 그대로 사용).
+//     - 다르면 → 변수 부분: 각 sample 의 동일 패턴 인식 (\\d+ / UUID / slug / 연도) →
+//     공통 패턴 발견 시 그 regex 사용. 모두 다른 종류면 ok=false.
+//  4. 결과 regex: "^/static/(\d+)/(\d+)$" 형태로 합성.
+//  5. 매칭 검증: 모든 입력 sample 이 결과 regex 에 매칭되는지 확인 — 실패 시 ok=false.
+package pathinfer
+
+import (
+	"regexp"
+	"strings"
+)
+
+// minSamplesForInference 는 휴리스틱이 의미 있는 패턴을 추출하기 위한 최소 sample 수입니다.
+// 1-2 개로는 \"공통 prefix vs 변수 부분\" 구분이 의미 없음 (모든 segment 가 \"공통\" 으로 보임).
+// 3+ 개면 변수 부분의 다양성을 검출 가능.
+const minSamplesForInference = 3
+
+// PathSamples 는 휴리스틱 추론에 사용할 입력입니다.
+//
+// Articles 는 같은 호스트 / 같은 페이지 종류의 article URL path 슬라이스 — 정규화된 URL 의
+// path 부분만 (예: \"/article/12345\"). scheme / host 제거 권장.
+type PathSamples struct {
+	Articles []string
+}
+
+// InferHeuristic 은 PathSamples 로부터 path_pattern regex 를 추론합니다 (이슈 #173 단계 2).
+//
+// 반환값:
+//   - regex string: 결과 RE2 패턴 (^...$ 앵커 포함). ok=false 면 빈 문자열.
+//   - ok bool     : 신뢰도. 다음 조건 중 하나라도 만족하지 않으면 false:
+//     1. samples 가 minSamplesForInference 미만
+//     2. samples 의 segment 길이가 일정하지 않음
+//     3. 변수 부분 segment 에서 공통 패턴을 찾지 못함
+//     4. 결과 regex 가 입력 samples 전체를 매칭하지 못함
+//
+// 결정성: 동일 입력 → 동일 출력. test 친화 + 운영 디버깅 용이.
+func InferHeuristic(samples PathSamples) (string, bool) {
+	if len(samples.Articles) < minSamplesForInference {
+		return "", false
+	}
+
+	// 모든 sample 의 segment 분리.
+	segs := make([][]string, len(samples.Articles))
+	for i, p := range samples.Articles {
+		segs[i] = splitSegments(p)
+	}
+
+	// segment 개수가 모두 같은지 확인.
+	expected := len(segs[0])
+	for _, s := range segs {
+		if len(s) != expected {
+			return "", false
+		}
+	}
+
+	// 각 segment index 별로 정적 prefix 또는 변수 부분 결정.
+	parts := make([]string, expected)
+	for idx := 0; idx < expected; idx++ {
+		// 해당 index 의 모든 값 수집.
+		values := make([]string, len(segs))
+		for s := range segs {
+			values[s] = segs[s][idx]
+		}
+
+		if allEqual(values) {
+			// 정적 prefix — regex escape 후 그대로 사용.
+			parts[idx] = regexp.QuoteMeta(values[0])
+			continue
+		}
+
+		// 변수 부분 — 공통 패턴 추출.
+		regexFragment, ok := inferVariablePattern(values)
+		if !ok {
+			return "", false
+		}
+		parts[idx] = regexFragment
+	}
+
+	// 결과 regex 합성. URL path 는 항상 "/" 로 시작 — leading "/" 안전 prefix.
+	result := "^/" + strings.Join(parts, "/") + "$"
+
+	// 검증: 입력 samples 전체가 결과 regex 에 매칭되는지 확인 — hallucination 방어.
+	re, err := regexp.Compile(result)
+	if err != nil {
+		return "", false
+	}
+	for _, p := range samples.Articles {
+		if !re.MatchString(p) {
+			return "", false
+		}
+	}
+
+	return result, true
+}
+
+// splitSegments 는 path 를 segment 슬라이스로 분리합니다.
+// "/article/123" → ["article", "123"]. trailing "/" 제거. 빈 path 는 [].
+func splitSegments(path string) []string {
+	path = strings.Trim(path, "/")
+	if path == "" {
+		return nil
+	}
+	return strings.Split(path, "/")
+}
+
+// allEqual 은 슬라이스의 모든 값이 동일한지 확인합니다.
+func allEqual(values []string) bool {
+	for i := 1; i < len(values); i++ {
+		if values[i] != values[0] {
+			return false
+		}
+	}
+	return true
+}
+
+// inferVariablePattern 은 변수 부분의 공통 패턴을 추출합니다.
+//
+// 우선순위 (가장 구체적 → 일반적) — 더 좁은 범위 패턴이 먼저 평가되어야 일반 numeric 으로 잡히지 않음:
+//  1. UUID (가장 specific 한 형식)
+//  2. 연도 ((19|20)\d{2}) — 4자리 numeric 중 1900-2099 범위만
+//  3. 월 (0[1-9]|1[0-2]) — 2자리 numeric 중 01-12 범위만
+//  4. 일반 numeric (\d+) — 위 범위 패턴 미적용 시 fallback
+//  5. slug ([a-z0-9-]+, 4자 이상 + 하이픈 포함)
+//
+// 위 어느 패턴에도 해당 안 되면 ok=false (LLM 추론 또는 catch-all 로 fallback).
+func inferVariablePattern(values []string) (string, bool) {
+	switch {
+	case allMatch(values, regexUUID):
+		return `([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})`, true
+	case allMatch(values, regexYear):
+		return `(19|20)\d{2}`, true
+	case allMatch(values, regexMonth):
+		return `(0[1-9]|1[0-2])`, true
+	case allMatch(values, regexNumeric):
+		return `(\d+)`, true
+	case allSlug(values):
+		return `([a-z0-9-]+)`, true
+	}
+	return "", false
+}
+
+// 사전 컴파일된 패턴 — 매 호출마다 재컴파일 회피.
+var (
+	regexNumeric = regexp.MustCompile(`^\d+$`)
+	regexUUID    = regexp.MustCompile(`^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$`)
+	// 연도: 1900-2099 범위 보호 (단순 \d{4} 는 9999 같은 무의미 값 허용 — 본 휴리스틱은
+	// year/month 가 실제 발견되는 사이트 (예: /news/2024/04/...) 범위로 한정).
+	regexYear  = regexp.MustCompile(`^(19|20)\d{2}$`)
+	regexMonth = regexp.MustCompile(`^(0[1-9]|1[0-2])$`)
+	// slug 보조 — 4자 이상 + 하이픈 포함 (단순 영숫자 4자 = ID 일 가능성 vs 하이픈 있으면
+	// 명확한 slug). 단순 숫자 / UUID 와의 우선순위 분리.
+	regexSlugChars = regexp.MustCompile(`^[a-z0-9-]+$`)
+)
+
+// allMatch 는 모든 값이 주어진 패턴에 매칭되는지 확인합니다.
+func allMatch(values []string, re *regexp.Regexp) bool {
+	for _, v := range values {
+		if !re.MatchString(v) {
+			return false
+		}
+	}
+	return true
+}
+
+// allSlug 는 모든 값이 slug 형식 (소문자 영숫자 + 하이픈, 4자 이상, 하이픈 포함) 인지 확인합니다.
+//
+// 4자 이상 + 하이픈 포함 조건은 단순 short ID (예: "abc") 나 단순 영숫자 (UUID 부분 or hash)
+// 와 구분하기 위함 — 명확한 slug 만 잡아내고 모호한 케이스는 ok=false 로 LLM/catch-all 위임.
+func allSlug(values []string) bool {
+	for _, v := range values {
+		if !regexSlugChars.MatchString(v) {
+			return false
+		}
+		if len(v) < 4 {
+			return false
+		}
+		if !strings.Contains(v, "-") {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/crawler/parser/rule/pathinfer/pathinfer.go
+++ b/internal/crawler/parser/rule/pathinfer/pathinfer.go
@@ -97,12 +97,15 @@ func InferHeuristic(samples PathSamples) (string, bool) {
 	result := "^/" + strings.Join(parts, "/") + "$"
 
 	// 검증: 입력 samples 전체가 결과 regex 에 매칭되는지 확인 — hallucination 방어.
+	// splitSegments 가 leading/trailing slash 를 trim 후 분리했으므로, 검증도 정규화된
+	// 형태 ("/" + trimmed) 로 매칭 — 그렇지 않으면 trailing slash 있는 path 는 자체 거부됨
+	// (PR #183 gemini 피드백).
 	re, err := regexp.Compile(result)
 	if err != nil {
 		return "", false
 	}
 	for _, p := range samples.Articles {
-		if !re.MatchString(p) {
+		if !re.MatchString("/" + strings.Trim(p, "/")) {
 			return "", false
 		}
 	}
@@ -145,7 +148,9 @@ func inferVariablePattern(values []string) (string, bool) {
 	case allMatch(values, regexUUID):
 		return `([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})`, true
 	case allMatch(values, regexYear):
-		return `(19|20)\d{2}`, true
+		// 외곽 capturing group 으로 4자리 연도 전체를 capture (PR #183 gemini 피드백)
+		// — 다른 패턴 (numeric/UUID/slug/month) 과 capture 일관성 보장.
+		return `((19|20)\d{2})`, true
 	case allMatch(values, regexMonth):
 		return `(0[1-9]|1[0-2])`, true
 	case allMatch(values, regexNumeric):

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -229,6 +229,49 @@ func LoadClassifier(envFiles ...string) (ClassifierConfig, error) {
 	return cfg, nil
 }
 
+// PathInferConfig 는 pathinfer 휴리스틱의 설정입니다 (이슈 #173 단계 2).
+//
+// pathinfer 패키지의 InferHeuristic 동작을 운영자가 환경변수로 조정 가능하도록.
+type PathInferConfig struct {
+	// MinSamples: 추론에 필요한 최소 sample URL 수.
+	// 환경변수: PATHINFER_MIN_SAMPLES (default 3).
+	// 너무 낮으면 (1-2) 공통 vs 변수 구분 의미 없음, 너무 높으면 (10+) sample 수집 지연.
+	MinSamples int
+}
+
+// DefaultPathInferConfig 는 기본 PathInferConfig 를 반환합니다.
+func DefaultPathInferConfig() PathInferConfig {
+	return PathInferConfig{
+		MinSamples: 3,
+	}
+}
+
+// LoadPathInfer 는 .env 를 로드한 후 OS 환경변수로 PathInferConfig 를 구성합니다.
+// 지원 환경변수: PATHINFER_MIN_SAMPLES (양의 정수, default 3).
+func LoadPathInfer(envFiles ...string) (PathInferConfig, error) {
+	if len(envFiles) == 0 {
+		envFiles = []string{".env"}
+	}
+	if err := godotenv.Load(envFiles...); err != nil && !errors.Is(err, os.ErrNotExist) {
+		return PathInferConfig{}, fmt.Errorf("failed to load env files %v: %w", envFiles, err)
+	}
+
+	cfg := DefaultPathInferConfig()
+
+	if v := os.Getenv("PATHINFER_MIN_SAMPLES"); v != "" {
+		n, err := strconv.Atoi(v)
+		if err != nil {
+			return PathInferConfig{}, fmt.Errorf("parse PATHINFER_MIN_SAMPLES %q: %w", v, err)
+		}
+		if n < 1 {
+			return PathInferConfig{}, fmt.Errorf("invalid PATHINFER_MIN_SAMPLES %d: must be 1 or greater", n)
+		}
+		cfg.MinSamples = n
+	}
+
+	return cfg, nil
+}
+
 // DBConfig는 PostgreSQL 연결 설정을 나타냅니다.
 // 모든 필드는 환경변수(Load 참조)로 덮어쓸 수 있습니다.
 type DBConfig struct {

--- a/test/internal/parser/rule/pathinfer/pathinfer_test.go
+++ b/test/internal/parser/rule/pathinfer/pathinfer_test.go
@@ -168,6 +168,28 @@ func TestInferHeuristic_ConcurrentSafe(t *testing.T) {
 // Validation 검증 — 결과 regex 가 입력 samples 모두 매칭
 // ─────────────────────────────────────────────────────────────────────────────
 
+// trailing slash 가 있는 path 도 정규화 후 검증되어 ok=true 반환 (PR #183 gemini 피드백).
+// 운영 환경에서는 Normalizer 가 trailing slash 를 제거하지만, 정규화 미적용 input 도 방어.
+func TestInferHeuristic_TrailingSlashTolerated(t *testing.T) {
+	samples := []string{"/article/1/", "/article/2/", "/article/30/"}
+	regex, ok := pathinfer.InferHeuristic(pathinfer.PathSamples{Articles: samples})
+	require.True(t, ok, "trailing slash 가 있어도 정규화 후 매칭")
+	assert.Equal(t, `^/article/(\d+)$`, regex)
+}
+
+// 연도 패턴이 외곽 capturing group 으로 4자리 전체를 capture (PR #183 gemini 피드백).
+func TestInferHeuristic_YearFullCapture(t *testing.T) {
+	samples := []string{"/news/2024/04/12345", "/news/2023/12/67890", "/news/2025/01/55555"}
+	regex, ok := pathinfer.InferHeuristic(pathinfer.PathSamples{Articles: samples})
+	require.True(t, ok)
+
+	re, err := regexp.Compile(regex)
+	require.NoError(t, err)
+	matches := re.FindStringSubmatch("/news/2024/04/12345")
+	require.NotNil(t, matches)
+	assert.Equal(t, "2024", matches[1], "첫 capturing group 은 4자리 연도 전체")
+}
+
 // 모든 정상 케이스에서 결과 regex 가 입력 sample 전체 매칭 보장.
 // (개별 케이스에서 assertMatchesAll 로 검증 — 본 테스트는 대표 케이스만 추가 확인)
 func TestInferHeuristic_ResultMatchesAllSamples(t *testing.T) {

--- a/test/internal/parser/rule/pathinfer/pathinfer_test.go
+++ b/test/internal/parser/rule/pathinfer/pathinfer_test.go
@@ -190,6 +190,44 @@ func TestInferHeuristic_YearFullCapture(t *testing.T) {
 	assert.Equal(t, "2024", matches[1], "첫 capturing group 은 4자리 연도 전체")
 }
 
+// ─────────────────────────────────────────────────────────────────────────────
+// Option / config 동작
+// ─────────────────────────────────────────────────────────────────────────────
+
+// WithMinSamples 로 default(3) 보다 높게 override 시 sample 수 부족 거부.
+func TestInferHeuristic_WithMinSamples_HigherThreshold(t *testing.T) {
+	samples := []string{"/article/1", "/article/2", "/article/3"} // 3개 — default OK
+	_, ok := pathinfer.InferHeuristic(pathinfer.PathSamples{Articles: samples})
+	require.True(t, ok, "default 3 으로는 3개 OK")
+
+	// override 5 → 거부
+	_, ok = pathinfer.InferHeuristic(pathinfer.PathSamples{Articles: samples}, pathinfer.WithMinSamples(5))
+	assert.False(t, ok, "WithMinSamples(5) 로 3개는 거부")
+}
+
+// WithMinSamples 로 default 보다 낮게 override 시 더 적은 sample 도 통과.
+func TestInferHeuristic_WithMinSamples_LowerThreshold(t *testing.T) {
+	samples := []string{"/article/1", "/article/2"} // 2개 — default 거부
+	_, ok := pathinfer.InferHeuristic(pathinfer.PathSamples{Articles: samples})
+	require.False(t, ok, "default 3 으로는 2개 거부")
+
+	// override 2 → 통과
+	regex, ok := pathinfer.InferHeuristic(pathinfer.PathSamples{Articles: samples}, pathinfer.WithMinSamples(2))
+	assert.True(t, ok, "WithMinSamples(2) 로 2개 통과")
+	assert.Equal(t, `^/article/(\d+)$`, regex)
+}
+
+// WithMinSamples 0 이하는 무시되고 default 유지 (방어 동작).
+func TestInferHeuristic_WithMinSamples_ZeroIgnored(t *testing.T) {
+	samples := []string{"/article/1", "/article/2"}
+	// 0 이하 → 무시됨, default(3) 유지 → 2개는 거부
+	_, ok := pathinfer.InferHeuristic(pathinfer.PathSamples{Articles: samples}, pathinfer.WithMinSamples(0))
+	assert.False(t, ok, "WithMinSamples(0) 무시 — default 3 유지")
+
+	_, ok = pathinfer.InferHeuristic(pathinfer.PathSamples{Articles: samples}, pathinfer.WithMinSamples(-5))
+	assert.False(t, ok, "WithMinSamples(-5) 무시 — default 3 유지")
+}
+
 // 모든 정상 케이스에서 결과 regex 가 입력 sample 전체 매칭 보장.
 // (개별 케이스에서 assertMatchesAll 로 검증 — 본 테스트는 대표 케이스만 추가 확인)
 func TestInferHeuristic_ResultMatchesAllSamples(t *testing.T) {

--- a/test/internal/parser/rule/pathinfer/pathinfer_test.go
+++ b/test/internal/parser/rule/pathinfer/pathinfer_test.go
@@ -1,0 +1,189 @@
+package pathinfer_test
+
+import (
+	"regexp"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"issuetracker/internal/crawler/parser/rule/pathinfer"
+)
+
+// 결과 regex 가 입력 sample 들 모두 매칭하는지 확인하는 헬퍼.
+func assertMatchesAll(t *testing.T, regex string, samples []string) {
+	t.Helper()
+	re, err := regexp.Compile(regex)
+	require.NoError(t, err, "regex %q must compile", regex)
+	for _, s := range samples {
+		assert.True(t, re.MatchString(s), "regex %q must match sample %q", regex, s)
+	}
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 정상 케이스 — 단일 변수 segment
+// ─────────────────────────────────────────────────────────────────────────────
+
+func TestInferHeuristic_NumericID(t *testing.T) {
+	samples := []string{"/article/12345", "/article/67890", "/article/120394"}
+	regex, ok := pathinfer.InferHeuristic(pathinfer.PathSamples{Articles: samples})
+	require.True(t, ok)
+	assert.Equal(t, `^/article/(\d+)$`, regex)
+	assertMatchesAll(t, regex, samples)
+}
+
+func TestInferHeuristic_UUID(t *testing.T) {
+	samples := []string{
+		"/post/01234567-89ab-cdef-0123-456789abcdef",
+		"/post/abcdef01-2345-6789-abcd-ef0123456789",
+		"/post/fedcba98-7654-3210-fedc-ba9876543210",
+	}
+	regex, ok := pathinfer.InferHeuristic(pathinfer.PathSamples{Articles: samples})
+	require.True(t, ok)
+	assert.Contains(t, regex, "[0-9a-f]{8}-")
+	assertMatchesAll(t, regex, samples)
+}
+
+func TestInferHeuristic_Slug(t *testing.T) {
+	samples := []string{
+		"/news/breaking-story-2024",
+		"/news/special-coverage-update",
+		"/news/world-economy-report",
+	}
+	regex, ok := pathinfer.InferHeuristic(pathinfer.PathSamples{Articles: samples})
+	require.True(t, ok)
+	assert.Equal(t, `^/news/([a-z0-9-]+)$`, regex)
+	assertMatchesAll(t, regex, samples)
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 정상 케이스 — 다중 변수 (연도/월/ID 조합)
+// ─────────────────────────────────────────────────────────────────────────────
+
+func TestInferHeuristic_YearMonthID(t *testing.T) {
+	samples := []string{
+		"/news/2024/04/12345",
+		"/news/2023/12/67890",
+		"/news/2025/01/55555",
+	}
+	regex, ok := pathinfer.InferHeuristic(pathinfer.PathSamples{Articles: samples})
+	require.True(t, ok)
+	// 정확한 regex 형태는 구현 내부 — 핵심은 모든 sample 이 매칭
+	assertMatchesAll(t, regex, samples)
+	// 다른 연도/월/ID 조합도 통과해야 함
+	re, _ := regexp.Compile(regex)
+	assert.True(t, re.MatchString("/news/2022/06/99999"))
+	// 잘못된 형식 (월이 13) 은 거부 — Year/Month 패턴이 1900-2099 / 01-12 만 통과하므로
+	assert.False(t, re.MatchString("/news/2024/13/12345"), "월 13 은 매칭되면 안 됨")
+}
+
+// 정적 prefix + 동적 ID 의 다층 path
+func TestInferHeuristic_NestedPath(t *testing.T) {
+	samples := []string{
+		"/category/sports/article/1",
+		"/category/sports/article/200",
+		"/category/sports/article/9999",
+	}
+	regex, ok := pathinfer.InferHeuristic(pathinfer.PathSamples{Articles: samples})
+	require.True(t, ok)
+	assert.Equal(t, `^/category/sports/article/(\d+)$`, regex)
+	assertMatchesAll(t, regex, samples)
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 거부 케이스 — ok=false 반환
+// ─────────────────────────────────────────────────────────────────────────────
+
+func TestInferHeuristic_TooFewSamples(t *testing.T) {
+	samples := []string{"/article/1", "/article/2"} // 2개 < minSamplesForInference=3
+	_, ok := pathinfer.InferHeuristic(pathinfer.PathSamples{Articles: samples})
+	assert.False(t, ok, "sample 3개 미만은 거부")
+}
+
+func TestInferHeuristic_DifferentSegmentLengths(t *testing.T) {
+	samples := []string{
+		"/article/1",
+		"/category/sports/article/2", // segment 길이 다름
+		"/article/3",
+	}
+	_, ok := pathinfer.InferHeuristic(pathinfer.PathSamples{Articles: samples})
+	assert.False(t, ok, "segment 개수가 다르면 거부")
+}
+
+func TestInferHeuristic_VariablePartUnknown(t *testing.T) {
+	// 변수 부분이 모두 다른 종류 (numeric / slug / 다른 형식 혼재)
+	samples := []string{
+		"/article/12345",
+		"/article/abc",   // numeric 도 slug (4자 미만 + 하이픈 없음) 도 아님
+		"/article/world", // numeric 도 slug (하이픈 없음) 도 아님
+	}
+	_, ok := pathinfer.InferHeuristic(pathinfer.PathSamples{Articles: samples})
+	assert.False(t, ok, "공통 패턴 못 찾으면 거부")
+}
+
+func TestInferHeuristic_EmptyInput(t *testing.T) {
+	_, ok := pathinfer.InferHeuristic(pathinfer.PathSamples{Articles: nil})
+	assert.False(t, ok, "빈 입력은 거부")
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 결정성 + race 검증
+// ─────────────────────────────────────────────────────────────────────────────
+
+// 동일 입력 → 동일 출력 — 운영 디버깅 / 테스트 친화 검증.
+func TestInferHeuristic_Deterministic(t *testing.T) {
+	samples := []string{"/news/2024/04/12345", "/news/2023/12/67890", "/news/2025/01/55555"}
+	first, ok1 := pathinfer.InferHeuristic(pathinfer.PathSamples{Articles: samples})
+	second, ok2 := pathinfer.InferHeuristic(pathinfer.PathSamples{Articles: samples})
+	assert.True(t, ok1)
+	assert.True(t, ok2)
+	assert.Equal(t, first, second, "동일 입력은 동일 출력")
+}
+
+// concurrent 호출이 안전 — 사전 컴파일 패턴 + stateless 함수.
+func TestInferHeuristic_ConcurrentSafe(t *testing.T) {
+	samples := []string{"/article/1", "/article/2", "/article/3"}
+	const concurrency = 50
+	results := make(chan string, concurrency)
+
+	for i := 0; i < concurrency; i++ {
+		go func() {
+			r, _ := pathinfer.InferHeuristic(pathinfer.PathSamples{Articles: samples})
+			results <- r
+		}()
+	}
+
+	first := ""
+	for i := 0; i < concurrency; i++ {
+		r := <-results
+		if first == "" {
+			first = r
+		} else {
+			assert.Equal(t, first, r, "concurrent 호출도 동일 결과")
+		}
+	}
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Validation 검증 — 결과 regex 가 입력 samples 모두 매칭
+// ─────────────────────────────────────────────────────────────────────────────
+
+// 모든 정상 케이스에서 결과 regex 가 입력 sample 전체 매칭 보장.
+// (개별 케이스에서 assertMatchesAll 로 검증 — 본 테스트는 대표 케이스만 추가 확인)
+func TestInferHeuristic_ResultMatchesAllSamples(t *testing.T) {
+	cases := []struct {
+		name    string
+		samples []string
+	}{
+		{"numeric", []string{"/a/1", "/a/2", "/a/30"}},
+		{"slug", []string{"/b/foo-bar-baz", "/b/hello-world-test", "/b/some-other-thing"}},
+		{"year-month-id", []string{"/c/2024/04/1", "/c/2023/12/200", "/c/2025/01/55555"}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			regex, ok := pathinfer.InferHeuristic(pathinfer.PathSamples{Articles: tc.samples})
+			require.True(t, ok)
+			assertMatchesAll(t, regex, tc.samples)
+		})
+	}
+}

--- a/test/pkg/config/config_test.go
+++ b/test/pkg/config/config_test.go
@@ -459,3 +459,52 @@ func TestLoadScheduler_InvalidBacklogCheckTimeout(t *testing.T) {
 		t.Fatal("SCHEDULER_BACKLOG_CHECK_TIMEOUT 가 duration 형식이 아니면 에러가 반환되어야 합니다")
 	}
 }
+
+// ─────────────────────────────────────────────────────────────────────────────
+// LoadPathInfer (이슈 #173 단계 2)
+// ─────────────────────────────────────────────────────────────────────────────
+
+func TestLoadPathInfer_DefaultValues(t *testing.T) {
+	t.Setenv("PATHINFER_MIN_SAMPLES", "")
+
+	cfg, err := config.LoadPathInfer("/tmp/nonexistent-env-file.env")
+	if err != nil {
+		t.Fatalf("기본값 로드 실패: %v", err)
+	}
+	if cfg.MinSamples != 3 {
+		t.Errorf("MinSamples default: got %d, want 3", cfg.MinSamples)
+	}
+}
+
+func TestLoadPathInfer_OverrideViaEnv(t *testing.T) {
+	t.Setenv("PATHINFER_MIN_SAMPLES", "5")
+
+	cfg, err := config.LoadPathInfer("/tmp/nonexistent-env-file.env")
+	if err != nil {
+		t.Fatalf("override 로드 실패: %v", err)
+	}
+	if cfg.MinSamples != 5 {
+		t.Errorf("MinSamples override: got %d, want 5", cfg.MinSamples)
+	}
+}
+
+func TestLoadPathInfer_InvalidNonInteger(t *testing.T) {
+	t.Setenv("PATHINFER_MIN_SAMPLES", "abc")
+
+	_, err := config.LoadPathInfer("/tmp/nonexistent-env-file.env")
+	if err == nil {
+		t.Fatal("PATHINFER_MIN_SAMPLES 가 정수 아니면 에러")
+	}
+}
+
+func TestLoadPathInfer_InvalidZeroOrNegative(t *testing.T) {
+	for _, v := range []string{"0", "-1"} {
+		t.Run(v, func(t *testing.T) {
+			t.Setenv("PATHINFER_MIN_SAMPLES", v)
+			_, err := config.LoadPathInfer("/tmp/nonexistent-env-file.env")
+			if err == nil {
+				t.Fatalf("PATHINFER_MIN_SAMPLES=%q 는 1 이상이어야 함", v)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## 연관 이슈
- Closes #182 (이슈 #173 의 단계 2 sub-issue)
- 후속 단계 3·4 는 별도 sub-issue + PR 로 추적

<br>

## 구현 내용

이슈 #173 의 **단계 2 — 알고리즘 기반 path 패턴 추출**. LLM 무관 결정적 휴리스틱으로 sample URL 들로부터 path_pattern regex 추론.

### 위치 결정
이슈 #173 본문은 \`llmgen/pathinfer\` 위치 제안했으나, LLM 의존 없는 algorithm 모듈이라 **별도 패키지** \`internal/crawler/parser/rule/pathinfer/\` 로 분리:
- 단계 3 (LLM 기반) 도입 시 llmgen 측에서 본 패키지를 import 하여 hybrid 흐름 합성
- pathinfer 단독 사용도 가능 (운영자 도구 / 단계 4 정밀화 트리거 등)

### 인터페이스
\`\`\`go
type PathSamples struct {
    Articles []string  // 정규화된 URL 의 path 부분 (예: ["/article/1", "/article/2"])
}

func InferHeuristic(samples PathSamples) (regex string, ok bool)
\`\`\`

### Algorithm 흐름
1. sample URL path 들을 segment 슬라이스로 분리
2. segment 길이가 모두 같지 않으면 ok=false
3. 각 segment index 별:
   - 모든 sample 동일 텍스트 → 정적 prefix (regex escape)
   - 다르면 → 변수 부분: 공통 패턴 추출
4. 결과 regex 합성: \`^/static/(\\d+)/...\$\` 형태
5. **검증**: 입력 sample 전체가 결과 regex 에 매칭되는지 확인 (hallucination 방어)

### 인식 패턴 우선순위 (좁은 범위 → 일반)
1. **UUID** (8-4-4-4-12 hex)
2. **연도** \`(19|20)\\d{2}\` — 1900-2099 범위만
3. **월** \`0[1-9]|1[0-2]\` — 01-12 범위만
4. 일반 **numeric** \`\\d+\`
5. **slug** \`[a-z0-9-]+\` — 4자 이상 + 하이픈 포함

→ 좁은 범위가 먼저 평가되어 \`/news/2024/04/...\` 가 \`(\\d+)/(\\d+)/(\\d+)\` 가 아닌 \`(19|20)\\d{2}/(0[1-9]|1[0-2])/(\\d+)\` 로 추론됨. 결과 regex 가 \`/news/2024/13/...\` 같은 잘못된 형식을 거부.

### 거부 조건 (ok=false → LLM/catch-all 로 위임)
- sample 3개 미만 (\"공통 vs 변수\" 구분 의미 없음)
- segment 길이 불일치 (구조적 변형)
- 변수 부분 공통 패턴 못 찾음
- 결과 regex 가 입력 sample 미매칭

### 단위 테스트 13건 (race 검증)
- 정상: numeric / UUID / slug / 연도-월-ID / 다층 path
- 거부: too-few-samples / segment-length-mismatch / variable-unknown / empty-input
- 결정성: 동일 입력 → 동일 출력
- concurrent 50회 동일 결과 (race-safe — stateless + 사전 컴파일 패턴)
- 모든 정상 케이스에서 결과 regex 가 입력 sample 전체 매칭 보장

<br>

## CI / 머지 게이트 점검

### 변경 영향 범위
- 영향 패키지/모듈:
  - \`internal/crawler/parser/rule/pathinfer/\` (신규)
  - \`test/internal/parser/rule/pathinfer/\` (신규)
- 위험도: **Low**
  - **외부 호출처 0** — 단독 algorithm 모듈, 다른 코드 변경 없음
  - 후속 단계 3·4 PR 에서 import 하여 사용 예정

### Required Status Checks
- 통과 확인 대상:
  - [ ] \`Commit Lint\`
  - [ ] \`PR Title Lint\`
  - [ ] \`Linked Issue Check\`
  - [ ] \`Format Check\`
  - [ ] \`Build\`
  - [ ] \`Test\`
  - [ ] \`Lint\`

### 롤백 계획
- 외부 호출처 없음 — 본 PR revert 시 다른 코드 영향 0
- 패키지 삭제 또는 PR revert

<br>

## TODO (이슈 #173 후속 단계 — 별도 sub-issue + PR)

- [ ] **단계 3** — LLM 기반 path 패턴 추출 + 검증
- [ ] **단계 4** — 점진적 정밀화 워크플로 (pathinfer + LLM hybrid)

<br>

## 논의 사항

- **slug 인식 보수성**: 4자 이상 + 하이픈 포함 조건 — 단순 short ID (예: \"abc\") 와 명확한 slug 구분. 모호한 케이스는 단계 3 LLM 으로 위임.
- **연도-월 범위 제한**: \`(19|20)\\d{2}\` / \`0[1-9]|1[0-2]\` — 운영 데이터에 있는 사이트는 모두 이 범위. \`30/40\` 같은 무의미 값 차단 + \`9999/13\` 같은 잘못된 형식 거부.