### PR TITLE
[REFAC#206] processor.Stage 인터페이스 도입 + ContentProcessor 제거 + main.go []Stage 패턴

### DIFF
--- a/cmd/issuetracker/main.go
+++ b/cmd/issuetracker/main.go
@@ -11,6 +11,8 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 
 	"issuetracker/internal/locks"
+	"issuetracker/internal/processor"
+	"issuetracker/internal/processor/fetcher"
 	"issuetracker/internal/processor/fetcher/core"
 	"issuetracker/internal/processor/fetcher/domain/general/sources/kr"
 	"issuetracker/internal/processor/fetcher/domain/general/sources/us"
@@ -19,6 +21,7 @@ import (
 	"issuetracker/internal/processor/parser/rule"
 	"issuetracker/internal/processor/parser/rule/llmgen"
 	"issuetracker/internal/processor/parser/rule/refiner"
+	parserStage "issuetracker/internal/processor/parser/stage"
 	parserWorker "issuetracker/internal/processor/parser/worker"
 	"issuetracker/internal/processor/validate"
 	"issuetracker/internal/publisher"
@@ -204,13 +207,12 @@ func main() {
 	}
 
 	manager := crawlerWorker.NewPoolManager(managerCfg, crawlerProducer, registry, contentSvc, resolver, log)
-	manager.Start(ctx)
 
 	log.WithFields(map[string]interface{}{
 		"high_workers":   managerCfg.High.WorkerCount,
 		"normal_workers": managerCfg.Normal.WorkerCount,
 		"low_workers":    managerCfg.Low.WorkerCount,
-	}).Info("crawler pool manager started")
+	}).Info("fetcher pool manager constructed")
 
 	// ── LLM rule generator (이슈 #149) ──────────────────────────────────────────
 	// rule.ErrNoRule (host 매칭 활성 규칙 없음) fallback 으로 LLM 이 selector 를 자동 생성합니다.
@@ -247,21 +249,16 @@ func main() {
 		parserWorkerCount,
 		log,
 	)
-	pw.Start(ctx)
 
 	// ── Refiner (이슈 #173 단계 4-2) ──────────────────────────────────────────
 	// catch-all + llm-auto rule 의 누적 sample URL 로부터 path_pattern 정밀화.
 	// REFINEMENT_ENABLED=false 또는 config 실패 시 nil — 기존 catch-all rule 그대로 동작.
 	// metricsRegistry 는 nil 허용 — Record* 호출이 noop (PR #191 피드백).
 	pathRefiner := buildRefiner(llmProvider, parsingRuleRepo, sampleRepo, ruleResolver, metricsRegistry, log)
-	if pathRefiner != nil {
-		pathRefiner.Start(ctx)
-	}
 
 	// Cleanup cron — parser worker 가 처리하지 못한 채 잔존한 raw_contents row 정리.
 	// 정상 흐름에서는 거의 동작 안 함. crash / rule.Error 잔존 / LLM 재처리 윈도우 만료된 row 만 대상.
 	cleaner := parserWorker.NewRawContentCleaner(rawSvc, parserWorker.CleanupConfig{}, log)
-	cleaner.Start(ctx)
 
 	// ── Scheduler (시드 Job 발행) ─────────────────────────────────────────────
 	schedulerCfg, err := config.LoadScheduler()
@@ -315,13 +312,26 @@ func main() {
 	defer validateProducer.Close()
 
 	validateWorker := validate.NewWorker(validateConsumer, validateProducer, contentSvc, procLock, validateWorkerCount, validateCfg)
-	validateWorker.Start(ctx)
 
 	log.WithFields(map[string]interface{}{
 		"worker_count": validateWorkerCount,
 		"input_topic":  queue.TopicNormalized,
 		"output_topic": queue.TopicValidated,
-	}).Info("validate worker started")
+	}).Info("validate worker constructed")
+
+	// ══════════════════════════════════════════════════════════════════════════
+	// Stage 통합 — processor.Stage 인터페이스로 모든 단계 균일 관리 (이슈 #206)
+	// ══════════════════════════════════════════════════════════════════════════
+
+	stages := []processor.Stage{
+		fetcher.NewStage(manager),
+		parserStage.NewStage(pw, cleaner, llmGen, pathRefiner, log),
+		validate.NewStage(validateWorker),
+	}
+	for _, s := range stages {
+		s.Start(ctx)
+		log.WithField("stage", s.Name()).Info("pipeline stage started")
+	}
 
 	// ══════════════════════════════════════════════════════════════════════════
 	// 종료 시그널 대기
