### PR TITLE
[DOCS#193] docs/architecture/ — 모듈/연결 관계 트리 문서화

### DIFF
--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -1,0 +1,205 @@
+# IssueTracker — Architecture Reference
+
+이 디렉토리는 IssueTracker 시스템의 모듈/연결 관계를 **프로젝트 디렉토리 트리와 동일한 구조**로
+정리한 참조 문서입니다. 각 문서는 코드 주석/스펙을 대체하지 않으며, **모듈이 무엇을 하고 어디로
+연결되는지** 빠르게 파악하기 위한 지도입니다.
+
+상위 규칙은 [.claude/rules/01-architecture.md](../../.claude/rules/01-architecture.md) 가 정의하며,
+이 문서는 그 규칙이 실제 코드에 어떻게 매핑되는지를 보여줍니다.
+
+<br>
+
+## 시스템 한 줄 요약
+
+글로벌 뉴스/커뮤니티 이슈를 **크롤 → 파싱 → 정규화 → 검증 → 분류** 단계로 흘려보내는
+Kafka 기반 Go 파이프라인. 각 단계는 토픽으로 분리되어 독립 스케일링 가능.
+
+<br>
+
+## 디렉토리 트리 (architecture docs)
+
+```
+docs/architecture/
+├── README.md                              ← (you are here)
+├── cmd/                                   ← entry point 별 역할
+│   ├── README.md
+│   ├── api.md
+│   ├── issuetracker.md                    ← 통합 파이프라인 오케스트레이터 (main wiring)
+│   ├── processor.md                       ← validator-only 단독 실행체
+│   ├── migrate.md
+│   ├── migrate-down.md
+│   └── rldebug.md
+├── internal/                              ← 비공개 비즈니스 로직
+│   ├── README.md
+│   ├── classifier/                        ← ELArchive Classifier client (gRPC + HTTP fallback)
+│   │   ├── README.md
+│   │   ├── grpc.md
+│   │   └── http.md
+│   ├── crawler/
+│   │   ├── README.md
+│   │   ├── core.md                        ← 인터페이스 + 모델 + 에러
+│   │   ├── domain.md                      ← Fetcher chain + 사이트 등록
+│   │   ├── handler.md                     ← Registry (crawler_name → Handler)
+│   │   ├── implementation.md              ← chromedp / goquery
+│   │   ├── parser.md                      ← rule.Parser (DB-driven) + llmgen + refiner
+│   │   ├── rate_limiter.md
+│   │   └── worker.md                      ← PoolManager + ProcessingLock + RetryScheduler
+│   ├── parser/
+│   │   └── README.md                      ← Claim Check 기반 ParserWorker
+│   ├── processor/
+│   │   ├── README.md
+│   │   └── validate.md                    ← news/community Validator
+│   ├── publisher.md                       ← chained job 발행 + IngestionLock
+│   ├── scheduler.md                       ← seed job 주기적 발행
+│   └── storage/
+│       ├── README.md
+│       ├── postgres.md
+│       └── service.md                     ← ContentService / RawContentService
+├── pkg/                                   ← 공개 유틸리티
+│   ├── README.md
+│   ├── config.md
+│   ├── links.md
+│   ├── llm.md                             ← provider 추상 + chain policy
+│   ├── logger.md
+│   ├── metrics.md
+│   ├── queue.md                           ← Kafka 토픽/그룹 상수
+│   ├── redis.md
+│   └── urlguard.md
+└── proto/
+    └── classifier.md                      ← classifier.proto 서비스 정의
+```
+
+<br>
+
+## 데이터 흐름 — 한 장 요약
+
+```
+┌─────────────┐
+│  Scheduler  │  internal/scheduler — DefaultEntries(): CNN, Naver, Yonhap, Daum 카테고리 URL
+└──────┬──────┘
+       │ CrawlJob (priority high/normal/low)
+       ▼
+┌──────────────────────────────────────────────────────────────────────────┐
+│ Kafka topics: issuetracker.crawl.{high,normal,low}                       │
+└──────┬───────────────────────────────────────────────────────────────────┘
+       │
+       ▼
+┌─────────────────────┐    ProcessingLock (Redis SETNX) — URL 동시처리 방지
+│   PoolManager       │    CircuitBreaker — source 단위 실패 트래킹
+│   (3-tier pools)    │    RetryScheduler (Redis ZSET) — 지연 재시도
+│ internal/crawler/   │
+│       worker        │
+└──────┬──────────────┘
+       │ dispatch by crawler_name
+       ▼
+┌─────────────────────┐    Chain of Responsibility:
+│  ChainHandler       │      goquery (정적 HTML)
+│ (crawler/domain/    │        ↓ (동적/lazy 감지)
+│      general)       │      chromedp (헤드리스 Chrome)
+└──────┬──────────────┘
+       │ RawContent → DB(raw_contents) → RawContentRef (Claim Check)
+       ▼
+┌──────────────────────────────────────────────────────────────────────────┐
+│ Kafka: issuetracker.fetched                                              │
+└──────┬───────────────────────────────────────────────────────────────────┘
+       │
+       ▼
+┌─────────────────────┐    rule.Parser (DB-driven, parsing_rules 테이블)
+│   ParserWorker      │      ├─ ErrNoRule  → llmgen.Generator (async, enabled=false)
+│ internal/parser/    │      └─ list 페이지 → Publisher.PublishBatch (chained CrawlJob)
+│       worker        │
+└──────┬──────────────┘
+       │ Content → ContentService.Store → ContentRef
+       ▼
+┌──────────────────────────────────────────────────────────────────────────┐
+│ Kafka: issuetracker.normalized                                           │
+└──────┬───────────────────────────────────────────────────────────────────┘
+       │
+       ▼
+┌─────────────────────┐    news / community Validator
+│  Validate Worker    │    Title/Body/PublishedAt 길이 검증, reliability scoring
+│ internal/processor/ │    Pass → ContentRef 발행 / Fail → 삭제 + DLQ
+│      validate       │
+└──────┬──────────────┘
+       │
+       ▼
+┌──────────────────────────────────────────────────────────────────────────┐
+│ Kafka: issuetracker.validated   (현 단계는 후속 분류기/임베더 진입점)     │
+└──────────────────────────────────────────────────────────────────────────┘
+
+부수 흐름:
+  • Refiner (internal/crawler/parser/rule/refiner) — 주기적 polling 으로 llm-auto 규칙의
+    path_pattern 을 sample_urls 기반으로 정밀화 (이슈 #173).
+  • Classifier (internal/classifier) — gRPC 기본 + HTTP fallback 으로 ELArchive Classifier
+    호출 — 향후 enrich 단계에서 사용.
+```
+
+<br>
+
+## Kafka 토픽 인덱스
+
+토픽명 상수 정의는 [`pkg/queue/config.go`](../../pkg/queue/config.go) 단일 소스. 자세한 partitioning
+전략은 [01-architecture.md](../../.claude/rules/01-architecture.md) 참조.
+
+| Topic                              | Producer                                              | Consumer Group                              |
+|------------------------------------|-------------------------------------------------------|---------------------------------------------|
+| `issuetracker.crawl.high`          | [scheduler](../../internal/scheduler/) / publisher    | `issuetracker-crawler-workers-high`         |
+| `issuetracker.crawl.normal`        | [scheduler](../../internal/scheduler/) / publisher    | `issuetracker-crawler-workers-normal`       |
+| `issuetracker.crawl.low`           | [scheduler](../../internal/scheduler/) / publisher    | `issuetracker-crawler-workers-low`          |
+| `issuetracker.fetched`             | [crawler/worker](../../internal/crawler/worker/)      | `issuetracker-parsers`                      |
+| `issuetracker.normalized`          | [parser/worker](../../internal/parser/worker/)        | `issuetracker-validators`                   |
+| `issuetracker.validated`           | [processor/validate](../../internal/processor/validate/) | (downstream — TBD)                       |
+| `issuetracker.dlq`                 | 모든 stage 실패 분기                                  | (운영 모니터링)                              |
+
+<br>
+
+## 외부 의존성 인덱스
+
+| 외부 시스템                | 어디서 사용                                                 | 용도                                          |
+|----------------------------|------------------------------------------------------------|-----------------------------------------------|
+| Kafka                      | [pkg/queue/](../../pkg/queue/)                              | 모든 stage 간 메시지 버스                      |
+| PostgreSQL                 | [internal/storage/postgres/](../../internal/storage/postgres/) | contents / content_bodies / content_meta / raw_contents / parsing_rules / sample_urls / schema_migrations |
+| Redis                      | [pkg/redis/](../../pkg/redis/), [internal/crawler/worker/](../../internal/crawler/worker/) | ProcessingLock(SETNX) / IngestionLock / RetryQueue(ZSET) |
+| LLM (Gemini/OpenAI/Claude) | [pkg/llm/](../../pkg/llm/)                                  | parser rule 자동 생성 / path_pattern refinement |
+| Chrome (CDP)               | [internal/crawler/implementation/chromedp/](../../internal/crawler/implementation/chromedp/) | 동적 페이지 헤드리스 렌더                      |
+| ELArchive Classifier       | [internal/classifier/](../../internal/classifier/) + [proto/classifier/](../../proto/classifier/) | 카테고리 분류 (gRPC primary, HTTP fallback)    |
+| Prometheus                 | [pkg/metrics/](../../pkg/metrics/)                          | `/metrics` 엔드포인트                          |
+
+<br>
+
+## DB 테이블 인덱스
+
+스키마는 [`migrations/`](../../migrations/) 가 단일 소스. 각 repo 의 자세한 스키마는
+[storage/postgres.md](internal/storage/postgres.md) 에서 확인.
+
+| 테이블             | Repository                                                       | 설명                                                 |
+|--------------------|------------------------------------------------------------------|------------------------------------------------------|
+| `contents`         | [ContentRepository](../../internal/storage/content.go)           | 정규화된 Content 메타 (id, url, title, source 등)   |
+| `content_bodies`   | (same)                                                           | 본문 분리 저장 (큰 텍스트)                            |
+| `content_meta`     | (same)                                                           | validation_status, classifier 결과 등 메타           |
+| `raw_contents`     | [RawContentRepository](../../internal/storage/raw_content.go)    | Claim Check — 임시 HTML 저장 후 parser 가 정리       |
+| `parsing_rules`    | [ParsingRuleRepository](../../internal/storage/parsing_rule.go)  | host_pattern + path_pattern → SelectorMap (이슈 #100) |
+| `sample_urls`      | [SampleURLRepository](../../internal/storage/sample_url.go)      | refiner 가 path_pattern 정밀화에 사용 (이슈 #173)    |
+| `schema_migrations`| (migrations 자체 관리)                                            | 마이그레이션 버전 추적                                |
+
+<br>
+
+## 읽는 순서 (권장)
+
+처음 합류한 사람 기준:
+
+1. [docs/architecture/cmd/issuetracker.md](cmd/issuetracker.md) — `main()` 가 어떤 모듈을 어떤 순서로 wire 하는지
+2. [docs/architecture/internal/crawler/worker.md](internal/crawler/worker.md) — Kafka consumer + lock + retry 의 핵심 패턴
+3. [docs/architecture/internal/parser/README.md](internal/parser/README.md) — Claim Check + rule-driven 파싱
+4. [docs/architecture/internal/storage/README.md](internal/storage/README.md) — Repository → Service 분리 원칙
+5. [docs/architecture/pkg/queue.md](pkg/queue.md) — 토픽 상수와 Kafka producer/consumer 추상
+
+<br>
+
+## 문서 작성 규약
+
+- **언어**: 한국어 본문 + 영어 기술용어 ([06-code-style.md](../../.claude/rules/06-code-style.md))
+- **링크**: 마크다운 파일 위치 기준 상대경로 — 모든 코드 참조는 프로젝트 디렉토리 안에 머무름
+- **다이어그램**: ASCII (Mermaid 미사용 — 의존성 없는 렌더링 보장)
+- **이슈 참조**: 관련 이슈 번호를 본문에 인라인 표기 (예: 이슈 #173)
+- **갱신**: 패키지 구조가 바뀌면 해당 마크다운만 갱신, 다른 곳에 중복 기술하지 않음

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -143,13 +143,17 @@ docs/architecture/
 
 | Topic                              | Producer                                              | Consumer Group                              |
 |------------------------------------|-------------------------------------------------------|---------------------------------------------|
-| `issuetracker.crawl.high`          | [scheduler](../../internal/scheduler/) / publisher    | `issuetracker-crawler-workers-high`         |
-| `issuetracker.crawl.normal`        | [scheduler](../../internal/scheduler/) / publisher    | `issuetracker-crawler-workers-normal`       |
-| `issuetracker.crawl.low`           | [scheduler](../../internal/scheduler/) / publisher    | `issuetracker-crawler-workers-low`          |
-| `issuetracker.fetched`             | [crawler/worker](../../internal/crawler/worker/)      | `issuetracker-parsers`                      |
-| `issuetracker.normalized`          | [parser/worker](../../internal/parser/worker/)        | `issuetracker-validators`                   |
-| `issuetracker.validated`           | [processor/validate](../../internal/processor/validate/) | (downstream — TBD)                       |
-| `issuetracker.dlq`                 | 모든 stage 실패 분기                                  | (운영 모니터링)                              |
+| `issuetracker.crawl.high`          | [scheduler](../../internal/scheduler/) / publisher    | `issuetracker-crawler-workers` (`GroupCrawlerWorkers`) — 3 토픽 단일 그룹 |
+| `issuetracker.crawl.normal`        | [scheduler](../../internal/scheduler/) / publisher    | `issuetracker-crawler-workers` (동일)                                    |
+| `issuetracker.crawl.low`           | [scheduler](../../internal/scheduler/) / publisher    | `issuetracker-crawler-workers` (동일)                                    |
+| `issuetracker.fetched`             | [crawler/worker](../../internal/crawler/worker/)      | `issuetracker-parsers` (`GroupParsers`)                                   |
+| `issuetracker.normalized`          | [parser/worker](../../internal/parser/worker/)        | `issuetracker-validators` (`GroupValidators`)                             |
+| `issuetracker.validated`           | [processor/validate](../../internal/processor/validate/) | (downstream — TBD)                                                    |
+| `issuetracker.dlq`                 | 모든 stage 실패 분기                                  | (운영 모니터링)                                                            |
+
+> 3-tier priority topic 은 **단일 consumer group** 을 공유합니다 — [PoolManager](../../internal/crawler/worker/manager.go) 가 priority 별
+> Consumer 인스턴스 3개를 같은 group ID 로 띄워, Kafka 가 파티션을 자동 분배합니다.
+> 상수 정의는 [`pkg/queue/config.go`](../../pkg/queue/config.go) 단일 소스.
 
 <br>
 

--- a/docs/architecture/cmd/README.md
+++ b/docs/architecture/cmd/README.md
@@ -1,0 +1,46 @@
+# cmd/ — Entry Points
+
+[`cmd/`](../../../cmd/) 는 모든 실행 바이너리의 main 패키지를 보관합니다. 각 서브디렉토리는
+하나의 바이너리에 대응하며 `make build` 로 [`bin/`](../../../bin/) 에 빌드됩니다.
+
+엔트리는 비즈니스 로직을 담지 않고 [`internal/`](../../../internal/) 와 [`pkg/`](../../../pkg/)
+의 패키지를 wire 하는 역할만 합니다 (의존성 역전).
+
+<br>
+
+## 바이너리 일람
+
+| 디렉토리                         | 산출물                | 역할                                         | 문서                                        |
+|---------------------------------|---------------------|---------------------------------------------|---------------------------------------------|
+| [`cmd/issuetracker/`](../../../cmd/issuetracker/) | `bin/issuetracker`  | **통합 파이프라인** — 모든 stage 를 단일 프로세스로 실행 | [issuetracker.md](issuetracker.md)          |
+| [`cmd/processor/`](../../../cmd/processor/)       | `bin/processor`     | **검증 단독 실행** — `issuetracker.normalized` → `issuetracker.validated` | [processor.md](processor.md)                |
+| [`cmd/migrate/`](../../../cmd/migrate/)           | `bin/migrate`       | DB 마이그레이션 적용 (forward)                | [migrate.md](migrate.md)                    |
+| [`cmd/migrate-down/`](../../../cmd/migrate-down/) | `bin/migrate-down`  | DB 마이그레이션 롤백 (배포 환경 전용)         | [migrate-down.md](migrate-down.md)          |
+| [`cmd/api/`](../../../cmd/api/)                   | (미구현)             | REST/GraphQL API 서버 — placeholder           | (계획)                                       |
+| [`cmd/rldebug/`](../../../cmd/rldebug/)           | (미구현)             | Rate limiter 디버깅 도구 — placeholder        | (계획)                                       |
+
+새 바이너리 추가 시 [`Makefile`](../../../Makefile) 의 `build` 타겟과 `*_BINARY` 변수를 동시 갱신
+([01-architecture.md](../../../.claude/rules/01-architecture.md) 의 cmd/ 규칙).
+
+<br>
+
+## 빌드 / 실행
+
+```bash
+make build              # 전체 빌드
+make run-issuetracker   # 통합 실행 (chrome + kafka 자동 기동, scripts/entrypoint.sh)
+make run-processor      # 검증 단독 실행
+make pg-migrate         # 마이그레이션 적용
+make pg-migrate-down    # 마이그레이션 롤백 (운영자 전용)
+```
+
+<br>
+
+## 의존 관계 (요약)
+
+```
+cmd/issuetracker  ──→ internal/* (전부) + pkg/* (전부)
+cmd/processor     ──→ internal/{processor/validate, storage/*, crawler/worker(NoopProcessingLock)} + pkg/*
+cmd/migrate       ──→ internal/storage/postgres + migrations
+cmd/migrate-down  ──→ internal/storage/postgres + migrations
+```

--- a/docs/architecture/cmd/issuetracker.md
+++ b/docs/architecture/cmd/issuetracker.md
@@ -1,0 +1,105 @@
+# cmd/issuetracker — Integrated Pipeline
+
+소스: [`cmd/issuetracker/main.go`](../../../cmd/issuetracker/main.go)
+산출물: `bin/issuetracker` (`make build`)
+
+전체 파이프라인 (Crawler + Parser + Validator + Scheduler + Refiner) 을 **단일 프로세스에서 wire** 하는
+오케스트레이터. 운영 시 권장 entry point.
+
+<br>
+
+## 역할
+
+- `main()` 은 오직 **wiring 다이어그램** — 비즈니스 로직 0
+- 각 단계는 동일 `context.Context` 를 공유 → SIGTERM 시 일괄 cancel
+- Redis / LLM 은 fail-soft — 부재 시 noop fallback 으로 graceful degrade
+
+<br>
+
+## Wiring 흐름 (코드 순서)
+
+```
+1. logger / metrics endpoint    (pkg/logger, pkg/metrics)
+2. Kafka producer + 3-tier consumers (high/normal/low)
+3. PostgreSQL pool              (internal/storage/postgres)
+4. rule.Parser + rule.Resolver  (parsing_rules 시드 검증 → 부재 시 fail-fast)
+5. raw_contents Service / Content Service (Claim Check)
+6. Source 등록                  (kr.Register / us.Register → handler.Registry)
+7. Redis: ProcessingLock / IngestionLock / DelayedRetryScheduler (이슈 #178, #82)
+8. PoolManager (3-tier crawler workers)
+9. LLM provider (chain policy, 이슈 #149)
+10. ParserWorker (consumer group: parsers)
+11. Refiner (path_pattern 정밀화, 이슈 #173 단계 4-2)
+12. RawContentCleaner cron       (Claim Check 잔존물 정리)
+13. Scheduler + BacklogThrottler (이슈 #124)
+14. Validate Worker
+15. SIGTERM 대기 → 역순 graceful shutdown
+```
+
+각 단계의 자세한 책임은 해당 패키지 문서 참조:
+
+- [internal/crawler/worker.md](../internal/crawler/worker.md) — PoolManager, ProcessingLock, RetryScheduler
+- [internal/crawler/parser.md](../internal/crawler/parser.md) — rule.Parser, llmgen, refiner
+- [internal/parser/README.md](../internal/parser/README.md) — ParserWorker (Claim Check)
+- [internal/processor/validate.md](../internal/processor/validate.md) — Validator
+- [internal/scheduler.md](../internal/scheduler.md) — seed job 발행
+
+<br>
+
+## Build helpers (main.go 내부)
+
+| 함수                      | 책임                                                        | 실패 동작        |
+|--------------------------|------------------------------------------------------------|------------------|
+| `buildLLMProvider()`      | `LLM_ENABLED` + API key 검증 → [`pkg/llm`](../../../pkg/llm/) chain provider 구성 | nil 반환 (LLM 비활성) |
+| `buildLLMGenerator()`     | provider nil 이면 nil — 아니면 [`llmgen.New`](../../../internal/crawler/parser/rule/llmgen/) | nil 허용         |
+| `buildRefiner()`          | `REFINEMENT_ENABLED` + provider 옵션 결합 → [`refiner.New`](../../../internal/crawler/parser/rule/refiner/) | nil 반환 (정밀화 비활성) |
+| `verifyParsingRulesSeeded()` | migration 007 의 seed 가 적용됐는지 확인              | **fail-fast (Fatal)** |
+
+<br>
+
+## 환경 변수 의존
+
+config 로딩은 [`pkg/config`](../../../pkg/config/) 가 단일 소스. 주요 키:
+
+| Loader                  | 결정 항목                                              | 비활성 시                               |
+|-------------------------|-------------------------------------------------------|----------------------------------------|
+| `LoadLog()`             | 로그 레벨 / Pretty 출력                                | 기본값                                  |
+| `LoadMetrics()`         | `METRICS_ADDR` (default `:9090`)                      | 빈 값이면 endpoint 미기동              |
+| `Load()` (DB)           | PostgreSQL 접속                                        | **fail-fast**                          |
+| `LoadRedis()`           | Redis 접속                                             | warn 후 NoopProcessingLock fallback    |
+| `LoadLLM()`             | provider, model, API key, timeout                     | nil provider                            |
+| `LoadRefinement()`      | refiner interval / min samples                        | nil refiner                             |
+| `LoadScheduler()`       | seed entry interval / backlog 임계값                  | **fail-fast**                          |
+| `LoadValidate()`        | 검증 임계값                                            | **fail-fast**                          |
+
+<br>
+
+## Worker 카운트 상수
+
+```go
+const (
+    validateWorkerCount = 8
+    parserWorkerCount   = 6
+)
+```
+
+- `validateWorkerCount` ≤ `issuetracker.normalized` 파티션 수 (기본 32)
+- `parserWorkerCount` 는 fetcher 와 독립 — chromedp/LLM 부담이 클수록 증설
+
+<br>
+
+## Graceful Shutdown 순서
+
+SIGINT/SIGTERM 수신 시:
+
+1. logger 에 `shutting_down=true` 부착 (이슈 #72)
+2. root `cancel()` — 모든 goroutine 의 ctx 무효화
+3. shutdownCtx (30s timeout) 로 역순 Stop:
+   - `sched.Stop()`
+   - `manager.Stop(shutdownCtx)` — drain crawler workers
+   - `pw.Stop(shutdownCtx)` — parser worker
+   - `llmGen.Stop(shutdownCtx)` — in-flight LLM call drain (이슈 #149)
+   - `pathRefiner.Stop(shutdownCtx)` — refiner cycle drain (PR #191)
+   - `cleaner.Stop()` — cleanup cron
+   - `validateWorker.Stop(shutdownCtx)`
+4. `defer` 체인이 Kafka producer/consumer, redis, pgpool 닫음

--- a/docs/architecture/cmd/issuetracker.md
+++ b/docs/architecture/cmd/issuetracker.md
@@ -53,7 +53,7 @@
 | `buildLLMProvider()`      | `LLM_ENABLED` + API key 검증 → [`pkg/llm`](../../../pkg/llm/) chain provider 구성 | nil 반환 (LLM 비활성) |
 | `buildLLMGenerator()`     | provider nil 이면 nil — 아니면 [`llmgen.New`](../../../internal/crawler/parser/rule/llmgen/) | nil 허용         |
 | `buildRefiner()`          | `REFINEMENT_ENABLED` + provider 옵션 결합 → [`refiner.New`](../../../internal/crawler/parser/rule/refiner/) | nil 반환 (정밀화 비활성) |
-| `verifyParsingRulesSeeded()` | migration 007 의 seed 가 적용됐는지 확인              | **fail-fast (Fatal)** |
+| `verifyParsingRulesSeeded()` | 기본 파싱 규칙(seed data) 이 DB 에 정상 로드됐는지 검증 | **fail-fast (Fatal)** |
 
 <br>
 

--- a/docs/architecture/cmd/migrate-down.md
+++ b/docs/architecture/cmd/migrate-down.md
@@ -1,0 +1,45 @@
+# cmd/migrate-down — DB Migration Runner (rollback)
+
+소스: [`cmd/migrate-down/main.go`](../../../cmd/migrate-down/main.go)
+산출물: `bin/migrate-down` (`make build` 또는 `make pg-migrate-down`)
+
+[`migrations.Rollback`](../../../migrations/) 를 호출해 마지막 마이그레이션을 되돌리는 thin CLI.
+[`cmd/migrate`](migrate.md) 와 구조가 동일하며 호출하는 함수만 다릅니다.
+
+<br>
+
+## 역할
+
+```
+1. logger 초기화
+2. config.Load() → DatabaseConfig
+3. pgstore.NewPool() → pgx 연결 풀
+4. migrations.Rollback(ctx, pool, log) — 적용된 마지막 마이그레이션 down 적용
+```
+
+<br>
+
+## ⚠️ 운영 주의
+
+- **운영 환경 전용** — dev 에서는 사용 지양 (Makefile help 명시)
+- destructive — 데이터 손실 가능
+- [.claude/rules/07-workflow.md](../../../.claude/rules/07-workflow.md) 의 destructive 영역으로 분류
+  → AI 가 자율 실행하지 않음, 사용자 사전 확인 필요
+
+<br>
+
+## 의존 패키지
+
+- [`internal/storage/postgres`](../../../internal/storage/postgres/)
+- [`migrations`](../../../migrations/) — `Rollback(ctx, pool, log)`
+- [`pkg/config`](../../../pkg/config/)
+- [`pkg/logger`](../../../pkg/logger/)
+
+<br>
+
+## 사용
+
+```bash
+make pg-migrate-down   # 빌드 후 실행 (운영자 직접 트리거)
+./bin/migrate-down     # 직접 실행
+```

--- a/docs/architecture/cmd/migrate.md
+++ b/docs/architecture/cmd/migrate.md
@@ -1,0 +1,43 @@
+# cmd/migrate — DB Migration Runner (forward)
+
+소스: [`cmd/migrate/main.go`](../../../cmd/migrate/main.go)
+산출물: `bin/migrate` (`make build` 또는 `make pg-migrate`)
+
+PostgreSQL 스키마 마이그레이션을 **앞 방향으로** 적용하는 thin CLI. 실제 마이그레이션 로직은
+[`migrations/`](../../../migrations/) 패키지가 보유하며, 본 바이너리는 단순히 그것을 호출합니다.
+
+<br>
+
+## 역할
+
+```
+1. logger 초기화 (Pretty=true, Level=info)
+2. config.Load() → DatabaseConfig
+3. pgstore.NewPool() → pgx 연결 풀
+4. migrations.Run(ctx, pool, log) — 미적용 마이그레이션을 schema_migrations 기준으로 멱등 적용
+```
+
+실패 시 `Fatal` — 비-zero exit. CI 와 운영 entrypoint 가 이를 신호로 사용.
+
+<br>
+
+## 의존 패키지
+
+- [`internal/storage/postgres`](../../../internal/storage/postgres/) — `NewPool`
+- [`migrations`](../../../migrations/) — `Run(ctx, pool, log)` (단일 소스)
+- [`pkg/config`](../../../pkg/config/) — `Load()` (DB 설정)
+- [`pkg/logger`](../../../pkg/logger/)
+
+<br>
+
+## 사용
+
+```bash
+make pg-migrate   # 빌드 후 실행
+./bin/migrate     # 직접 실행
+```
+
+마이그레이션 파일 추가 시 [`migrations/`](../../../migrations/) 에 추가 + 등록 — `cmd/migrate` 자체는
+변경 불필요.
+
+롤백은 [migrate-down.md](migrate-down.md) 참조.

--- a/docs/architecture/cmd/processor.md
+++ b/docs/architecture/cmd/processor.md
@@ -1,0 +1,50 @@
+# cmd/processor — Standalone Validator
+
+소스: [`cmd/processor/main.go`](../../../cmd/processor/main.go)
+산출물: `bin/processor` (`make build` 또는 `make run-processor`)
+
+[`internal/processor/validate`](../../../internal/processor/validate/) 단계만 단독 실행하는 바이너리.
+[`cmd/issuetracker`](issuetracker.md) 의 부분집합으로, dev/test 또는 검증 단독 스케일링이 필요할 때 사용합니다.
+
+<br>
+
+## 역할
+
+- `issuetracker.normalized` consume → `issuetracker.validated` (또는 DLQ) 발행
+- crawler / parser 가 이미 떠 있는 환경에서 검증 인스턴스를 별도 process 로 띄울 때 사용
+- **NoopProcessingLock 사용** — Redis wiring 없음, 다중 인스턴스 운영은 [`cmd/issuetracker`](issuetracker.md) 권장
+
+<br>
+
+## Wiring 요약
+
+```
+1. logger / metrics endpoint
+2. LoadValidate() — 검증 임계값
+3. Kafka: Consumer(TopicNormalized) + Producer
+4. PostgreSQL pool → ContentRepository → ContentService
+5. validate.NewWorker(... NoopProcessingLock{} ...)
+6. SIGTERM → cancel → worker.Stop(30s timeout)
+```
+
+자세한 검증 로직은 [internal/processor/validate.md](../internal/processor/validate.md) 참조.
+
+<br>
+
+## 의존 패키지
+
+- [`internal/processor/validate`](../../../internal/processor/validate/) — Worker / Validator
+- [`internal/crawler/worker`](../../../internal/crawler/worker/) — `NoopProcessingLock`
+- [`internal/storage/postgres`](../../../internal/storage/postgres/) + [`internal/storage/service`](../../../internal/storage/service/)
+- [`pkg/config`](../../../pkg/config/), [`pkg/queue`](../../../pkg/queue/), [`pkg/logger`](../../../pkg/logger/), [`pkg/metrics`](../../../pkg/metrics/)
+
+<br>
+
+## issuetracker 와의 차이
+
+| 항목                    | `cmd/processor`                        | `cmd/issuetracker`                      |
+|-------------------------|---------------------------------------|----------------------------------------|
+| 실행 stage              | validate 만                            | crawler + parser + validator + scheduler + refiner |
+| ProcessingLock          | `NoopProcessingLock{}` (no-op)         | `NewRedisProcessingLock` (Redis SETNX)  |
+| RetryScheduler / IngestionLock | 없음                            | Redis 기반 (이슈 #82, #178)             |
+| 다중 인스턴스 안전성    | Kafka consumer group rebalance 로 동시 처리 가능성 — dev/test 권장 | 단일 ProcessingLock 공유로 안전        |

--- a/docs/architecture/internal/README.md
+++ b/docs/architecture/internal/README.md
@@ -1,0 +1,33 @@
+# internal/ — Private Application Code
+
+[`internal/`](../../../internal/) 는 IssueTracker 의 비공개 비즈니스 로직을 담는 디렉토리입니다.
+Go 의 `internal` 규칙에 의해 외부 모듈에서 import 할 수 없으므로 안전하게 깨질 수 있는 인터페이스를
+보유합니다.
+
+이 디렉토리의 패키지는 [`pkg/`](../../../pkg/) 의 generic 유틸을 사용해 도메인 로직을 구성하며,
+[`cmd/`](../../../cmd/) 의 entry point 가 이들을 wire 합니다.
+
+<br>
+
+## 패키지 일람
+
+| 디렉토리                                       | 역할                                                       | 문서                                                       |
+|-----------------------------------------------|-----------------------------------------------------------|-----------------------------------------------------------|
+| [`internal/crawler/`](../../../internal/crawler/) | 웹 크롤링 — fetch + DB-driven parse + rate limit + worker pool | [crawler/README.md](crawler/README.md)                    |
+| [`internal/parser/`](../../../internal/parser/)   | Claim Check 기반 ParserWorker (TopicFetched 소비)         | [parser/README.md](parser/README.md)                      |
+| [`internal/processor/`](../../../internal/processor/) | 검증 stage (news/community Validator)                | [processor/README.md](processor/README.md)                |
+| [`internal/classifier/`](../../../internal/classifier/) | ELArchive Classifier client (gRPC + HTTP fallback)  | [classifier/README.md](classifier/README.md)              |
+| [`internal/publisher/`](../../../internal/publisher/) | chained CrawlJob 발행 + IngestionLock                 | [publisher.md](publisher.md)                              |
+| [`internal/scheduler/`](../../../internal/scheduler/) | 주기적 seed job 발행 + backlog throttle              | [scheduler.md](scheduler.md)                              |
+| [`internal/storage/`](../../../internal/storage/)     | Repository 인터페이스 + PostgreSQL 구현 + Service 계층 | [storage/README.md](storage/README.md)                    |
+
+<br>
+
+## 레이어 규칙
+
+[.claude/rules/04-error-handling.md](../../../.claude/rules/04-error-handling.md) 의
+"Layer Rules" 와 정합:
+
+- 외부에 노출되는 boundary 메소드는 `core.CrawlerError` 로 카테고리화된 에러 반환
+- 내부 helper 는 `fmt.Errorf("...: %w", err)` wrap 사용
+- `pkg/` 의 generic util 이 반환한 에러는 `internal/` boundary 에서 categorized 에러로 변환

--- a/docs/architecture/internal/classifier/README.md
+++ b/docs/architecture/internal/classifier/README.md
@@ -1,0 +1,66 @@
+# internal/classifier — ELArchive Classifier Client
+
+소스: [`internal/classifier/`](../../../../internal/classifier/)
+
+외부 ELArchive Classifier 서비스 (텍스트 → 카테고리 분류) 를 호출하는 클라이언트. **gRPC 우선 + HTTP
+fallback** 의 dual-protocol Handler 를 제공합니다.
+
+> 현재 시점에는 파이프라인 내 실제 호출 지점이 없으나, enrichment / classify stage 도입 시 사용될
+> 모듈로 미리 wiring 가능하도록 유지됩니다.
+
+<br>
+
+## 핵심 인터페이스
+
+```go
+type Classifier interface {
+    Classify(ctx, text, []CategoryInput) (*ClassifyResponse, error)
+    ClassifyBatch(ctx, []string, []CategoryInput) (*BatchClassifyResponse, error)
+    Health(ctx) (*HealthResponse, error)
+    Close() error
+}
+```
+
+CategoryInput 생략 시 서비스의 기본 카테고리 (`configs/categories.yaml`) 사용.
+
+<br>
+
+## Handler 구조
+
+[handler.go](../../../../internal/classifier/handler.go) 는 `grpc` 와 `http` 클라이언트를 모두 보유하고
+`primary` 프로토콜 우선 호출 + 실패 시 `fallback`:
+
+```
+Handler.Classify
+   ├ primary=gRPC → grpc.Classify
+   │     ├ 성공 → 반환
+   │     └ 실패 + fallback=true → http.Classify
+   └ primary=HTTP → http.Classify
+         └ (대칭)
+```
+
+<br>
+
+## 서브패키지
+
+| 디렉토리                                                           | 문서                                |
+|-------------------------------------------------------------------|-------------------------------------|
+| [`internal/classifier/grpc/`](../../../../internal/classifier/grpc/) | [grpc.md](grpc.md)                 |
+| [`internal/classifier/http/`](../../../../internal/classifier/http/) | [http.md](http.md)                 |
+
+생성된 gRPC stub 은 [`internal/classifier/grpc/pb/`](../../../../internal/classifier/grpc/pb/) 에 위치
+([proto/classifier.md](../../proto/classifier.md) 의 `make proto` 가 생성).
+
+<br>
+
+## 의존
+
+- [`pkg/logger`](../../pkg/logger.md)
+- 외부: `google.golang.org/grpc`, `net/http`
+- 외부 서비스: ELArchive Classifier (gRPC `:50051`, HTTP `:8000`)
+
+<br>
+
+## 관련 이슈
+
+- 이슈 #142 — LLM chain (별개 시스템이지만 fallback 패턴이 유사)

--- a/docs/architecture/internal/classifier/README.md
+++ b/docs/architecture/internal/classifier/README.md
@@ -14,9 +14,9 @@ fallback** 의 dual-protocol Handler 를 제공합니다.
 
 ```go
 type Classifier interface {
-    Classify(ctx, text, []CategoryInput) (*ClassifyResponse, error)
-    ClassifyBatch(ctx, []string, []CategoryInput) (*BatchClassifyResponse, error)
-    Health(ctx) (*HealthResponse, error)
+    Classify(ctx context.Context, text string, categories []CategoryInput) (*ClassifyResponse, error)
+    ClassifyBatch(ctx context.Context, texts []string, categories []CategoryInput) (*BatchClassifyResponse, error)
+    Health(ctx context.Context) (*HealthResponse, error)
     Close() error
 }
 ```

--- a/docs/architecture/internal/classifier/grpc.md
+++ b/docs/architecture/internal/classifier/grpc.md
@@ -1,0 +1,48 @@
+# internal/classifier/grpc — gRPC Client
+
+소스: [`internal/classifier/grpc/`](../../../../internal/classifier/grpc/)
+
+[`proto/classifier/classifier.proto`](../../../../proto/classifier/classifier.proto) 의 service stub
+을 wrap 하여 [Classifier 인터페이스](README.md) 를 만족하는 클라이언트를 제공합니다.
+
+<br>
+
+## 구성
+
+| 파일                                                                        | 역할                                                  |
+|----------------------------------------------------------------------------|-------------------------------------------------------|
+| [client.go](../../../../internal/classifier/grpc/client.go)                 | `Client` — Dial / Classify / ClassifyBatch / Health / Close |
+| [pb/classifier.pb.go](../../../../internal/classifier/grpc/pb/classifier.pb.go) | proto 메시지 stub (자동 생성)                       |
+| [pb/classifier_grpc.pb.go](../../../../internal/classifier/grpc/pb/classifier_grpc.pb.go) | service stub (자동 생성)                  |
+
+`pb/` 는 [`make proto`](../../../../Makefile) (`protoc + protoc-gen-go + protoc-gen-go-grpc`) 가
+자동 생성 — **수정하지 않음**.
+
+<br>
+
+## 사용
+
+```go
+client, err := grpc.NewClient(grpc.Config{Endpoint: "localhost:50051", Timeout: 5*time.Second})
+defer client.Close()
+
+resp, err := client.Classify(ctx, "오늘의 정치 뉴스", nil)
+```
+
+[Handler](README.md) 가 본 클라이언트와 [HTTP 클라이언트](http.md) 를 묶어 fallback 처리.
+
+<br>
+
+## 의존
+
+- 자동 생성 stub (`pb/`)
+- `google.golang.org/grpc`
+- [`pkg/logger`](../../pkg/logger.md)
+
+<br>
+
+## proto 변경 시
+
+1. [`proto/classifier/classifier.proto`](../../../../proto/classifier/classifier.proto) 수정
+2. `make proto` 실행 → `pb/*.go` 재생성
+3. `client.go` 가 새 메시지/메소드 사용하도록 수정

--- a/docs/architecture/internal/classifier/http.md
+++ b/docs/architecture/internal/classifier/http.md
@@ -1,0 +1,46 @@
+# internal/classifier/http — HTTP REST Client
+
+소스: [`internal/classifier/http/`](../../../../internal/classifier/http/)
+
+ELArchive Classifier 의 HTTP REST 인터페이스를 호출하는 클라이언트. [Classifier 인터페이스](README.md)
+를 만족합니다.
+
+<br>
+
+## 구성
+
+| 파일                                                              | 역할                                                  |
+|------------------------------------------------------------------|-------------------------------------------------------|
+| [client.go](../../../../internal/classifier/http/client.go)       | `Client` — Classify / ClassifyBatch / Health / Close   |
+
+엔드포인트:
+- `POST /v1/classify`
+- `POST /v1/classify_batch`
+- `GET  /v1/health`
+
+요청/응답 JSON 스키마는 proto 메시지와 1:1 대응 (Classifier 서비스 측 단일 소스).
+
+<br>
+
+## 사용
+
+```go
+client := http.NewClient(http.Config{BaseURL: "http://localhost:8000", Timeout: 10*time.Second})
+defer client.Close()
+
+resp, err := client.Classify(ctx, "오늘의 정치 뉴스", nil)
+```
+
+<br>
+
+## 의존
+
+- 표준 `net/http`
+- [`pkg/logger`](../../pkg/logger.md)
+
+<br>
+
+## gRPC 와의 관계
+
+[Handler](README.md) 의 fallback 경로 — gRPC 가 unavailable 일 때 사용. 직접 사용보다 Handler 를 통해
+사용하는 것이 권장.

--- a/docs/architecture/internal/crawler/README.md
+++ b/docs/architecture/internal/crawler/README.md
@@ -1,0 +1,118 @@
+# internal/crawler/ — Web Crawling Subsystem
+
+[`internal/crawler/`](../../../../internal/crawler/) 는 IssueTracker 의 **fetch 단계**를 구성하는
+패키지군입니다. 토픽 `issuetracker.crawl.{high,normal,low}` 를 consume 하여 웹페이지 본문을 가져오고,
+[Claim Check 패턴](https://learn.microsoft.com/en-us/azure/architecture/patterns/claim-check) 으로
+`raw_contents` 테이블에 저장한 뒤 `RawContentRef` 를 `issuetracker.fetched` 에 발행합니다.
+
+<br>
+
+## 서브패키지 트리
+
+```
+internal/crawler/
+├── core/             ← 인터페이스 + 모델 + 에러 (모든 다른 패키지가 의존)
+├── handler/          ← Registry: crawler_name → Handler
+├── domain/general/   ← Fetcher Chain of Responsibility + 사이트별 config
+│   └── sources/      ← KR (naver/daum/yonhap), US (cnn) 카테고리 URL + RPS
+├── implementation/   ← Fetcher 구현체
+│   ├── chromedp/     ← 헤드리스 Chrome (CDP)
+│   └── goquery/      ← 정적 HTTP + goquery
+├── parser/           ← (별도 도메인) DB-driven Parser 인터페이스 + rule engine
+│   └── rule/
+│       ├── llmgen/   ← LLM 으로 selector 자동 생성 (이슈 #149)
+│       ├── pathinfer/← path_pattern 추론
+│       └── refiner/  ← path_pattern 정밀화 polling (이슈 #173)
+├── rate_limiter/     ← IP 단위 token bucket
+└── worker/           ← PoolManager + ProcessingLock + RetryScheduler + CircuitBreaker
+```
+
+<br>
+
+## 패키지별 문서
+
+| 패키지                                                              | 문서                                       |
+|---------------------------------------------------------------------|-------------------------------------------|
+| [`internal/crawler/core/`](../../../../internal/crawler/core/)       | [core.md](core.md)                        |
+| [`internal/crawler/handler/`](../../../../internal/crawler/handler/) | [handler.md](handler.md)                  |
+| [`internal/crawler/domain/`](../../../../internal/crawler/domain/)   | [domain.md](domain.md)                    |
+| [`internal/crawler/implementation/`](../../../../internal/crawler/implementation/) | [implementation.md](implementation.md) |
+| [`internal/crawler/parser/`](../../../../internal/crawler/parser/)   | [parser.md](parser.md)                    |
+| [`internal/crawler/rate_limiter/`](../../../../internal/crawler/rate_limiter/) | [rate_limiter.md](rate_limiter.md) |
+| [`internal/crawler/worker/`](../../../../internal/crawler/worker/)   | [worker.md](worker.md)                    |
+
+<br>
+
+## 의존 그래프 (서브패키지간)
+
+```
+worker ──→ handler ──→ (domain/general → fetcher) ──→ implementation/{goquery,chromedp}
+   │           │              │
+   │           │              ├──→ rate_limiter
+   │           │              └──→ pkg/links / pkg/urlguard
+   │           │
+   │           └──→ noop fallback
+   │
+   └──→ core (interfaces, models, errors) ──── 모든 패키지가 의존
+
+parser/rule ──→ storage (parsing_rules / sample_urls 조회)
+parser/rule/llmgen ──→ pkg/llm (provider abstract)
+parser/rule/refiner ──→ pkg/llm + storage + pathinfer
+```
+
+`core` 가 sink 노드 (다른 어떤 서브패키지도 의존하지 않음 — 가장 안정적인 인터페이스 계층).
+
+<br>
+
+## 호출 흐름 (한 page 의 일생)
+
+```
+1. CrawlJob 메시지가 Kafka 로 도착
+       │
+       ▼ worker/pool.go
+2. PoolManager 의 priority 별 KafkaConsumerPool 이 메시지를 fetch
+       │
+       ▼ worker/processing_lock.go (Acquire)
+3. ProcessingLock 획득 (같은 URL 의 다른 인스턴스 차단)
+       │
+       ▼ handler/handler.go (Registry.Handle)
+4. crawler_name 으로 Handler dispatch → ChainHandler
+       │
+       ▼ domain/general/chain_handler.go
+5. ChainHandler 가 fetcher chain 순회 (goquery 우선 → 실패 시 chromedp)
+       │
+       ▼ implementation/{goquery,chromedp}/fetch.go
+6. RawContent (HTML) 획득
+       │
+       ▼ rate_limiter (다음 요청을 위한 토큰 소비)
+7. ChainHandler 가 raw_contents 에 저장 (Claim Check)
+       │
+       ▼ pkg/queue.Producer
+8. RawContentRef 를 issuetracker.fetched 토픽에 발행
+       │
+       ▼
+   (parser stage 로 핸드오프 — internal/parser/README.md)
+```
+
+각 단계의 자세한 책임은 위 패키지별 문서 참조.
+
+<br>
+
+## 외부 의존
+
+- **Kafka**: `issuetracker.crawl.{high,normal,low}` consume / `issuetracker.fetched` produce
+- **PostgreSQL**: `raw_contents` (Claim Check) / `parsing_rules` (rule engine, parser/) / `sample_urls` (refiner)
+- **Redis**: ProcessingLock (SETNX) / IngestionLock / RetryQueue (ZSET)
+- **Chrome (CDP)**: `implementation/chromedp` 가 `ws://localhost:9222` 또는 컨테이너 내장 chrome 사용
+- **LLM**: `parser/rule/llmgen` 과 `parser/rule/refiner` 가 [`pkg/llm`](../../../../pkg/llm/) 통해 호출
+
+<br>
+
+## 관련 이슈
+
+- 이슈 #100 — DB-driven parsing rules (사이트별 hardcode 파서 폐기)
+- 이슈 #134 — fetcher 와 parser 분리 (Claim Check 도입)
+- 이슈 #82 — Redis delayed retry queue (worker slot 점유 회피)
+- 이슈 #178 — IngestionLock + ProcessingLock 단일 책임화
+- 이슈 #149 — LLM 기반 selector 자동 생성
+- 이슈 #173 — path_pattern 정밀화 (refiner)

--- a/docs/architecture/internal/crawler/core.md
+++ b/docs/architecture/internal/crawler/core.md
@@ -1,0 +1,67 @@
+# internal/crawler/core — Interfaces, Models, Errors
+
+소스: [`internal/crawler/core/`](../../../../internal/crawler/core/)
+
+크롤러 서브시스템의 가장 기초가 되는 **타입/인터페이스/에러** 만 담는 패키지. 다른 어떤 crawler
+하위 패키지도 본 패키지를 import 합니다 (sink 노드).
+
+<br>
+
+## 핵심 인터페이스
+
+| 인터페이스         | 위치                                                              | 책임                                                  |
+|--------------------|------------------------------------------------------------------|-------------------------------------------------------|
+| `Crawler`          | [crawler.go](../../../../internal/crawler/core/crawler.go)        | Initialize / Start / Stop / Fetch / HealthCheck       |
+| `Parser`           | (동일 파일)                                                       | RawContent → 도메인 모델 (별도 [parser](parser.md) 가 구현)  |
+| `RateLimiter`      | (동일 파일)                                                       | Wait(ctx) — 토큰 buckets 등으로 호출 빈도 제한        |
+| `URLRateLimiter`   | (동일 파일)                                                       | URL → IP 매핑 + per-IP rate limit (DNS 해석 필요)     |
+| `HTTPClient`       | [http_client.go](../../../../internal/crawler/core/http_client.go) | Do(req) — 표준 `*http.Client` wrapper                |
+
+<br>
+
+## 핵심 모델
+
+| 타입                  | 위치                                                              | 설명                                                    |
+|-----------------------|------------------------------------------------------------------|---------------------------------------------------------|
+| `SourceInfo`          | [models.go](../../../../internal/crawler/core/models.go)          | Country / Type / Name / BaseURL / Language              |
+| `Target`, `TargetType` | (동일)                                                            | URL + page/list/article 등 타입                         |
+| `RawContent`          | (동일)                                                            | HTML / StatusCode / Headers + 메타                      |
+| `Content`             | (동일)                                                            | 파싱된 본문 (ID, Title, Body, Author, PublishedAt, …)   |
+| `RawContentRef`, `ContentRef` | (동일)                                                    | Kafka 메시지로 보내는 lightweight 참조 (Claim Check)   |
+| `CrawlJob`            | [job.go](../../../../internal/crawler/core/job.go)                | Kafka 직렬화 가능 JSON (RetryCount/Priority 포함)       |
+| `ProcessingMessage`   | (동일)                                                            | 파이프라인 stage 간 wrapper                              |
+| `Priority`            | (동일)                                                            | High=1 / Normal=2 / Low=3                              |
+| `Config`              | (동일)                                                            | HTTP timeout / User-Agent / RPS 등 기본값               |
+
+<br>
+
+## 에러 / HTTP 상태
+
+| 파일                                                                  | 책임                                                |
+|----------------------------------------------------------------------|-----------------------------------------------------|
+| [errors.go](../../../../internal/crawler/core/errors.go)              | `CrawlerError` + 카테고리 / 코드 / Retryable 플래그 |
+| [http_status.go](../../../../internal/crawler/core/http_status.go)    | 상태 코드 → 카테고리 변환 helper                    |
+| [retry.go](../../../../internal/crawler/core/retry.go)                | `WithRetry` (지수 backoff + Retryable 검사)         |
+
+`CrawlerError` 의 카테고리 / 코드 체계는 [.claude/rules/04-error-handling.md](../../../../.claude/rules/04-error-handling.md)
+가 단일 소스. boundary 레이어에서는 반드시 본 타입으로 반환.
+
+<br>
+
+## 부수 helper
+
+| 파일                                                                  | 역할                                                     |
+|----------------------------------------------------------------------|----------------------------------------------------------|
+| [extractor.go](../../../../internal/crawler/core/extractor.go)        | HTML 으로부터 link 추출 wrapper (boundary 레이어)         |
+| [http2_metrics.go](../../../../internal/crawler/core/http2_metrics.go) | HTTP/2 latency 등 metrics 수집                          |
+| [ip_resolver.go](../../../../internal/crawler/core/ip_resolver.go)    | host → IP 해석 (rate limiter 가 IP 단위로 동작)         |
+
+<br>
+
+## 의존 관계
+
+- **누구도 import 하지 않는** 외부 의존 외엔 standard lib + zerolog 정도
+- 본 패키지를 import 하는 패키지: `domain/`, `handler/`, `worker/`, `parser/`, `rate_limiter/`, 그리고 [`internal/parser`](../parser/README.md), [`internal/scheduler`](../scheduler.md), [`internal/storage/service`](../storage/service.md) 등 — 사실상 거의 모든 곳
+
+본 패키지가 변경되면 광범위한 영향이 있으므로 신중히. 새 인터페이스 추가는 자유롭지만 기존 인터페이스
+시그니처 변경은 큰 PR 이 됩니다.

--- a/docs/architecture/internal/crawler/domain.md
+++ b/docs/architecture/internal/crawler/domain.md
@@ -1,0 +1,102 @@
+# internal/crawler/domain — Generic Fetcher Chain & Source Configs
+
+소스: [`internal/crawler/domain/`](../../../../internal/crawler/domain/)
+주 패키지: [`internal/crawler/domain/general/`](../../../../internal/crawler/domain/general/)
+
+도메인 중립 (news / community / blog 모두 공용) 의 Fetcher Chain of Responsibility 와, 사이트별 config
+(카테고리 URL / RPS / Source 메타) 등록 지점입니다.
+
+<br>
+
+## 핵심 추상
+
+| 위치                                                                      | 역할                                                            |
+|--------------------------------------------------------------------------|-----------------------------------------------------------------|
+| [types.go](../../../../internal/crawler/domain/general/types.go)          | `SourceCrawler` (=`core.Crawler` 별칭), `Fetcher`, `JobPublisher` 인터페이스 |
+| [handler.go](../../../../internal/crawler/domain/general/handler.go)      | `FetchHandler` (Chain link) — 실패 시 다음 link 로 위임          |
+| [chain_handler.go](../../../../internal/crawler/domain/general/chain_handler.go) | `ChainHandler` — fetch chain 실행 → raw_contents 저장 → RawContentRef 발행 |
+| [source_crawler.go](../../../../internal/crawler/domain/general/source_crawler.go) | `genericCrawler` — `core.Crawler` 의 default 구현               |
+| [convert.go](../../../../internal/crawler/domain/general/convert.go)      | `parser.Page` ↔ `core.Content` 양방향 변환                      |
+
+<br>
+
+## Fetcher Chain (Chain of Responsibility)
+
+```
+ChainHandler (handler.Handler 구현)
+    │
+    ▼ chain[0]: GoQueryFetchHandler  (정적 HTML 우선 — 빠르고 가벼움)
+    │       │
+    │       ├ 성공 → RawContent 반환
+    │       └ 실패 (lazy 감지 / status 4xx-5xx 일부) → 다음 link
+    │
+    ▼ chain[1]: BrowserFetchHandler  (chromedp 헤드리스 Chrome)
+            │
+            ├ 성공 → RawContent
+            └ 실패 → CrawlerError 반환 (worker 가 retry/CB 처리)
+```
+
+각 chain link 의 구현은 [implementation.md](implementation.md) 참조 (실제 fetcher 는
+`fetcher/goquery.go`, `fetcher/browser.go` 가 담당).
+
+<br>
+
+## 사이트별 config
+
+```
+domain/general/sources/
+├── kr/
+│   ├── registry.go      ← kr.Register(registry, cfg, rawSvc, producer, log)
+│   ├── naver/config.go  ← Naver 카테고리 URL + RequestsPerHour
+│   ├── daum/config.go
+│   └── yonhap/config.go
+└── us/
+    ├── registry.go      ← us.Register(...)
+    └── cnn/config.go
+```
+
+각 `config.go` 는:
+
+- `SourceInfo` (Country, Type=News, Name, BaseURL, Language)
+- 카테고리 URL 목록 (스케줄러 seed 로 사용)
+- `RequestsPerHour` (rate_limiter 에 전달)
+
+`registry.go` 는 사이트별 ChainHandler 를 구성하여 [`handler.Registry`](handler.md) 에 등록합니다.
+
+<br>
+
+## 사용 흐름
+
+[`cmd/issuetracker/main.go`](../../../../cmd/issuetracker/main.go):
+
+```go
+registry := handler.NewRegistry(log)
+kr.Register(registry, core.DefaultConfig(), rawSvc, crawlerProducer, log)
+us.Register(registry, core.DefaultConfig(), rawSvc, crawlerProducer, log)
+```
+
+`Register` 함수는 사이트별로:
+1. `goquery.Crawler` + `chromedp.Crawler` 인스턴스 생성
+2. `BuildChain` 으로 Fetcher chain 조립
+3. `ChainHandler` 로 wrap (raw_contents 저장 + RawContentRef 발행 책임)
+4. `registry.Register("naver", chainHandler)` 등록
+
+<br>
+
+## 의존
+
+- [`internal/crawler/core`](core.md) — 모든 인터페이스/모델
+- [`internal/crawler/handler`](handler.md) — Registry 등록 대상
+- [`internal/crawler/implementation/{goquery,chromedp}`](implementation.md) — 실제 fetcher
+- [`internal/storage/service`](../storage/service.md) — `RawContentService` (Claim Check 저장)
+- [`pkg/queue`](../../pkg/queue.md) — Kafka producer
+- [`pkg/links`](../../pkg/links.md) — URL normalize / link extract
+
+<br>
+
+## 새 사이트 추가 절차
+
+1. `sources/<country>/<site>/config.go` 생성 (`SourceInfo` + 카테고리 URL + RPS)
+2. `sources/<country>/registry.go` 의 `Register` 에 site 추가
+3. [`internal/scheduler.DefaultEntries`](../scheduler.md) 에 카테고리 seed entry 추가
+4. `parsing_rules` 에 host_pattern + selectors 시드 (마이그레이션 또는 운영자 INSERT)

--- a/docs/architecture/internal/crawler/domain.md
+++ b/docs/architecture/internal/crawler/domain.md
@@ -99,4 +99,6 @@ us.Register(registry, core.DefaultConfig(), rawSvc, crawlerProducer, log)
 1. `sources/<country>/<site>/config.go` 생성 (`SourceInfo` + 카테고리 URL + RPS)
 2. `sources/<country>/registry.go` 의 `Register` 에 site 추가
 3. [`internal/scheduler.DefaultEntries`](../scheduler.md) 에 카테고리 seed entry 추가
-4. `parsing_rules` 에 host_pattern + selectors 시드 (마이그레이션 또는 운영자 INSERT)
+4. `parsing_rules` 에 host_pattern + path_pattern + selectors 시드 (마이그레이션 또는 운영자 INSERT)
+   — `path_pattern` 은 빈 문자열이면 catch-all 로 동작하며, [refiner](parser.md) 가 누적 sample
+   기반으로 정밀화합니다 (이슈 #173).

--- a/docs/architecture/internal/crawler/handler.md
+++ b/docs/architecture/internal/crawler/handler.md
@@ -1,0 +1,53 @@
+# internal/crawler/handler — Crawler Registry
+
+소스: [`internal/crawler/handler/`](../../../../internal/crawler/handler/)
+
+`crawler_name` (예: `"naver"`, `"cnn"`) 을 실제 처리 함수에 매핑하는 **Registry**. [`worker/PoolManager`](worker.md)
+가 Kafka 에서 받은 `CrawlJob.CrawlerName` 으로 본 Registry 를 lookup 해서 처리를 위임합니다.
+
+<br>
+
+## 인터페이스 + 구현
+
+| 위치                                                                  | 역할                                                |
+|----------------------------------------------------------------------|-----------------------------------------------------|
+| [handler.go](../../../../internal/crawler/handler/handler.go)         | `Handler` 인터페이스 + `Registry` (map + RWMutex)   |
+| [noop.go](../../../../internal/crawler/handler/noop.go)               | unknown crawler_name 에 대한 fallback (Warn 로그)   |
+
+```go
+type Handler interface {
+    Handle(ctx context.Context, job core.CrawlJob) ([]*core.Content, error)
+}
+```
+
+<br>
+
+## 사용 흐름
+
+```
+1. cmd/issuetracker/main.go 가 NewRegistry(log) 생성
+2. kr.Register(...) / us.Register(...) 가 사이트별 Handler 를 등록
+3. PoolManager 가 worker 마다 Registry.Handle(ctx, job) 호출
+4. CrawlerName 에 매칭 없으면 noop.Handler 가 Warn 로그 + 빈 결과 반환
+```
+
+<br>
+
+## 등록 측
+
+`internal/crawler/domain/general/sources/{kr,us}/registry.go` 가 `Register(registry, …)` 함수를 노출하며,
+[`cmd/issuetracker`](../../cmd/issuetracker.md) 에서 호출. 자세한 구조는
+[domain.md](domain.md) 참조.
+
+<br>
+
+## 의존
+
+- [`internal/crawler/core`](core.md) — `CrawlJob`, `Content`
+- [`pkg/logger`](../../pkg/logger.md)
+
+<br>
+
+## Test 위치
+
+[`test/internal/crawler_handler/`](../../../../test/internal/) (있다면) — Registry 등록/조회/충돌 처리 검증.

--- a/docs/architecture/internal/crawler/handler.md
+++ b/docs/architecture/internal/crawler/handler.md
@@ -11,14 +11,24 @@
 
 | 위치                                                                  | 역할                                                |
 |----------------------------------------------------------------------|-----------------------------------------------------|
-| [handler.go](../../../../internal/crawler/handler/handler.go)         | `Handler` 인터페이스 + `Registry` (map + RWMutex)   |
+| [handler.go](../../../../internal/crawler/handler/handler.go)         | `Handler` 인터페이스 + `Registry` (map + fallback)  |
 | [noop.go](../../../../internal/crawler/handler/noop.go)               | unknown crawler_name 에 대한 fallback (Warn 로그)   |
 
 ```go
 type Handler interface {
-    Handle(ctx context.Context, job core.CrawlJob) ([]*core.Content, error)
+    Handle(ctx context.Context, job *core.CrawlJob) ([]*core.Content, error)
+}
+
+type Registry struct {
+    handlers map[string]Handler
+    fallback Handler
+    log      *logger.Logger
 }
 ```
+
+`Registry` 는 mutex 가 없습니다 — 등록은 entry point ([`cmd/issuetracker`](../../cmd/issuetracker.md))
+의 wiring 단계에서 단일 goroutine 으로 일괄 수행되고, 그 후 worker 들의 read-only lookup 만 발생하므로
+race 가 없습니다 (등록/조회 동시성을 도입한다면 별도 mutex 필요).
 
 <br>
 

--- a/docs/architecture/internal/crawler/implementation.md
+++ b/docs/architecture/internal/crawler/implementation.md
@@ -1,0 +1,66 @@
+# internal/crawler/implementation — Fetcher Backends
+
+소스: [`internal/crawler/implementation/`](../../../../internal/crawler/implementation/)
+
+[`domain/general`](domain.md) 의 Fetcher chain 에 link 되는 **실제 fetch 구현체**. 두 가지 전략 제공:
+
+- [`goquery/`](../../../../internal/crawler/implementation/goquery/) — 정적 HTTP + goquery 파싱 (빠름/저비용)
+- [`chromedp/`](../../../../internal/crawler/implementation/chromedp/) — 헤드리스 Chrome (CDP) 으로 JS 렌더 후 DOM 캡처
+
+<br>
+
+## goquery 구현
+
+| 파일                                                                          | 역할                                                |
+|------------------------------------------------------------------------------|-----------------------------------------------------|
+| [crawler.go](../../../../internal/crawler/implementation/goquery/crawler.go)  | `Crawler` (=`core.Crawler` 구현) — Initialize/Start/Stop |
+| [fetch.go](../../../../internal/crawler/implementation/goquery/fetch.go)      | `Fetch(ctx, target) → RawContent` — 표준 HTTP GET   |
+| [parse.go](../../../../internal/crawler/implementation/goquery/parse.go)      | (legacy 용) goquery 기반 파싱 helper                 |
+| [types.go](../../../../internal/crawler/implementation/goquery/types.go)      | `Config` — Timeout, UA, MaxBodySize 등              |
+
+특성:
+- 가벼움 — net/http + PuerkitoBio/goquery
+- JS 실행 X → SPA / lazy-load 페이지는 빈 DOM 반환 가능
+- Fetch chain 의 첫 번째 link 로 사용 (실패 시 chromedp 로 fallback)
+
+<br>
+
+## chromedp 구현
+
+| 파일                                                                              | 역할                                                            |
+|----------------------------------------------------------------------------------|-----------------------------------------------------------------|
+| [crawler.go](../../../../internal/crawler/implementation/chromedp/crawler.go)     | `Crawler` 구현 — local Chrome 또는 remote (`ws://localhost:9222`) |
+| [fetch.go](../../../../internal/crawler/implementation/chromedp/fetch.go)         | `Fetch` — Navigate + Wait + OuterHTML 캡처                       |
+| [parse.go](../../../../internal/crawler/implementation/chromedp/parse.go)         | (legacy) chromedp 기반 파싱 helper                               |
+| [graceful_timeout.go](../../../../internal/crawler/implementation/chromedp/graceful_timeout.go) | tab leak 방지 — context cancel 후에도 Chrome resource 회수 |
+| [types.go](../../../../internal/crawler/implementation/chromedp/types.go)         | `Config`, `ChromedpOptions` (RemoteURL 등)                      |
+
+특성:
+- 비싸지만 SPA / dynamic page 에서 안정
+- `make chrome-start` 가 `chromedp/headless-shell` 컨테이너 기동 (포트 9222)
+- timeout / tab leak 처리는 `graceful_timeout.go` 가 단일 책임
+
+<br>
+
+## 의존
+
+- [`internal/crawler/core`](core.md) — `Crawler`, `RawContent`, `Target`, `Config`
+- [`internal/crawler/rate_limiter`](rate_limiter.md) — 요청 rate 제한 (host/IP 기준)
+- 외부: `net/http`, `github.com/PuerkitoBio/goquery`, `github.com/chromedp/chromedp`
+
+<br>
+
+## 호출 측
+
+- [`internal/crawler/domain/general/fetcher/goquery.go`](../../../../internal/crawler/domain/general/fetcher/goquery.go) — chain link 로 wrap
+- [`internal/crawler/domain/general/fetcher/browser.go`](../../../../internal/crawler/domain/general/fetcher/browser.go) — chain link 로 wrap
+- 사이트별 `Register` 함수가 둘을 결합한 chain 을 [`handler.Registry`](handler.md) 에 등록
+
+본 패키지는 `core.Crawler` 인터페이스를 구현할 뿐이며, **chain 구성은 domain/general 책임**.
+
+<br>
+
+## 관련 이슈
+
+- 이슈 #134 — fetcher / parser 분리 (Claim Check)
+- 이슈 #175 — host 단위 fetcher rule + validation 기반 자동 chromedp 전환 (백로그)

--- a/docs/architecture/internal/crawler/parser.md
+++ b/docs/architecture/internal/crawler/parser.md
@@ -1,0 +1,146 @@
+# internal/crawler/parser — Domain-Agnostic Parser + Rule Engine
+
+소스: [`internal/crawler/parser/`](../../../../internal/crawler/parser/)
+
+이 패키지는 사이트별 hardcode 파서 (NaverParser/CNNParser/…) 를 폐기하고 **DB 기반 rule 한 개의
+parser engine** 으로 모든 사이트를 처리하기 위한 layer 입니다 (이슈 #100). 두 layer 로 구성:
+
+1. [parser.go](../../../../internal/crawler/parser/parser.go) — 도메인 중립 인터페이스 + `Page` 모델
+2. [rule/](../../../../internal/crawler/parser/rule/) — `parsing_rules` 테이블 기반 단일 engine 구현
+
+> 주의: 본 패키지(`internal/crawler/parser`)는 `internal/parser` (Kafka worker) 와 다른 것입니다.
+> [internal/parser](../parser/README.md) 는 본 engine 을 사용하는 **소비자**.
+
+<br>
+
+## 1. 도메인 중립 인터페이스 ([parser.go](../../../../internal/crawler/parser/parser.go))
+
+```go
+type ContentParser interface {
+    ParsePage(ctx context.Context, raw *core.RawContent) (*Page, error)
+}
+
+type LinkListParser interface {
+    ParseLinks(ctx context.Context, raw *core.RawContent) ([]LinkItem, error)
+}
+
+type Page struct {
+    URL, Title, MainContent, Summary, Author, Language, Category string
+    PublishedAt time.Time
+    Tags        []string
+    Images      []string
+    Metadata    map[string]string
+}
+```
+
+호출자는 도메인 (news / blog / community) 별로 `Page → 자기 모델` 변환 책임을 가집니다 (예:
+[`domain/general/convert.go`](../../../../internal/crawler/domain/general/convert.go) 가 `Page → Content`).
+
+<br>
+
+## 2. Rule Engine ([rule/](../../../../internal/crawler/parser/rule/))
+
+| 파일                                                                                     | 역할                                                            |
+|----------------------------------------------------------------------------------------|-----------------------------------------------------------------|
+| [parser.go](../../../../internal/crawler/parser/rule/parser.go)                         | `Parser` 구조체 — `ParsePage` / `ParseLinks` 를 SelectorMap 으로 실행 |
+| [resolver.go](../../../../internal/crawler/parser/rule/resolver.go)                     | `Resolver` — host → `[]*ParsingRuleRecord` 캐시 (TTL 5min/30s, regex compile cache) |
+| [discovery.go](../../../../internal/crawler/parser/rule/discovery.go)                   | `PageLinkDiscovery` — 전체 페이지 `<a>` 스캔 모드 (이슈 #139)    |
+| [errors.go](../../../../internal/crawler/parser/rule/errors.go)                         | `Error` + `ErrCode` (`ErrNoRule`, `ErrEmptySelector`, `ErrParseFailure`) |
+
+**처리 흐름**:
+```
+ParsePage(ctx, raw)
+   ├ Resolver.ResolveByURL(raw.URL) → 매칭 ParsingRuleRecord
+   │   ├ host_pattern = exact / wildcard
+   │   └ path_pattern = regex (애플리케이션 레벨 매칭, 다중 rule 지원)
+   ├ 없음 → ErrNoRule (호출자가 llmgen 으로 fallback)
+   └ 있음 → SelectorMap 으로 goquery 추출 → Page 반환
+```
+
+<br>
+
+## 3. LLM Selector Generator ([rule/llmgen/](../../../../internal/crawler/parser/rule/llmgen/))
+
+이슈 #149. `ErrNoRule` 발생 시 **비동기**로 LLM 에게 selector 를 생성시키고 `enabled=false` 로
+DB 에 INSERT (운영자 검토 후 활성).
+
+| 파일                                                                                              | 역할                                                  |
+|--------------------------------------------------------------------------------------------------|-------------------------------------------------------|
+| [generator.go](../../../../internal/crawler/parser/rule/llmgen/generator.go)                      | `Generator` — Enqueue / 처리 goroutine / Stop          |
+| [prompt.go](../../../../internal/crawler/parser/rule/llmgen/prompt.go)                            | LLM 프롬프트 템플릿 (HTML 샘플 + 출력 스키마)          |
+| [dedup.go](../../../../internal/crawler/parser/rule/llmgen/dedup.go)                              | in-flight set — 동일 host 중복 enqueue 방지            |
+
+**동작**: ParserWorker 가 `ErrNoRule` 받으면 `llmGen.Enqueue(host, sampleHTML)` 호출. Generator 는
+별도 goroutine 에서 LLM 호출 → 결과 검증 (selector 가 실제 매칭되는지 확인) → INSERT (enabled=false) →
+[`Resolver.Invalidate(host)`](../../../../internal/crawler/parser/rule/resolver.go) 로 캐시 무효화.
+
+<br>
+
+## 4. Path Pattern Inference ([rule/pathinfer/](../../../../internal/crawler/parser/rule/pathinfer/))
+
+| 파일                                                                                              | 역할                                                  |
+|--------------------------------------------------------------------------------------------------|-------------------------------------------------------|
+| [pathinfer.go](../../../../internal/crawler/parser/rule/pathinfer/pathinfer.go)                   | `InferHeuristic` — 알고리즘 only (공통 prefix / 숫자 ID 패턴) |
+| [llm.go](../../../../internal/crawler/parser/rule/pathinfer/llm.go)                               | `InferLLM` — heuristic 실패 시 LLM 에 위임            |
+
+[refiner](../../../../internal/crawler/parser/rule/refiner/) 가 본 함수들을 호출.
+
+<br>
+
+## 5. Refiner ([rule/refiner/](../../../../internal/crawler/parser/rule/refiner/))
+
+이슈 #173 단계 4-2. `llm-auto` source 의 **catch-all** rule 의 `path_pattern` 을 `sample_urls`
+누적 데이터로 정밀화.
+
+| 파일                                                                                                 | 역할                                                 |
+|-----------------------------------------------------------------------------------------------------|------------------------------------------------------|
+| [refiner.go](../../../../internal/crawler/parser/rule/refiner/refiner.go)                            | `Refiner` — Start / Stop / RunOnce — interval polling goroutine |
+| [llm_adapter.go](../../../../internal/crawler/parser/rule/refiner/llm_adapter.go)                    | `pkg/llm.Provider` → `LLMClient` 인터페이스 어댑터    |
+| [metrics.go](../../../../internal/crawler/parser/rule/refiner/metrics.go)                            | `refiner_attempts` Prometheus counter (PR #191)      |
+
+**동작**:
+```
+1. polling goroutine 가 interval 마다 RunOnce 호출
+2. parsing_rules 에서 source_name='llm-auto' AND path_pattern='' (catch-all) 조회
+3. 각 rule 에 대해 sample_urls 에서 누적 URL 로드 (MinSamples 미만이면 skip)
+4. pathinfer.InferHeuristic → 실패 + LLM 있으면 InferLLM
+5. 결과 path_pattern 으로 parsing_rules.UpdatePathPattern (optimistic guard)
+6. Resolver.Invalidate(host) + SampleURLRepository.Purge(rule_id)
+```
+
+<br>
+
+## 의존 그래프
+
+```
+parser.go (interface)
+    │
+    ▼
+rule/parser.go ──→ rule/resolver.go ──→ internal/storage (ParsingRuleRepository)
+                          │
+                          └──→ regex cache + TTL cache
+
+rule/llmgen/ ──→ pkg/llm + storage (parsing_rules INSERT)
+rule/refiner/ ──→ pathinfer + pkg/llm + storage (parsing_rules UPDATE / sample_urls)
+rule/discovery/ ──→ pkg/links (link extract)
+```
+
+<br>
+
+## 호출 측
+
+- [`internal/parser/worker.ParserWorker`](../parser/README.md) — `rule.Parser` 와 `Resolver` 를 인스턴스로 보유, 각 메시지마다 `ParsePage` / `ParseLinks` 호출
+- [`internal/parser/worker.ParserWorker`](../parser/README.md) — `ErrNoRule` 발생 시 `llmGen.Enqueue` 호출
+- [`cmd/issuetracker.buildRefiner`](../../cmd/issuetracker.md) — Refiner 인스턴스 wire
+
+<br>
+
+## 관련 이슈
+
+- 이슈 #100 — DB-driven parsing rules
+- 이슈 #139 — full-page link discovery (LinkDiscoveryConfig)
+- 이슈 #149 — LLM selector 자동 생성
+- 이슈 #173 — path_pattern 정밀화 (refiner)
+- 이슈 #190 — refinement trigger refinement
+- 이슈 #192 — refiner LLM 추론 검증 강화 (백로그)
+- PR #191 — refiner Prometheus metric (refinement_attempts)

--- a/docs/architecture/internal/crawler/parser.md
+++ b/docs/architecture/internal/crawler/parser.md
@@ -70,9 +70,11 @@ DB 에 INSERT (운영자 검토 후 활성).
 | [prompt.go](../../../../internal/crawler/parser/rule/llmgen/prompt.go)                            | LLM 프롬프트 템플릿 (HTML 샘플 + 출력 스키마)          |
 | [dedup.go](../../../../internal/crawler/parser/rule/llmgen/dedup.go)                              | in-flight set — 동일 host 중복 enqueue 방지            |
 
-**동작**: ParserWorker 가 `ErrNoRule` 받으면 `llmGen.Enqueue(host, sampleHTML)` 호출. Generator 는
-별도 goroutine 에서 LLM 호출 → 결과 검증 (selector 가 실제 매칭되는지 확인) → INSERT (enabled=false) →
-[`Resolver.Invalidate(host)`](../../../../internal/crawler/parser/rule/resolver.go) 로 캐시 무효화.
+**동작**: ParserWorker 가 `ErrNoRule` 받으면 `llmGen.Enqueue(ctx, host, targetType, raw)` 호출 —
+`targetType` (`page`/`list`) 별로 별도 in-flight set 으로 dedup 됩니다. Generator 는 별도 goroutine 에서
+LLM 호출 → 결과 검증 (selector 가 실제 매칭되는지 확인) → INSERT (enabled=false) →
+[`Resolver.Invalidate(host, targetType)`](../../../../internal/crawler/parser/rule/resolver.go) 로
+해당 (host, targetType) 캐시 항목 무효화 (전체 invalidation 은 `Resolver.InvalidateAll()`).
 
 <br>
 

--- a/docs/architecture/internal/crawler/rate_limiter.md
+++ b/docs/architecture/internal/crawler/rate_limiter.md
@@ -1,0 +1,43 @@
+# internal/crawler/rate_limiter — IP-Based Token Bucket
+
+소스: [`internal/crawler/rate_limiter/`](../../../../internal/crawler/rate_limiter/)
+
+URL → IP 해석 후 **per-IP token bucket** 으로 fetch rate 를 제한합니다. 동일 호스팅 사이트 (CDN
+공유 등) 가 IP 단위로 묶이므로 host 단위보다 안정적입니다.
+
+<br>
+
+## 구성
+
+| 파일                                                                          | 역할                                                  |
+|------------------------------------------------------------------------------|-------------------------------------------------------|
+| [token_bucket.go](../../../../internal/crawler/rate_limiter/token_bucket.go)  | `TokenBucketRateLimiter` (구현) — `core.RateLimiter` 만족 |
+| [dns_resolver.go](../../../../internal/crawler/rate_limiter/dns_resolver.go)  | host → IP 해석 + 캐시                                  |
+| [ip_registry.go](../../../../internal/crawler/rate_limiter/ip_registry.go)    | `IPRegistry` — IP → bucket 매핑 (lazy 생성)            |
+
+<br>
+
+## 사용
+
+```go
+limiter := rate_limiter.NewRateLimiter(requestsPerHour, burst)  // → core.RateLimiter
+// fetcher 가 매 요청 전에:
+limiter.Wait(ctx)
+```
+
+`burst` 는 단기 spike 허용량. requestsPerHour 는 사이트별 [`config.go`](../../../../internal/crawler/domain/general/sources/) 에서
+지정 (예: Naver 200/h, CNN 100/h).
+
+<br>
+
+## 의존
+
+- [`internal/crawler/core`](core.md) — `RateLimiter` 인터페이스
+- 외부: standard `net` (DNS), `time`
+
+<br>
+
+## 한계 / TODO
+
+- 분산 환경에서는 인스턴스마다 별도 bucket 보유 → 실제 RPS = (인스턴스 수) × (bucket 한도)
+- Redis 기반 분산 토큰 버킷은 백로그 (장기적으로 IP shared 라면 필요)

--- a/docs/architecture/internal/crawler/worker.md
+++ b/docs/architecture/internal/crawler/worker.md
@@ -57,14 +57,20 @@ ProcessingLock / IngestionLock / RetryScheduler** 로 다중 인스턴스 환경
 ## ProcessingLock (Redis SETNX 또는 Noop)
 
 이슈 #178. 동일 URL 이 여러 worker / 인스턴스에서 단계별 (fetcher / parser / validator) 중복 처리되는 것을
-차단. Stage prefix (`processing:fetcher:URL`, `processing:parser:URL` 등) 로 단계 구분.
+차단. 인터페이스는 prebuilt key 만 받으며, **stage 분기는 별도 helper `ProcessingKey(stage, url)` 가
+담당** — 호출자가 정규화된 URL 을 hashed key 로 변환해 전달.
 
 ```go
 type ProcessingLock interface {
-    Acquire(ctx context.Context, stage, url string) (acquired bool, err error)
-    Release(ctx context.Context, stage, url string) error
+    Acquire(ctx context.Context, key string) (acquired bool, err error)
+    Release(ctx context.Context, key string) error
 }
+
+// helper — (stage, normalized_url) → Redis key
+func ProcessingKey(stage, url string) string
 ```
+
+stage 상수는 패키지 외부에서도 일관 사용 가능 (예: parser worker 가 `worker.ProcessingKey(StageParser, url)`).
 
 구현:
 - [`NewRedisProcessingLock`](../../../../internal/crawler/worker/processing_lock.go) — Redis `SET NX PX ttl`

--- a/docs/architecture/internal/crawler/worker.md
+++ b/docs/architecture/internal/crawler/worker.md
@@ -1,0 +1,156 @@
+# internal/crawler/worker — Pool Manager + Distributed Coordination
+
+소스: [`internal/crawler/worker/`](../../../../internal/crawler/worker/)
+
+크롤러 단계의 핵심 오케스트레이터. **3-tier priority Kafka consumer pool** 을 운영하며, **Redis 기반
+ProcessingLock / IngestionLock / RetryScheduler** 로 다중 인스턴스 환경의 중복 처리/재시도를 안전하게
+처리합니다. 추가로 **per-source CircuitBreaker** 로 실패 폭주를 차단합니다.
+
+<br>
+
+## 핵심 타입
+
+| 타입                          | 위치                                                                   | 책임                                                            |
+|------------------------------|-----------------------------------------------------------------------|-----------------------------------------------------------------|
+| `PoolManager`                 | [manager.go](../../../../internal/crawler/worker/manager.go)           | 3개 priority pool 의 lifecycle 관리                              |
+| `KafkaConsumerPool`           | [pool.go](../../../../internal/crawler/worker/pool.go)                 | 단일 priority 의 worker goroutine pool + retry 라우팅           |
+| `ProcessingLock` (interface)  | [processing_lock.go](../../../../internal/crawler/worker/processing_lock.go) | URL 동시 처리 방지 — Redis SETNX / Noop 두 구현                |
+| `IngestionLock` (interface)   | [ingestion_lock.go](../../../../internal/crawler/worker/ingestion_lock.go)   | URL pipeline 진입 marker — Publisher 가 사용                  |
+| `RetryScheduler` (interface)  | [retry_scheduler.go](../../../../internal/crawler/worker/retry_scheduler.go) | 지연 retry — Redis ZSET 또는 즉시 republish                  |
+| `CircuitBreakerRegistry`      | [circuit_breaker.go](../../../../internal/crawler/worker/circuit_breaker.go) | per-source 실패율 트래킹 + 차단                              |
+| `PriorityResolver` (interface) | [resolver.go](../../../../internal/crawler/worker/resolver.go)         | retry/escalation 시 새 priority 결정 전략                       |
+
+<br>
+
+## 3-Tier Pool 구조
+
+```
+            ┌─────────────────────────────────┐
+            │         PoolManager             │
+            └────┬────────────┬──────────┬────┘
+                 │            │          │
+   ┌─────────────▼─┐  ┌───────▼───┐  ┌───▼─────────┐
+   │ HighPool (3)  │  │ NormalPool│  │ LowPool (2) │
+   │ TopicCrawlHigh│  │     (6)   │  │TopicCrawlLow│
+   └───────────────┘  │TopicCrawl-│  └─────────────┘
+                      │   Normal  │
+                      └───────────┘
+
+각 pool 의 worker goroutine 이 수행:
+  1. Kafka.FetchMessage
+  2. ProcessingLock.Acquire(stage="fetcher", url)
+     ├ 실패 (이미 처리 중) → skip + commit
+     └ 성공 → continue
+  3. CircuitBreaker.Allow(source)
+     ├ open → defer/skip
+     └ closed → continue
+  4. handler.Registry.Handle(ctx, job)
+     ├ 성공 → commit
+     └ 에러:
+        - Retryable + RetryCount < Max → RetryScheduler.Schedule(job, backoff)
+        - 비-Retryable 또는 Max 초과 → DLQ 발행 + commit
+        - CircuitBreaker.RecordFailure(source)
+```
+
+<br>
+
+## ProcessingLock (Redis SETNX 또는 Noop)
+
+이슈 #178. 동일 URL 이 여러 worker / 인스턴스에서 단계별 (fetcher / parser / validator) 중복 처리되는 것을
+차단. Stage prefix (`processing:fetcher:URL`, `processing:parser:URL` 등) 로 단계 구분.
+
+```go
+type ProcessingLock interface {
+    Acquire(ctx context.Context, stage, url string) (acquired bool, err error)
+    Release(ctx context.Context, stage, url string) error
+}
+```
+
+구현:
+- [`NewRedisProcessingLock`](../../../../internal/crawler/worker/processing_lock.go) — Redis `SET NX PX ttl`
+- [`NoopProcessingLock`](../../../../internal/crawler/worker/processing_lock.go) — 항상 acquired=true (단일 프로세스 / dev)
+
+<br>
+
+## IngestionLock (Publisher 와 짝)
+
+[`internal/publisher`](../publisher.md) 가 Kafka enqueue **직전**에 URL 을 marking — 이미 marked URL 은
+Publisher 가 무시. ProcessingLock 은 처리 단계 dedup, IngestionLock 은 진입 dedup 으로 책임 분리.
+
+```go
+type IngestionLock interface {
+    Acquire(ctx context.Context, url string) (acquired bool, err error)
+}
+```
+
+기본 TTL 은 `redisCfg.IngestionLockTTL` (ENV 로 조정).
+
+<br>
+
+## RetryScheduler (Redis ZSET 또는 즉시)
+
+이슈 #82. retry 대상 job 을 **worker slot 점유 없이** 미래 시점에 재발행.
+
+```go
+type RetryScheduler interface {
+    Schedule(ctx context.Context, job core.CrawlJob, runAt time.Time) error
+    Start(ctx context.Context)
+    Stop()
+}
+```
+
+구현:
+- [`NewRedisDelayedRetryScheduler`](../../../../internal/crawler/worker/retry_scheduler.go) — Redis ZSET (score=RunAt unixtime)
+  + 별도 goroutine 이 ready job 을 Kafka 에 publish
+- [`KafkaImmediateRetryScheduler`](../../../../internal/crawler/worker/retry_scheduler.go) — Redis 부재 시 fallback,
+  즉시 republish (worker slot 점유)
+
+<br>
+
+## CircuitBreaker (per-source)
+
+[circuit_breaker.go](../../../../internal/crawler/worker/circuit_breaker.go). 사이트별 실패율을 추적하다가
+일정 threshold 초과 시 일정 시간 차단 (Closed → Open → HalfOpen).
+
+상태 전이는 INFO 로 로그.
+
+<br>
+
+## PriorityResolver
+
+[resolver.go](../../../../internal/crawler/worker/resolver.go). retry 시 새 priority 결정 전략. 합성
+가능 — `CompositeResolver` 가 여러 전략을 fallback chain 으로:
+
+```go
+resolver := NewCompositeResolver(PriorityNormal)
+resolver.Add(NewSourcePriorityResolver(PriorityNormal))   // 사이트별 명시 우선순위
+resolver.Add(NewRuleBasedPriorityResolver(PriorityNormal)) // 룰 기반 우선순위
+```
+
+<br>
+
+## 의존
+
+- [`internal/crawler/core`](core.md) — `CrawlJob`, `Priority`, `CrawlerError`
+- [`internal/crawler/handler`](handler.md) — Registry dispatch
+- [`internal/storage/service`](../storage/service.md) — `ContentService` (성공 시 ContentRef 발행)
+- [`pkg/queue`](../../pkg/queue.md), [`pkg/redis`](../../pkg/redis.md), [`pkg/logger`](../../pkg/logger.md)
+
+<br>
+
+## 외부 시스템
+
+| 시스템    | 용도                                                              |
+|----------|------------------------------------------------------------------|
+| Kafka    | TopicCrawlHigh/Normal/Low consume / TopicFetched / TopicDLQ produce |
+| Redis    | ProcessingLock (SETNX) / IngestionLock (SETNX) / RetryQueue (ZSET) |
+
+<br>
+
+## 관련 이슈
+
+- 이슈 #82 — Redis delayed retry queue
+- 이슈 #178 — IngestionLock + ProcessingLock 단일 책임화
+- 이슈 #134 — fetcher / parser 분리
+- 이슈 #72 — graceful shutdown shutting_down 필드
+- 이슈 #124 — backlog throttle (scheduler 와 연계)

--- a/docs/architecture/internal/crawler/worker.md
+++ b/docs/architecture/internal/crawler/worker.md
@@ -47,7 +47,7 @@ ProcessingLock / IngestionLock / RetryScheduler** 로 다중 인스턴스 환경
   4. handler.Registry.Handle(ctx, job)
      ├ 성공 → commit
      └ 에러:
-        - Retryable + RetryCount < Max → RetryScheduler.Schedule(job, backoff)
+        - Retryable + RetryCount < Max → job.ScheduledAt 셋팅 후 RetryScheduler.Enqueue(ctx, job, lastErr)
         - 비-Retryable 또는 Max 초과 → DLQ 발행 + commit
         - CircuitBreaker.RecordFailure(source)
 ```
@@ -93,17 +93,19 @@ type IngestionLock interface {
 
 ```go
 type RetryScheduler interface {
-    Schedule(ctx context.Context, job core.CrawlJob, runAt time.Time) error
-    Start(ctx context.Context)
-    Stop()
+    Enqueue(ctx context.Context, job *core.CrawlJob, lastErr error) error
 }
 ```
 
+호출자 (worker pool) 는 `job.ScheduledAt` 과 `job.RetryCount` 를 미리 셋팅해 전달합니다 — 구현체가
+score 로 사용하거나 즉시 발행하거나의 차이만 흡수.
+
 구현:
-- [`NewRedisDelayedRetryScheduler`](../../../../internal/crawler/worker/retry_scheduler.go) — Redis ZSET (score=RunAt unixtime)
-  + 별도 goroutine 이 ready job 을 Kafka 에 publish
-- [`KafkaImmediateRetryScheduler`](../../../../internal/crawler/worker/retry_scheduler.go) — Redis 부재 시 fallback,
-  즉시 republish (worker slot 점유)
+- [`NewRedisDelayedRetryScheduler`](../../../../internal/crawler/worker/retry_scheduler.go) — Redis ZSET
+  (score=`ScheduledAt` unix timestamp) + 별도 goroutine (`Start(ctx)` / `Stop()`) 이 ready job 을
+  Kafka 에 publish — worker slot 미점유 (이슈 #82)
+- [`KafkaImmediateRetryScheduler`](../../../../internal/crawler/worker/retry_scheduler.go) — Redis 부재 시
+  fallback, 즉시 republish 후 worker 가 `ScheduledAt` 까지 sleep (worker slot 점유)
 
 <br>
 

--- a/docs/architecture/internal/parser/README.md
+++ b/docs/architecture/internal/parser/README.md
@@ -1,0 +1,93 @@
+# internal/parser — Claim Check Parser Worker
+
+소스: [`internal/parser/worker/`](../../../../internal/parser/worker/)
+
+> ⚠️ 이름 주의: 본 패키지(`internal/parser`)는 [internal/crawler/parser](../crawler/parser.md) 와 다릅니다.
+> `internal/crawler/parser` 가 **rule engine** 이라면, 본 패키지는 그 engine 을 사용하는 **Kafka worker** 입니다.
+
+이슈 #134 에서 fetcher 와 parser 를 분리하면서 도입된 별도 consumer group `issuetracker-parsers`.
+[Claim Check 패턴](https://learn.microsoft.com/en-us/azure/architecture/patterns/claim-check) 으로
+Kafka 메시지에 raw HTML 을 싣지 않고 DB 에서 로드합니다.
+
+<br>
+
+## 구성
+
+| 파일                                                                    | 역할                                                |
+|------------------------------------------------------------------------|-----------------------------------------------------|
+| [parser_worker.go](../../../../internal/parser/worker/parser_worker.go) | `ParserWorker` — TopicFetched consume + parse + content store |
+| [cleanup.go](../../../../internal/parser/worker/cleanup.go)             | `RawContentCleaner` — cron 으로 오래된 raw_contents 정리 |
+
+<br>
+
+## 동작 흐름 (per message)
+
+```
+1. Kafka.FetchMessage (TopicFetched)
+   → ProcessingMessage → RawContentRef
+2. RawContentService.GetByID(ref.ID) → core.RawContent (HTML)
+3. ProcessingLock.Acquire("parser", raw.URL)
+4. target_type 분기:
+   ┌─ TargetTypeCategory (list)
+   │  ├ rule.Parser.ParseLinks(ctx, raw) → []LinkItem
+   │  └ Publisher.PublishBatch(...) — chained article CrawlJob 발행
+   └─ TargetTypePage (article)
+      ├ rule.Parser.ParsePage(ctx, raw) → Page
+      │     ├ ErrNoRule → llmGen.Enqueue (이슈 #149) + commit (raw 잔존)
+      │     └ ErrParseFailure / ErrEmptySelector → commit (raw 잔존)
+      ├ general.ConvertPageToContent(page) → core.Content
+      ├ ContentService.Store → ContentRef
+      ├ Producer.Publish(TopicNormalized, ContentRef)
+      └ Resolver 매칭 결과 + sample URL 누적 (SampleURLRepository.Insert) — 이슈 #173 단계 4-1
+5. RawContentService.Delete(ref.ID) — Claim Check 정리
+6. Kafka.CommitMessages
+```
+
+**실패 정책**:
+- `rule.Error` 계열: raw 잔존 + commit (재시도 X) — LLM 재처리 대기
+- 기타 transient 에러: commit 안 함 → Kafka 재배달
+
+<br>
+
+## RawContentCleaner
+
+ParserWorker 가 이상 종료 / rule.Error 잔존 / LLM 재처리 윈도우 만료된 row 가 누적되는 것을 방지하는
+간단한 cron. [`cleanup.go`](../../../../internal/parser/worker/cleanup.go) 가 일정 주기마다
+`RawContentService.PurgeOlderThan(...)` 호출.
+
+<br>
+
+## 의존
+
+- [`internal/crawler/parser/rule`](../crawler/parser.md) — `Parser`, `Resolver`
+- [`internal/crawler/parser/rule/llmgen`](../crawler/parser.md) — `Generator.Enqueue` (선택)
+- [`internal/crawler/domain/general`](../crawler/domain.md) — `ConvertPageToContent`
+- [`internal/crawler/worker`](../crawler/worker.md) — `ProcessingLock`
+- [`internal/storage/service`](../storage/service.md) — `RawContentService`, `ContentService`
+- [`internal/storage`](../storage/README.md) — `SampleURLRepository`
+- [`internal/publisher`](../publisher.md) — chained job 발행
+- [`pkg/queue`](../../pkg/queue.md), [`pkg/logger`](../../pkg/logger.md)
+
+<br>
+
+## Wiring 위치
+
+[`cmd/issuetracker/main.go`](../../../../cmd/issuetracker/main.go) — 단계 10 (parser worker), 단계 12
+(cleanup cron). 자세한 wiring 은 [cmd/issuetracker.md](../../cmd/issuetracker.md) 참조.
+
+<br>
+
+## 외부 시스템
+
+- Kafka: `issuetracker.fetched` consume / `issuetracker.normalized` + `issuetracker.crawl.{high,normal,low}` (chained jobs) produce
+- PostgreSQL: `raw_contents` (load+delete), `contents` (store), `parsing_rule_sample_urls` (insert)
+- Redis: ProcessingLock (단계="parser")
+
+<br>
+
+## 관련 이슈
+
+- 이슈 #134 — fetcher / parser 분리, Claim Check
+- 이슈 #149 — LLM 기반 selector 자동 생성
+- 이슈 #173 단계 4-1 — sample URL 누적
+- 이슈 #178 — ProcessingLock 단계 prefix

--- a/docs/architecture/internal/processor/README.md
+++ b/docs/architecture/internal/processor/README.md
@@ -1,0 +1,44 @@
+# internal/processor — Processing Pipeline Stage Interfaces
+
+소스: [`internal/processor/`](../../../../internal/processor/)
+
+처리 단계 (validate / enrich / classify 등) 의 공통 인터페이스를 정의하고, 현재 시점의 단일 구현인
+검증(validate) 단계 패키지를 보유합니다.
+
+<br>
+
+## 핵심 인터페이스
+
+[processor.go](../../../../internal/processor/processor.go):
+
+```go
+type ContentProcessor interface {
+    Process(ctx context.Context, c *core.Content) (*core.Content, error)
+}
+
+type Validator interface {
+    Validate(ctx context.Context, c *core.Content) ValidationResult
+}
+
+type ValidationResult struct {
+    Valid       bool
+    Errors      []ValidationError
+    Reliability float64
+}
+```
+
+<br>
+
+## 서브패키지
+
+| 디렉토리                                                                  | 문서                                |
+|--------------------------------------------------------------------------|-------------------------------------|
+| [`internal/processor/validate/`](../../../../internal/processor/validate/) | [validate.md](validate.md)         |
+
+<br>
+
+## 향후 확장
+
+- `internal/processor/enrich/` — entity / sentiment / topic
+- `internal/processor/embed/` — vector embedding
+- `internal/processor/classify/` — [internal/classifier](../classifier/README.md) 호출 stage

--- a/docs/architecture/internal/processor/README.md
+++ b/docs/architecture/internal/processor/README.md
@@ -17,13 +17,13 @@ type ContentProcessor interface {
 }
 
 type Validator interface {
-    Validate(ctx context.Context, c *core.Content) ValidationResult
+    Validate(ctx context.Context, content *core.Content) ValidationResult
 }
 
 type ValidationResult struct {
-    Valid       bool
-    Errors      []ValidationError
-    Reliability float64
+    IsValid      bool
+    QualityScore float32  // 0.0 ~ 1.0; 0.5 미만이면 DLQ 라우팅 대상
+    Errors       []ValidationError
 }
 ```
 

--- a/docs/architecture/internal/processor/validate.md
+++ b/docs/architecture/internal/processor/validate.md
@@ -1,0 +1,89 @@
+# internal/processor/validate — Content Validation Stage
+
+소스: [`internal/processor/validate/`](../../../../internal/processor/validate/)
+
+`issuetracker.normalized` 토픽을 consume 하여 Content 를 검증한 뒤 결과에 따라 분기:
+
+- 통과 → `issuetracker.validated` 발행
+- 실패 → `contents` row 삭제 + `issuetracker.dlq` 발행
+
+<br>
+
+## 구성
+
+| 파일                                                                                 | 역할                                                            |
+|-------------------------------------------------------------------------------------|-----------------------------------------------------------------|
+| [validator.go](../../../../internal/processor/validate/validator.go)                 | `NewValidator(SourceType, ValidateConfig)` — news/community 분기 |
+| [worker.go](../../../../internal/processor/validate/worker.go)                       | `Worker` — Kafka consumer + at-least-once 처리                  |
+| [community/](../../../../internal/processor/validate/community/)                     | community 도메인 검증 규칙                                       |
+| [news/](../../../../internal/processor/validate/news/)                               | news 도메인 검증 규칙                                            |
+
+<br>
+
+## Validator 분기
+
+```go
+switch sourceType {
+case core.SourceTypeCommunity:
+    return community.NewValidator(cfg)
+default:
+    return news.NewValidator(cfg)  // 기본 + 알 수 없는 타입
+}
+```
+
+`ValidateConfig` 는 [`pkg/config.LoadValidate`](../../pkg/config.md) 가 제공 — 본문 길이, 신뢰도 임계값
+등 환경변수로 조정.
+
+<br>
+
+## Worker 동작 (per message)
+
+```
+1. Kafka.FetchMessage (TopicNormalized)
+   → ProcessingMessage → ContentRef
+2. ContentService.GetByID(ref.ID) → core.Content
+3. ProcessingLock.Acquire("validator", ref.URL)
+4. Validator.Validate(ctx, content) → ValidationResult
+   ├ Valid=true:
+   │   ├ ContentService.UpdateValidationStatus(ref.ID, Passed) (이슈 #135 / #161)
+   │   └ Producer.Publish(TopicValidated, ref)
+   └ Valid=false:
+       ├ ContentService.Delete(ref.ID)
+       └ Producer.Publish(TopicDLQ, ref + error info)
+5. drainTimeout (5s) 안에 Kafka.CommitMessages 시도 — at-least-once 보장
+```
+
+graceful shutdown 시 in-flight 메시지를 `drainTimeout` 동안 finalize.
+
+<br>
+
+## 의존
+
+- [`internal/crawler/core`](../crawler/core.md)
+- [`internal/crawler/worker`](../crawler/worker.md) — `ProcessingLock` (issuetracker 통합 모드) / `NoopProcessingLock` (processor 단독 모드)
+- [`internal/storage/service`](../storage/service.md) — `ContentService`
+- [`internal/storage`](../storage/README.md) — `ValidationStatus`
+- [`pkg/queue`](../../pkg/queue.md), [`pkg/config`](../../pkg/config.md), [`pkg/logger`](../../pkg/logger.md)
+
+<br>
+
+## Wiring 위치
+
+- 통합: [`cmd/issuetracker`](../../cmd/issuetracker.md) 단계 14
+- 단독: [`cmd/processor`](../../cmd/processor.md)
+
+<br>
+
+## 외부 시스템
+
+- Kafka: `issuetracker.normalized` consume / `issuetracker.validated` + `issuetracker.dlq` produce
+- PostgreSQL: `contents` / `content_meta` (validation_status update / delete)
+- Redis: ProcessingLock (단계="validator", 통합 모드만)
+
+<br>
+
+## 관련 이슈
+
+- 이슈 #135 / #161 — validation_status 영속화
+- 이슈 #178 — ProcessingLock 단계 prefix
+- 이슈 #72 — graceful shutdown shutting_down 필드

--- a/docs/architecture/internal/publisher.md
+++ b/docs/architecture/internal/publisher.md
@@ -1,0 +1,85 @@
+# internal/publisher — Chained Job Publisher
+
+소스: [`internal/publisher/publisher.go`](../../../internal/publisher/publisher.go)
+
+크롤된 페이지에서 발견된 URL 들을 **다음 CrawlJob** 으로 변환해 Kafka 에 발행하는 컴포넌트.
+[scheduler](scheduler.md) 가 등록된 시드만 다루는 것과 책임 분리.
+
+<br>
+
+## 책임
+
+- URL 정규화 ([`pkg/links.Normalizer`](../pkg/links.md))
+- IngestionLock atomic dedup ([`crawler/worker.IngestionLock`](crawler/worker.md))
+- URL Guard 검사 ([`pkg/urlguard.Gate`](../pkg/urlguard.md))
+- Priority 결정 ([`crawler/worker.PriorityResolver`](crawler/worker.md))
+- 토픽 라우팅 (Priority → TopicCrawlHigh/Normal/Low)
+
+<br>
+
+## 인터페이스
+
+```go
+type Publisher struct { … }
+func New(producer queue.Producer, resolver PriorityResolver, log *logger.Logger) *Publisher
+
+// Optional dependencies (lazy injection 으로 nil 허용)
+(*Publisher) SetNormalizer(*links.Normalizer)
+(*Publisher) SetIngestionLock(IngestionLock)
+(*Publisher) SetGate(*urlguard.Gate)
+
+// 사용 측이 호출
+(*Publisher) PublishBatch(ctx context.Context, jobs []core.CrawlJob) error
+```
+
+<br>
+
+## PublishBatch 흐름
+
+```
+for each job in batch:
+   1. Normalizer.Normalize(job.Target.URL)            ← Set 됐으면
+   2. Gate.Allow(url) → 차단 시 silent drop + WARN    ← Set 됐으면
+   3. IngestionLock.Acquire(url)                      ← Set 됐으면
+        ├ already_locked → skip
+        └ acquired → continue
+   4. PriorityResolver.Resolve(job) → priority
+   5. queue.Producer.Publish(topic[priority], jobMsg)
+```
+
+각 dependency 는 **nil 허용** — 미설정 시 해당 단계만 skip 하고 통과 (graceful degrade).
+
+<br>
+
+## 호출 측
+
+- [`internal/parser/worker.ParserWorker`](parser/README.md) — TargetTypeList 처리 시 발견 링크 발행
+- [`internal/scheduler.Scheduler`](scheduler.md) 는 **미사용** — Scheduler 는 직접 `Emitter.Emit` 호출
+
+<br>
+
+## 의존
+
+- [`internal/crawler/core`](crawler/core.md) — `CrawlJob`
+- [`internal/crawler/worker`](crawler/worker.md) — `PriorityResolver`, `IngestionLock`
+- [`pkg/queue`](../pkg/queue.md), [`pkg/links`](../pkg/links.md), [`pkg/urlguard`](../pkg/urlguard.md), [`pkg/logger`](../pkg/logger.md)
+
+<br>
+
+## Wiring 위치
+
+[`cmd/issuetracker/main.go`](../../../cmd/issuetracker/main.go):
+```go
+jobPublisher := publisher.New(crawlerProducer, resolver, log)
+jobPublisher.SetNormalizer(links.NewNormalizer())
+jobPublisher.SetIngestionLock(ingestionLock)  // Redis 가 살아있을 때만
+// jobPublisher.SetGate(...)  ← URL Guard wiring 위치
+```
+
+<br>
+
+## 관련 이슈
+
+- 이슈 #126 — Publisher 단일 책임화
+- 이슈 #178 — IngestionLock 단일 책임화
+- 이슈 #119 — URL Guard

--- a/docs/architecture/internal/scheduler.md
+++ b/docs/architecture/internal/scheduler.md
@@ -32,7 +32,7 @@ type ScheduleEntry struct {
 }
 
 type Throttler interface {
-    ShouldThrottle(ctx) (bool, error)
+    ShouldThrottle(ctx context.Context, job *core.CrawlJob) bool
 }
 
 type JobEmitter interface {
@@ -58,6 +58,9 @@ Start(ctx):
 ```
 
 옵션 의존성 (Gate, Throttler) 은 atomic.Pointer 로 lock-free 하게 주입/조회.
+
+`ShouldThrottle` 이 `error` 를 반환하지 않는 이유: throttle 결정은 best-effort 운영 신호이며 실패 시 통과
+정책 (false 반환) 으로 graceful degrade — 구현체 (`BacklogThrottler`) 가 내부에서 WARN 로그를 책임집니다.
 
 <br>
 

--- a/docs/architecture/internal/scheduler.md
+++ b/docs/architecture/internal/scheduler.md
@@ -1,0 +1,115 @@
+# internal/scheduler — Seed Job Scheduler
+
+소스: [`internal/scheduler/`](../../../internal/scheduler/)
+
+등록된 카테고리 URL 목록 (CNN sections / Naver categories / …) 을 **주기적으로 Kafka crawl 토픽에
+시드 발행**합니다. 크롤 결과로부터 발견된 URL 의 chained 발행은 [publisher](publisher.md) 책임.
+
+<br>
+
+## 구성
+
+| 파일                                                          | 역할                                                  |
+|--------------------------------------------------------------|-------------------------------------------------------|
+| [scheduler.go](../../../internal/scheduler/scheduler.go)      | `Scheduler` — entry 별 polling goroutine 관리         |
+| [entries.go](../../../internal/scheduler/entries.go)          | `DefaultEntries(SchedulerConfig)` — CNN/Naver/Yonhap/Daum entries  |
+| [emitter.go](../../../internal/scheduler/emitter.go)          | `JobEmitter` — Kafka 발행 어댑터                      |
+| [source.go](../../../internal/scheduler/source.go)            | source 별 entry 빌더 helper                            |
+| [throttle.go](../../../internal/scheduler/throttle.go)        | `BacklogThrottler` — consumer-group lag 임계값 검사  |
+
+<br>
+
+## 핵심 타입
+
+```go
+type ScheduleEntry struct {
+    CrawlerName string
+    URL         string
+    TargetType  core.TargetType
+    Interval    time.Duration
+    Priority    core.Priority
+    Timeout     time.Duration
+}
+
+type Throttler interface {
+    ShouldThrottle(ctx) (bool, error)
+}
+
+type JobEmitter interface {
+    Emit(ctx, job core.CrawlJob) error
+}
+```
+
+<br>
+
+## 동작
+
+```
+Start(ctx):
+   for each entry:
+      go func() {
+         tick := time.NewTicker(entry.Interval)
+         for range tick.C:
+            if Gate.Allow(entry.URL) == false → drop
+            if Throttler.ShouldThrottle() == true → drop (이슈 #124)
+            job := buildJob(entry)
+            Emitter.Emit(ctx, job)
+      }
+```
+
+옵션 의존성 (Gate, Throttler) 은 atomic.Pointer 로 lock-free 하게 주입/조회.
+
+<br>
+
+## BacklogThrottler
+
+이슈 #124. crawl 토픽의 consumer-group lag 가 `MaxBacklog` 초과면 publish 차단:
+
+```go
+backlogChecker := queue.NewBacklogChecker(brokers, timeout)
+throttler := scheduler.NewBacklogThrottler(
+    backlogChecker, queue.GroupCrawlerWorkers, MaxBacklog, timeout, log,
+)
+sched.SetThrottler(throttler)
+```
+
+`SCHEDULER_MAX_BACKLOG` 환경변수가 0 이면 비활성.
+
+<br>
+
+## 의존
+
+- [`internal/crawler/core`](crawler/core.md) — `CrawlJob`, `Priority`, `TargetType`
+- [`internal/crawler/domain/general/sources/{kr,us}/.../config`](crawler/domain.md) — 카테고리 URL
+- [`pkg/queue`](../pkg/queue.md) — Kafka producer / BacklogChecker
+- [`pkg/urlguard`](../pkg/urlguard.md), [`pkg/logger`](../pkg/logger.md)
+
+<br>
+
+## Wiring 위치
+
+[`cmd/issuetracker/main.go`](../../../cmd/issuetracker/main.go) 단계 13:
+```go
+schedulerCfg, _ := config.LoadScheduler()
+emitter := scheduler.NewJobEmitter(crawlerProducer, log)
+entries := scheduler.DefaultEntries(schedulerCfg)
+sched := scheduler.New(entries, emitter, log, schedulerCfg.MaxRetries)
+if schedulerCfg.MaxBacklog > 0 {
+    sched.SetThrottler(...)
+}
+sched.Start(ctx)
+```
+
+<br>
+
+## 외부 시스템
+
+- Kafka: `issuetracker.crawl.{high,normal,low}` produce + (BacklogChecker 가) `__consumer_offsets` 조회
+
+<br>
+
+## 관련 이슈
+
+- 이슈 #119 — URL Guard
+- 이슈 #124 — BacklogThrottler
+- 이슈 #126 — Scheduler / Publisher 책임 분리

--- a/docs/architecture/internal/storage/README.md
+++ b/docs/architecture/internal/storage/README.md
@@ -1,0 +1,88 @@
+# internal/storage — Repository + Service Layer
+
+소스: [`internal/storage/`](../../../../internal/storage/)
+
+데이터 접근 계층의 **인터페이스 + 공유 타입** 을 보유하며, 실제 SQL 구현은 [postgres.md](postgres.md) 가,
+비즈니스 로직 (중복 감지, validation status 업데이트 등) 은 [service.md](service.md) 가 담당합니다.
+
+<br>
+
+## 레이어 분리
+
+```
+┌─────────────────────────────────────────────────┐
+│            Service Layer                        │
+│  internal/storage/service/                      │
+│  ContentService / RawContentService             │
+│  - 중복 감지 (ContentHash / URL)                │
+│  - 비즈니스 로직 (validation status update 등)  │
+└──────────────────────┬──────────────────────────┘
+                       │
+                       ▼
+┌─────────────────────────────────────────────────┐
+│            Repository Interfaces                │
+│  internal/storage/                              │
+│  ContentRepository / RawContentRepository /     │
+│  ParsingRuleRepository / SampleURLRepository    │
+└──────────────────────┬──────────────────────────┘
+                       │
+                       ▼
+┌─────────────────────────────────────────────────┐
+│            PostgreSQL Implementation            │
+│  internal/storage/postgres/                     │
+│  pgx/v5 + pgxpool.Pool 공유                     │
+└─────────────────────────────────────────────────┘
+```
+
+<br>
+
+## Repository 인터페이스
+
+| 인터페이스                  | 위치                                                              | 테이블                                    |
+|----------------------------|------------------------------------------------------------------|-------------------------------------------|
+| `ContentRepository`         | [content.go](../../../../internal/storage/content.go)             | `contents` + `content_bodies` + `content_meta` (3-table 트랜잭션) |
+| `RawContentRepository`      | [raw_content.go](../../../../internal/storage/raw_content.go)     | `raw_contents` (Claim Check)               |
+| `ParsingRuleRepository`     | [parsing_rule.go](../../../../internal/storage/parsing_rule.go)   | `parsing_rules` (이슈 #100)                |
+| `SampleURLRepository`       | [sample_url.go](../../../../internal/storage/sample_url.go)       | `parsing_rule_sample_urls` (이슈 #173 4-1) |
+
+공유 타입:
+- `TargetType` (page / list)
+- `FieldSelector`, `SelectorMap`
+- `ParsingRuleRecord` (host_pattern + path_pattern + selectors + source_name + enabled)
+- `ContentFilter`, `RawContentFilter` (query 빌더)
+- `ValidationStatus` ([validation_status.go](../../../../internal/storage/validation_status.go))
+
+<br>
+
+## 에러 / 필터
+
+| 파일                                                          | 책임                                                      |
+|--------------------------------------------------------------|-----------------------------------------------------------|
+| [errors.go](../../../../internal/storage/errors.go)           | `ErrNotFound`, `ErrDuplicate` 등 sentinel 에러             |
+| [filter.go](../../../../internal/storage/filter.go)           | `ContentFilter`, `RawContentFilter` — limit/offset/where  |
+
+<br>
+
+## 서브패키지
+
+| 디렉토리                                                                          | 문서                                |
+|----------------------------------------------------------------------------------|-------------------------------------|
+| [`internal/storage/postgres/`](../../../../internal/storage/postgres/)            | [postgres.md](postgres.md)         |
+| [`internal/storage/service/`](../../../../internal/storage/service/)              | [service.md](service.md)           |
+
+<br>
+
+## 의존
+
+- [`internal/crawler/core`](../crawler/core.md) — `Content`, `RawContent`
+- [`pkg/config`](../../pkg/config.md), [`pkg/logger`](../../pkg/logger.md)
+- 외부: `github.com/jackc/pgx/v5`, `github.com/jackc/pgerrcode`
+
+<br>
+
+## 관련 이슈
+
+- 이슈 #100 — DB-driven parsing rules
+- 이슈 #134 — Claim Check 분리 (raw_contents 테이블)
+- 이슈 #135 / #161 — validation_status 영속화
+- 이슈 #173 — sample_urls 누적 / refiner

--- a/docs/architecture/internal/storage/postgres.md
+++ b/docs/architecture/internal/storage/postgres.md
@@ -1,0 +1,83 @@
+# internal/storage/postgres — pgx/v5 Implementation
+
+소스: [`internal/storage/postgres/`](../../../../internal/storage/postgres/)
+
+[Repository 인터페이스](README.md) 의 PostgreSQL 구현체. 모든 repo 가 단일 `pgxpool.Pool` 을 공유.
+
+<br>
+
+## 구성
+
+| 파일                                                                          | 역할                                                                |
+|------------------------------------------------------------------------------|---------------------------------------------------------------------|
+| [db.go](../../../../internal/storage/postgres/db.go)                          | `NewPool(ctx, DBConfig, log)` — pgxpool 생성 + ping + 풀 설정        |
+| [content.go](../../../../internal/storage/postgres/content.go)                | `ContentRepository` 구현 — 3-table 트랜잭션 (`contents` + `content_bodies` + `content_meta`) |
+| [raw_content.go](../../../../internal/storage/postgres/raw_content.go)        | `RawContentRepository` 구현                                         |
+| [parsing_rule.go](../../../../internal/storage/postgres/parsing_rule.go)      | `ParsingRuleRepository` 구현 (regex pattern 컬럼)                   |
+| [sample_url.go](../../../../internal/storage/postgres/sample_url.go)          | `SampleURLRepository` 구현 (cap 100/rule)                           |
+| [scanner.go](../../../../internal/storage/postgres/scanner.go)                | row → struct scan helper (시간/JSONB 변환)                          |
+
+<br>
+
+## Pool 설정
+
+[db.go](../../../../internal/storage/postgres/db.go):
+```go
+poolCfg.MaxConns = cfg.MaxConns
+poolCfg.MinConns = cfg.MinConns
+poolCfg.MaxConnLifetime = 30 * time.Minute
+poolCfg.MaxConnIdleTime = 10 * time.Minute
+```
+
+설정값은 [`pkg/config.DBConfig`](../../pkg/config.md) (ENV) 에서 로드.
+
+<br>
+
+## 테이블 스키마 (요약)
+
+자세한 컬럼/인덱스는 [`migrations/`](../../../../migrations/) 가 단일 소스. 핵심 테이블:
+
+### `contents`
+- `id` (UUID), `url` (UNIQUE), `title`, `source`, `country`, `language`, `published_at`, `content_hash`, `created_at`
+- 핵심 인덱스: `(country, published_at DESC)`, `(content_hash)`
+
+### `content_bodies`
+- `content_id` FK → `contents.id`
+- `body` (TEXT, 큰 본문 분리)
+
+### `content_meta`
+- `content_id` FK
+- `validation_status`, `reliability`, JSONB extra
+
+### `raw_contents`
+- Claim Check 임시 저장 — parser 가 처리 후 즉시 delete
+- `id`, `url` (UNIQUE), `html` (TEXT), `status_code`, `headers` (JSONB), `fetched_at`
+
+### `parsing_rules` (이슈 #100)
+- `id`, `host_pattern`, `path_pattern` (regex), `target_type` (page/list)
+- `selectors` (JSONB), `source_name` (`manual` / `llm-auto`), `enabled`, `created_at`, `updated_at`
+
+### `parsing_rule_sample_urls` (이슈 #173 단계 4-1)
+- `id`, `rule_id` FK, `url`, `observed_at`
+- `(rule_id, url)` UNIQUE — 같은 rule 의 동일 URL 중복 방지
+- per-rule cap 100 (`SampleCapPerRule`)
+
+### `schema_migrations`
+- 마이그레이션 버전 추적 (migrations 패키지가 관리)
+
+<br>
+
+## 의존
+
+- [`internal/storage`](README.md) — 인터페이스 + 공유 타입
+- [`internal/crawler/core`](../crawler/core.md) — `Content`, `RawContent`
+- [`pkg/config`](../../pkg/config.md), [`pkg/logger`](../../pkg/logger.md)
+- 외부: `github.com/jackc/pgx/v5`, `pgxpool`, `github.com/jackc/pgerrcode`
+
+<br>
+
+## Wiring 위치
+
+[`cmd/issuetracker`](../../cmd/issuetracker.md), [`cmd/processor`](../../cmd/processor.md),
+[`cmd/migrate`](../../cmd/migrate.md), [`cmd/migrate-down`](../../cmd/migrate-down.md) 모두
+`pgstore.NewPool(ctx, dbCfg, log)` 로 시작.

--- a/docs/architecture/internal/storage/service.md
+++ b/docs/architecture/internal/storage/service.md
@@ -21,7 +21,10 @@ type ContentService interface {
     Delete(ctx, id string) error
 
     // validation_status 업데이트 (이슈 #135 / #161)
-    UpdateValidationStatus(ctx, id string, status storage.ValidationStatus) error
+    // status: "passed" / "rejected" 등 storage.ValidationStatus 의 string 표현
+    // code:   분류 코드 (예: "VAL_001"); 빈 문자열 허용
+    // detail: 자유 형식 사유 (예: "title length < 10"); 빈 문자열 허용
+    UpdateValidationStatus(ctx context.Context, id, status, code, detail string) error
 }
 ```
 

--- a/docs/architecture/internal/storage/service.md
+++ b/docs/architecture/internal/storage/service.md
@@ -1,0 +1,78 @@
+# internal/storage/service — Business Logic Layer
+
+소스: [`internal/storage/service/`](../../../../internal/storage/service/)
+
+[Repository 인터페이스](README.md) 위에 **순수 CRUD 이상의 로직** (중복 감지 / 일괄 저장 / 상태 업데이트)
+을 제공하는 service 계층.
+
+<br>
+
+## ContentService
+
+[content.go](../../../../internal/storage/service/content.go):
+
+```go
+type ContentService interface {
+    // ContentHash 동일 시 기존 ID 반환 (저장 X)
+    Store(ctx, *core.Content) (id string, isDuplicate bool, err error)
+
+    StoreBatch(ctx, []*core.Content) ([]StoreResult, error)
+    GetByID(ctx, id string) (*core.Content, error)
+    Delete(ctx, id string) error
+
+    // validation_status 업데이트 (이슈 #135 / #161)
+    UpdateValidationStatus(ctx, id string, status storage.ValidationStatus) error
+}
+```
+
+**중복 감지**: ContentHash (제목+본문 해시) 가 동일하면 기존 row 유지 — Title/PublishedAt 갱신만 또는
+완전 무시. 결정 로직은 [content.go](../../../../internal/storage/service/content.go) 에 명시.
+
+<br>
+
+## RawContentService
+
+[raw_content.go](../../../../internal/storage/service/raw_content.go):
+
+```go
+type RawContentService interface {
+    // 동일 URL 시 기존 ID 반환
+    Store(ctx, *core.RawContent) (id string, isDuplicate bool, err error)
+
+    GetByID(ctx, id string) (*core.RawContent, error)
+
+    // idempotent (없어도 nil) — Claim Check 정리 (이슈 #134)
+    Delete(ctx, id string) error
+
+    List(ctx, filter storage.RawContentFilter) ([]*core.RawContent, error)
+    PurgeOlderThan(ctx, t time.Time) (int64, error)  // cleanup cron 용
+}
+```
+
+ParserWorker (이슈 #134) 가 파싱 완료된 raw row 를 즉시 `Delete` — Claim Check 패턴.
+
+<br>
+
+## 의존
+
+- [`internal/storage`](README.md) — Repository 인터페이스 + 공유 타입
+- [`internal/crawler/core`](../crawler/core.md) — `Content`, `RawContent`
+- [`pkg/logger`](../../pkg/logger.md)
+
+<br>
+
+## 호출 측
+
+| 호출자                                              | 사용 메소드                                       |
+|----------------------------------------------------|--------------------------------------------------|
+| [crawler/domain/general.ChainHandler](../crawler/domain.md) | `RawContentService.Store` (Claim Check)   |
+| [parser/worker.ParserWorker](../parser/README.md)   | `RawContentService.GetByID` / `Delete`<br>`ContentService.Store` |
+| [parser/worker.RawContentCleaner](../parser/README.md) | `RawContentService.PurgeOlderThan`            |
+| [processor/validate.Worker](../processor/validate.md) | `ContentService.GetByID` / `Delete` / `UpdateValidationStatus` |
+
+<br>
+
+## 관련 이슈
+
+- 이슈 #134 — Claim Check (Delete idempotent)
+- 이슈 #135 / #161 — validation_status 영속화

--- a/docs/architecture/pkg/README.md
+++ b/docs/architecture/pkg/README.md
@@ -1,0 +1,44 @@
+# pkg/ — Public Library Code
+
+[`pkg/`](../../../pkg/) 는 외부 모듈도 import 할 수 있는 generic 유틸리티를 보유합니다.
+도메인 의존성이 없는 standalone 라이브러리로 설계되어, [`internal/`](../../../internal/) 의 비즈니스
+로직과 분리됩니다.
+
+[.claude/rules/04-error-handling.md](../../../.claude/rules/04-error-handling.md) 의 레이어 규칙:
+**`pkg/` 는 `fmt.Errorf` wrap 만 사용**, `CrawlerError` 는 호출하는 `internal/` boundary 가 변환.
+
+<br>
+
+## 패키지 일람
+
+| 디렉토리                                  | 역할                                                            | 문서                                |
+|------------------------------------------|----------------------------------------------------------------|-------------------------------------|
+| [`pkg/config/`](../../../pkg/config/)     | 환경변수 + .env 기반 설정 로더 (DB / Kafka / Redis / LLM / Validate / Scheduler / Refinement / Metrics / Log / Classifier) | [config.md](config.md) |
+| [`pkg/links/`](../../../pkg/links/)       | URL 정규화 (Normalizer) + 링크 추출 (Extractor)                | [links.md](links.md)                |
+| [`pkg/llm/`](../../../pkg/llm/)           | 다중 LLM provider 추상 + Chain 합성 + 정책 라우팅              | [llm.md](llm.md)                    |
+| [`pkg/logger/`](../../../pkg/logger/)     | zerolog 기반 구조화 로거 + ctx 전파                             | [logger.md](logger.md)              |
+| [`pkg/metrics/`](../../../pkg/metrics/)   | Prometheus registry + `/metrics` HTTP endpoint                  | [metrics.md](metrics.md)            |
+| [`pkg/queue/`](../../../pkg/queue/)       | Kafka producer/consumer + 토픽/그룹 상수 + BacklogChecker      | [queue.md](queue.md)                |
+| [`pkg/redis/`](../../../pkg/redis/)       | Redis 클라이언트 wrapper + 분산 락 + ZSET retry queue          | [redis.md](redis.md)                |
+| [`pkg/urlguard/`](../../../pkg/urlguard/) | URL 허용/차단 술어 (Guard) + 적용 dispatcher (Gate)            | [urlguard.md](urlguard.md)          |
+
+<br>
+
+## 의존 그래프 (pkg 내부)
+
+```
+config ── 다른 pkg 가 의존 (logger / queue / redis / llm 모두 config 를 받음)
+logger ── 다른 pkg 가 옵션으로 의존 (nil 허용)
+queue / redis / metrics / llm / links / urlguard ── 서로 독립
+
+llm/{anthropic, gemini, openai} ── llm/{providers, factory} 가 init() 으로 등록
+llm/chain ── llm 인터페이스 사용
+llm/policy ── llm 인터페이스 사용
+```
+
+<br>
+
+## 외부 노출 가능 여부
+
+`pkg/` 는 이름상 외부 import 가능하지만, 실제로는 IssueTracker 전용으로만 사용 중입니다. 네이밍/시그니처
+변경 시 cross-package 영향 검토 필요.

--- a/docs/architecture/pkg/config.md
+++ b/docs/architecture/pkg/config.md
@@ -1,0 +1,67 @@
+# pkg/config — Environment-Driven Configuration
+
+소스: [`pkg/config/config.go`](../../../pkg/config/config.go)
+
+`.env` + 환경변수 기반 설정 로더. 모든 컴포넌트가 본 패키지의 Load* 함수를 호출해 자기 config struct
+를 받습니다.
+
+<br>
+
+## Loader 함수
+
+| 함수                  | 반환 타입             | 결정 항목                                          |
+|----------------------|---------------------|---------------------------------------------------|
+| `Load()`              | `DBConfig`           | PostgreSQL host/port/user/password/database/MaxConns/MinConns |
+| `LoadLog()`           | `LogConfig`          | log level, pretty                                  |
+| `LoadMetrics()`       | `MetricsConfig`      | `METRICS_ADDR` (default `:9090`)                  |
+| `LoadValidate()`      | `ValidateConfig`     | 본문 길이 임계값 / reliability 임계값             |
+| `LoadScheduler()`     | `SchedulerConfig`    | entry interval / MaxBacklog / MaxRetries          |
+| `LoadRefinement()`    | `RefinementConfig`   | refiner enabled / interval / minSamples (이슈 #173) |
+| `LoadLLM()`           | `LLMConfig`          | provider / API key / model / timeout / enabled (이슈 #149) |
+| `LoadRedis()`         | `RedisConfig`        | host/port/password/DB/IngestionLockTTL/poolSize   |
+| `LoadClassifier()`    | `ClassifierConfig`   | gRPC/HTTP endpoint / timeout                       |
+
+각 Config struct 는 보통 `DSN()` 등 헬퍼 메소드를 포함합니다.
+
+<br>
+
+## 설계 원칙
+
+- 환경변수는 모두 `os.Getenv` 또는 `joho/godotenv` 로 읽음
+- 누락 시 default 적용 또는 명시적 에러 (Loader 마다 정책)
+- 한 곳 (`config.go`) 에 집중 — ENV 키 추가는 본 파일에 새 Load* 함수 추가 또는 기존 함수 확장
+- struct 필드는 export — 호출자가 직접 읽음 (getter 없음)
+
+<br>
+
+## 호출 측
+
+거의 모든 [`cmd/`](../cmd/README.md) entry point 와 [`internal/`](../internal/README.md) 의 wiring 진입부.
+[`cmd/issuetracker.md`](../cmd/issuetracker.md) 의 "환경 변수 의존" 표 참조.
+
+<br>
+
+## 의존
+
+- 외부: `github.com/joho/godotenv` — `.env` 파일 자동 로드 (entry point 가 호출)
+- 본 패키지를 import 하는 다른 pkg/ 모듈 (queue, redis, llm 등) 은 자기 Config struct 만 받음 — `pkg/config`
+  자체에 의존하는 일은 권장되지 않으나 현재 `pkg/redis` 등은 의존 (config struct 직접 사용 편의상)
+
+<br>
+
+## ENV 키 (요약)
+
+| Prefix             | 사용처                                        |
+|--------------------|----------------------------------------------|
+| `DB_*`             | [Load](../internal/storage/postgres.md)       |
+| `KAFKA_*`          | [pkg/queue](queue.md)                         |
+| `REDIS_*`          | [pkg/redis](redis.md)                         |
+| `LLM_*`, `GEMINI_API_KEY`, `OPENAI_API_KEY`, `ANTHROPIC_API_KEY` | [pkg/llm](llm.md) |
+| `VALIDATE_*`       | [validate.md](../internal/processor/validate.md) |
+| `SCHEDULER_*`      | [scheduler.md](../internal/scheduler.md)      |
+| `REFINEMENT_*`     | [refiner](../internal/crawler/parser.md)      |
+| `METRICS_ADDR`     | [pkg/metrics](metrics.md)                     |
+| `LOG_*`            | [pkg/logger](logger.md)                        |
+| `CLASSIFIER_*`     | [classifier](../internal/classifier/README.md) |
+
+전체 키 목록은 [`.env.example`](../../../.env.example) 가 단일 소스.

--- a/docs/architecture/pkg/links.md
+++ b/docs/architecture/pkg/links.md
@@ -1,0 +1,69 @@
+# pkg/links — URL Normalization & Extraction
+
+소스: [`pkg/links/`](../../../pkg/links/)
+
+URL 정규화 (`Normalizer`) 와 페이지 내 `<a>` 추출 (`Extractor`) 을 제공합니다. 중복 감지 / 큐 dedup /
+ingestion lock 의 일관성을 위해 모든 진입점이 동일 Normalizer 를 통과합니다.
+
+<br>
+
+## 구성
+
+| 파일                                               | 역할                                                  |
+|--------------------------------------------------|-------------------------------------------------------|
+| [normalizer.go](../../../pkg/links/normalizer.go)  | `Normalizer` — Normalize(url) + functional options    |
+| [extractor.go](../../../pkg/links/extractor.go)    | goquery 기반 `<a href>` 추출 helper                   |
+
+<br>
+
+## Normalizer
+
+```go
+n := links.NewNormalizer(opts...)
+canonical, err := n.Normalize("https://www.Example.com/path/?utm_source=x#frag")
+// → "https://example.com/path"
+```
+
+**기본 정책**:
+- 스킴 lowercase (`HTTP` → `http`)
+- HTTPS 강제 옵션 (또는 원본 유지)
+- `www.` 제거
+- trailing slash 제거
+- fragment (`#…`) 제거
+- query 파라미터: host 별 allow-list 외 제거 (utm_*, fbclid 등 추적 파라미터 제거)
+
+<br>
+
+## Extractor
+
+[extractor.go](../../../pkg/links/extractor.go) — HTML + base URL → 절대 URL 리스트. 구현 자체는 generic 이며,
+boundary 변환은 [`internal/crawler/core.HTMLLinkExtractor`](../internal/crawler/core.md) 가 수행:
+
+```go
+// pkg/links (generic util — fmt.Errorf wrap)
+extracted, err := pkgLinks.Extract(html, baseURL)
+
+// internal/crawler/core (boundary — CrawlerError 변환)
+func (e *HTMLLinkExtractor) Extract(raw *RawContent) ([]Link, error) {
+    res, err := e.inner.Extract(raw.HTML, raw.URL)
+    if err != nil {
+        return nil, NewParseError(CodeParseHTML, "...", raw.URL, err)
+    }
+    ...
+}
+```
+
+<br>
+
+## 의존
+
+- 외부: 표준 `net/url` + `github.com/PuerkitoBio/goquery`
+- 본 패키지가 import 하는 다른 패키지: 없음 (sink 노드)
+
+<br>
+
+## 호출 측
+
+- [`internal/publisher`](../internal/publisher.md) — Publisher.SetNormalizer
+- [`internal/crawler/parser/rule/discovery`](../internal/crawler/parser.md) — full-page link discovery
+- [`internal/crawler/core/extractor`](../internal/crawler/core.md) — boundary wrapper

--- a/docs/architecture/pkg/llm.md
+++ b/docs/architecture/pkg/llm.md
@@ -1,0 +1,129 @@
+# pkg/llm — Unified LLM Provider Abstraction
+
+소스: [`pkg/llm/`](../../../pkg/llm/)
+
+다중 LLM provider (Gemini / OpenAI ChatGPT / Anthropic Claude) 를 **단일 인터페이스 `Provider`** 로
+추상화합니다. 호출자는 provider 교체를 [`Config`](../../../pkg/llm/factory.go) 한 줄로 처리.
+
+<br>
+
+## 핵심 인터페이스
+
+[llm.go](../../../pkg/llm/llm.go):
+
+```go
+type Provider interface {
+    Name() string
+    Generate(ctx context.Context, req Request) (*Response, error)
+}
+
+type Request struct {
+    Messages    []Message  // Role + Content
+    Model       string
+    Temperature float64
+    MaxTokens   int
+    TaskHint    string     // policy 가 사용 (cheapest/latency 등)
+}
+
+type Response struct {
+    Text  string
+    Usage TokenUsage
+}
+
+type Role string
+const (
+    RoleSystem    Role = "system"
+    RoleUser      Role = "user"
+    RoleAssistant Role = "assistant"
+)
+```
+
+<br>
+
+## Factory
+
+[factory.go](../../../pkg/llm/factory.go):
+```go
+provider, err := llm.New(llm.Config{
+    Provider: "gemini" | "openai" | "anthropic",
+    APIKey:   "...",
+    Model:    "...",
+    Timeout:  60 * time.Second,
+})
+```
+
+provider 빌더는 각 서브패키지 `init()` 에서 [`RegisterProvider`](../../../pkg/llm/factory.go) 로 등록 —
+[`pkg/llm/providers`](../../../pkg/llm/providers/) 가 import side-effect 로 모두 등록.
+
+본 패키지를 사용할 때는 보통 `_ "issuetracker/pkg/llm/providers"` 를 함께 import.
+
+<br>
+
+## 서브패키지
+
+| 디렉토리                                                  | 역할                                                  |
+|----------------------------------------------------------|-------------------------------------------------------|
+| [`pkg/llm/anthropic/`](../../../pkg/llm/anthropic/)       | Claude Messages API 어댑터                            |
+| [`pkg/llm/gemini/`](../../../pkg/llm/gemini/)             | Gemini Generative API 어댑터                          |
+| [`pkg/llm/openai/`](../../../pkg/llm/openai/)             | OpenAI Chat Completions 어댑터                        |
+| [`pkg/llm/providers/`](../../../pkg/llm/providers/)       | side-effect import — 모든 provider 의 init() 트리거    |
+| [`pkg/llm/chain/`](../../../pkg/llm/chain/)               | Chain-of-Responsibility 합성 (이슈 #142)              |
+| [`pkg/llm/policy/`](../../../pkg/llm/policy/)             | 라우팅 정책 — fixed / cheapest / hybrid / latency     |
+| [`pkg/llm/prompt/`](../../../pkg/llm/prompt/)             | 프롬프트 빌더 helper                                   |
+
+<br>
+
+## Chain & Policy
+
+[chain.go](../../../pkg/llm/chain/chain.go):
+```go
+primary,   _ := llm.New(...)
+secondary, _ := llm.New(...)
+
+p := chain.New(primary, secondary, fallback)            // 단순 fallback chain
+// 또는 정책 기반:
+pol := policy.NewFixedOrder("gemini", "openai")
+p := chain.NewWithPolicy(pol, []llm.Provider{...}, chain.WithPolicyLogger(log))
+```
+
+정책 종류:
+- [`fixed.go`](../../../pkg/llm/policy/fixed.go) — 명시 순서대로 시도
+- [`cheapest.go`](../../../pkg/llm/policy/cheapest.go) — 가격 우선
+- [`hybrid.go`](../../../pkg/llm/policy/hybrid.go) — TaskHint 기반 분기
+- [`latency.go`](../../../pkg/llm/policy/latency.go) — 응답 시간 우선
+
+<br>
+
+## 부수 helper
+
+| 파일                                                   | 역할                                              |
+|--------------------------------------------------------|---------------------------------------------------|
+| [http.go](../../../pkg/llm/http.go)                    | provider 가 공유하는 HTTP 클라이언트 helper       |
+| [errors.go](../../../pkg/llm/errors.go)                | `ErrCode` (Auth / RateLimit / Timeout / …)        |
+| [capabilities.go](../../../pkg/llm/capabilities.go)    | provider 별 capability 메타 (정책이 사용)         |
+| [measured.go](../../../pkg/llm/measured.go)            | latency / token usage metric 측정 wrapper         |
+
+<br>
+
+## 의존
+
+- [`pkg/logger`](logger.md) (선택)
+- 외부: provider 별 SDK 또는 표준 `net/http`
+
+<br>
+
+## 호출 측
+
+- [`cmd/issuetracker.buildLLMProvider`](../cmd/issuetracker.md) — chain 구성
+- [`internal/crawler/parser/rule/llmgen`](../internal/crawler/parser.md) — selector 자동 생성
+- [`internal/crawler/parser/rule/refiner`](../internal/crawler/parser.md) — path_pattern 정밀화
+
+<br>
+
+## 관련 이슈
+
+- 이슈 #140 — generic LLM client 도입
+- 이슈 #142 — chain composition
+- 이슈 #144 — 정책 (cheapest / latency / hybrid) 확장
+- 이슈 #149 — selector 자동 생성에서 사용
+- 이슈 #173 단계 4-2 — refiner 가 동일 provider 공유

--- a/docs/architecture/pkg/logger.md
+++ b/docs/architecture/pkg/logger.md
@@ -1,0 +1,78 @@
+# pkg/logger — Structured Logging Wrapper
+
+소스: [`pkg/logger/logger.go`](../../../pkg/logger/logger.go)
+
+`zerolog` 위에 얇게 wrap 한 구조화 로거. **로그 메시지 문자열은 영어**, 구조화 필드 키는 snake_case 가
+규약 ([04-error-handling.md](../../../.claude/rules/04-error-handling.md) 참조).
+
+<br>
+
+## API
+
+```go
+log := logger.New(logger.DefaultConfig())
+
+log.Info("crawl job started")
+log.WithError(err).Error("failed to fetch")
+log.WithField("url", u).Debug("fetching")
+log.WithFields(map[string]interface{}{
+    "job_id":  id,
+    "crawler": "naver",
+}).Info("dispatching job")
+
+// Context 전파
+ctx = log.ToContext(ctx)
+sublog := logger.FromContext(ctx)  // ctx 안의 logger 또는 default 반환
+```
+
+<br>
+
+## Level
+
+| Level    | 용도                                                     |
+|----------|---------------------------------------------------------|
+| `debug`  | 개발 / 트러블슈팅 (운영에서 필터링)                      |
+| `info`   | 정상 동작 마일스톤                                       |
+| `warn`   | 예상 외 상황이지만 처리됨 (재시도 / fallback / shutdown timeout) |
+| `error`  | 작업 실패 — 다른 요청은 계속 처리 가능                   |
+| `fatal`  | 복구 불가 — `os.Exit(1)`                                  |
+
+자세한 선택 기준은 [04-error-handling.md](../../../.claude/rules/04-error-handling.md) 의 표 참조.
+
+<br>
+
+## Context Propagation
+
+```go
+// 컴포넌트 초기화 시 scoped logger
+ctx = log.WithFields(map[string]interface{}{
+    "request_id": rid,
+    "crawler":    name,
+}).ToContext(ctx)
+
+// 하위 함수에서:
+sublog := logger.FromContext(ctx)
+sublog.Info("started processing")  // 위의 fields 자동 상속
+```
+
+`shutting_down=true` 등 graceful shutdown 마커도 본 메커니즘으로 전파 (이슈 #72 / #161).
+
+<br>
+
+## 의존
+
+- 외부: `github.com/rs/zerolog`
+- [`pkg/config`](config.md) — `LogConfig` (level / pretty)
+
+<br>
+
+## 호출 측
+
+거의 모든 패키지. nil 허용 옵션 의존인 경우도 다수.
+
+<br>
+
+## 관련 이슈
+
+- 이슈 #72 — graceful shutdown shutting_down 필드
+- 이슈 #161 — shutdown 로그 정합성

--- a/docs/architecture/pkg/metrics.md
+++ b/docs/architecture/pkg/metrics.md
@@ -1,0 +1,56 @@
+# pkg/metrics — Prometheus Registry & HTTP Endpoint
+
+소스: [`pkg/metrics/metrics.go`](../../../pkg/metrics/metrics.go)
+
+Prometheus `Registry` 생성과 `/metrics` HTTP endpoint 노출을 담당하는 얇은 helper. 모든 컴포넌트가
+동일 registry 를 공유하여 단일 endpoint 로 export.
+
+<br>
+
+## API
+
+```go
+metricsRegistry := metrics.NewRegistry()  // Go runtime + process collectors 포함
+
+stop, err := metrics.Serve(ctx, ":9090", metricsRegistry, log)
+defer stop()
+```
+
+`Serve` 는 nonblocking — context cancel 또는 stop() 호출까지 background goroutine 으로 동작.
+
+`addr` 가 빈 문자열이면 endpoint 미기동 (`METRICS_ADDR` ENV 가 빈 값일 때).
+
+<br>
+
+## 등록되는 메트릭
+
+| 메트릭                              | 종류       | 위치                                                                | 의미                                |
+|------------------------------------|-----------|---------------------------------------------------------------------|-------------------------------------|
+| Go runtime / process               | Collector | NewRegistry 자동                                                     | GC, goroutine, mem, fd 등           |
+| `refiner_attempts`                 | Counter   | [refiner/metrics.go](../../../internal/crawler/parser/rule/refiner/metrics.go) | path_pattern 정밀화 시도 횟수 (PR #191) |
+| (그 외) Circuit Breaker 상태 등    | (개별 패키지가 자체 등록) | -                                                  |                                     |
+
+신규 메트릭 추가 시 해당 패키지 (예: `internal/crawler/parser/rule/refiner`) 가
+`prometheus.NewCounterVec` 등으로 만들고 `metricsRegistry.MustRegister` 로 등록 — registry 인스턴스를
+[`cmd/issuetracker`](../cmd/issuetracker.md) 가 wiring 시점에 주입.
+
+<br>
+
+## 의존
+
+- 외부: `github.com/prometheus/client_golang/prometheus`, `prometheus/promhttp`
+- [`pkg/logger`](logger.md)
+
+<br>
+
+## Wiring 위치
+
+- [`cmd/issuetracker`](../cmd/issuetracker.md) 단계 1
+- [`cmd/processor`](../cmd/processor.md) 동일
+
+<br>
+
+## 관련 이슈
+
+- 이슈 #165 — metrics endpoint 도입
+- PR #191 — refiner_attempts counter 추가

--- a/docs/architecture/pkg/queue.md
+++ b/docs/architecture/pkg/queue.md
@@ -93,11 +93,18 @@ GroupEmbedders      = "issuetracker-embedders"
 [backlog.go](../../../pkg/queue/backlog.go):
 
 ```go
-checker := queue.NewBacklogChecker(brokers, timeout)
-lag, err := checker.GetLag(ctx, GroupCrawlerWorkers)
+type BacklogChecker interface {
+    Backlog(ctx context.Context, topic, group string) (int64, error)
+}
+
+checker := queue.NewBacklogChecker(brokers, timeout)  // *KafkaBacklogChecker
+lag, err := checker.Backlog(ctx, queue.TopicCrawlNormal, queue.GroupCrawlerWorkers)
 ```
 
-[`internal/scheduler.BacklogThrottler`](../internal/scheduler.md) 가 사용 — lag 가 임계값 초과 시
+내부에서 토픽의 partition 목록을 metadata 로 조회한 뒤 각 partition 의 latest offset 과 consumer-group
+committed offset 의 차이를 합산합니다.
+
+[`internal/scheduler.BacklogThrottler`](../internal/scheduler.md) 가 사용 — backlog 가 임계값 초과 시
 seed publish 차단.
 
 <br>

--- a/docs/architecture/pkg/queue.md
+++ b/docs/architecture/pkg/queue.md
@@ -1,0 +1,130 @@
+# pkg/queue — Kafka Abstractions
+
+소스: [`pkg/queue/`](../../../pkg/queue/)
+
+Kafka producer / consumer 의 generic 인터페이스 + 모든 토픽 / 컨슈머 그룹 상수 + BacklogChecker 를
+제공합니다. 구현체는 `github.com/segmentio/kafka-go` 사용.
+
+<br>
+
+## 인터페이스
+
+[queue.go](../../../pkg/queue/queue.go):
+
+```go
+type Producer interface {
+    Publish(ctx, msg Message) error
+    PublishBatch(ctx, msgs []Message) error
+    Close() error
+}
+
+type Consumer interface {
+    FetchMessage(ctx) (*Message, error)             // auto-commit 안 함
+    CommitMessages(ctx, msgs ...*Message) error     // 처리 성공 후 명시 commit
+    Close() error
+}
+
+type Message struct {
+    Topic     string
+    Partition int
+    Offset    int64
+    Key       []byte
+    Value     []byte
+    Headers   map[string][]byte
+    Time      time.Time
+}
+```
+
+at-least-once 시맨틱 — `FetchMessage` 후 처리 → `CommitMessages` 호출 순서 (실패 시 재배달).
+
+<br>
+
+## 구현체
+
+| 파일                                          | 역할                                                |
+|----------------------------------------------|-----------------------------------------------------|
+| [producer.go](../../../pkg/queue/producer.go) | `KafkaProducer` (segmentio Writer wrap)             |
+| [consumer.go](../../../pkg/queue/consumer.go) | `KafkaConsumer` (segmentio Reader wrap, Manual commit) |
+| [config.go](../../../pkg/queue/config.go)     | `Config` + `DefaultConfig()` + 모든 상수            |
+| [backlog.go](../../../pkg/queue/backlog.go)   | `BacklogChecker` — consumer-group lag 측정 (이슈 #124) |
+
+<br>
+
+## 토픽 / 그룹 상수 (단일 소스)
+
+[config.go](../../../pkg/queue/config.go):
+
+```go
+// Crawl jobs (priority)
+TopicCrawlHigh   = "issuetracker.crawl.high"
+TopicCrawlNormal = "issuetracker.crawl.normal"
+TopicCrawlLow    = "issuetracker.crawl.low"
+
+// Pipeline stages
+TopicFetched     = "issuetracker.fetched"      // ← fetcher → parser (이슈 #134)
+TopicNormalized  = "issuetracker.normalized"
+TopicValidated   = "issuetracker.validated"
+TopicEnriched    = "issuetracker.enriched"     // (계획)
+TopicEmbedded    = "issuetracker.embedded"     // (계획)
+TopicClusters    = "issuetracker.clusters"     // (계획)
+
+// System
+TopicDLQ         = "issuetracker.dlq"
+
+// (legacy) country-별 raw — 현재는 TopicFetched 사용
+TopicRawUS = "issuetracker.raw.us"
+TopicRawKR = "issuetracker.raw.kr"
+
+// Consumer groups
+GroupCrawlerWorkers = "issuetracker-crawler-workers"
+GroupParsers        = "issuetracker-parsers"   // 이슈 #134
+GroupNormalizers    = "issuetracker-normalizers"
+GroupValidators     = "issuetracker-validators"
+GroupEnrichers      = "issuetracker-enrichers"
+GroupEmbedders      = "issuetracker-embedders"
+```
+
+신규 토픽/그룹 추가 시 본 파일에만 추가하고 다른 곳에서 문자열 리터럴 직접 사용 금지.
+
+<br>
+
+## BacklogChecker
+
+[backlog.go](../../../pkg/queue/backlog.go):
+
+```go
+checker := queue.NewBacklogChecker(brokers, timeout)
+lag, err := checker.GetLag(ctx, GroupCrawlerWorkers)
+```
+
+[`internal/scheduler.BacklogThrottler`](../internal/scheduler.md) 가 사용 — lag 가 임계값 초과 시
+seed publish 차단.
+
+<br>
+
+## 의존
+
+- 외부: `github.com/segmentio/kafka-go`
+- [`pkg/logger`](logger.md) (옵션)
+
+<br>
+
+## 호출 측
+
+거의 모든 단계 worker — [`crawler/worker`](../internal/crawler/worker.md), [`parser/worker`](../internal/parser/README.md),
+[`processor/validate`](../internal/processor/validate.md), [`scheduler`](../internal/scheduler.md), [`publisher`](../internal/publisher.md).
+
+<br>
+
+## Topic Configuration
+
+토픽 partition / replication / retention 은 [`deployments/docker/`](../../../deployments/docker/) 의
+kafka-init 컨테이너가 관리. 자세한 partitioning 전략은 [01-architecture.md](../../../.claude/rules/01-architecture.md)
+참조.
+
+<br>
+
+## 관련 이슈
+
+- 이슈 #124 — BacklogChecker 도입
+- 이슈 #134 — TopicFetched + GroupParsers 신설

--- a/docs/architecture/pkg/redis.md
+++ b/docs/architecture/pkg/redis.md
@@ -1,0 +1,65 @@
+# pkg/redis — Redis Client Wrapper
+
+소스: [`pkg/redis/`](../../../pkg/redis/)
+
+`go-redis/v9` 위에 얇게 wrap 한 클라이언트. 분산 락 (SET NX PX) 과 ZSET 기반 retry queue 를 위한
+연결 객체를 제공합니다.
+
+<br>
+
+## API
+
+```go
+client, err := redis.New(ctx, redisCfg)  // Ping 으로 연결 검증
+defer client.Close()
+```
+
+`*Client` 자체에는 `AcquireLock` / `ReleaseLock` / `Enqueue` / `Dequeue` 등 helper 가 정의되어 있을 수
+있으나, 현재 시스템에서는 **`*Client` 를 직접 받아** [`internal/crawler/worker`](../internal/crawler/worker.md)
+의 다음 컴포넌트들이 필요한 명령을 발행합니다:
+
+- `RedisProcessingLock` — `SET ... NX PX ttl` (이슈 #178)
+- `RedisIngestionLock` — `SET ... NX PX ttl`
+- `RedisDelayedRetryScheduler` — ZSET (`ZADD score=runAt`, `ZRANGEBYSCORE`, `ZREM`)
+
+<br>
+
+## 구성
+
+| 파일                                         | 역할                                                |
+|---------------------------------------------|-----------------------------------------------------|
+| [client.go](../../../pkg/redis/client.go)    | `Client` — go-redis wrap + Ping 검증                |
+| (필요 시) lock.go / retry_queue.go           | 락/재시도 큐 helper (사용 패턴에 따라 추가)         |
+
+<br>
+
+## RedisConfig
+
+[`pkg/config.LoadRedis`](config.md):
+- `Host`, `Port`, `Password`, `DB`
+- `DialTimeout`, `ReadTimeout`, `WriteTimeout`, `PoolSize`
+- `IngestionLockTTL` — IngestionLock 의 SET PX 값 (URL 진입 marker 유효 시간)
+
+<br>
+
+## 의존
+
+- 외부: `github.com/redis/go-redis/v9`
+- [`pkg/config`](config.md) — `RedisConfig`
+
+<br>
+
+## 호출 측
+
+- [`cmd/issuetracker`](../cmd/issuetracker.md) 단계 7 — `redis.New(ctx, cfg)` + `defer client.Close()`
+- [`internal/crawler/worker`](../internal/crawler/worker.md) — Client 를 받아 lock / retry 동작
+
+Redis 가 부재일 때 [`cmd/issuetracker`](../cmd/issuetracker.md) 는 graceful degrade — `NoopProcessingLock`
+fallback.
+
+<br>
+
+## 관련 이슈
+
+- 이슈 #82 — delayed retry queue
+- 이슈 #178 — ProcessingLock + IngestionLock 단일 책임화

--- a/docs/architecture/pkg/urlguard.md
+++ b/docs/architecture/pkg/urlguard.md
@@ -1,0 +1,63 @@
+# pkg/urlguard — URL Guard & Gate
+
+소스: [`pkg/urlguard/`](../../../pkg/urlguard/)
+
+URL 처리 가능 여부를 판정하는 술어 (`Guard`) 와, 그 결과를 일관되게 적용/로깅하는 dispatcher
+(`Gate`) 를 제공합니다. Scheduler / Publisher / Worker 등 여러 진입점이 동일 인스턴스를 공유하여
+차단 정책을 일관 적용합니다 (이슈 #119).
+
+<br>
+
+## API
+
+[guard.go](../../../pkg/urlguard/guard.go), [gate.go](../../../pkg/urlguard/gate.go), [pattern.go](../../../pkg/urlguard/pattern.go):
+
+```go
+type Guard interface {
+    Allow(url string) (allowed bool, reason string)
+}
+
+type AllowAllGuard struct{}  // no-op (테스트 / 비활성화)
+
+type Gate struct { /* … */ }
+
+func NewGate(guard Guard, log *logger.Logger) *Gate
+func (g *Gate) Allow(url string) bool         // 차단 시 WARN 로그 자동
+func (g *Gate) Filter(urls []string) []string // 일괄 필터 + 사유 로그
+```
+
+<br>
+
+## 사용 패턴
+
+```go
+gate := urlguard.NewGate(urlguard.Default(), log)
+
+// 각 진입점이 동일 gate 인스턴스 공유
+scheduler.SetGate(gate)
+publisher.SetGate(gate)
+pool.SetGate(gate)
+```
+
+각 진입점은 publish/dispatch 직전에 `gate.Allow(url)` 호출. 차단 시 silent drop + WARN.
+
+<br>
+
+## 의존
+
+- [`pkg/logger`](logger.md) — 차단 사유 로깅
+- 본 패키지가 import 하는 다른 패키지: 없음 (sink 노드)
+
+<br>
+
+## 호출 측
+
+- [`internal/scheduler`](../internal/scheduler.md) — seed publish 직전
+- [`internal/publisher`](../internal/publisher.md) — chained job publish 직전
+- [`internal/crawler/worker`](../internal/crawler/worker.md) — 추가 가드 적용 가능
+
+<br>
+
+## 관련 이슈
+
+- 이슈 #119 — URL Guard 도입

--- a/docs/architecture/proto/classifier.md
+++ b/docs/architecture/proto/classifier.md
@@ -1,0 +1,88 @@
+# proto/classifier — Classifier Service Definition
+
+소스: [`proto/classifier/classifier.proto`](../../../proto/classifier/classifier.proto)
+
+외부 ELArchive Classifier 서비스의 gRPC 인터페이스 정의. `make proto` 가 이 파일로부터
+[`internal/classifier/grpc/pb/`](../../../internal/classifier/grpc/pb/) 의 Go stub 을 생성합니다.
+
+<br>
+
+## 패키지 / Go import path
+
+```proto
+syntax = "proto3";
+package classifier;
+option go_package = "issuetracker/internal/classifier/grpc/pb";
+```
+
+<br>
+
+## 서비스
+
+```proto
+service ClassifierService {
+  rpc Classify      (ClassifyRequest)       returns (ClassifyResponse);
+  rpc ClassifyBatch (BatchClassifyRequest)  returns (BatchClassifyResponse);
+  rpc Health        (HealthRequest)         returns (HealthResponse);
+}
+```
+
+| RPC                | 설명                                                         |
+|-------------------|--------------------------------------------------------------|
+| `Classify`         | 단일 텍스트 → 카테고리 1건                                    |
+| `ClassifyBatch`    | 복수 텍스트 (최대 100건) → 결과 배열 + total                  |
+| `Health`           | 상태 / 모델 로드 여부 / default 카테고리 개수                  |
+
+<br>
+
+## 메시지
+
+### Common
+
+```proto
+message CategoryInput {
+  string name        = 1;  // 카테고리 식별자
+  string description = 2;  // LLM 프롬프트에 포함될 설명
+}
+
+message ClassifyResult {
+  string label      = 1;  // 예측 카테고리
+  string reason     = 2;  // LLM 근거 (1문장)
+  bool   parse_ok   = 3;  // 파싱 성공 여부
+  string raw_output = 4;  // parse_ok=false 일 때 LLM 원본 출력
+}
+```
+
+### Classify / Batch / Health
+
+`ClassifyRequest`, `ClassifyResponse`, `BatchClassifyRequest`, `BatchClassifyItem`,
+`BatchClassifyResponse`, `HealthRequest`, `HealthResponse` — 자세한 필드는
+[classifier.proto](../../../proto/classifier/classifier.proto) 단일 소스.
+
+<br>
+
+## 코드 생성
+
+```bash
+make proto
+```
+
+[`Makefile`](../../../Makefile) 의 `proto` 타겟이 다음을 수행:
+1. `protoc` / `protoc-gen-go` / `protoc-gen-go-grpc` 설치 확인 (없으면 install)
+2. `protoc --proto_path=proto --go_out=. --go-grpc_out=. proto/classifier/classifier.proto`
+3. 결과: `internal/classifier/grpc/pb/classifier.pb.go`, `classifier_grpc.pb.go`
+
+생성된 파일은 **수정하지 않음** — proto 변경 후 `make proto` 재실행.
+
+<br>
+
+## 호출 측
+
+- [`internal/classifier/grpc.Client`](../internal/classifier/grpc.md) — stub 을 wrap 한 클라이언트
+- [`internal/classifier/Handler`](../internal/classifier/README.md) — gRPC 우선 + HTTP fallback
+
+<br>
+
+## 외부 서비스
+
+ELArchive Classifier — IssueTracker 외부 별도 프로세스 (Python). gRPC `:50051`, HTTP `:8000`.


### PR DESCRIPTION
## 연관 이슈
- Closes #193

<br>

## 구현 내용

프로젝트 디렉토리 트리(`cmd/`, `internal/`, `pkg/`, `proto/`)를 미러링한 `docs/architecture/` 마크다운 문서 트리 36개를 신설했습니다. 각 문서는 패키지의 역할 / 핵심 타입 / 의존 관계 / 외부 연결(Kafka 토픽, DB 테이블, Redis 키, LLM provider, gRPC endpoint)을 정리하며, 모듈 참조는 모두 **프로젝트 디렉토리 기준 상대경로**로 링크됩니다.

### 작성한 문서

- `docs/architecture/README.md` — 디렉토리 트리, 데이터 흐름 ASCII, Kafka 토픽 / 외부 의존성 / DB 테이블 인덱스
- `docs/architecture/cmd/` — issuetracker / processor / migrate / migrate-down + README (api / rldebug 는 미구현 placeholder 로 표기)
- `docs/architecture/internal/` — crawler 7종 (core, handler, domain, implementation, parser, rate_limiter, worker), classifier 3종, parser, processor 2종, publisher, scheduler, storage 3종 + 각 디렉토리 README
- `docs/architecture/pkg/` — config, links, llm, logger, metrics, queue, redis, urlguard + README
- `docs/architecture/proto/` — classifier.proto 서비스 정의

### 작성 규약 ([rules/06-code-style.md](.claude/rules/06-code-style.md) / [rules/01-architecture.md](.claude/rules/01-architecture.md))

- 본문 한국어 + 영어 기술용어 혼용
- 다이어그램은 ASCII (Mermaid 미사용 — 의존성 없는 렌더링 보장)
- 각 문서는 의존 / 호출 측 / 외부 시스템 / 관련 이슈 섹션 표준화
- Python 스크립트로 모든 markdown link 검증 → broken link 0건

<br>

## CI / 머지 게이트 점검

> [CI 운영 규약](docs/ci/conventions.md) 및 [Required Status Checks 단일 소스](docs/ci/status-checks.md)에 따라 작성합니다.

### 변경 영향 범위
- 영향 패키지/모듈: `docs/architecture/` 신규 생성만 — 코드/Go 모듈 변경 0
- 위험도(택1): `Low`

### Required Status Checks
- 통과 확인 대상 (PR Checks 탭에서 확인):
  - [ ] `Commit Lint` — 모든 commit 이 `[DOCS]:` prefix + 한국어 형식 준수
  - [ ] `PR Title Lint` — `[DOCS#193] …` 형식 (이슈 #121 정규식)
  - [ ] `Linked Issue Check` — `Closes #193` 명시
  - [ ] `Format Check` — Go 변경 없음, no-op 통과 예상
  - [ ] `Build` — Go 변경 없음, no-op 통과 예상
  - [ ] `Test` — Go 변경 없음, no-op 통과 예상
  - [ ] `Lint` — Go 변경 없음, no-op 통과 예상

### 롤백 계획
- `git revert <merge-commit>` 으로 단순 롤백 — 코드 변경이 없어 부수 영향 없음

<br>

## TODO
- 본 PR 머지 후, 패키지 구조가 변경되는 후속 PR 에서 해당 마크다운만 갱신 (다른 곳에 중복 기술하지 않음)
- 백로그: 다이어그램이 무거워질 경우 [`docs/architecture/diagrams/`](docs/architecture/) 분리 검토

<br>

## 논의 사항
- `docs/en/` / `docs/ko/` 양어 정책과 별개의 영역 — 본 트리는 한국어 단일 (개발자 내부 reference). 영어 번역 필요시 별도 PR 로 분리 추천.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Comprehensive architecture documentation covering IssueTracker pipeline overview, end-to-end data flows, and component design
  * Documented command-line tools with execution flows, configuration dependencies, and operational requirements
  * Added detailed guides for internal modules (crawler, parser, processor, scheduler, storage) with dependency graphs
  * Provided utility package documentation for configuration, logging, metrics, queuing, Redis integration, and URL guarding
  * Included recommended reading sequences and documentation standards

<!-- end of auto-generated comment: release notes by coderabbit.ai -->