### PR TITLE
[FEAT#186] pathinfer LLM 기반 path 패턴 추출 + 검증 (이슈 #173 단계 3)

### DIFF
--- a/internal/crawler/parser/rule/pathinfer/llm.go
+++ b/internal/crawler/parser/rule/pathinfer/llm.go
@@ -125,31 +125,34 @@ func joinOrNone(items []string) string {
 
 // extractPattern 은 LLM 응답에서 첫 번째 RE2 패턴 라인을 추출합니다 (이슈 #173 단계 3).
 //
-// 처리:
-//   - markdown 코드 펜스 (```...```) 안에 들어있어도 추출 가능 — 펜스 안의 첫 비어있지 않은 라인 사용
-//   - 펜스 없으면 응답 첫 비어있지 않은 라인 사용
-//   - 라인 trim (whitespace 제거)
-//   - 빈 결과 → ""
+// 처리 우선순위:
+//  1. markdown 코드 펜스 (```...```) 가 응답 어느 위치에든 있으면 → 펜스 내부 첫 비어있지 않은 라인 우선 사용
+//     (LLM 이 prose 먼저 출력 후 펜스로 regex 를 감싸는 케이스 cover — PR #187 CodeRabbit 피드백)
+//  2. 펜스 없으면 응답 첫 비어있지 않은 라인 사용
+//  3. 라인 trim (whitespace 제거)
+//  4. 빈 결과 → ""
 func extractPattern(resp string) string {
 	resp = strings.TrimSpace(resp)
 	if resp == "" {
 		return ""
 	}
 
-	// markdown 펜스 처리 — ```regex 또는 ``` 로 시작하면 펜스 내부의 첫 라인 사용.
-	if strings.HasPrefix(resp, "```") {
-		// 첫 줄 (펜스 시작) 제외
-		if nl := strings.IndexByte(resp, '\n'); nl >= 0 {
-			resp = resp[nl+1:]
+	// fenced block 우선 — 응답 어느 위치에 있든 fence 안의 첫 비어있지 않은 라인 사용.
+	if strings.Contains(resp, "```") {
+		inFence := false
+		for _, raw := range strings.Split(resp, "\n") {
+			line := strings.TrimSpace(raw)
+			if strings.HasPrefix(line, "```") {
+				inFence = !inFence
+				continue
+			}
+			if inFence && line != "" {
+				return line
+			}
 		}
-		// 닫는 펜스 이전까지만
-		if end := strings.Index(resp, "```"); end >= 0 {
-			resp = resp[:end]
-		}
-		resp = strings.TrimSpace(resp)
 	}
 
-	// 첫 비어있지 않은 라인 사용.
+	// fence 없거나 fence 안에 비어있지 않은 라인이 없으면 첫 비어있지 않은 라인 fallback.
 	for _, line := range strings.Split(resp, "\n") {
 		line = strings.TrimSpace(line)
 		if line != "" {

--- a/internal/crawler/parser/rule/pathinfer/llm.go
+++ b/internal/crawler/parser/rule/pathinfer/llm.go
@@ -143,6 +143,13 @@ func extractPattern(resp string) string {
 		for _, raw := range strings.Split(resp, "\n") {
 			line := strings.TrimSpace(raw)
 			if strings.HasPrefix(line, "```") {
+				// single-line fence — ```pattern``` 형식 — 안의 패턴을 즉시 추출
+				// (PR #187 gemini 피드백, ``` 가 한 라인에 양쪽으로 있는 경우).
+				if strings.HasSuffix(line, "```") && len(line) > 6 {
+					if inner := strings.TrimSpace(line[3 : len(line)-3]); inner != "" {
+						return inner
+					}
+				}
 				inFence = !inFence
 				continue
 			}

--- a/internal/crawler/parser/rule/pathinfer/llm.go
+++ b/internal/crawler/parser/rule/pathinfer/llm.go
@@ -1,0 +1,219 @@
+package pathinfer
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+// LLMClient 는 InferLLM 이 사용하는 최소 LLM 호출 인터페이스입니다 (이슈 #173 단계 3).
+//
+// pathinfer 가 pkg/llm 을 직접 import 하지 않도록 작은 abstraction —
+// 호출자 (단계 4 의 hybrid 흐름) 가 pkg/llm.Provider 위에 adapter 를 만들어 주입합니다.
+//
+// 구현체는 goroutine-safe 해야 합니다.
+type LLMClient interface {
+	// Generate 는 system + user 프롬프트로 LLM 호출 후 응답 텍스트를 반환합니다.
+	// 호출자는 timeout / cancel 을 ctx 로 제어.
+	Generate(ctx context.Context, system, user string) (string, error)
+}
+
+// LLMSamples 는 InferLLM 의 입력 샘플입니다.
+//
+// Articles : positive — 결과 regex 가 매칭해야 할 URL path 슬라이스.
+// NonArticles : negative — 결과 regex 가 매칭하면 안 될 URL path (선택, 빈 슬라이스 허용).
+//
+// path 는 정규화된 URL 의 path 부분 (예: "/article/12345"). scheme/host 제거 권장.
+type LLMSamples struct {
+	Articles    []string
+	NonArticles []string
+}
+
+// llmSystemPrompt 는 모든 InferLLM 호출에 공통으로 사용되는 system 프롬프트입니다.
+//
+// 응답 형식 강제 — markdown 펜스 / prose 없이 단일 RE2 패턴 라인만 반환하도록 지시.
+// 본 PR scope: pathinfer 패키지 안 inline 상수. 이슈 #171 (프롬프트 외부 파일) 머지 후 그곳으로 이전 가능.
+const llmSystemPrompt = `You are an expert at writing URL path regular expressions.
+
+Strict rules:
+1. Respond with ONLY a single RE2-compatible regex pattern on the first line — no prose, no markdown fences, no explanation.
+2. The regex must match ALL provided positive (article) URL paths.
+3. The regex must NOT match any of the provided negative (non-article) URL paths.
+4. Avoid trivially broad patterns (e.g. ".*", "^/.*$", ".+") — produce a pattern that is as specific as possible while satisfying rules 2 and 3.
+5. Anchor the pattern with ^ and $ if appropriate.
+6. Use only standard RE2 syntax (no lookaround, no backreferences).`
+
+// llmUserPromptTemplate 은 LLMSamples 를 채워 user 프롬프트를 생성합니다.
+const llmUserPromptTemplate = `Given these URL paths from the same site, generate a single RE2 regex that matches the article URLs but not the non-article URLs.
+
+Article URLs (positive — must match):
+%s
+
+Non-article URLs (negative — must NOT match):
+%s
+
+Respond with ONLY the regex pattern.`
+
+// InferLLM 은 LLMClient 를 사용해 path_pattern regex 를 추론합니다 (이슈 #173 단계 3).
+//
+// 흐름:
+//  1. samples.Articles 가 cfg.minSamples 미만이면 ("", false, nil) — pathinfer.InferHeuristic 과 동일 정책
+//  2. LLM 호출 (system + user 프롬프트)
+//  3. 응답에서 첫 번째 RE2 패턴 라인 추출 (markdown 펜스 무시)
+//  4. 검증 (validateLLMResult): 컴파일 / positive / negative / trivially-broad
+//  5. 검증 통과 시 (regex, true, nil), 실패 시 ("", false, nil) — 호출자가 catch-all 또는 다른 fallback 으로 분기
+//
+// LLM 호출 자체의 에러 (network / API) 는 (regex="", ok=false, err=원본) 로 반환 — 호출자가 retry / 알림 결정.
+//
+// opts 로 default override 가능 (WithMinSamples 등 — InferHeuristic 과 동일).
+func InferLLM(ctx context.Context, samples LLMSamples, client LLMClient, opts ...Option) (string, bool, error) {
+	cfg := config{minSamples: DefaultMinSamples}
+	for _, o := range opts {
+		o(&cfg)
+	}
+
+	if len(samples.Articles) < cfg.minSamples {
+		return "", false, nil
+	}
+	if client == nil {
+		return "", false, errors.New("InferLLM: nil LLMClient")
+	}
+
+	user := buildUserPrompt(samples)
+	resp, err := client.Generate(ctx, llmSystemPrompt, user)
+	if err != nil {
+		return "", false, fmt.Errorf("llm generate: %w", err)
+	}
+
+	pattern := extractPattern(resp)
+	if pattern == "" {
+		return "", false, nil
+	}
+
+	if !validateLLMResult(pattern, samples) {
+		return "", false, nil
+	}
+	return pattern, true, nil
+}
+
+// buildUserPrompt 는 samples 로 user 프롬프트 본문을 생성합니다.
+//
+// Articles / NonArticles 가 비어있으면 "(none)" 으로 표시 — LLM 이 빈 슬라이스를 "negative 없음"
+// 으로 정확히 해석하도록.
+func buildUserPrompt(samples LLMSamples) string {
+	pos := joinOrNone(samples.Articles)
+	neg := joinOrNone(samples.NonArticles)
+	return fmt.Sprintf(llmUserPromptTemplate, pos, neg)
+}
+
+func joinOrNone(items []string) string {
+	if len(items) == 0 {
+		return "(none)"
+	}
+	var b strings.Builder
+	for i, s := range items {
+		if i > 0 {
+			b.WriteByte('\n')
+		}
+		b.WriteString("- ")
+		b.WriteString(s)
+	}
+	return b.String()
+}
+
+// extractPattern 은 LLM 응답에서 첫 번째 RE2 패턴 라인을 추출합니다 (이슈 #173 단계 3).
+//
+// 처리:
+//   - markdown 코드 펜스 (```...```) 안에 들어있어도 추출 가능 — 펜스 안의 첫 비어있지 않은 라인 사용
+//   - 펜스 없으면 응답 첫 비어있지 않은 라인 사용
+//   - 라인 trim (whitespace 제거)
+//   - 빈 결과 → ""
+func extractPattern(resp string) string {
+	resp = strings.TrimSpace(resp)
+	if resp == "" {
+		return ""
+	}
+
+	// markdown 펜스 처리 — ```regex 또는 ``` 로 시작하면 펜스 내부의 첫 라인 사용.
+	if strings.HasPrefix(resp, "```") {
+		// 첫 줄 (펜스 시작) 제외
+		if nl := strings.IndexByte(resp, '\n'); nl >= 0 {
+			resp = resp[nl+1:]
+		}
+		// 닫는 펜스 이전까지만
+		if end := strings.Index(resp, "```"); end >= 0 {
+			resp = resp[:end]
+		}
+		resp = strings.TrimSpace(resp)
+	}
+
+	// 첫 비어있지 않은 라인 사용.
+	for _, line := range strings.Split(resp, "\n") {
+		line = strings.TrimSpace(line)
+		if line != "" {
+			return line
+		}
+	}
+	return ""
+}
+
+// validateLLMResult 는 LLM 응답 regex 가 모든 검증 단계를 통과하는지 확인합니다 (이슈 #173 단계 3).
+//
+// 검증 단계:
+//  1. RE2 컴파일 가능
+//  2. positive (samples.Articles) 100% 매칭
+//  3. negative (samples.NonArticles) 0% 매칭
+//  4. trivially broad 거부 (isTriviallyBroad)
+//
+// 모든 단계 통과 시 true, 1단계라도 실패 시 false.
+func validateLLMResult(pattern string, samples LLMSamples) bool {
+	if isTriviallyBroad(pattern) {
+		return false
+	}
+	re, err := regexp.Compile(pattern)
+	if err != nil {
+		return false
+	}
+	// positive: 모든 article path 가 매칭되어야 함 (정규화된 형태로 매칭 — InferHeuristic 정책 일관)
+	for _, p := range samples.Articles {
+		if !re.MatchString("/" + strings.Trim(p, "/")) {
+			return false
+		}
+	}
+	// negative: 어떤 non-article 도 매칭되면 안 됨
+	for _, p := range samples.NonArticles {
+		if re.MatchString("/" + strings.Trim(p, "/")) {
+			return false
+		}
+	}
+	return true
+}
+
+// triviallyBroadPatterns 는 \"의미 있는 path 차별화 없음\" 으로 거부할 패턴 집합입니다.
+//
+// 호출자가 hand-tuned regex 를 운영 환경에서 잘못 입력 (예: \".*\") 한 케이스도 본 검증으로
+// 차단됨 — LLM hallucination 외에도 운영 안전망 역할.
+var triviallyBroadPatterns = map[string]struct{}{
+	"":        {},
+	".*":      {},
+	".+":      {},
+	"/.*":     {},
+	"/.+":     {},
+	"^.*$":    {},
+	"^.+$":    {},
+	"^/$":     {},
+	"^/.*$":   {},
+	"^/.+$":   {},
+	"^/(.*)$": {},
+	"^/(.+)$": {},
+}
+
+// isTriviallyBroad 는 pattern 이 \"의미 있는 path 차별화 없음\" 인지 확인합니다.
+// 정규화 (trim whitespace) 후 set lookup.
+func isTriviallyBroad(pattern string) bool {
+	p := strings.TrimSpace(pattern)
+	_, ok := triviallyBroadPatterns[p]
+	return ok
+}

--- a/test/internal/parser/rule/pathinfer/llm_test.go
+++ b/test/internal/parser/rule/pathinfer/llm_test.go
@@ -83,6 +83,18 @@ func TestInferLLM_ExtractFirstLineSkipsEmpty(t *testing.T) {
 	assert.Equal(t, `^/news/\d+$`, regex)
 }
 
+// single-line fence (```pattern```) 추출 (PR #187 gemini 피드백).
+func TestInferLLM_ExtractFromSingleLineFence(t *testing.T) {
+	llm := &fakeLLM{resp: "```^/article/\\d+$```"}
+	samples := pathinfer.LLMSamples{
+		Articles: []string{"/article/1", "/article/2", "/article/30"},
+	}
+	regex, ok, err := pathinfer.InferLLM(context.Background(), samples, llm)
+	require.NoError(t, err)
+	require.True(t, ok, "single-line fence 안의 regex 추출")
+	assert.Equal(t, `^/article/\d+$`, regex)
+}
+
 // LLM 이 prose 를 먼저 출력하고 fenced regex 로 감싸는 패턴 cover (PR #187 CodeRabbit 피드백).
 // 기존 로직은 prose 첫 줄을 반환하던 회귀 케이스.
 func TestInferLLM_ExtractFromMidResponseFence(t *testing.T) {

--- a/test/internal/parser/rule/pathinfer/llm_test.go
+++ b/test/internal/parser/rule/pathinfer/llm_test.go
@@ -1,0 +1,239 @@
+package pathinfer_test
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"issuetracker/internal/crawler/parser/rule/pathinfer"
+)
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Mock LLMClient
+// ─────────────────────────────────────────────────────────────────────────────
+
+// fakeLLM 은 응답과 에러를 미리 설정해 반환하는 LLMClient 입니다.
+type fakeLLM struct {
+	mu       sync.Mutex
+	resp     string
+	err      error
+	calls    int
+	lastSys  string
+	lastUser string
+}
+
+func (f *fakeLLM) Generate(_ context.Context, system, user string) (string, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.calls++
+	f.lastSys = system
+	f.lastUser = user
+	return f.resp, f.err
+}
+
+func (f *fakeLLM) callCount() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.calls
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 정상 케이스
+// ─────────────────────────────────────────────────────────────────────────────
+
+func TestInferLLM_HappyPath(t *testing.T) {
+	llm := &fakeLLM{resp: `^/article/\d+$`}
+	samples := pathinfer.LLMSamples{
+		Articles:    []string{"/article/1", "/article/200", "/article/9999"},
+		NonArticles: []string{"/about", "/category/sports"},
+	}
+
+	regex, ok, err := pathinfer.InferLLM(context.Background(), samples, llm)
+	require.NoError(t, err)
+	require.True(t, ok)
+	assert.Equal(t, `^/article/\d+$`, regex)
+	assert.Equal(t, 1, llm.callCount())
+}
+
+// markdown 펜스 안에 들어있는 패턴 추출.
+func TestInferLLM_ExtractFromMarkdownFence(t *testing.T) {
+	llm := &fakeLLM{resp: "```regex\n^/article/\\d+$\n```"}
+	samples := pathinfer.LLMSamples{
+		Articles: []string{"/article/1", "/article/2", "/article/30"},
+	}
+	regex, ok, err := pathinfer.InferLLM(context.Background(), samples, llm)
+	require.NoError(t, err)
+	require.True(t, ok)
+	assert.Equal(t, `^/article/\d+$`, regex)
+}
+
+// 응답에 prose 가 같이 있어도 첫 비어있지 않은 라인 사용.
+func TestInferLLM_ExtractFirstLineSkipsEmpty(t *testing.T) {
+	llm := &fakeLLM{resp: "\n\n^/news/\\d+$\nThis is the regex."}
+	samples := pathinfer.LLMSamples{
+		Articles: []string{"/news/1", "/news/2", "/news/30"},
+	}
+	regex, ok, err := pathinfer.InferLLM(context.Background(), samples, llm)
+	require.NoError(t, err)
+	require.True(t, ok)
+	assert.Equal(t, `^/news/\d+$`, regex)
+}
+
+// negative 가 있어도 정상 매칭 + 거부 동작.
+func TestInferLLM_NegativeRejected(t *testing.T) {
+	// LLM 이 잘못된 (너무 broad) 패턴 반환 — negative match 시 거부
+	llm := &fakeLLM{resp: `^/.+$`}
+	samples := pathinfer.LLMSamples{
+		Articles:    []string{"/article/1", "/article/2", "/article/3"},
+		NonArticles: []string{"/about"}, // 이 path 가 ^/.+$ 에 매칭 → 거부
+	}
+	regex, ok, err := pathinfer.InferLLM(context.Background(), samples, llm)
+	require.NoError(t, err)
+	assert.False(t, ok, "negative 매칭 시 거부")
+	assert.Empty(t, regex)
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 거부 케이스
+// ─────────────────────────────────────────────────────────────────────────────
+
+func TestInferLLM_TooFewSamples(t *testing.T) {
+	llm := &fakeLLM{resp: `^/article/\d+$`}
+	samples := pathinfer.LLMSamples{Articles: []string{"/article/1", "/article/2"}}
+
+	_, ok, err := pathinfer.InferLLM(context.Background(), samples, llm)
+	require.NoError(t, err)
+	assert.False(t, ok)
+	assert.Equal(t, 0, llm.callCount(), "sample 부족 시 LLM 호출 안 함")
+}
+
+func TestInferLLM_NilClient(t *testing.T) {
+	samples := pathinfer.LLMSamples{Articles: []string{"/a/1", "/a/2", "/a/3"}}
+	_, ok, err := pathinfer.InferLLM(context.Background(), samples, nil)
+	require.Error(t, err)
+	assert.False(t, ok)
+}
+
+func TestInferLLM_LLMError(t *testing.T) {
+	llm := &fakeLLM{err: errors.New("api timeout")}
+	samples := pathinfer.LLMSamples{Articles: []string{"/a/1", "/a/2", "/a/3"}}
+
+	_, ok, err := pathinfer.InferLLM(context.Background(), samples, llm)
+	require.Error(t, err)
+	assert.False(t, ok)
+}
+
+// LLM 응답이 RE2 컴파일 실패 시 거부.
+func TestInferLLM_InvalidRegexRejected(t *testing.T) {
+	llm := &fakeLLM{resp: `[unclosed-bracket`}
+	samples := pathinfer.LLMSamples{Articles: []string{"/a/1", "/a/2", "/a/3"}}
+
+	_, ok, err := pathinfer.InferLLM(context.Background(), samples, llm)
+	require.NoError(t, err)
+	assert.False(t, ok)
+}
+
+// positive 를 매칭 못 하는 패턴 거부.
+func TestInferLLM_PositiveMissmatchRejected(t *testing.T) {
+	llm := &fakeLLM{resp: `^/news/\d+$`}
+	samples := pathinfer.LLMSamples{
+		Articles: []string{"/article/1", "/article/2", "/article/3"}, // /article 인데 regex 는 /news
+	}
+	_, ok, err := pathinfer.InferLLM(context.Background(), samples, llm)
+	require.NoError(t, err)
+	assert.False(t, ok)
+}
+
+// 빈 응답 거부.
+func TestInferLLM_EmptyResponseRejected(t *testing.T) {
+	llm := &fakeLLM{resp: ""}
+	samples := pathinfer.LLMSamples{Articles: []string{"/a/1", "/a/2", "/a/3"}}
+	_, ok, err := pathinfer.InferLLM(context.Background(), samples, llm)
+	require.NoError(t, err)
+	assert.False(t, ok)
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// trivially-broad 거부
+// ─────────────────────────────────────────────────────────────────────────────
+
+func TestInferLLM_TriviallyBroadRejected(t *testing.T) {
+	cases := []string{
+		".*",
+		".+",
+		"/.*",
+		"/.+",
+		"^.*$",
+		"^.+$",
+		"^/$",
+		"^/.*$",
+		"^/.+$",
+		"^/(.*)$",
+		"^/(.+)$",
+	}
+	for _, p := range cases {
+		t.Run(p, func(t *testing.T) {
+			llm := &fakeLLM{resp: p}
+			samples := pathinfer.LLMSamples{
+				Articles: []string{"/a/1", "/a/2", "/a/3"},
+			}
+			_, ok, err := pathinfer.InferLLM(context.Background(), samples, llm)
+			require.NoError(t, err)
+			assert.False(t, ok, "trivially-broad %q 는 거부되어야 함", p)
+		})
+	}
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Option 동작 — InferHeuristic 과 일관성
+// ─────────────────────────────────────────────────────────────────────────────
+
+func TestInferLLM_WithMinSamples_Override(t *testing.T) {
+	llm := &fakeLLM{resp: `^/a/\d+$`}
+	samples := pathinfer.LLMSamples{Articles: []string{"/a/1", "/a/2"}} // 2개
+
+	// default 3 → 거부, LLM 호출 안 함
+	_, ok, _ := pathinfer.InferLLM(context.Background(), samples, llm)
+	assert.False(t, ok)
+	assert.Equal(t, 0, llm.callCount())
+
+	// override 2 → LLM 호출 + 통과
+	regex, ok, err := pathinfer.InferLLM(context.Background(), samples, llm, pathinfer.WithMinSamples(2))
+	require.NoError(t, err)
+	require.True(t, ok)
+	assert.Equal(t, `^/a/\d+$`, regex)
+	assert.Equal(t, 1, llm.callCount())
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 프롬프트 검증 — system / user 가 정확히 전달되는지
+// ─────────────────────────────────────────────────────────────────────────────
+
+func TestInferLLM_PromptIncludesSamples(t *testing.T) {
+	llm := &fakeLLM{resp: `^/a/\d+$`}
+	samples := pathinfer.LLMSamples{
+		Articles:    []string{"/a/1", "/a/2", "/a/3"},
+		NonArticles: []string{"/about", "/category"},
+	}
+	_, _, _ = pathinfer.InferLLM(context.Background(), samples, llm)
+
+	assert.Contains(t, llm.lastSys, "RE2", "system 에 RE2 명시")
+	for _, a := range samples.Articles {
+		assert.Contains(t, llm.lastUser, a, "user 에 article path 포함: %s", a)
+	}
+	for _, n := range samples.NonArticles {
+		assert.Contains(t, llm.lastUser, n, "user 에 non-article path 포함: %s", n)
+	}
+}
+
+// NonArticles 가 비어있으면 "(none)" 표기.
+func TestInferLLM_PromptShowsNoneForEmpty(t *testing.T) {
+	llm := &fakeLLM{resp: `^/a/\d+$`}
+	samples := pathinfer.LLMSamples{Articles: []string{"/a/1", "/a/2", "/a/3"}}
+	_, _, _ = pathinfer.InferLLM(context.Background(), samples, llm)
+	assert.Contains(t, llm.lastUser, "(none)", "NonArticles 비어있으면 (none) 표기")
+}

--- a/test/internal/parser/rule/pathinfer/llm_test.go
+++ b/test/internal/parser/rule/pathinfer/llm_test.go
@@ -83,6 +83,19 @@ func TestInferLLM_ExtractFirstLineSkipsEmpty(t *testing.T) {
 	assert.Equal(t, `^/news/\d+$`, regex)
 }
 
+// LLM 이 prose 를 먼저 출력하고 fenced regex 로 감싸는 패턴 cover (PR #187 CodeRabbit 피드백).
+// 기존 로직은 prose 첫 줄을 반환하던 회귀 케이스.
+func TestInferLLM_ExtractFromMidResponseFence(t *testing.T) {
+	llm := &fakeLLM{resp: "Here is the regex you requested:\n\n```\n^/article/\\d+$\n```\n\nLet me know if you need adjustments."}
+	samples := pathinfer.LLMSamples{
+		Articles: []string{"/article/1", "/article/2", "/article/30"},
+	}
+	regex, ok, err := pathinfer.InferLLM(context.Background(), samples, llm)
+	require.NoError(t, err)
+	require.True(t, ok, "fenced block 이 응답 중간에 있어도 안의 regex 추출")
+	assert.Equal(t, `^/article/\d+$`, regex)
+}
+
 // negative 가 있어도 정상 매칭 + 거부 동작.
 func TestInferLLM_NegativeRejected(t *testing.T) {
 	// LLM 이 잘못된 (너무 broad) 패턴 반환 — negative match 시 거부


### PR DESCRIPTION
## 연관 이슈
- Closes #186 (이슈 #173 의 단계 3 sub-issue)
- 메인 이슈 #173 은 단계 4 까지 완료 후 close

<br>

## 구현 내용

이슈 #173 의 **단계 3 — LLM 기반 path 패턴 추출 + 검증**. pathinfer 의 알고리즘 휴리스틱 (단계 2, PR #183) 으로 처리 못한 케이스를 LLM 으로 추론하고 검증.

### 핵심 설계 — 의존 분리
\`pathinfer\` 는 \`pkg/llm\` 을 직접 import 하지 않고 작은 \`LLMClient\` 인터페이스만 정의. 호출자 (단계 4 의 hybrid 흐름) 가 \`pkg/llm.Provider\` 위에 adapter 를 만들어 주입 — 양 패키지 결합도 약화.

\`\`\`go
type LLMClient interface {
    Generate(ctx context.Context, system, user string) (string, error)
}

type LLMSamples struct {
    Articles    []string  // positive — 매칭되어야 함
    NonArticles []string  // negative — 매칭되면 안 됨 (선택)
}

func InferLLM(ctx, samples, client, opts...) (regex string, ok bool, err error)
\`\`\`

### 흐름
1. \`Articles\` 가 \`cfg.minSamples\` (default 3) 미만이면 (\"\", false, nil)
2. \`client\` nil 이면 에러
3. system + user 프롬프트로 LLM 호출
4. 응답 파싱 — markdown 펜스 무시 + 첫 비어있지 않은 라인 추출
5. 4단계 검증 — 통과 시 (regex, true, nil)

### 검증 4단계
1. **RE2 컴파일 가능**
2. **positive 100% 매칭** — Articles 전체가 결과 regex 에 매칭
3. **negative 0% 매칭** — NonArticles 가 결과 regex 에 매칭되면 안 됨
4. **trivially-broad 거부** — \`.*\` / \`.+\` / \`^/.*\$\` / \`^/(.*)\$\` 등 11종

### 프롬프트
이슈 #173 본문 명시 그대로 (이슈 #171 외부 파일 도입은 별도 작업) — 본 PR 은 inline 상수.

### 옵션 패턴
\`WithMinSamples\` — InferHeuristic 과 동일 — 운영자가 환경변수로 조정 가능.

### 단위 테스트 14건 (race 검증)
- 정상: HappyPath / markdown 펜스 / 다중 라인 첫 줄 / negative 거부
- 거부: sample 부족 / nil client / LLM 에러 / RE2 실패 / positive 미매칭 / 빈 응답
- trivially-broad 11종 패턴 거부 (table-driven)
- WithMinSamples override
- 프롬프트에 sample 포함 / NonArticles 빈 시 (none) 표기

<br>

## CI / 머지 게이트 점검

### 변경 영향 범위
- 영향 패키지/모듈:
  - \`internal/crawler/parser/rule/pathinfer/\` (llm.go 신규)
  - \`test/internal/parser/rule/pathinfer/\` (llm_test.go 신규)
- 위험도: **Low**
  - 외부 호출처 0 — 본 PR 은 함수만 제공, 호출자 wiring 은 단계 4 PR 에서
  - 기존 InferHeuristic / WithMinSamples 등 단계 2 코드 변경 없음

### Required Status Checks
- 통과 확인 대상:
  - [ ] \`Commit Lint\`
  - [ ] \`PR Title Lint\`
  - [ ] \`Linked Issue Check\`
  - [ ] \`Format Check\`
  - [ ] \`Build\`
  - [ ] \`Test\`
  - [ ] \`Lint\`

### 롤백 계획
- 외부 호출처 없음 — 본 PR revert 시 다른 코드 영향 0
- 패키지 파일 삭제 또는 PR revert

<br>

## TODO (이슈 #173 후속 단계)

- [ ] **단계 4** (별도 sub-issue + PR): hybrid 흐름 (algorithm → LLM → catch-all) + sample 누적 + DB UPDATE
  - 호출자 wiring (pkg/llm.Provider 의 LLMClient adapter)
  - 본 PR 의 InferLLM + 단계 2 의 InferHeuristic 합성

<br>

## 논의 사항

- **trivially-broad 패턴 set 의 완전성**: 현재 11종 — 운영 데이터에서 다른 \"의미 없는 broad\" 패턴 발견 시 추가. 단, 너무 엄격하면 정상 패턴도 거부 위험. 현재 set 은 명백히 \"path 차별화 없음\" 만 포함.
- **PoC 권장**: 본 PR 머지 후 5개 호스트 \* sample 5+5 (positive/negative) 으로 LLM regex 생성 품질 측정. 통과율 < 60% 면 단계 4 의 hybrid 정책 \"LLM 보조\" 로 약화 (현재는 \"LLM 우선\" 가정).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added LLM-driven path inference capability that intelligently generates regex patterns from positive and negative sample paths, with built-in validation to ensure pattern correctness and coverage.

* **Tests**
  * Added comprehensive test suite validating path inference behavior across various scenarios including pattern validation and error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->