@@ -353,26 +363,16 @@ func main() {
 
 	sched.Stop()
 
-	if err := manager.Stop(shutdownCtx); err != nil {
-		log.WithError(err).Error("error during crawler shutdown")
-	}
-	if err := pw.Stop(shutdownCtx); err != nil {
-		log.WithError(err).Error("error during parser worker shutdown")
-	}
-	// llmGen.Stop 은 parser worker 정지 후 호출 — 새 Enqueue source 가 차단된 시점에
-	// in-flight LLM 호출 완료 대기 (graceful shutdown, 이슈 #149 gemini 피드백).
-	if llmGen != nil {
-		llmGen.Stop(shutdownCtx)
-	}
-	// refiner.Stop 은 in-flight polling cycle 의 완료를 대기 (PR #191 피드백).
-	// rootCtx (위 cancel()) 가 이미 cancel 된 상태이므로 cycle 안의 RunOnce 가 즉시 종료됨 —
-	// 본 호출은 cycle 종료 + goroutine drain 보장.
-	if pathRefiner != nil {
-		pathRefiner.Stop(shutdownCtx)
-	}
-	cleaner.Stop()
-	if err := validateWorker.Stop(shutdownCtx); err != nil {
-		log.WithError(err).Error("error during validate worker shutdown")
+	// Stage 들을 정의 역순으로 stop — fetcher → parser → validate 로 시작했으므로
+	// validate → parser → fetcher 순서로 정리. parser.Stage 내부에서 lifecycle 의존성
+	// (worker → llmGen → refiner → cleaner) 이 처리됨 — 본 main 은 단순 역순 loop.
+	for i := len(stages) - 1; i >= 0; i-- {
+		s := stages[i]
+		if err := s.Stop(shutdownCtx); err != nil {
+			log.WithFields(map[string]interface{}{"stage": s.Name()}).WithError(err).Error("error during stage shutdown")
+		} else {
+			log.WithField("stage", s.Name()).Info("pipeline stage stopped")
+		}
 	}
 
 	log.Info("shutdown completed")

--- a/cmd/issuetracker/main.go
+++ b/cmd/issuetracker/main.go
@@ -363,11 +363,11 @@ func main() {
 
 	sched.Stop()
 
-	// Stage 들을 정의 역순으로 stop — fetcher → parser → validate 로 시작했으므로
-	// validate → parser → fetcher 순서로 정리. parser.Stage 내부에서 lifecycle 의존성
-	// (worker → llmGen → refiner → cleaner) 이 처리됨 — 본 main 은 단순 역순 loop.
-	for i := len(stages) - 1; i >= 0; i-- {
-		s := stages[i]
+	// Stage 들을 정의 순서대로 stop — fetcher → parser → validate 순서로 정리.
+	// 데이터 파이프라인 source-first 원칙: fetcher 가 먼저 Kafka 발행을 멈추면 downstream
+	// stage 가 in-flight 메시지를 graceful drain 가능. parser.Stage 내부에서 lifecycle
+	// 의존성 (worker → llmGen → refiner → cleaner) 이 처리됨.
+	for _, s := range stages {
 		if err := s.Stop(shutdownCtx); err != nil {
 			log.WithFields(map[string]interface{}{"stage": s.Name()}).WithError(err).Error("error during stage shutdown")
 		} else {

--- a/docs/architecture/internal/processor/README.md
+++ b/docs/architecture/internal/processor/README.md
@@ -1,21 +1,61 @@
-# internal/processor — Processing Pipeline Stage Interfaces
+# internal/processor — Pipeline Stage Interface + Implementations
 
 소스: [`internal/processor/`](../../../../internal/processor/)
 
-처리 단계 (validate / enrich / classify 등) 의 공통 인터페이스를 정의하고, 현재 시점의 단일 구현인
-검증(validate) 단계 패키지를 보유합니다.
+파이프라인 단계 (fetcher / parser / validate) 의 공통 lifecycle 인터페이스를 정의하고, 각 단계의
+실구현 패키지 (`fetcher/`, `parser/`, `validate/`) 를 보유합니다.
 
 <br>
 
-## 핵심 인터페이스
+## Stage 인터페이스 (이슈 #206)
 
 [processor.go](../../../../internal/processor/processor.go):
 
 ```go
-type ContentProcessor interface {
-    Process(ctx context.Context, c *core.Content) (*core.Content, error)
+// 모든 파이프라인 단계가 구현하는 lifecycle 인터페이스.
+type Stage interface {
+    Name() string                              // "fetcher" / "parser" / "validate"
+    Start(ctx context.Context)                 // 비-blocking, worker goroutine 기동
+    Stop(ctx context.Context) error            // graceful shutdown 대기
 }
+```
 
+`cmd/issuetracker/main.go` 는 모든 단계를 `[]processor.Stage` 로 균일하게 Start/Stop:
+
+```go
+stages := []processor.Stage{
+    fetcher.NewStage(manager),
+    parserStage.NewStage(pw, cleaner, llmGen, pathRefiner, log),
+    validate.NewStage(validateWorker),
+}
+for _, s := range stages { s.Start(ctx) }
+// shutdown 은 정의 역순
+for i := len(stages)-1; i >= 0; i-- { stages[i].Stop(shutdownCtx) }
+```
+
+stage 추가 (예: enrich, embed) 시 `Stage` 인터페이스만 만족하면 main wiring 자동 통합.
+
+<br>
+
+## 단계별 Stage 구현 위치
+
+| Stage | Wrapper 위치 | wrapping 대상 |
+|---|---|---|
+| `fetcher` | [`fetcher/stage.go`](../../../../internal/processor/fetcher/stage.go) | `worker.PoolManager` (단일) |
+| `parser` | [`parser/stage/stage.go`](../../../../internal/processor/parser/stage/stage.go) | `worker.ParserWorker` + `worker.RawContentCleaner` + `llmgen.Generator` (선택) + `refiner.Refiner` (선택) — 여러 background goroutine 묶음 |
+| `validate` | [`validate/stage.go`](../../../../internal/processor/validate/stage.go) | `validate.Worker` (단일) |
+
+> **`parser/stage` 가 sub-package 인 이유:** `parser/parser.go` 의 `Page` 타입을 `rule/*` 가 import 하므로,
+> parser 부모 패키지가 `rule/*` 를 import 하면 cycle 발생. stage 를 `parser/stage/` 로 분리하여 회피.
+
+<br>
+
+## 검증 타입 (validate 단계 공유 hub)
+
+`Validator` / `ValidationResult` / `ValidationError` 는 `validate/news/` + `validate/community/`
+sub-validator 가 공유하는 타입이라 본 패키지에 잔류 (validate/ 로 옮기면 sub-package 가 부모를 import → cycle).
+
+```go
 type Validator interface {
     Validate(ctx context.Context, content *core.Content) ValidationResult
 }
@@ -31,9 +71,11 @@ type ValidationResult struct {
 
 ## 서브패키지
 
-| 디렉토리                                                                  | 문서                                |
-|--------------------------------------------------------------------------|-------------------------------------|
-| [`internal/processor/validate/`](../../../../internal/processor/validate/) | [validate.md](validate.md)         |
+| 디렉토리                                                                       | 문서                                |
+|-------------------------------------------------------------------------------|-------------------------------------|
+| [`internal/processor/fetcher/`](../../../../internal/processor/fetcher/)       | [fetcher/README.md](fetcher/README.md) |
+| [`internal/processor/parser/`](../../../../internal/processor/parser/)         | [parser/README.md](parser/README.md)   |
+| [`internal/processor/validate/`](../../../../internal/processor/validate/)     | [validate.md](validate.md)             |
 
 <br>
 
@@ -42,3 +84,9 @@ type ValidationResult struct {
 - `internal/processor/enrich/` — entity / sentiment / topic
 - `internal/processor/embed/` — vector embedding
 - `internal/processor/classify/` — [internal/classifier](../classifier/README.md) 호출 stage
+
+새 stage 추가 시:
+1. `internal/processor/<stage>/` 디렉토리 생성
+2. worker 구현
+3. `<stage>/stage.go` (또는 sub-package 의 `stage/`) 에 `processor.Stage` 구현
+4. `cmd/issuetracker/main.go` 의 `stages` 슬라이스에 추가

--- a/docs/architecture/internal/processor/README.md
+++ b/docs/architecture/internal/processor/README.md
@@ -50,12 +50,18 @@ stage 추가 (예: enrich, embed) 시 `Stage` 인터페이스만 만족하면 ma
 
 <br>
 
-## 검증 타입 (validate 단계 공유 hub)
+## 검증 타입 (validate 단계 leaf hub)
 
-`Validator` / `ValidationResult` / `ValidationError` 는 `validate/news/` + `validate/community/`
-sub-validator 가 공유하는 타입이라 본 패키지에 잔류 (validate/ 로 옮기면 sub-package 가 부모를 import → cycle).
+`Validator` / `ValidationResult` / `ValidationError` 는 `internal/processor/validate/types/`
+leaf sub-package 에 위치합니다 — `validate/news/` + `validate/community/` sub-validator 가
+본 타입을 import 하고, `validate` (parent) 도 `NewValidator` 에서 sub-validator 를 import.
+타입을 validate (parent) 에 두면 sub → parent → sub 의 import cycle 이 발생하므로,
+leaf-only sub-package 가 cycle 을 회피합니다.
 
 ```go
+// internal/processor/validate/types/types.go
+package types
+
 type Validator interface {
     Validate(ctx context.Context, content *core.Content) ValidationResult
 }
@@ -65,6 +71,14 @@ type ValidationResult struct {
     QualityScore float32  // 0.0 ~ 1.0; 0.5 미만이면 DLQ 라우팅 대상
     Errors       []ValidationError
 }
+```
+
+import 의존:
+```
+validate (parent)  → types  (NewValidator 가 types.Validator 반환)
+validate/news      → types
+validate/community → types
+validate/worker.go → types  (RunValidation 이 types.Validator 인자)
 ```
 
 <br>

--- a/internal/processor/fetcher/stage.go
+++ b/internal/processor/fetcher/stage.go
@@ -1,0 +1,49 @@
+// Package fetcher 는 fetcher 단계의 processor.Stage 래퍼를 제공합니다 (이슈 #206).
+//
+// 디렉토리 정렬상 본 파일은 internal/processor/fetcher/ 의 entry-point — 하위 패키지
+// (core / handler / domain / implementation / rate_limiter / worker) 의 wiring 결과를
+// processor.Stage 인터페이스로 노출.
+package fetcher
+
+import (
+	"context"
+
+	"issuetracker/internal/processor"
+	"issuetracker/internal/processor/fetcher/worker"
+)
+
+// stageName 은 fetcher 단계의 식별자입니다 (locks.StageFetcher 와 일치).
+const stageName = "fetcher"
+
+// Stage 는 PoolManager 를 processor.Stage 인터페이스로 wrapping 합니다.
+//
+// 본 wrapper 는 lifecycle 만 담당 — Pool 의 모든 wiring (resolver, retry scheduler 주입 등) 은
+// 호출자 (cmd/issuetracker/main.go) 책임으로 유지하여 dependency injection 일관.
+type Stage struct {
+	manager *worker.PoolManager
+}
+
+// NewStage 는 wired PoolManager 를 받아 fetcher.Stage 를 반환합니다.
+// manager 가 nil 이면 panic — wiring 누락 즉시 가시화.
+func NewStage(manager *worker.PoolManager) *Stage {
+	if manager == nil {
+		panic("fetcher: NewStage requires non-nil PoolManager")
+	}
+	return &Stage{manager: manager}
+}
+
+// Name 은 stage 식별자 ("fetcher") 를 반환합니다.
+func (s *Stage) Name() string { return stageName }
+
+// Start 는 PoolManager 의 worker pool 을 기동합니다.
+func (s *Stage) Start(ctx context.Context) {
+	s.manager.Start(ctx)
+}
+
+// Stop 은 PoolManager 의 graceful shutdown 을 수행합니다.
+func (s *Stage) Stop(ctx context.Context) error {
+	return s.manager.Stop(ctx)
+}
+
+// 컴파일 타임 인터페이스 만족 검증.
+var _ processor.Stage = (*Stage)(nil)

--- a/internal/processor/parser/stage/stage.go
+++ b/internal/processor/parser/stage/stage.go
@@ -100,9 +100,9 @@ func (s *Stage) Start(ctx context.Context) {
 func (s *Stage) Stop(ctx context.Context) error {
 	var firstErr error
 
-	// 1. ParserWorker — Enqueue source 차단
+	// 1. ParserWorker — Enqueue source 차단. 에러는 호출자 (main) 에서 stage 별로 일괄 로깅하므로
+	// 본 위치에서는 중복 로그 회피 — 단순 first-error 보존만 (PR #207 gemini 피드백).
 	if err := s.worker.Stop(ctx); err != nil {
-		s.log.WithError(err).Error("parser worker stop failed")
 		firstErr = err
 	}
 
@@ -116,8 +116,22 @@ func (s *Stage) Stop(ctx context.Context) error {
 		s.refiner.Stop(ctx)
 	}
 
-	// 4. RawContentCleaner — ctx 무시 (시그니처상 인자 없음). janitor 라 마지막에 정리.
-	s.cleaner.Stop()
+	// 4. RawContentCleaner — 시그니처가 ctx 를 받지 않아 별도 goroutine + select 로 caller 의
+	// timeout 을 honor (PR #207 CodeRabbit 피드백). janitor 라 ctx cancel 시 firstErr 만 기록하고
+	// 강제 반환 — 본 stop 은 best-effort.
+	cleanerStopped := make(chan struct{})
+	go func() {
+		s.cleaner.Stop()
+		close(cleanerStopped)
+	}()
+	select {
+	case <-cleanerStopped:
+	case <-ctx.Done():
+		s.log.WithError(ctx.Err()).Warn("raw content cleaner stop canceled by ctx")
+		if firstErr == nil {
+			firstErr = ctx.Err()
+		}
+	}
 
 	return firstErr
 }

--- a/internal/processor/parser/stage/stage.go
+++ b/internal/processor/parser/stage/stage.go
@@ -1,0 +1,126 @@
+// Package stage 는 parser 단계의 processor.Stage 래퍼를 제공합니다 (이슈 #206).
+//
+// 본 wrapper 는 별도 sub-package 에 위치 — internal/processor/parser/parser.go 의 Page 타입을
+// rule/* 가 import 하므로, parser 부모 패키지가 rule/* 를 import 하면 import cycle 발생.
+// stage 를 sub-package 로 분리하여 cycle 회피.
+//
+// 본 stage 는 단일 worker 가 아닌 **여러 background goroutine 의 묶음** 입니다:
+//   - worker.ParserWorker (Kafka consume + 파싱 + content 저장)
+//   - worker.RawContentCleaner (잔존 raw_contents purge cron)
+//   - llmgen.Generator (ErrNoRule 시 async LLM 호출, optional)
+//   - refiner.Refiner (path_pattern 정밀화 polling, optional)
+//
+// 모든 component 의 lifecycle 을 본 wrapper 가 단일 Start/Stop 으로 통합.
+// llmGen / refiner 는 nil 허용 (LLM 비활성 / REFINEMENT_ENABLED=false 환경 cover).
+package stage
+
+import (
+	"context"
+
+	"issuetracker/internal/processor"
+	"issuetracker/internal/processor/parser/rule/llmgen"
+	"issuetracker/internal/processor/parser/rule/refiner"
+	"issuetracker/internal/processor/parser/worker"
+	"issuetracker/pkg/logger"
+)
+
+// stageName 은 parser 단계의 식별자입니다 (locks.StageParser 와 일치).
+const stageName = "parser"
+
+// Stage 는 parser 단계의 모든 background goroutine 을 묶어 processor.Stage 로 노출합니다.
+//
+// component 의존 order (Stop 시 역순 처리):
+//  1. ParserWorker — Kafka consumer + 파싱 (필수)
+//  2. RawContentCleaner — janitor (필수, Stop 은 ctx 무시)
+//  3. llmgen.Generator (선택) — ErrNoRule async LLM 호출. ParserWorker 가 유일 Enqueue source 이므로
+//     ParserWorker.Stop 후에 Stop 해야 in-flight LLM 호출 완료 보장.
+//  4. refiner.Refiner (선택) — interval polling. ctx cancel 시 cycle 즉시 종료.
+type Stage struct {
+	worker  *worker.ParserWorker
+	cleaner *worker.RawContentCleaner
+	llmGen  *llmgen.Generator // nil 허용
+	refiner *refiner.Refiner  // nil 허용
+	log     *logger.Logger
+}
+
+// NewStage 는 component 들을 받아 parser.Stage 를 반환합니다.
+// worker / cleaner 는 필수 (nil 이면 panic), llmGen / refiner 는 nil 허용.
+func NewStage(
+	pw *worker.ParserWorker,
+	cleaner *worker.RawContentCleaner,
+	llmGen *llmgen.Generator,
+	pathRefiner *refiner.Refiner,
+	log *logger.Logger,
+) *Stage {
+	if pw == nil {
+		panic("parser: NewStage requires non-nil ParserWorker")
+	}
+	if cleaner == nil {
+		panic("parser: NewStage requires non-nil RawContentCleaner")
+	}
+	if log == nil {
+		panic("parser: NewStage requires non-nil logger")
+	}
+	return &Stage{
+		worker:  pw,
+		cleaner: cleaner,
+		llmGen:  llmGen,
+		refiner: pathRefiner,
+		log:     log,
+	}
+}
+
+// Name 은 stage 식별자 ("parser") 를 반환합니다.
+func (s *Stage) Name() string { return stageName }
+
+// Start 는 parser 단계의 모든 background goroutine 을 기동합니다.
+//
+//   - ParserWorker: consumer pool start
+//   - RawContentCleaner: cron start
+//   - refiner: polling goroutine start (있으면)
+//
+// llmgen.Generator 는 별도 Start 메소드 없음 — Enqueue 호출 시점에 lazy 로 처리 goroutine 생성.
+func (s *Stage) Start(ctx context.Context) {
+	s.worker.Start(ctx)
+	s.cleaner.Start(ctx)
+	if s.refiner != nil {
+		s.refiner.Start(ctx)
+	}
+}
+
+// Stop 은 parser 단계의 graceful shutdown 을 수행합니다.
+//
+// 처리 순서가 중요:
+//  1. ParserWorker 먼저 — llmGen 의 유일 Enqueue source 차단
+//  2. llmGen — in-flight LLM 호출 완료 대기
+//  3. refiner — in-flight polling cycle 완료 대기
+//  4. RawContentCleaner — janitor 마지막
+//
+// 첫 번째 발생한 에러를 반환 (나머지는 log 에 남김). 호출자가 ctx.WithTimeout 으로 강제 종료 시간 제어.
+func (s *Stage) Stop(ctx context.Context) error {
+	var firstErr error
+
+	// 1. ParserWorker — Enqueue source 차단
+	if err := s.worker.Stop(ctx); err != nil {
+		s.log.WithError(err).Error("parser worker stop failed")
+		firstErr = err
+	}
+
+	// 2. llmGen — 새 Enqueue 차단된 시점 이후 in-flight 완료 대기
+	if s.llmGen != nil {
+		s.llmGen.Stop(ctx)
+	}
+
+	// 3. refiner — in-flight polling cycle 완료 대기
+	if s.refiner != nil {
+		s.refiner.Stop(ctx)
+	}
+
+	// 4. RawContentCleaner — ctx 무시 (시그니처상 인자 없음). janitor 라 마지막에 정리.
+	s.cleaner.Stop()
+
+	return firstErr
+}
+
+// 컴파일 타임 인터페이스 만족 검증.
+var _ processor.Stage = (*Stage)(nil)

--- a/internal/processor/processor.go
+++ b/internal/processor/processor.go
@@ -1,18 +1,17 @@
-// Package processor 는 파이프라인 단계 (fetcher / parser / validate) 의 공통 인터페이스를 정의합니다.
+// Package processor 는 파이프라인 단계 (fetcher / parser / validate) 의 공통 lifecycle
+// 인터페이스를 정의합니다.
 //
 // Package processor defines the common Stage interface for pipeline stages
 // (fetcher / parser / validate). Each stage owns its Kafka consumer + worker pool
 // (and optional auxiliary background goroutines) and is managed uniformly via Stage.
 //
-// 부수 검증 타입 (Validator / ValidationResult / ValidationError) 은 validate 단계 안의
-// news/community sub-validator 가 공유하는 hub 라 본 패키지에 잔류 — `validate/` 로 옮기면
-// news/community 가 validate 부모 패키지를 import 하게 되어 import cycle 발생 (이슈 #206).
+// 검증 인터페이스 (Validator / ValidationResult / ValidationError) 는
+// `internal/processor/validate/types/` 로 분리됨 (이슈 #206 후속) — sub-validator
+// (news / community) 가 import 하므로 leaf-only sub-package 에 두어 cycle 회피.
 package processor
 
 import (
 	"context"
-
-	"issuetracker/internal/processor/fetcher/core"
 )
 
 // Stage 는 파이프라인 단계의 공통 lifecycle 인터페이스입니다 (이슈 #206).
@@ -30,25 +29,4 @@ type Stage interface {
 	Name() string
 	Start(ctx context.Context)
 	Stop(ctx context.Context) error
-}
-
-// ValidationError 는 단일 필드 검증 실패 정보를 담습니다.
-type ValidationError struct {
-	Field   string // 검증 실패한 필드명
-	Rule    string // 위반된 검증 규칙
-	Message string // 사람이 읽을 수 있는 실패 설명
-}
-
-// ValidationResult 는 컨텐츠 검증 결과를 담습니다.
-type ValidationResult struct {
-	IsValid      bool
-	QualityScore float32 // 0.0~1.0; 0.5 미만이면 DLQ로 라우팅
-	Errors       []ValidationError
-}
-
-// Validator 는 SourceType 별로 Content 를 검증하는 인터페이스입니다.
-// news, community 등 각 소스 타입별 구현체가 본 인터페이스를 구현합니다.
-// 구현체는 goroutine-safe 해야 합니다.
-type Validator interface {
-	Validate(ctx context.Context, content *core.Content) ValidationResult
 }

--- a/internal/processor/processor.go
+++ b/internal/processor/processor.go
@@ -1,7 +1,12 @@
-// Package processor는 Content 처리 파이프라인의 공통 인터페이스를 정의합니다.
+// Package processor 는 파이프라인 단계 (fetcher / parser / validate) 의 공통 인터페이스를 정의합니다.
 //
-// Package processor defines the common interfaces for the content processing pipeline.
-// Each stage (validate, enrich, embed) implements ContentProcessor.
+// Package processor defines the common Stage interface for pipeline stages
+// (fetcher / parser / validate). Each stage owns its Kafka consumer + worker pool
+// (and optional auxiliary background goroutines) and is managed uniformly via Stage.
+//
+// 부수 검증 타입 (Validator / ValidationResult / ValidationError) 은 validate 단계 안의
+// news/community sub-validator 가 공유하는 hub 라 본 패키지에 잔류 — `validate/` 로 옮기면
+// news/community 가 validate 부모 패키지를 import 하게 되어 import cycle 발생 (이슈 #206).
 package processor
 
 import (
@@ -10,45 +15,40 @@ import (
 	"issuetracker/internal/processor/fetcher/core"
 )
 
-// ContentProcessor는 Content를 변환하는 파이프라인 단계의 공통 인터페이스입니다.
-// validate, enrich, embed 등 각 처리 단계가 이 인터페이스를 구현합니다.
-// 구현체는 여러 goroutine에서 동시에 호출되므로 goroutine-safe해야 합니다.
+// Stage 는 파이프라인 단계의 공통 lifecycle 인터페이스입니다 (이슈 #206).
 //
-// ContentProcessor is the common interface for pipeline stages (validate, enrich, embed).
-// Implementations must be safe for concurrent use.
-type ContentProcessor interface {
-	// Process는 content를 처리하여 변환된 결과를 반환합니다.
-	// 처리 실패 시 에러를 반환합니다.
-	//
-	// Process transforms content and returns the result.
-	// Returns an error if processing fails.
-	Process(ctx context.Context, content *core.Content) (*core.Content, error)
+// 각 stage 는 Kafka consumer + worker pool 을 보유하며 background goroutine 으로 동작.
+// `cmd/issuetracker/main.go` 는 `[]Stage` 로 모든 단계를 균일하게 Start/Stop 관리합니다.
+//
+// Lifecycle 계약:
+//   - Start(ctx): 비-blocking. worker goroutine 기동.
+//   - Stop(ctx):  in-flight 작업의 graceful shutdown 대기. ctx timeout 시 강제 반환.
+//   - Name():    stage 식별자 ("fetcher" / "parser" / "validate"). 로깅/메트릭/locks.ProcessingKey 에 사용.
+//
+// 구현체는 goroutine-safe 해야 합니다.
+type Stage interface {
+	Name() string
+	Start(ctx context.Context)
+	Stop(ctx context.Context) error
 }
 
-// ValidationError는 단일 필드 검증 실패 정보를 담습니다.
-//
-// ValidationError holds details of a single field validation failure.
+// ValidationError 는 단일 필드 검증 실패 정보를 담습니다.
 type ValidationError struct {
 	Field   string // 검증 실패한 필드명
 	Rule    string // 위반된 검증 규칙
 	Message string // 사람이 읽을 수 있는 실패 설명
 }
 
-// ValidationResult는 컨텐츠 검증 결과를 담습니다.
-//
-// ValidationResult holds the outcome of content validation.
+// ValidationResult 는 컨텐츠 검증 결과를 담습니다.
 type ValidationResult struct {
 	IsValid      bool
 	QualityScore float32 // 0.0~1.0; 0.5 미만이면 DLQ로 라우팅
 	Errors       []ValidationError
 }
 
-// Validator는 SourceType별로 Content를 검증하는 인터페이스입니다.
-// news, community 등 각 소스 타입별 구현체가 이 인터페이스를 구현합니다.
-// 구현체는 여러 goroutine에서 동시에 호출되므로 goroutine-safe해야 합니다.
-//
-// Validator validates Content for a specific source type.
-// Implementations must be safe for concurrent use.
+// Validator 는 SourceType 별로 Content 를 검증하는 인터페이스입니다.
+// news, community 등 각 소스 타입별 구현체가 본 인터페이스를 구현합니다.
+// 구현체는 goroutine-safe 해야 합니다.
 type Validator interface {
 	Validate(ctx context.Context, content *core.Content) ValidationResult
 }

--- a/internal/processor/validate/community/validator.go
+++ b/internal/processor/validate/community/validator.go
@@ -11,8 +11,8 @@ import (
 	"strings"
 	"unicode/utf8"
 
-	"issuetracker/internal/processor"
 	"issuetracker/internal/processor/fetcher/core"
+	"issuetracker/internal/processor/validate/types"
 	"issuetracker/pkg/config"
 )
 
@@ -30,8 +30,8 @@ func NewValidator(cfg config.ValidateConfig) *Validator {
 }
 
 // Validate는 커뮤니티 컨텐츠의 필드 검증, 품질 점수, 도배 패턴을 검사합니다.
-func (v *Validator) Validate(_ context.Context, content *core.Content) processor.ValidationResult {
-	var errs []processor.ValidationError
+func (v *Validator) Validate(_ context.Context, content *core.Content) types.ValidationResult {
+	var errs []types.ValidationError
 
 	errs = append(errs, v.validateBody(content)...)
 	errs = append(errs, v.detectFlood(content)...)
@@ -44,7 +44,7 @@ func (v *Validator) Validate(_ context.Context, content *core.Content) processor
 	if score < threshold && len(errs) == 0 {
 		bodyScore := v.scoreBody(content.Body)
 		metaScore := scoreMeta(content)
-		errs = append(errs, processor.ValidationError{
+		errs = append(errs, types.ValidationError{
 			Field: "QualityScore",
 			Rule:  "quality_low",
 			Message: fmt.Sprintf(
@@ -56,17 +56,17 @@ func (v *Validator) Validate(_ context.Context, content *core.Content) processor
 
 	isValid := len(errs) == 0 && score >= threshold
 
-	return processor.ValidationResult{
+	return types.ValidationResult{
 		IsValid:      isValid,
 		QualityScore: score,
 		Errors:       errs,
 	}
 }
 
-func (v *Validator) validateBody(c *core.Content) []processor.ValidationError {
+func (v *Validator) validateBody(c *core.Content) []types.ValidationError {
 	length := utf8.RuneCountInString(c.Body)
 	if length < v.cfg.CommunityBodyMinLen {
-		return []processor.ValidationError{{
+		return []types.ValidationError{{
 			Field:   "Body",
 			Rule:    "min_length",
 			Message: fmt.Sprintf("body must be at least %d characters, got %d", v.cfg.CommunityBodyMinLen, length),
@@ -77,7 +77,7 @@ func (v *Validator) validateBody(c *core.Content) []processor.ValidationError {
 
 // detectFlood는 동일 문자 반복(도배) 패턴을 탐지합니다.
 // 예: "ㅋㅋㅋㅋㅋ", "aaaaa", "!!!!!"
-func (v *Validator) detectFlood(c *core.Content) []processor.ValidationError {
+func (v *Validator) detectFlood(c *core.Content) []types.ValidationError {
 	text := c.Body
 	runes := []rune(text)
 	total := len(runes)
@@ -87,7 +87,7 @@ func (v *Validator) detectFlood(c *core.Content) []processor.ValidationError {
 
 	repeatCount := v.countRepeatRunes(runes)
 	if float64(repeatCount)/float64(total) > v.cfg.CommunityMaxRepeatRatio {
-		return []processor.ValidationError{{
+		return []types.ValidationError{{
 			Field:   "Body",
 			Rule:    "spam_flood",
 			Message: fmt.Sprintf("flood pattern detected (%.0f%% repetitive characters)", float64(repeatCount)/float64(total)*100),

--- a/internal/processor/validate/news/validator.go
+++ b/internal/processor/validate/news/validator.go
@@ -12,8 +12,8 @@ import (
 	"unicode"
 	"unicode/utf8"
 
-	"issuetracker/internal/processor"
 	"issuetracker/internal/processor/fetcher/core"
+	"issuetracker/internal/processor/validate/types"
 	"issuetracker/pkg/config"
 )
 
@@ -31,8 +31,8 @@ func NewValidator(cfg config.ValidateConfig) *Validator {
 }
 
 // Validate는 뉴스 컨텐츠의 필수 필드, 품질 점수, 스팸 여부를 검증합니다.
-func (v *Validator) Validate(_ context.Context, content *core.Content) processor.ValidationResult {
-	var errs []processor.ValidationError
+func (v *Validator) Validate(_ context.Context, content *core.Content) types.ValidationResult {
+	var errs []types.ValidationError
 
 	errs = append(errs, v.validateTitle(content)...)
 	errs = append(errs, v.validateBody(content)...)
@@ -48,7 +48,7 @@ func (v *Validator) Validate(_ context.Context, content *core.Content) processor
 		wordScore := v.scoreWordCount(content.WordCount)
 		metaScore := scoreMetadata(content)
 		structScore := scoreStructure(content)
-		errs = append(errs, processor.ValidationError{
+		errs = append(errs, types.ValidationError{
 			Field: "QualityScore",
 			Rule:  "quality_low",
 			Message: fmt.Sprintf(
@@ -60,24 +60,24 @@ func (v *Validator) Validate(_ context.Context, content *core.Content) processor
 
 	isValid := len(errs) == 0 && score >= threshold
 
-	return processor.ValidationResult{
+	return types.ValidationResult{
 		IsValid:      isValid,
 		QualityScore: score,
 		Errors:       errs,
 	}
 }
 
-func (v *Validator) validateTitle(c *core.Content) []processor.ValidationError {
+func (v *Validator) validateTitle(c *core.Content) []types.ValidationError {
 	length := utf8.RuneCountInString(c.Title)
 	if length < v.cfg.NewsTitleMinLen {
-		return []processor.ValidationError{{
+		return []types.ValidationError{{
 			Field:   "Title",
 			Rule:    "min_length",
 			Message: fmt.Sprintf("title must be at least %d characters, got %d", v.cfg.NewsTitleMinLen, length),
 		}}
 	}
 	if length > v.cfg.NewsTitleMaxLen {
-		return []processor.ValidationError{{
+		return []types.ValidationError{{
 			Field:   "Title",
 			Rule:    "max_length",
 			Message: fmt.Sprintf("title must be at most %d characters, got %d", v.cfg.NewsTitleMaxLen, length),
@@ -86,17 +86,17 @@ func (v *Validator) validateTitle(c *core.Content) []processor.ValidationError {
 	return nil
 }
 
-func (v *Validator) validateBody(c *core.Content) []processor.ValidationError {
+func (v *Validator) validateBody(c *core.Content) []types.ValidationError {
 	length := utf8.RuneCountInString(c.Body)
 	if length < v.cfg.NewsBodyMinLen {
-		return []processor.ValidationError{{
+		return []types.ValidationError{{
 			Field:   "Body",
 			Rule:    "min_length",
 			Message: fmt.Sprintf("body must be at least %d characters, got %d", v.cfg.NewsBodyMinLen, length),
 		}}
 	}
 	if length > v.cfg.NewsBodyMaxLen {
-		return []processor.ValidationError{{
+		return []types.ValidationError{{
 			Field:   "Body",
 			Rule:    "max_length",
 			Message: fmt.Sprintf("body must be at most %d characters, got %d", v.cfg.NewsBodyMaxLen, length),
@@ -105,9 +105,9 @@ func (v *Validator) validateBody(c *core.Content) []processor.ValidationError {
 	return nil
 }
 
-func (v *Validator) validatePublishedAt(c *core.Content) []processor.ValidationError {
+func (v *Validator) validatePublishedAt(c *core.Content) []types.ValidationError {
 	if c.PublishedAt.IsZero() {
-		return []processor.ValidationError{{
+		return []types.ValidationError{{
 			Field:   "PublishedAt",
 			Rule:    "required",
 			Message: "published_at is required for news content",
@@ -117,7 +117,7 @@ func (v *Validator) validatePublishedAt(c *core.Content) []processor.ValidationE
 }
 
 // detectSpam은 과도한 대문자 및 구두점 비율로 스팸을 탐지합니다.
-func (v *Validator) detectSpam(c *core.Content) []processor.ValidationError {
+func (v *Validator) detectSpam(c *core.Content) []types.ValidationError {
 	text := c.Title + " " + c.Body
 	runes := []rune(text)
 	total := len(runes)
@@ -135,10 +135,10 @@ func (v *Validator) detectSpam(c *core.Content) []processor.ValidationError {
 		}
 	}
 
-	var errs []processor.ValidationError
+	var errs []types.ValidationError
 
 	if float64(capCount)/float64(total) > v.cfg.NewsMaxCapRatio {
-		errs = append(errs, processor.ValidationError{
+		errs = append(errs, types.ValidationError{
 			Field:   "Body",
 			Rule:    "spam_caps",
 			Message: fmt.Sprintf("excessive capitalization detected (%.0f%%)", float64(capCount)/float64(total)*100),
@@ -146,7 +146,7 @@ func (v *Validator) detectSpam(c *core.Content) []processor.ValidationError {
 	}
 
 	if float64(punctCount)/float64(total) > v.cfg.NewsMaxPunctRatio {
-		errs = append(errs, processor.ValidationError{
+		errs = append(errs, types.ValidationError{
 			Field:   "Body",
 			Rule:    "spam_punct",
 			Message: fmt.Sprintf("excessive punctuation detected (%.0f%%)", float64(punctCount)/float64(total)*100),

--- a/internal/processor/validate/stage.go
+++ b/internal/processor/validate/stage.go
@@ -1,0 +1,44 @@
+// 본 파일은 validate 단계의 processor.Stage 래퍼를 제공합니다 (이슈 #206).
+//
+// validate 는 단일 worker 만 갖는 단순 stage — Worker.Start/Stop 을 그대로 위임.
+
+package validate
+
+import (
+	"context"
+
+	"issuetracker/internal/processor"
+)
+
+// stageName 은 validate 단계의 식별자입니다 (locks.StageValidator 와 일치).
+const stageName = "validate"
+
+// Stage 는 validate.Worker 를 processor.Stage 인터페이스로 wrapping 합니다.
+type Stage struct {
+	worker *Worker
+}
+
+// NewStage 는 wired Worker 를 받아 validate.Stage 를 반환합니다.
+// worker 가 nil 이면 panic — wiring 누락 즉시 가시화.
+func NewStage(worker *Worker) *Stage {
+	if worker == nil {
+		panic("validate: NewStage requires non-nil Worker")
+	}
+	return &Stage{worker: worker}
+}
+
+// Name 은 stage 식별자 ("validate") 를 반환합니다.
+func (s *Stage) Name() string { return stageName }
+
+// Start 는 validate worker pool 을 기동합니다.
+func (s *Stage) Start(ctx context.Context) {
+	s.worker.Start(ctx)
+}
+
+// Stop 은 validate worker 의 graceful shutdown 을 수행합니다.
+func (s *Stage) Stop(ctx context.Context) error {
+	return s.worker.Stop(ctx)
+}
+
+// 컴파일 타임 인터페이스 만족 검증.
+var _ processor.Stage = (*Stage)(nil)

--- a/internal/processor/validate/types/types.go
+++ b/internal/processor/validate/types/types.go
@@ -1,0 +1,43 @@
+// Package types 는 validate 단계의 검증 인터페이스와 결과 타입을 정의합니다.
+//
+// Sub-package 인 이유 (이슈 #206 후속):
+//
+//	validate/news + validate/community sub-validator 가 본 타입을 import 하고,
+//	validate (parent) 도 dispatch 함수 NewValidator 에서 sub-validator 를 import.
+//	타입을 validate (parent) 에 두면 sub → parent import 로 cycle 발생.
+//	leaf-only sub-package 인 types/ 는 누구도 import 하지 않으므로 cycle 회피.
+//
+// import 의존:
+//
+//	validate (parent)  → types
+//	validate/news      → types
+//	validate/community → types
+//	validate/worker.go → types (validate package 안)
+package types
+
+import (
+	"context"
+
+	"issuetracker/internal/processor/fetcher/core"
+)
+
+// ValidationError 는 단일 필드 검증 실패 정보를 담습니다.
+type ValidationError struct {
+	Field   string // 검증 실패한 필드명
+	Rule    string // 위반된 검증 규칙
+	Message string // 사람이 읽을 수 있는 실패 설명
+}
+
+// ValidationResult 는 컨텐츠 검증 결과를 담습니다.
+type ValidationResult struct {
+	IsValid      bool
+	QualityScore float32 // 0.0~1.0; 0.5 미만이면 DLQ로 라우팅
+	Errors       []ValidationError
+}
+
+// Validator 는 SourceType 별로 Content 를 검증하는 인터페이스입니다.
+// news, community 등 각 소스 타입별 구현체가 본 인터페이스를 구현합니다.
+// 구현체는 goroutine-safe 해야 합니다.
+type Validator interface {
+	Validate(ctx context.Context, content *core.Content) ValidationResult
+}

--- a/internal/processor/validate/validator.go
+++ b/internal/processor/validate/validator.go
@@ -9,10 +9,10 @@ import (
 	"context"
 	"fmt"
 
-	"issuetracker/internal/processor"
 	"issuetracker/internal/processor/fetcher/core"
 	"issuetracker/internal/processor/validate/community"
 	"issuetracker/internal/processor/validate/news"
+	"issuetracker/internal/processor/validate/types"
 	"issuetracker/pkg/config"
 )
 
@@ -21,7 +21,7 @@ import (
 //
 // NewValidator returns the appropriate Validator for the given SourceType.
 // Defaults to the news validator for unknown or social types.
-func NewValidator(sourceType core.SourceType, cfg config.ValidateConfig) processor.Validator {
+func NewValidator(sourceType core.SourceType, cfg config.ValidateConfig) types.Validator {
 	switch sourceType {
 	case core.SourceTypeCommunity:
 		return community.NewValidator(cfg)
@@ -35,7 +35,7 @@ func NewValidator(sourceType core.SourceType, cfg config.ValidateConfig) process
 //
 // 검증 통과 시: content.Reliability = QualityScore 설정, (content, nil) 반환.
 // 검증 실패 시: core.CrawlerError(Validation 카테고리) 반환 — 첫 번째 룰 기준 코드 부여.
-func RunValidation(ctx context.Context, v processor.Validator, content *core.Content) (*core.Content, error) {
+func RunValidation(ctx context.Context, v types.Validator, content *core.Content) (*core.Content, error) {
 	result := v.Validate(ctx, content)
 	content.Reliability = result.QualityScore
 
@@ -51,7 +51,7 @@ func RunValidation(ctx context.Context, v processor.Validator, content *core.Con
 // codeForValidationResult 는 ValidationResult.Errors 에서 첫 번째 룰을 참조하여
 // 가장 적절한 에러 코드를 결정합니다. errors 가 비어있으면 임계 미달로 간주합니다 (legacy 안전망 —
 // 이슈 #135 이후 validator 들은 임계 미달 시 명시적으로 quality_low 룰을 errors 에 추가합니다).
-func codeForValidationResult(result processor.ValidationResult) string {
+func codeForValidationResult(result types.ValidationResult) string {
 	if len(result.Errors) == 0 {
 		return core.CodeValQualityLow
 	}

--- a/internal/processor/validate/validator.go
+++ b/internal/processor/validate/validator.go
@@ -1,8 +1,8 @@
-// Package validate는 Content 검증 처리 단계를 구현합니다.
+// Package validate 는 Content 검증 처리 단계를 구현합니다.
 //
 // Package validate implements the content validation stage of the processing pipeline.
-// It dispatches to source-type-specific validators (news, community) via NewValidator,
-// and adapts them to ContentProcessor via NewContentProcessor.
+// It dispatches to source-type-specific validators (news, community) via NewValidator.
+// Worker 가 Validator 결과를 직접 사용 — 별도 ContentProcessor 어댑터 없음 (이슈 #206).
 package validate
 
 import (
@@ -16,7 +16,7 @@ import (
 	"issuetracker/pkg/config"
 )
 
-// NewValidator는 SourceType에 맞는 Validator를 반환합니다.
+// NewValidator 는 SourceType 에 맞는 Validator 를 반환합니다.
 // 알 수 없는 타입은 뉴스 검증기를 기본으로 사용합니다.
 //
 // NewValidator returns the appropriate Validator for the given SourceType.
@@ -30,27 +30,13 @@ func NewValidator(sourceType core.SourceType, cfg config.ValidateConfig) process
 	}
 }
 
-// NewContentProcessor는 Validator를 감싸는 ContentProcessor를 반환합니다.
-// 검증 통과 시 content.Reliability를 QualityScore로 설정하고 반환합니다.
-// 검증 실패(IsValid == false) 시 에러를 반환하며, 호출자(Worker)가 DLQ로 라우팅합니다.
+// RunValidation 은 content 를 검증하고 결과에 따라 Reliability 설정 + 에러 변환을 수행합니다.
+// 이전의 ContentProcessor 어댑터를 대체 (이슈 #206) — 단순 함수로 충분.
 //
-// NewContentProcessor wraps a Validator as a ContentProcessor.
-// On success, sets content.Reliability = QualityScore and returns the content.
-// On failure, returns an error so the Worker can route to DLQ.
-func NewContentProcessor(v processor.Validator) processor.ContentProcessor {
-	return &validatorProcessor{validator: v}
-}
-
-// validatorProcessor는 Validator를 ContentProcessor로 어댑팅합니다.
-type validatorProcessor struct {
-	validator processor.Validator
-}
-
-// Process는 content를 검증하고 Reliability를 설정합니다.
-// 검증 실패 시 core.CrawlerError(Validation 카테고리)로 반환하며,
-// 첫 번째 룰에 따라 코드를 부여합니다(임계 미달은 VAL_005, errors 가 비어있는 임계 실패도 VAL_005).
-func (p *validatorProcessor) Process(ctx context.Context, content *core.Content) (*core.Content, error) {
-	result := p.validator.Validate(ctx, content)
+// 검증 통과 시: content.Reliability = QualityScore 설정, (content, nil) 반환.
+// 검증 실패 시: core.CrawlerError(Validation 카테고리) 반환 — 첫 번째 룰 기준 코드 부여.
+func RunValidation(ctx context.Context, v processor.Validator, content *core.Content) (*core.Content, error) {
+	result := v.Validate(ctx, content)
 	content.Reliability = result.QualityScore
 
 	if !result.IsValid {
@@ -62,7 +48,7 @@ func (p *validatorProcessor) Process(ctx context.Context, content *core.Content)
 	return content, nil
 }
 
-// codeForValidationResult는 ValidationResult.Errors 에서 첫 번째 룰을 참조하여
+// codeForValidationResult 는 ValidationResult.Errors 에서 첫 번째 룰을 참조하여
 // 가장 적절한 에러 코드를 결정합니다. errors 가 비어있으면 임계 미달로 간주합니다 (legacy 안전망 —
 // 이슈 #135 이후 validator 들은 임계 미달 시 명시적으로 quality_low 룰을 errors 에 추가합니다).
 func codeForValidationResult(result processor.ValidationResult) string {

--- a/internal/processor/validate/worker.go
+++ b/internal/processor/validate/worker.go
@@ -234,9 +234,8 @@ func (w *Worker) process(ctx context.Context, msg *queue.Message) error {
 	}).Debug("starting content validation")
 
 	v := NewValidator(content.SourceType, w.cfg)
-	cp := NewContentProcessor(v)
 
-	_, err = cp.Process(ctx, content)
+	_, err = RunValidation(ctx, v, content)
 	if err != nil {
 		// 검증 실패: contents에서 삭제 후 DLQ 또는 재큐잉
 		if pm.RetryCount >= maxRetries(msg) {

--- a/test/internal/processor/validate/processor_test.go
+++ b/test/internal/processor/validate/processor_test.go
@@ -81,10 +81,8 @@ func TestContentProcessor_Process_AssignsCodeFromFirstRule(t *testing.T) {
 					Errors:       tt.errors,
 				},
 			}
-			cp := validate.NewContentProcessor(v)
-
 			content := &core.Content{ID: "test-id"}
-			out, err := cp.Process(context.Background(), content)
+			out, err := validate.RunValidation(context.Background(), v, content)
 
 			assert.Nil(t, out)
 			require.Error(t, err)
@@ -107,10 +105,8 @@ func TestContentProcessor_Process_SuccessSetsReliability(t *testing.T) {
 			Errors:       nil,
 		},
 	}
-	cp := validate.NewContentProcessor(v)
-
 	content := &core.Content{ID: "ok-id"}
-	out, err := cp.Process(context.Background(), content)
+	out, err := validate.RunValidation(context.Background(), v, content)
 
 	require.NoError(t, err)
 	assert.Equal(t, content, out)

--- a/test/internal/processor/validate/processor_test.go
+++ b/test/internal/processor/validate/processor_test.go
@@ -8,17 +8,17 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"issuetracker/internal/processor"
 	core "issuetracker/internal/processor/fetcher/core"
 	"issuetracker/internal/processor/validate"
+	"issuetracker/internal/processor/validate/types"
 )
 
 // stubValidator는 입력에 관계없이 고정된 ValidationResult 를 반환합니다.
 type stubValidator struct {
-	result processor.ValidationResult
+	result types.ValidationResult
 }
 
-func (s *stubValidator) Validate(_ context.Context, _ *core.Content) processor.ValidationResult {
+func (s *stubValidator) Validate(_ context.Context, _ *core.Content) types.ValidationResult {
 	return s.result
 }
 
@@ -27,42 +27,42 @@ func (s *stubValidator) Validate(_ context.Context, _ *core.Content) processor.V
 func TestContentProcessor_Process_AssignsCodeFromFirstRule(t *testing.T) {
 	tests := []struct {
 		name     string
-		errors   []processor.ValidationError
+		errors   []types.ValidationError
 		wantCode string
 	}{
 		{
 			name:     "min_length → VAL_003",
-			errors:   []processor.ValidationError{{Field: "Title", Rule: "min_length"}},
+			errors:   []types.ValidationError{{Field: "Title", Rule: "min_length"}},
 			wantCode: core.CodeValContentShort,
 		},
 		{
 			name:     "max_length → VAL_004",
-			errors:   []processor.ValidationError{{Field: "Body", Rule: "max_length"}},
+			errors:   []types.ValidationError{{Field: "Body", Rule: "max_length"}},
 			wantCode: core.CodeValContentLong,
 		},
 		{
 			name:     "required → VAL_001",
-			errors:   []processor.ValidationError{{Field: "PublishedAt", Rule: "required"}},
+			errors:   []types.ValidationError{{Field: "PublishedAt", Rule: "required"}},
 			wantCode: core.CodeValMissingField,
 		},
 		{
 			name:     "spam_caps → VAL_006",
-			errors:   []processor.ValidationError{{Field: "Body", Rule: "spam_caps"}},
+			errors:   []types.ValidationError{{Field: "Body", Rule: "spam_caps"}},
 			wantCode: core.CodeValSpam,
 		},
 		{
 			name:     "spam_punct → VAL_006",
-			errors:   []processor.ValidationError{{Field: "Body", Rule: "spam_punct"}},
+			errors:   []types.ValidationError{{Field: "Body", Rule: "spam_punct"}},
 			wantCode: core.CodeValSpam,
 		},
 		{
 			name:     "spam_flood → VAL_006",
-			errors:   []processor.ValidationError{{Field: "Body", Rule: "spam_flood"}},
+			errors:   []types.ValidationError{{Field: "Body", Rule: "spam_flood"}},
 			wantCode: core.CodeValSpam,
 		},
 		{
 			name:     "unknown rule → VAL_002 (default fallback)",
-			errors:   []processor.ValidationError{{Field: "Body", Rule: "weird_rule_xyz"}},
+			errors:   []types.ValidationError{{Field: "Body", Rule: "weird_rule_xyz"}},
 			wantCode: core.CodeValInvalidFormat,
 		},
 		{
@@ -75,7 +75,7 @@ func TestContentProcessor_Process_AssignsCodeFromFirstRule(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			v := &stubValidator{
-				result: processor.ValidationResult{
+				result: types.ValidationResult{
 					IsValid:      false,
 					QualityScore: 0.1,
 					Errors:       tt.errors,
@@ -99,7 +99,7 @@ func TestContentProcessor_Process_AssignsCodeFromFirstRule(t *testing.T) {
 // 검증 통과 시 Reliability 가 QualityScore 로 설정되고 에러 없이 content 가 반환되는지 검증.
 func TestContentProcessor_Process_SuccessSetsReliability(t *testing.T) {
 	v := &stubValidator{
-		result: processor.ValidationResult{
+		result: types.ValidationResult{
 			IsValid:      true,
 			QualityScore: 0.85,
 			Errors:       nil,


### PR DESCRIPTION
## 연관 이슈
- Closes #206

<br>

## 구현 내용

이슈 [#195](https://github.com/EinSofINTEREST/IssueTracker/issues/195) 의 디렉토리 정렬 후속 — **인터페이스 차원에서도 stage-agnostic 추상화** 도입. `cmd/issuetracker/main.go` 가 모든 단계를 `[]processor.Stage` 로 균일 관리하도록 정리.

### 코드 변경 (commit 1: 인터페이스 정리)

- **`internal/processor/processor.go`** 재정의:
  ```go
  type Stage interface {
      Name() string
      Start(ctx context.Context)
      Stop(ctx context.Context) error
  }
  ```
- `ContentProcessor` 제거 — validate-only 활용도 낮아 어댑터 제거
- `Validator` / `ValidationResult` / `ValidationError` 는 본 패키지 잔류 (validate/news + validate/community sub-validator 가 import — validate/ 로 옮기면 cycle)
- `validate/validator.go`: `NewContentProcessor` / `validatorProcessor` 제거, 단순 함수 `RunValidation(ctx, v, content) → (*Content, error)` 로 대체
- `validate/worker.go`: `cp.Process(...)` → `RunValidation(...)` 직접 호출
- 테스트 (`test/internal/processor/validate/processor_test.go`) 동일 갱신

### 코드 변경 (commit 2: Stage wrapper + main.go)

신규 Stage 구현체 3개:
| Stage | 위치 | wrap 대상 |
|---|---|---|
| `fetcher.Stage` | [internal/processor/fetcher/stage.go](internal/processor/fetcher/stage.go) | `worker.PoolManager` (단일) |
| `parser/stage.Stage` | [internal/processor/parser/stage/stage.go](internal/processor/parser/stage/stage.go) | `ParserWorker` + `RawContentCleaner` + `llmgen.Generator` (선택) + `refiner.Refiner` (선택) — 여러 background goroutine 묶음, 내부 lifecycle 의존성 처리 |
| `validate.Stage` | [internal/processor/validate/stage.go](internal/processor/validate/stage.go) | `validate.Worker` (단일) |

`cmd/issuetracker/main.go` 리팩토링:
```go
stages := []processor.Stage{
    fetcher.NewStage(manager),
    parserStage.NewStage(pw, cleaner, llmGen, pathRefiner, log),
    validate.NewStage(validateWorker),
}
for _, s := range stages { s.Start(ctx) }
// ... shutdown ...
for i := len(stages)-1; i >= 0; i-- { stages[i].Stop(shutdownCtx) }
```

이전의 stage 별 분산된 `.Start(ctx)` / `.Stop(shutdownCtx)` 호출이 균일한 loop 로 통합.

### 문서

- [docs/architecture/internal/processor/README.md](docs/architecture/internal/processor/README.md) 전면 갱신 — Stage 인터페이스 정의, 단계별 구현 위치 표, `parser/stage` sub-package 사유, 향후 stage 추가 가이드

### `parser/stage` 가 sub-package 인 이유

`parser/parser.go` 의 `Page` 타입을 `rule/*` 가 import 하므로, parser 부모 패키지가 `rule/*` 를 import 하면 cycle 발생. stage 를 `parser/stage/` sub-package 로 분리하여 회피. README + 패키지 doc 에 명시.

### 의도적 trade-off

이슈 본문은 `Validator` / `ValidationResult` / `ValidationError` 를 `validate/` 로 이동하자고 제안. 초기에는 cycle 회피 위해 `processor` 패키지에 잔류시켰으나, 사용자 후속 요청으로 leaf-only sub-package `internal/processor/validate/types/` 신설 → cycle 없이 의미 정렬 완성 (commit 63c2b67). 이제 `internal/processor/processor.go` 는 Stage interface 만 노출.

<br>

## CI / 머지 게이트 점검

> [CI 운영 규약](docs/ci/conventions.md) 및 [Required Status Checks 단일 소스](docs/ci/status-checks.md)에 따라 작성합니다.

### 변경 영향 범위
- 영향 패키지/모듈: `internal/processor/*` (인터페이스 + Stage wrapper), `cmd/issuetracker/main.go` (lifecycle wiring 패턴 변경), 테스트
- 위험도(택1): `Medium`
  - lifecycle 동작은 동일 — Start/Stop 순서 보존 (parser.Stage 내부에서 worker → llmGen → refiner → cleaner)
  - 인터페이스 변경 (`ContentProcessor` 제거) 은 validate 내부에 격리, 외부 caller 영향 없음
  - DB / Kafka / Redis / 환경변수 변경 없음
  - `go build ./... && go test -race ./...` 28 패키지 모두 통과 (failure 0)

### Required Status Checks
- 통과 확인 대상 (PR Checks 탭에서 확인):
  - [ ] `Commit Lint`
  - [ ] `PR Title Lint`
  - [ ] `Linked Issue Check`
  - [ ] `Format Check`
  - [ ] `Build`
  - [ ] `Test`
  - [ ] `Lint`

### 롤백 계획
- `git revert` 2개 commit. DB / Redis / Kafka 영향 없음.

<br>

## TODO
- ✅ Validator / ValidationResult 타입을 `internal/processor/validate/types/` sub-package 로 분리 — 본 PR 추가 commit 으로 처리 (사용자 요청)

<br>

## 논의 사항
- `Stage` 인터페이스 시그니처 (`Stop(ctx) error`) 는 기존 PoolManager / ParserWorker / Worker 와 일치 — 어댑터 비용 0
- `RawContentCleaner.Stop()` 은 ctx 인자 없음 — parser.Stage 가 내부에서 ctx 무시하고 호출 (시그니처 mismatch 흡수)
- `llmgen.Generator` 는 별도 Start 메소드 없음 (Enqueue 시 lazy goroutine spawn) — parser.Stage.Start 에서도 호출 안 함
- 향후 stage 추가 (enrich / embed / classify) 시 `Stage` 인터페이스만 만족하면 main wiring 자동 통합

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Unified pipeline stage lifecycle management for consistent startup and shutdown of fetcher, parser, and validation components.
  * Centralized worker orchestration for improved control over initialization and graceful termination across all pipeline stages.

* **Documentation**
  * Updated architecture documentation to reflect revised pipeline stage patterns and component organization guidelines.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
