### PR TITLE
[REFAC#197] crawler/worker 의 lock 인프라 → internal/locks 분리 (메타 이슈 #195 단계 2)

### DIFF
--- a/.claude/rules/01-architecture.md
+++ b/.claude/rules/01-architecture.md
@@ -125,6 +125,9 @@ issuetracker/
 │   │   │   ├── pathinfer/     # path_pattern 추론 알고리즘 (이슈 #173)
 │   │   │   └── refiner/       # path_pattern 정밀화 polling
 │   │   └── worker/            # Claim Check 기반 ParserWorker (Kafka consumer)
+│   ├── locks/                 # ✅ 단계 무관 distributed lock — fetcher/parser/validator 공유 (이슈 #197)
+│   │   ├── ingestion_lock.go  # IngestionLock (Publisher 가 Kafka enqueue 직전 사용)
+│   │   └── processing_lock.go # ProcessingLock + ProcessingKey(stage, url)
 │   ├── processor/             # Processing pipeline (planned)
 │   │   ├── normalize/         # Data normalization
 │   │   ├── enrich/            # Data enrichment

--- a/cmd/issuetracker/main.go
+++ b/cmd/issuetracker/main.go
@@ -15,6 +15,7 @@ import (
 	"issuetracker/internal/crawler/domain/general/sources/us"
 	"issuetracker/internal/crawler/handler"
 	crawlerWorker "issuetracker/internal/crawler/worker"
+	"issuetracker/internal/locks"
 	"issuetracker/internal/parser/rule"
 	"issuetracker/internal/parser/rule/llmgen"
 	"issuetracker/internal/parser/rule/refiner"
@@ -143,8 +144,8 @@ func main() {
 	// 단계 구분은 ProcessingKey(stage, url) 의 stage prefix 로 처리.
 	// worker/manager 가 nil 을 NoopProcessingLock 로 fallback 처리하는 설계와 일관되게,
 	// Redis 초기화 실패 시에도 크롤링이 중단되지 않도록 graceful degrade 합니다.
-	var procLock crawlerWorker.ProcessingLock
-	var ingestionLock crawlerWorker.IngestionLock
+	var procLock locks.ProcessingLock
+	var ingestionLock locks.IngestionLock
 	var retryScheduler crawlerWorker.RetryScheduler
 	var retrySchedulerStop func()
 	redisCfg, err := config.LoadRedis()
@@ -160,8 +161,8 @@ func main() {
 				"host": redisCfg.Host,
 				"port": redisCfg.Port,
 			}).Info("redis connected for processing lock and ingestion lock")
-			procLock = crawlerWorker.NewRedisProcessingLock(redisClient, crawlerWorker.DefaultProcessingLockTTL)
-			ingestionLock = crawlerWorker.NewRedisIngestionLock(redisClient, redisCfg.IngestionLockTTL)
+			procLock = locks.NewRedisProcessingLock(redisClient, locks.DefaultProcessingLockTTL)
+			ingestionLock = locks.NewRedisIngestionLock(redisClient, redisCfg.IngestionLockTTL)
 
 			// Delayed retry queue (이슈 #82): retry 를 Redis ZSET 에 보관하고 별도
 			// goroutine 이 ScheduledAt 도달 시 Kafka 에 발행 — worker 슬롯 점유 회피.

--- a/cmd/processor/main.go
+++ b/cmd/processor/main.go
@@ -7,7 +7,7 @@ import (
 	"syscall"
 	"time"
 
-	crawlerWorker "issuetracker/internal/crawler/worker"
+	"issuetracker/internal/locks"
 	"issuetracker/internal/processor/validate"
 	pgstore "issuetracker/internal/storage/postgres"
 	"issuetracker/internal/storage/service"
@@ -93,7 +93,7 @@ func main() {
 	// validator 결과 (passed/rejected) 는 contentSvc.UpdateValidationStatus 로 contents 에 기록 (이슈 #135 / #161).
 	// processor 단독 실행은 dev/test 시나리오 — Redis wiring 없이 NoopProcessingLock 사용.
 	// 다중 인스턴스 운영은 cmd/issuetracker 통합 바이너리에서 Redis 기반 ProcessingLock 공유.
-	worker := validate.NewWorker(consumer, producer, contentSvc, crawlerWorker.NoopProcessingLock{}, validateWorkerCount, validateCfg)
+	worker := validate.NewWorker(consumer, producer, contentSvc, locks.NoopProcessingLock{}, validateWorkerCount, validateCfg)
 	worker.Start(ctx)
 
 	log.WithFields(map[string]interface{}{

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -42,7 +42,9 @@ docs/architecture/
 │   │   ├── handler.md                     ← Registry (crawler_name → Handler)
 │   │   ├── implementation.md              ← chromedp / goquery
 │   │   ├── rate_limiter.md
-│   │   └── worker.md                      ← PoolManager + ProcessingLock + RetryScheduler
+│   │   └── worker.md                      ← PoolManager + RetryScheduler + CircuitBreaker
+│   ├── locks/                             ← 단계 무관 distributed lock (이슈 #197)
+│   │   └── README.md                      ← ProcessingLock + IngestionLock (Redis SETNX)
 │   ├── parser/
 │   │   ├── README.md                      ← Domain-Agnostic Parser + Claim Check Worker
 │   │   └── rule.md                        ← rule.Parser (DB-driven) + llmgen + pathinfer + refiner
@@ -163,7 +165,7 @@ docs/architecture/
 |----------------------------|------------------------------------------------------------|-----------------------------------------------|
 | Kafka                      | [pkg/queue/](../../pkg/queue/)                              | 모든 stage 간 메시지 버스                      |
 | PostgreSQL                 | [internal/storage/postgres/](../../internal/storage/postgres/) | contents / content_bodies / content_meta / raw_contents / parsing_rules / sample_urls / schema_migrations |
-| Redis                      | [pkg/redis/](../../pkg/redis/), [internal/crawler/worker/](../../internal/crawler/worker/) | ProcessingLock(SETNX) / IngestionLock / RetryQueue(ZSET) |
+| Redis                      | [pkg/redis/](../../pkg/redis/), [internal/locks/](../../internal/locks/), [internal/crawler/worker/](../../internal/crawler/worker/) | ProcessingLock + IngestionLock (locks) / RetryQueue ZSET (crawler/worker) |
 | LLM (Gemini/OpenAI/Claude) | [pkg/llm/](../../pkg/llm/)                                  | parser rule 자동 생성 / path_pattern refinement |
 | Chrome (CDP)               | [internal/crawler/implementation/chromedp/](../../internal/crawler/implementation/chromedp/) | 동적 페이지 헤드리스 렌더                      |
 | ELArchive Classifier       | [internal/classifier/](../../internal/classifier/) + [proto/classifier/](../../proto/classifier/) | 카테고리 분류 (gRPC primary, HTTP fallback)    |

--- a/docs/architecture/cmd/README.md
+++ b/docs/architecture/cmd/README.md
@@ -40,7 +40,7 @@ make pg-migrate-down    # 마이그레이션 롤백 (운영자 전용)
 
 ```
 cmd/issuetracker  ──→ internal/* (전부) + pkg/* (전부)
-cmd/processor     ──→ internal/{processor/validate, storage/*, crawler/worker(NoopProcessingLock)} + pkg/*
+cmd/processor     ──→ internal/{processor/validate, storage/*, locks(NoopProcessingLock)} + pkg/*
 cmd/migrate       ──→ internal/storage/postgres + migrations
 cmd/migrate-down  ──→ internal/storage/postgres + migrations
 ```

--- a/docs/architecture/cmd/issuetracker.md
+++ b/docs/architecture/cmd/issuetracker.md
@@ -38,7 +38,8 @@
 
 각 단계의 자세한 책임은 해당 패키지 문서 참조:
 
-- [internal/crawler/worker.md](../internal/crawler/worker.md) — PoolManager, ProcessingLock, RetryScheduler
+- [internal/crawler/worker.md](../internal/crawler/worker.md) — PoolManager, RetryScheduler
+- [internal/locks/README.md](../internal/locks/README.md) — ProcessingLock, IngestionLock
 - [internal/parser/rule.md](../internal/parser/rule.md) — rule.Parser, llmgen, refiner
 - [internal/parser/README.md](../internal/parser/README.md) — ParserWorker (Claim Check)
 - [internal/processor/validate.md](../internal/processor/validate.md) — Validator

--- a/docs/architecture/cmd/processor.md
+++ b/docs/architecture/cmd/processor.md
@@ -34,7 +34,7 @@
 ## 의존 패키지
 
 - [`internal/processor/validate`](../../../internal/processor/validate/) — Worker / Validator
-- [`internal/crawler/worker`](../../../internal/crawler/worker/) — `NoopProcessingLock`
+- [`internal/locks`](../../../internal/locks/) — `NoopProcessingLock`
 - [`internal/storage/postgres`](../../../internal/storage/postgres/) + [`internal/storage/service`](../../../internal/storage/service/)
 - [`pkg/config`](../../../pkg/config/), [`pkg/queue`](../../../pkg/queue/), [`pkg/logger`](../../../pkg/logger/), [`pkg/metrics`](../../../pkg/metrics/)
 

--- a/docs/architecture/internal/crawler/worker.md
+++ b/docs/architecture/internal/crawler/worker.md
@@ -1,23 +1,23 @@
-# internal/crawler/worker — Pool Manager + Distributed Coordination
+# internal/crawler/worker — Pool Manager + Retry/CircuitBreaker
 
 소스: [`internal/crawler/worker/`](../../../../internal/crawler/worker/)
 
 크롤러 단계의 핵심 오케스트레이터. **3-tier priority Kafka consumer pool** 을 운영하며, **Redis 기반
-ProcessingLock / IngestionLock / RetryScheduler** 로 다중 인스턴스 환경의 중복 처리/재시도를 안전하게
-처리합니다. 추가로 **per-source CircuitBreaker** 로 실패 폭주를 차단합니다.
+RetryScheduler** 로 지연 재시도를 처리하고 **per-source CircuitBreaker** 로 실패 폭주를 차단합니다.
+
+> 단계 무관 distributed lock (ProcessingLock / IngestionLock) 은 [`internal/locks`](../locks/README.md)
+> 로 분리됨 (이슈 #197). fetcher worker 는 `locks.ProcessingLock(stage="fetcher", url)` 형태로 사용.
 
 <br>
 
 ## 핵심 타입
 
-| 타입                          | 위치                                                                   | 책임                                                            |
-|------------------------------|-----------------------------------------------------------------------|-----------------------------------------------------------------|
-| `PoolManager`                 | [manager.go](../../../../internal/crawler/worker/manager.go)           | 3개 priority pool 의 lifecycle 관리                              |
-| `KafkaConsumerPool`           | [pool.go](../../../../internal/crawler/worker/pool.go)                 | 단일 priority 의 worker goroutine pool + retry 라우팅           |
-| `ProcessingLock` (interface)  | [processing_lock.go](../../../../internal/crawler/worker/processing_lock.go) | URL 동시 처리 방지 — Redis SETNX / Noop 두 구현                |
-| `IngestionLock` (interface)   | [ingestion_lock.go](../../../../internal/crawler/worker/ingestion_lock.go)   | URL pipeline 진입 marker — Publisher 가 사용                  |
-| `RetryScheduler` (interface)  | [retry_scheduler.go](../../../../internal/crawler/worker/retry_scheduler.go) | 지연 retry — Redis ZSET 또는 즉시 republish                  |
-| `CircuitBreakerRegistry`      | [circuit_breaker.go](../../../../internal/crawler/worker/circuit_breaker.go) | per-source 실패율 트래킹 + 차단                              |
+| 타입                           | 위치                                                                   | 책임                                                            |
+|-------------------------------|-----------------------------------------------------------------------|-----------------------------------------------------------------|
+| `PoolManager`                  | [manager.go](../../../../internal/crawler/worker/manager.go)           | 3개 priority pool 의 lifecycle 관리                              |
+| `KafkaConsumerPool`            | [pool.go](../../../../internal/crawler/worker/pool.go)                 | 단일 priority 의 worker goroutine pool + retry 라우팅           |
+| `RetryScheduler` (interface)   | [retry_scheduler.go](../../../../internal/crawler/worker/retry_scheduler.go) | 지연 retry — Redis ZSET 또는 즉시 republish                  |
+| `CircuitBreakerRegistry`       | [circuit_breaker.go](../../../../internal/crawler/worker/circuit_breaker.go) | per-source 실패율 트래킹 + 차단                              |
 | `PriorityResolver` (interface) | [resolver.go](../../../../internal/crawler/worker/resolver.go)         | retry/escalation 시 새 priority 결정 전략                       |
 
 <br>
@@ -51,45 +51,6 @@ ProcessingLock / IngestionLock / RetryScheduler** 로 다중 인스턴스 환경
         - 비-Retryable 또는 Max 초과 → DLQ 발행 + commit
         - CircuitBreaker.RecordFailure(source)
 ```
-
-<br>
-
-## ProcessingLock (Redis SETNX 또는 Noop)
-
-이슈 #178. 동일 URL 이 여러 worker / 인스턴스에서 단계별 (fetcher / parser / validator) 중복 처리되는 것을
-차단. 인터페이스는 prebuilt key 만 받으며, **stage 분기는 별도 helper `ProcessingKey(stage, url)` 가
-담당** — 호출자가 정규화된 URL 을 hashed key 로 변환해 전달.
-
-```go
-type ProcessingLock interface {
-    Acquire(ctx context.Context, key string) (acquired bool, err error)
-    Release(ctx context.Context, key string) error
-}
-
-// helper — (stage, normalized_url) → Redis key
-func ProcessingKey(stage, url string) string
-```
-
-stage 상수는 패키지 외부에서도 일관 사용 가능 (예: parser worker 가 `worker.ProcessingKey(StageParser, url)`).
-
-구현:
-- [`NewRedisProcessingLock`](../../../../internal/crawler/worker/processing_lock.go) — Redis `SET NX PX ttl`
-- [`NoopProcessingLock`](../../../../internal/crawler/worker/processing_lock.go) — 항상 acquired=true (단일 프로세스 / dev)
-
-<br>
-
-## IngestionLock (Publisher 와 짝)
-
-[`internal/publisher`](../publisher.md) 가 Kafka enqueue **직전**에 URL 을 marking — 이미 marked URL 은
-Publisher 가 무시. ProcessingLock 은 처리 단계 dedup, IngestionLock 은 진입 dedup 으로 책임 분리.
-
-```go
-type IngestionLock interface {
-    Acquire(ctx context.Context, url string) (acquired bool, err error)
-}
-```
-
-기본 TTL 은 `redisCfg.IngestionLockTTL` (ENV 로 조정).
 
 <br>
 

--- a/docs/architecture/internal/locks/README.md
+++ b/docs/architecture/internal/locks/README.md
@@ -1,0 +1,71 @@
+## internal/locks — Stage-Agnostic Distributed Coordination
+
+소스: [`internal/locks/`](../../../../internal/locks/)
+
+크롤링 파이프라인 단계 (fetcher / parser / validator) 간 공통으로 사용하는 **Redis 기반 distributed lock**
+인터페이스. 단일 패키지로 분리되어 어떤 stage 도 동일 lock 인스턴스를 공유 — 단계 prefix 만으로 stage 구분.
+
+## 핵심 타입
+
+| 타입                              | 위치                                                                | 책임                                                          |
+|----------------------------------|---------------------------------------------------------------------|---------------------------------------------------------------|
+| `IngestionLock` (interface)       | [ingestion_lock.go](../../../../internal/locks/ingestion_lock.go)   | URL pipeline 진입 marker — Publisher 가 사용 (이슈 #178, #126) |
+| `RedisIngestionLock`              | [ingestion_lock.go](../../../../internal/locks/ingestion_lock.go)   | Redis SETNX 기반 구현                                          |
+| `NoopIngestionLock`               | [ingestion_lock.go](../../../../internal/locks/ingestion_lock.go)   | 항상 acquired=true (단일 프로세스 / dev)                        |
+| `ProcessingLock` (interface)      | [processing_lock.go](../../../../internal/locks/processing_lock.go) | URL 동시 처리 방지 — fetcher/parser/validator 공유 (이슈 #178)  |
+| `RedisProcessingLock`             | [processing_lock.go](../../../../internal/locks/processing_lock.go) | Redis SETNX 기반 구현                                          |
+| `NoopProcessingLock`              | [processing_lock.go](../../../../internal/locks/processing_lock.go) | 항상 acquired=true (단일 프로세스 / dev)                        |
+| `ProcessingKey(stage, url)`       | [processing_lock.go](../../../../internal/locks/processing_lock.go) | (stage, normalized_url) → Redis key 변환 헬퍼                  |
+| `Stage{Fetcher,Parser,Validator}` | [processing_lock.go](../../../../internal/locks/processing_lock.go) | stage 상수                                                     |
+
+## ProcessingLock 패턴
+
+```go
+type ProcessingLock interface {
+    Acquire(ctx context.Context, key string) (acquired bool, err error)
+    Release(ctx context.Context, key string) error
+}
+
+key := locks.ProcessingKey(locks.StageFetcher, normalizedURL)
+acquired, err := lock.Acquire(ctx, key)
+if !acquired {
+    // 다른 worker 가 처리 중 — skip + commit
+}
+defer lock.Release(ctx, key)
+```
+
+stage 분기는 호출자 책임 — `locks` 패키지 자체는 단순 key/value SETNX 만 노출.
+
+## IngestionLock 패턴
+
+```go
+type IngestionLock interface {
+    Acquire(ctx context.Context, url string) (acquired bool, err error)
+    Invalidate(ctx context.Context, url string) error
+}
+
+// Publisher 가 enqueue 직전 호출
+acquired, err := lock.Acquire(ctx, normalizedURL)
+if !acquired {
+    // 이미 pipeline 진입 marker 있음 — 발행 skip
+}
+```
+
+기본 TTL 은 `redisCfg.IngestionLockTTL` (`INGESTION_LOCK_TTL` 환경변수).
+
+## 호출 측
+
+- [`internal/publisher`](../publisher.md) — `IngestionLock` (Kafka enqueue 직전 dedup)
+- [`internal/crawler/worker`](../crawler/worker.md) — fetcher worker pool 의 `ProcessingLock(StageFetcher)`
+- [`internal/parser/worker`](../parser/README.md) — parser worker 의 `ProcessingLock(StageParser)`
+- [`internal/processor/validate`](../processor/validate.md) — validator 의 `ProcessingLock(StageValidator)`
+
+## 외부 시스템
+
+- **Redis**: SETNX (`SET NX PX ttl`) — Acquire / Release / Invalidate
+
+## 관련 이슈
+
+- 이슈 #126 — URL dedup 도입 (Ingestion Lock 의 전신)
+- 이슈 #178 — Ingestion Lock + Processing Lock 분리, 단계별 단일 책임화
+- 이슈 #197 — `crawler/worker` 에서 lock 인프라를 `internal/locks` 로 분리 (단계 무관 패키지화)

--- a/docs/architecture/internal/parser/README.md
+++ b/docs/architecture/internal/parser/README.md
@@ -64,7 +64,7 @@ ParserWorker 가 이상 종료 / rule.Error 잔존 / LLM 재처리 윈도우 만
 - [`internal/parser/rule`](rule.md) — `Parser`, `Resolver`
 - [`internal/parser/rule/llmgen`](rule.md) — `Generator.Enqueue` (선택)
 - [`internal/crawler/domain/general`](../crawler/domain.md) — `ConvertPageToContent`
-- [`internal/crawler/worker`](../crawler/worker.md) — `ProcessingLock`
+- [`internal/locks`](../locks/README.md) — `ProcessingLock`
 - [`internal/storage/service`](../storage/service.md) — `RawContentService`, `ContentService`
 - [`internal/storage`](../storage/README.md) — `SampleURLRepository`
 - [`internal/publisher`](../publisher.md) — chained job 발행

--- a/docs/architecture/internal/processor/validate.md
+++ b/docs/architecture/internal/processor/validate.md
@@ -60,7 +60,7 @@ graceful shutdown 시 in-flight 메시지를 `drainTimeout` 동안 finalize.
 ## 의존
 
 - [`internal/crawler/core`](../crawler/core.md)
-- [`internal/crawler/worker`](../crawler/worker.md) — `ProcessingLock` (issuetracker 통합 모드) / `NoopProcessingLock` (processor 단독 모드)
+- [`internal/locks`](../locks/README.md) — `ProcessingLock` (issuetracker 통합 모드) / `NoopProcessingLock` (processor 단독 모드)
 - [`internal/storage/service`](../storage/service.md) — `ContentService`
 - [`internal/storage`](../storage/README.md) — `ValidationStatus`
 - [`pkg/queue`](../../pkg/queue.md), [`pkg/config`](../../pkg/config.md), [`pkg/logger`](../../pkg/logger.md)

--- a/docs/architecture/internal/publisher.md
+++ b/docs/architecture/internal/publisher.md
@@ -10,7 +10,7 @@
 ## 책임
 
 - URL 정규화 ([`pkg/links.Normalizer`](../pkg/links.md))
-- IngestionLock atomic dedup ([`crawler/worker.IngestionLock`](crawler/worker.md))
+- IngestionLock atomic dedup ([`locks.IngestionLock`](locks/README.md))
 - URL Guard 검사 ([`pkg/urlguard.Gate`](../pkg/urlguard.md))
 - Priority 결정 ([`crawler/worker.PriorityResolver`](crawler/worker.md))
 - 토픽 라우팅 (Priority → TopicCrawlHigh/Normal/Low)
@@ -61,7 +61,8 @@ for each job in batch:
 ## 의존
 
 - [`internal/crawler/core`](crawler/core.md) — `CrawlJob`
-- [`internal/crawler/worker`](crawler/worker.md) — `PriorityResolver`, `IngestionLock`
+- [`internal/crawler/worker`](crawler/worker.md) — `PriorityResolver`
+- [`internal/locks`](locks/README.md) — `IngestionLock`
 - [`pkg/queue`](../pkg/queue.md), [`pkg/links`](../pkg/links.md), [`pkg/urlguard`](../pkg/urlguard.md), [`pkg/logger`](../pkg/logger.md)
 
 <br>

--- a/docs/architecture/pkg/redis.md
+++ b/docs/architecture/pkg/redis.md
@@ -15,12 +15,11 @@ defer client.Close()
 ```
 
 `*Client` 자체에는 `AcquireLock` / `ReleaseLock` / `Enqueue` / `Dequeue` 등 helper 가 정의되어 있을 수
-있으나, 현재 시스템에서는 **`*Client` 를 직접 받아** [`internal/crawler/worker`](../internal/crawler/worker.md)
-의 다음 컴포넌트들이 필요한 명령을 발행합니다:
+있으나, 현재 시스템에서는 **`*Client` 를 직접 받아** 다음 컴포넌트들이 필요한 명령을 발행합니다:
 
-- `RedisProcessingLock` — `SET ... NX PX ttl` (이슈 #178)
-- `RedisIngestionLock` — `SET ... NX PX ttl`
-- `RedisDelayedRetryScheduler` — ZSET (`ZADD score=runAt`, `ZRANGEBYSCORE`, `ZREM`)
+- `RedisProcessingLock` ([`internal/locks`](../internal/locks/README.md)) — `SET ... NX PX ttl` (이슈 #178)
+- `RedisIngestionLock` ([`internal/locks`](../internal/locks/README.md)) — `SET ... NX PX ttl`
+- `RedisDelayedRetryScheduler` ([`internal/crawler/worker`](../internal/crawler/worker.md)) — ZSET (`ZADD score=runAt`, `ZRANGEBYSCORE`, `ZREM`)
 
 <br>
 
@@ -52,7 +51,8 @@ defer client.Close()
 ## 호출 측
 
 - [`cmd/issuetracker`](../cmd/issuetracker.md) 단계 7 — `redis.New(ctx, cfg)` + `defer client.Close()`
-- [`internal/crawler/worker`](../internal/crawler/worker.md) — Client 를 받아 lock / retry 동작
+- [`internal/locks`](../internal/locks/README.md) — Client 를 받아 ProcessingLock / IngestionLock 구현
+- [`internal/crawler/worker`](../internal/crawler/worker.md) — Client 를 받아 RetryScheduler 구현
 
 Redis 가 부재일 때 [`cmd/issuetracker`](../cmd/issuetracker.md) 는 graceful degrade — `NoopProcessingLock`
 fallback.

--- a/internal/crawler/worker/manager.go
+++ b/internal/crawler/worker/manager.go
@@ -6,6 +6,7 @@ import (
 	"sync"
 
 	"issuetracker/internal/crawler/core"
+	"issuetracker/internal/locks"
 	"issuetracker/internal/storage/service"
 	"issuetracker/pkg/logger"
 	"issuetracker/pkg/queue"
@@ -36,7 +37,7 @@ type ManagerConfig struct {
 	High           PoolConfig
 	Normal         PoolConfig
 	Low            PoolConfig
-	ProcessingLock ProcessingLock
+	ProcessingLock locks.ProcessingLock
 	RetryScheduler RetryScheduler
 }
 
@@ -75,7 +76,7 @@ func NewPoolManager(
 ) *PoolManager {
 	procLock := cfg.ProcessingLock
 	if procLock == nil {
-		procLock = NoopProcessingLock{}
+		procLock = locks.NoopProcessingLock{}
 	}
 
 	// 세 개 Pool이 동일한 CircuitBreakerRegistry를 공유하여

--- a/internal/crawler/worker/pool.go
+++ b/internal/crawler/worker/pool.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"issuetracker/internal/crawler/core"
+	"issuetracker/internal/locks"
 	"issuetracker/internal/storage/service"
 	"issuetracker/pkg/links"
 	"issuetracker/pkg/logger"
@@ -68,7 +69,7 @@ type KafkaConsumerPool struct {
 	jobs        chan jobItem
 	wg          sync.WaitGroup
 	cbRegistry  *CircuitBreakerRegistry
-	procLock    ProcessingLock
+	procLock    locks.ProcessingLock
 	// normalizer는 URL 정규화기입니다.
 	// 미설정(nil) 이면 정규화가 적용되지 않으며, 기존 동작이 유지됩니다.
 	// atomic.Pointer 를 사용하여 polling/worker goroutine 의 동시 Load 와
@@ -119,7 +120,7 @@ func NewKafkaConsumerPool(
 	return NewKafkaConsumerPoolWithOptions(
 		consumer, producer, handler, contentSvc, workerCount,
 		NewCircuitBreakerRegistry(DefaultCircuitBreakerConfig, nil),
-		NoopProcessingLock{},
+		locks.NoopProcessingLock{},
 	)
 }
 
@@ -136,7 +137,7 @@ func NewKafkaConsumerPoolWithCB(
 	return NewKafkaConsumerPoolWithOptions(
 		consumer, producer, handler, contentSvc, workerCount,
 		cbRegistry,
-		NoopProcessingLock{},
+		locks.NoopProcessingLock{},
 	)
 }
 
@@ -149,12 +150,12 @@ func NewKafkaConsumerPoolWithOptions(
 	contentSvc service.ContentService,
 	workerCount int,
 	cbRegistry *CircuitBreakerRegistry,
-	procLock ProcessingLock,
+	procLock locks.ProcessingLock,
 ) *KafkaConsumerPool {
 	// nil guard — NewParserWorker / validate.NewWorker 와 일관성 보장.
 	// 외부 호출자가 nil 을 전달해도 panic 없이 dedup 비활성으로 동작.
 	if procLock == nil {
-		procLock = NoopProcessingLock{}
+		procLock = locks.NoopProcessingLock{}
 	}
 	return &KafkaConsumerPool{
 		consumer:    consumer,
@@ -443,7 +444,7 @@ func (p *KafkaConsumerPool) processJob(ctx context.Context, item jobItem) (err e
 	// 이슈 #178: 동일 URL 이 여러 worker 에서 동시 처리되는 것을 ProcessingLock (stage=fetcher) 로 차단.
 	// Kafka rebalance/재시작으로 동일 메시지가 중복 소비될 때 + 같은 URL 의 다른 jobID 가 동시 처리될 때
 	// 모두 흡수. backoff 대기 이후에 Acquire 하여 락 점유 시간을 실제 처리 구간으로 최소화합니다.
-	procKey := ProcessingKey(StageFetcher, item.job.Target.URL)
+	procKey := locks.ProcessingKey(locks.StageFetcher, item.job.Target.URL)
 	acquired, err := p.procLock.Acquire(ctx, procKey)
 	if err != nil {
 		// 락 획득 오류 시 처리를 건너뛰지 않고 경고 후 진행합니다 (graceful degrade).

--- a/internal/locks/ingestion_lock.go
+++ b/internal/locks/ingestion_lock.go
@@ -1,4 +1,4 @@
-package worker
+package locks
 
 import (
 	"context"

--- a/internal/locks/processing_lock.go
+++ b/internal/locks/processing_lock.go
@@ -1,4 +1,4 @@
-package worker
+package locks
 
 import (
 	"context"

--- a/internal/parser/worker/parser_worker.go
+++ b/internal/parser/worker/parser_worker.go
@@ -27,7 +27,7 @@ import (
 
 	"issuetracker/internal/crawler/core"
 	"issuetracker/internal/crawler/domain/general"
-	crawlerWorker "issuetracker/internal/crawler/worker"
+	"issuetracker/internal/locks"
 	"issuetracker/internal/parser"
 	"issuetracker/internal/parser/rule"
 	"issuetracker/internal/parser/rule/llmgen"
@@ -54,10 +54,10 @@ type ParserWorker struct {
 	contentSvc  service.ContentService
 	publisher   general.JobPublisher
 	parser      *rule.Parser
-	resolver    *rule.Resolver               // 이슈 #173 단계 4-1 — sample 누적 시 매칭된 rule lookup
-	sampleSvc   storage.SampleURLRepository  // nil 허용 — nil 이면 sample 누적 skip (단계 4-1)
-	procLock    crawlerWorker.ProcessingLock // nil 이면 NoopProcessingLock 사용 (단일 인스턴스 fallback)
-	llmGen      *llmgen.Generator            // nil 허용 — nil 이면 ErrNoRule 시 raw 잔존만 (LLM auto-rule 비활성)
+	resolver    *rule.Resolver              // 이슈 #173 단계 4-1 — sample 누적 시 매칭된 rule lookup
+	sampleSvc   storage.SampleURLRepository // nil 허용 — nil 이면 sample 누적 skip (단계 4-1)
+	procLock    locks.ProcessingLock        // nil 이면 NoopProcessingLock 사용 (단일 인스턴스 fallback)
+	llmGen      *llmgen.Generator           // nil 허용 — nil 이면 ErrNoRule 시 raw 잔존만 (LLM auto-rule 비활성)
 	workerCount int
 	log         *logger.Logger
 
@@ -85,7 +85,7 @@ func NewParserWorker(
 	parser *rule.Parser,
 	resolver *rule.Resolver,
 	sampleSvc storage.SampleURLRepository,
-	procLock crawlerWorker.ProcessingLock,
+	procLock locks.ProcessingLock,
 	llmGen *llmgen.Generator,
 	workerCount int,
 	log *logger.Logger,
@@ -94,7 +94,7 @@ func NewParserWorker(
 		workerCount = 1
 	}
 	if procLock == nil {
-		procLock = crawlerWorker.NoopProcessingLock{}
+		procLock = locks.NoopProcessingLock{}
 	}
 	return &ParserWorker{
 		consumer:    consumer,
@@ -200,7 +200,7 @@ func (w *ParserWorker) processMessage(ctx context.Context, msg *queue.Message) e
 	// 이슈 #178: parser 단계 ProcessingLock — 같은 URL 의 동시 파싱을 차단.
 	// Kafka rebalance / 재배달 시 같은 raw 가 두 parser worker 에 도달해도 1회만 처리.
 	// ref.URL 은 fetcher 가 정규화한 URL — Ingestion Lock 키와 같은 정규형 사용.
-	procKey := crawlerWorker.ProcessingKey(crawlerWorker.StageParser, ref.URL)
+	procKey := locks.ProcessingKey(locks.StageParser, ref.URL)
 	acquired, lockErr := w.procLock.Acquire(ctx, procKey)
 	if lockErr != nil {
 		mlog.WithError(lockErr).Warn("failed to acquire parser processing lock, proceeding without lock")

--- a/internal/processor/validate/worker.go
+++ b/internal/processor/validate/worker.go
@@ -9,7 +9,7 @@ import (
 	"time"
 
 	"issuetracker/internal/crawler/core"
-	crawlerWorker "issuetracker/internal/crawler/worker"
+	"issuetracker/internal/locks"
 	"issuetracker/internal/storage"
 	"issuetracker/internal/storage/service"
 	"issuetracker/pkg/config"
@@ -34,7 +34,7 @@ type Worker struct {
 	consumer    queue.Consumer
 	producer    queue.Producer
 	contentSvc  service.ContentService
-	procLock    crawlerWorker.ProcessingLock // nil 허용 → NoopProcessingLock 으로 fallback (이슈 #178)
+	procLock    locks.ProcessingLock // nil 허용 → NoopProcessingLock 으로 fallback (이슈 #178)
 	cfg         config.ValidateConfig
 	workerCount int
 	jobs        chan *queue.Message
@@ -56,12 +56,12 @@ func NewWorker(
 	consumer queue.Consumer,
 	producer queue.Producer,
 	contentSvc service.ContentService,
-	procLock crawlerWorker.ProcessingLock,
+	procLock locks.ProcessingLock,
 	workerCount int,
 	cfg config.ValidateConfig,
 ) *Worker {
 	if procLock == nil {
-		procLock = crawlerWorker.NoopProcessingLock{}
+		procLock = locks.NoopProcessingLock{}
 	}
 	return &Worker{
 		consumer:    consumer,
@@ -185,7 +185,7 @@ func (w *Worker) process(ctx context.Context, msg *queue.Message) error {
 
 	// 이슈 #178: validator 단계 ProcessingLock — 같은 ref.URL 의 동시 검증을 차단.
 	// Kafka rebalance / 재배달 시 같은 ref 가 두 validator 에 도달해도 1회만 처리.
-	procKey := crawlerWorker.ProcessingKey(crawlerWorker.StageValidator, ref.URL)
+	procKey := locks.ProcessingKey(locks.StageValidator, ref.URL)
 	acquired, lockErr := w.procLock.Acquire(ctx, procKey)
 	if lockErr != nil {
 		log.WithFields(map[string]interface{}{

--- a/test/internal/locks/ingestion_lock_test.go
+++ b/test/internal/locks/ingestion_lock_test.go
@@ -1,4 +1,4 @@
-package worker_test
+package locks_test
 
 import (
 	"context"
@@ -10,7 +10,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"issuetracker/internal/crawler/worker"
+	"issuetracker/internal/locks"
 )
 
 // fakeRedisLocker — 테스트용 in-memory SETNX 시뮬레이션.
@@ -65,7 +65,7 @@ func (f *fakeRedisLocker) callCount() int {
 
 func TestRedisIngestionLock_AcquireReturnsTrueOnFirstCall(t *testing.T) {
 	r := newFakeRedisLocker()
-	lock := worker.NewRedisIngestionLock(r, time.Hour)
+	lock := locks.NewRedisIngestionLock(r, time.Hour)
 
 	acquired, err := lock.Acquire(context.Background(), "https://example.com/article/1")
 	assert.NoError(t, err)
@@ -74,7 +74,7 @@ func TestRedisIngestionLock_AcquireReturnsTrueOnFirstCall(t *testing.T) {
 
 func TestRedisIngestionLock_AcquireReturnsFalseOnDuplicate(t *testing.T) {
 	r := newFakeRedisLocker()
-	lock := worker.NewRedisIngestionLock(r, time.Hour)
+	lock := locks.NewRedisIngestionLock(r, time.Hour)
 
 	first, _ := lock.Acquire(context.Background(), "https://example.com/x")
 	second, _ := lock.Acquire(context.Background(), "https://example.com/x")
@@ -84,7 +84,7 @@ func TestRedisIngestionLock_AcquireReturnsFalseOnDuplicate(t *testing.T) {
 
 func TestRedisIngestionLock_DifferentURLsIndependent(t *testing.T) {
 	r := newFakeRedisLocker()
-	lock := worker.NewRedisIngestionLock(r, time.Hour)
+	lock := locks.NewRedisIngestionLock(r, time.Hour)
 
 	a, _ := lock.Acquire(context.Background(), "https://example.com/a")
 	b, _ := lock.Acquire(context.Background(), "https://example.com/b")
@@ -94,7 +94,7 @@ func TestRedisIngestionLock_DifferentURLsIndependent(t *testing.T) {
 
 func TestRedisIngestionLock_InvalidateAllowsReacquire(t *testing.T) {
 	r := newFakeRedisLocker()
-	lock := worker.NewRedisIngestionLock(r, time.Hour)
+	lock := locks.NewRedisIngestionLock(r, time.Hour)
 
 	_, _ = lock.Acquire(context.Background(), "https://example.com/x")
 	err := lock.Invalidate(context.Background(), "https://example.com/x")
@@ -107,7 +107,7 @@ func TestRedisIngestionLock_InvalidateAllowsReacquire(t *testing.T) {
 func TestRedisIngestionLock_PropagatesError(t *testing.T) {
 	r := newFakeRedisLocker()
 	r.failErr = errors.New("redis unavailable")
-	lock := worker.NewRedisIngestionLock(r, time.Hour)
+	lock := locks.NewRedisIngestionLock(r, time.Hour)
 
 	acquired, err := lock.Acquire(context.Background(), "https://example.com/x")
 	assert.Error(t, err)
@@ -118,14 +118,14 @@ func TestRedisIngestionLock_DefaultTTLOnZero(t *testing.T) {
 	r := newFakeRedisLocker()
 	// ttl 0 → DefaultIngestionLockTTL (24h) 사용 — panic 없이 동작 확인
 	assert.NotPanics(t, func() {
-		_ = worker.NewRedisIngestionLock(r, 0)
+		_ = locks.NewRedisIngestionLock(r, 0)
 	})
 }
 
 // nil receiver / nil locker 보호 — zero-value 또는 NewRedisIngestionLock(nil, ...) 호출 시
 // panic 없이 에러 반환 (PR #179 CodeRabbit 피드백).
 func TestRedisIngestionLock_NilLockerReturnsError(t *testing.T) {
-	lock := worker.NewRedisIngestionLock(nil, time.Hour)
+	lock := locks.NewRedisIngestionLock(nil, time.Hour)
 	acquired, err := lock.Acquire(context.Background(), "https://example.com/x")
 	assert.Error(t, err)
 	assert.False(t, acquired)
@@ -135,7 +135,7 @@ func TestRedisIngestionLock_NilLockerReturnsError(t *testing.T) {
 }
 
 func TestRedisIngestionLock_NilReceiverReturnsError(t *testing.T) {
-	var lock *worker.RedisIngestionLock // zero value
+	var lock *locks.RedisIngestionLock // zero value
 	acquired, err := lock.Acquire(context.Background(), "https://example.com/x")
 	assert.Error(t, err)
 	assert.False(t, acquired)
@@ -145,14 +145,14 @@ func TestRedisIngestionLock_NilReceiverReturnsError(t *testing.T) {
 }
 
 func TestNoopIngestionLock_AlwaysAcquires(t *testing.T) {
-	lock := worker.NoopIngestionLock{}
+	lock := locks.NoopIngestionLock{}
 	acquired, err := lock.Acquire(context.Background(), "https://example.com/x")
 	assert.NoError(t, err)
 	assert.True(t, acquired, "Noop 은 항상 acquired=true (단일 인스턴스 fallback)")
 }
 
 func TestNoopIngestionLock_InvalidateNoOp(t *testing.T) {
-	lock := worker.NoopIngestionLock{}
+	lock := locks.NoopIngestionLock{}
 	err := lock.Invalidate(context.Background(), "https://example.com/x")
 	assert.NoError(t, err)
 }
@@ -161,7 +161,7 @@ func TestNoopIngestionLock_InvalidateNoOp(t *testing.T) {
 // fakeRedisLocker 가 mutex 보호하므로 SETNX semantics 시뮬레이션 정확.
 func TestRedisIngestionLock_ConcurrentAcquireSingleWinner(t *testing.T) {
 	r := newFakeRedisLocker()
-	lock := worker.NewRedisIngestionLock(r, time.Hour)
+	lock := locks.NewRedisIngestionLock(r, time.Hour)
 
 	const concurrency = 50
 	var winners int
@@ -190,7 +190,7 @@ func TestRedisIngestionLock_ConcurrentAcquireSingleWinner(t *testing.T) {
 // 같은 URL 은 같은 SETNX 결과 — 두 번째 acquire false 를 통해 간접 검증).
 func TestRedisIngestionLock_SameURLProducesSameKey(t *testing.T) {
 	r := newFakeRedisLocker()
-	lock := worker.NewRedisIngestionLock(r, time.Hour)
+	lock := locks.NewRedisIngestionLock(r, time.Hour)
 
 	url := strings.Repeat("https://example.com/very/long/path/", 20) // 720+ chars
 	first, _ := lock.Acquire(context.Background(), url)

--- a/test/internal/locks/processing_lock_test.go
+++ b/test/internal/locks/processing_lock_test.go
@@ -1,0 +1,62 @@
+package locks_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+
+	"issuetracker/internal/locks"
+)
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Mock ProcessingLock — pool integration test (test/internal/worker/processing_lock_pool_test.go)
+// 에서도 재사용. 본 파일에는 NoopProcessingLock + ProcessingKey 단위 테스트만 둠.
+// ─────────────────────────────────────────────────────────────────────────────
+
+type mockProcessingLock struct{ mock.Mock }
+
+func (m *mockProcessingLock) Acquire(ctx context.Context, key string) (bool, error) {
+	args := m.Called(ctx, key)
+	return args.Bool(0), args.Error(1)
+}
+
+func (m *mockProcessingLock) Release(ctx context.Context, key string) error {
+	args := m.Called(ctx, key)
+	return args.Error(0)
+}
+
+// 컴파일 타임 인터페이스 만족 검증.
+var _ locks.ProcessingLock = (*mockProcessingLock)(nil)
+
+// TestNoopProcessingLock_AlwaysAcquires는 NoopProcessingLock 이 항상 락 획득에 성공하는지 검증합니다.
+func TestNoopProcessingLock_AlwaysAcquires(t *testing.T) {
+	var locker locks.NoopProcessingLock
+
+	acquired, err := locker.Acquire(context.Background(), "any-key")
+	assert.NoError(t, err)
+	assert.True(t, acquired)
+}
+
+// TestNoopProcessingLock_ReleaseNoError 는 NoopProcessingLock 의 Release 가 항상 성공하는지 검증합니다.
+func TestNoopProcessingLock_ReleaseNoError(t *testing.T) {
+	var locker locks.NoopProcessingLock
+
+	err := locker.Release(context.Background(), "any-key")
+	assert.NoError(t, err)
+}
+
+// ProcessingKey 가 (stage, url) 페어로 일관된 키를 만들고, stage 가 다르거나 url 이 다르면 키도 다른지 검증.
+func TestProcessingKey_Determinism(t *testing.T) {
+	url := "https://example.com/article/1"
+	a1 := locks.ProcessingKey(locks.StageFetcher, url)
+	a2 := locks.ProcessingKey(locks.StageFetcher, url)
+	assert.Equal(t, a1, a2, "동일 (stage, url) 은 동일 키")
+
+	b := locks.ProcessingKey(locks.StageParser, url)
+	assert.NotEqual(t, a1, b, "stage 다르면 키 다름")
+
+	c := locks.ProcessingKey(locks.StageFetcher, "https://example.com/article/2")
+	assert.NotEqual(t, a1, c, "url 다르면 키 다름")
+}

--- a/test/internal/processor/validate/worker_test.go
+++ b/test/internal/processor/validate/worker_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/mock"
 
 	"issuetracker/internal/crawler/core"
-	crawlerWorker "issuetracker/internal/crawler/worker"
+	"issuetracker/internal/locks"
 	"issuetracker/internal/processor/validate"
 	"issuetracker/internal/storage"
 	"issuetracker/internal/storage/service"
@@ -155,7 +155,7 @@ func makeProcessingMessage(content *core.Content, retryCount int) *queue.Message
 }
 
 func newWorker(consumer queue.Consumer, producer queue.Producer, contentSvc service.ContentService) *validate.Worker {
-	return validate.NewWorker(consumer, producer, contentSvc, crawlerWorker.NoopProcessingLock{}, 1, config.DefaultValidateConfig())
+	return validate.NewWorker(consumer, producer, contentSvc, locks.NoopProcessingLock{}, 1, config.DefaultValidateConfig())
 }
 
 func runWorker(t *testing.T, consumer *mockConsumer, w *validate.Worker, msg *queue.Message) {

--- a/test/internal/worker/processing_lock_pool_test.go
+++ b/test/internal/worker/processing_lock_pool_test.go
@@ -6,16 +6,17 @@ import (
 	"testing"
 	"time"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 
 	"issuetracker/internal/crawler/core"
 	"issuetracker/internal/crawler/worker"
+	"issuetracker/internal/locks"
 	"issuetracker/pkg/queue"
 )
 
 // ─────────────────────────────────────────────────────────────────────────────
-// Mock ProcessingLock
+// Mock ProcessingLock — 본 파일 안에서만 사용 (test/internal/locks 의 동일명 mock 와 분리).
+// 단위 테스트 (NoopProcessingLock / ProcessingKey) 는 test/internal/locks 에 있음.
 // ─────────────────────────────────────────────────────────────────────────────
 
 type mockProcessingLock struct{ mock.Mock }
@@ -29,10 +30,6 @@ func (m *mockProcessingLock) Release(ctx context.Context, key string) error {
 	args := m.Called(ctx, key)
 	return args.Error(0)
 }
-
-// ─────────────────────────────────────────────────────────────────────────────
-// 헬퍼
-// ─────────────────────────────────────────────────────────────────────────────
 
 func runPoolWithLocker(t *testing.T, consumer *mockConsumer, pool *worker.KafkaConsumerPool, msg *queue.Message) {
 	t.Helper()
@@ -53,45 +50,6 @@ func runPoolWithLocker(t *testing.T, consumer *mockConsumer, pool *worker.KafkaC
 	_ = pool.Stop(stopCtx)
 }
 
-// ─────────────────────────────────────────────────────────────────────────────
-// ProcessingLock 단위 테스트
-// ─────────────────────────────────────────────────────────────────────────────
-
-// TestNoopProcessingLock_AlwaysAcquires는 NoopProcessingLock 이 항상 락 획득에 성공하는지 검증합니다.
-func TestNoopProcessingLock_AlwaysAcquires(t *testing.T) {
-	var locker worker.NoopProcessingLock
-
-	acquired, err := locker.Acquire(context.Background(), "any-key")
-	assert.NoError(t, err)
-	assert.True(t, acquired)
-}
-
-// TestNoopProcessingLock_ReleaseNoError 는 NoopProcessingLock 의 Release 가 항상 성공하는지 검증합니다.
-func TestNoopProcessingLock_ReleaseNoError(t *testing.T) {
-	var locker worker.NoopProcessingLock
-
-	err := locker.Release(context.Background(), "any-key")
-	assert.NoError(t, err)
-}
-
-// ProcessingKey 가 (stage, url) 페어로 일관된 키를 만들고, stage 가 다르거나 url 이 다르면 키도 다른지 검증.
-func TestProcessingKey_Determinism(t *testing.T) {
-	url := "https://example.com/article/1"
-	a1 := worker.ProcessingKey(worker.StageFetcher, url)
-	a2 := worker.ProcessingKey(worker.StageFetcher, url)
-	assert.Equal(t, a1, a2, "동일 (stage, url) 은 동일 키")
-
-	b := worker.ProcessingKey(worker.StageParser, url)
-	assert.NotEqual(t, a1, b, "stage 다르면 키 다름")
-
-	c := worker.ProcessingKey(worker.StageFetcher, "https://example.com/article/2")
-	assert.NotEqual(t, a1, c, "url 다르면 키 다름")
-}
-
-// ─────────────────────────────────────────────────────────────────────────────
-// Pool + ProcessingLock 통합 테스트
-// ─────────────────────────────────────────────────────────────────────────────
-
 // TestKafkaConsumerPool_ProcessingLock_AlreadyAcquired_SkipsWithoutCommit 는
 // 다른 worker 가 이미 락을 보유 중일 때 처리와 commit 을 모두 건너뛰는지 검증합니다.
 // 메시지 유실 방지: 락 보유 워커가 처리 도중 장애로 종료되어도 해당 워커가 commit 하지
@@ -111,7 +69,7 @@ func TestKafkaConsumerPool_ProcessingLock_AlreadyAcquired_SkipsWithoutCommit(t *
 
 	job := newTestJob()
 	msg := marshaledJobMsg(t, job)
-	wantKey := worker.ProcessingKey(worker.StageFetcher, job.Target.URL)
+	wantKey := locks.ProcessingKey(locks.StageFetcher, job.Target.URL)
 
 	// 이미 다른 worker 가 락을 보유 중
 	locker.On("Acquire", mock.Anything, wantKey).Return(false, nil)
@@ -143,7 +101,7 @@ func TestKafkaConsumerPool_ProcessingLock_Acquired_ReleasedAfterProcessing(t *te
 	job := newTestJob()
 	content := newTestContent()
 	msg := marshaledJobMsg(t, job)
-	wantKey := worker.ProcessingKey(worker.StageFetcher, job.Target.URL)
+	wantKey := locks.ProcessingKey(locks.StageFetcher, job.Target.URL)
 
 	locker.On("Acquire", mock.Anything, wantKey).Return(true, nil)
 	locker.On("Release", mock.Anything, wantKey).Return(nil)
@@ -179,7 +137,7 @@ func TestKafkaConsumerPool_ProcessingLock_AcquireError_ProceedsWithoutLock(t *te
 	job := newTestJob()
 	content := newTestContent()
 	msg := marshaledJobMsg(t, job)
-	wantKey := worker.ProcessingKey(worker.StageFetcher, job.Target.URL)
+	wantKey := locks.ProcessingKey(locks.StageFetcher, job.Target.URL)
 
 	// 락 획득 오류 — Redis 장애 시뮬레이션
 	locker.On("Acquire", mock.Anything, wantKey).Return(false, errors.New("redis unavailable"))


### PR DESCRIPTION
## 연관 이슈
- Closes #197

<br>

## 구현 내용

메타 이슈 [#195](https://github.com/EinSofINTEREST/IssueTracker/issues/195) 의 단계 2 — `internal/crawler/worker/` 의 단계 무관 lock 인프라를 `internal/locks/` 패키지로 분리. fetcher/parser/validator 모두 동등한 위치에서 import 가능한 hub 위치.

### 코드 변경 (commit 1)

**이동:**
- `internal/crawler/worker/ingestion_lock.go` → `internal/locks/ingestion_lock.go`
- `internal/crawler/worker/processing_lock.go` → `internal/locks/processing_lock.go`
- 패키지명 `worker` → `locks` 로 변경

**Caller import 갱신:**
- `cmd/issuetracker/main.go` — `crawlerWorker` 유지 + `locks` 추가 (RetryScheduler 등 다른 심볼 때문에 둘 다 필요)
- `cmd/processor/main.go` — `crawlerWorker` 제거 + `locks` 추가 (lock symbol만 사용)
- `internal/parser/worker/parser_worker.go` — 동일 (crawlerWorker import 제거)
- `internal/processor/validate/worker.go` — 동일
- `internal/crawler/worker/{manager,pool}.go` — `locks` import 추가 (자기 패키지 내부에서 lock 사용)

**테스트 mirror 분리:**
- `test/internal/worker/{ingestion,processing}_lock_test.go` → `test/internal/locks/`
- `processing_lock_test.go` 의 단위 테스트 (NoopProcessingLock_*, ProcessingKey_Determinism) 만 새 위치 잔류
- pool 통합 테스트 3건 (`TestKafkaConsumerPool_ProcessingLock_*`) 은 worker 패키지 헬퍼 의존이라 `test/internal/worker/processing_lock_pool_test.go` 로 별도 신설
- 두 위치의 `mockProcessingLock` 은 각자 패키지 안에서만 사용

### 문서 변경 (commit 2)

- `docs/architecture/internal/locks/README.md` 신규 — 단일 패키지 doc
- `docs/architecture/internal/crawler/worker.md` — ProcessingLock / IngestionLock 섹션 제거 + locks 외부 링크 추가
- 다른 6개 doc (`publisher.md` / `parser/README.md` / `processor/validate.md` / `pkg/redis.md` / `cmd/*.md` / 최상 `README.md`) 의 lock 인용 위치 갱신
- `.claude/rules/01-architecture.md` 디렉토리 트리에 `internal/locks/` 항목 추가

### 변경 후 구조

```
internal/
├── crawler/worker/         (PoolManager + KafkaConsumerPool + RetryScheduler + CircuitBreaker + PriorityResolver)
├── locks/                  ← 신규
│   ├── ingestion_lock.go   (IngestionLock + Redis/Noop)
│   └── processing_lock.go  (ProcessingLock + Redis/Noop + ProcessingKey + Stage{Fetcher,Parser,Validator})
├── parser/                 (parser engine + worker)
└── processor/validate/     (validate worker)
```

<br>

## CI / 머지 게이트 점검

> [CI 운영 규약](docs/ci/conventions.md) 및 [Required Status Checks 단일 소스](docs/ci/status-checks.md)에 따라 작성합니다.

### 변경 영향 범위
- 영향 패키지/모듈: `internal/crawler/worker/*` (lock 부분 제거), `internal/locks/*` (신규), `cmd/{issuetracker,processor}/main.go`, `internal/parser/worker/parser_worker.go`, `internal/processor/validate/worker.go`, `internal/crawler/worker/{manager,pool}.go` (locks import), 다수 docs/architecture md
- 위험도(택1): `Low-Medium`
  - import 경로 + 패키지명만 변경 — Redis SETNX 로직 / 단계별 사용 패턴 / TTL 동작 변경 없음
  - `git mv` 로 git history 보존
  - `go build ./... && go test -race ./...` 28 패키지 모두 통과 (failure 0)
  - publisher 의 duck-typed `IngestionLock` interface 그대로 동작 (구조적 의존성 영향 0)

### Required Status Checks
- 통과 확인 대상 (PR Checks 탭에서 확인):
  - [ ] `Commit Lint`
  - [ ] `PR Title Lint`
  - [ ] `Linked Issue Check`
  - [ ] `Format Check`
  - [ ] `Build`
  - [ ] `Test`
  - [ ] `Lint`

### 롤백 계획
- `git revert` 2개 commit (코드 / 문서). DB / Redis / Kafka 영향 없음.

<br>

## TODO
- (다음 sub-issue) #198 — `internal/crawler/{core,handler,implementation,domain,rate_limiter,worker}` → `internal/processor/fetcher/...` 이동 + 메타 이슈 #195 close

<br>

## 논의 사항
- `RetryScheduler` 는 lock 과 함께 옮길지 검토했지만, 현재 fetcher worker 만 사용 + retry 발행 후의 priority topic 라우팅 책임이 있어 fetcher 영역에 잔류. 향후 parser/validator 도 retry queue 가 필요해지면 별도 sub-issue 로 단계 무관 위치로 이동 검토.
- `CircuitBreaker` / `PriorityResolver` 는 fetcher 전용이라 잔류.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized internal distributed lock coordination into a dedicated module for improved code organization and separation of concerns across system stages.

* **Tests**
  * Updated test suites to align with refactored lock module structure and added deterministic behavior validation for lock key generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->