### PR TITLE
[REFAC#208] panic-on-nil constructor → error 반환 마이그레이션 (codebase-wide)

### DIFF
--- a/cmd/issuetracker/main.go
+++ b/cmd/issuetracker/main.go
@@ -117,8 +117,14 @@ func main() {
 	// rule.Parser: parsing_rules 테이블 기반 단일 파서 엔진 (이슈 #100 / #139).
 	// 사이트별 NaverParser/CNNParser/... 를 대체 — 모든 사이트가 본 단일 인스턴스를 공유.
 	parsingRuleRepo := pgstore.NewParsingRuleRepository(pool, log)
-	ruleResolver := rule.NewResolver(parsingRuleRepo)
-	ruleParser := rule.NewParser(ruleResolver)
+	ruleResolver, err := rule.NewResolver(parsingRuleRepo)
+	if err != nil {
+		log.WithError(err).Fatal("failed to construct rule resolver")
+	}
+	ruleParser, err := rule.NewParser(ruleResolver)
+	if err != nil {
+		log.WithError(err).Fatal("failed to construct rule parser")
+	}
 
 	// Readiness check: 사이트 등록 전 parsing_rules 가 seed 됐는지 검증.
 	// 부재 시 fail-fast — 실행 중 모든 ParsePage/ParseLinks 가 ErrNoRule 로 죽는 것보다 즉시 종료.
@@ -320,14 +326,22 @@ func main() {
 	}).Info("validate worker constructed")
 
 	// ══════════════════════════════════════════════════════════════════════════
-	// Stage 통합 — processor.Stage 인터페이스로 모든 단계 균일 관리 (이슈 #206)
+	// Stage 통합 — processor.Stage 인터페이스로 모든 단계 균일 관리 (이슈 #206 / #208)
 	// ══════════════════════════════════════════════════════════════════════════
 
-	stages := []processor.Stage{
-		fetcher.NewStage(manager),
-		parserStage.NewStage(pw, cleaner, llmGen, pathRefiner, log),
-		validate.NewStage(validateWorker),
+	fetcherStage, err := fetcher.NewStage(manager)
+	if err != nil {
+		log.WithError(err).Fatal("failed to construct fetcher stage")
 	}
+	parserStg, err := parserStage.NewStage(pw, cleaner, llmGen, pathRefiner, log)
+	if err != nil {
+		log.WithError(err).Fatal("failed to construct parser stage")
+	}
+	validateStage, err := validate.NewStage(validateWorker)
+	if err != nil {
+		log.WithError(err).Fatal("failed to construct validate stage")
+	}
+	stages := []processor.Stage{fetcherStage, parserStg, validateStage}
 	for _, s := range stages {
 		s.Start(ctx)
 		log.WithField("stage", s.Name()).Info("pipeline stage started")
@@ -427,11 +441,16 @@ func buildLLMProvider(log *logger.Logger) llm.Provider {
 // buildLLMGenerator 는 buildLLMProvider 결과로 llmgen.Generator 를 구성합니다 (이슈 #149).
 //
 // provider 가 nil (LLM 비활성) 이면 nil 반환 — parser worker 는 ErrNoRule 시 raw 만 잔존.
+// llmgen.New 자체 실패는 wiring 버그라 fatal — 도달하면 dependency injection 모순 (이슈 #208).
 func buildLLMGenerator(provider llm.Provider, repo storage.ParsingRuleRepository, resolver *rule.Resolver, log *logger.Logger) *llmgen.Generator {
 	if provider == nil {
 		return nil
 	}
-	return llmgen.New(provider, repo, resolver, log)
+	gen, err := llmgen.New(provider, repo, resolver, log)
+	if err != nil {
+		log.WithError(err).Fatal("failed to construct llmgen generator")
+	}
+	return gen
 }
 
 // buildRefiner 는 RefinementConfig + LLM provider 로 refiner.Refiner 를 구성합니다 (이슈 #173 단계 4-2).
@@ -463,9 +482,17 @@ func buildRefiner(
 		refiner.WithMetrics(refiner.NewMetrics(metricsRegistry)),
 	}
 	if provider != nil {
-		opts = append(opts, refiner.WithLLMClient(refiner.NewLLMAdapter(provider)))
+		adapter, err := refiner.NewLLMAdapter(provider)
+		if err != nil {
+			log.WithError(err).Fatal("failed to construct refiner LLM adapter")
+		}
+		opts = append(opts, refiner.WithLLMClient(adapter))
 	}
-	return refiner.New(rules, samples, resolver, log, opts...)
+	r, err := refiner.New(rules, samples, resolver, log, opts...)
+	if err != nil {
+		log.WithError(err).Fatal("failed to construct refiner")
+	}
+	return r
 }
 
 // verifyParsingRulesSeeded 는 본 PR 이 등록할 모든 사이트의 (host, target_type) 페어가

--- a/internal/processor/fetcher/stage.go
+++ b/internal/processor/fetcher/stage.go
@@ -7,6 +7,7 @@ package fetcher
 
 import (
 	"context"
+	"errors"
 
 	"issuetracker/internal/processor"
 	"issuetracker/internal/processor/fetcher/worker"
@@ -24,12 +25,12 @@ type Stage struct {
 }
 
 // NewStage 는 wired PoolManager 를 받아 fetcher.Stage 를 반환합니다.
-// manager 가 nil 이면 panic — wiring 누락 즉시 가시화.
-func NewStage(manager *worker.PoolManager) *Stage {
+// manager 가 nil 이면 error — 호출자 (cmd/main) 가 boot fatal 처리 (이슈 #208).
+func NewStage(manager *worker.PoolManager) (*Stage, error) {
 	if manager == nil {
-		panic("fetcher: NewStage requires non-nil PoolManager")
+		return nil, errors.New("fetcher: NewStage requires non-nil PoolManager")
 	}
-	return &Stage{manager: manager}
+	return &Stage{manager: manager}, nil
 }
 
 // Name 은 stage 식별자 ("fetcher") 를 반환합니다.

--- a/internal/processor/parser/rule/llmgen/generator.go
+++ b/internal/processor/parser/rule/llmgen/generator.go
@@ -72,19 +72,20 @@ type Generator struct {
 
 // New 는 Generator 를 생성합니다.
 //
-// provider / repo / resolver / log 모두 비-nil 필수. 하나라도 nil 이면 panic — wire 누락 즉시 가시화.
-func New(provider llm.Provider, repo storage.ParsingRuleRepository, resolver *rule.Resolver, log *logger.Logger) *Generator {
+// provider / repo / resolver / log 모두 비-nil 필수. 하나라도 nil 이면 error —
+// 호출자 (cmd/main) 가 boot fatal 처리 (이슈 #208).
+func New(provider llm.Provider, repo storage.ParsingRuleRepository, resolver *rule.Resolver, log *logger.Logger) (*Generator, error) {
 	if provider == nil {
-		panic("llmgen: New requires non-nil provider")
+		return nil, errors.New("llmgen: New requires non-nil provider")
 	}
 	if repo == nil {
-		panic("llmgen: New requires non-nil repo")
+		return nil, errors.New("llmgen: New requires non-nil repo")
 	}
 	if resolver == nil {
-		panic("llmgen: New requires non-nil resolver")
+		return nil, errors.New("llmgen: New requires non-nil resolver")
 	}
 	if log == nil {
-		panic("llmgen: New requires non-nil log")
+		return nil, errors.New("llmgen: New requires non-nil log")
 	}
 	return &Generator{
 		provider: provider,
@@ -92,7 +93,7 @@ func New(provider llm.Provider, repo storage.ParsingRuleRepository, resolver *ru
 		resolver: resolver,
 		log:      log,
 		inflight: newInflightSet(),
-	}
+	}, nil
 }
 
 // Enqueue 는 (host, type) 에 대한 LLM rule 생성을 비동기로 시작합니다.

--- a/internal/processor/parser/rule/parser.go
+++ b/internal/processor/parser/rule/parser.go
@@ -2,6 +2,7 @@ package rule
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/url"
 	"strings"
@@ -37,16 +38,16 @@ type Parser struct {
 }
 
 // NewParser 는 Resolver 를 사용하는 Parser 를 생성합니다.
-// resolver 가 nil 이면 panic — wire 누락 즉시 가시화.
-func NewParser(resolver *Resolver) *Parser {
+// resolver 가 nil 이면 error — 호출자 (cmd/main) 가 boot fatal 처리 (이슈 #208).
+func NewParser(resolver *Resolver) (*Parser, error) {
 	if resolver == nil {
-		panic("rule: NewParser requires non-nil resolver")
+		return nil, errors.New("rule: NewParser requires non-nil resolver")
 	}
 	return &Parser{
 		resolver:    resolver,
 		discovery:   NewPageLinkDiscovery(),
 		dateLayouts: defaultDateLayouts(),
-	}
+	}, nil
 }
 
 // defaultDateLayouts 는 PublishedAt 추출 시 시도할 layout 목록입니다.

--- a/internal/processor/parser/rule/refiner/llm_adapter.go
+++ b/internal/processor/parser/rule/refiner/llm_adapter.go
@@ -19,12 +19,12 @@ type providerAdapter struct {
 
 // NewLLMAdapter 는 pkg/llm.Provider 를 pathinfer.LLMClient 로 변환하는 어댑터를 반환합니다.
 //
-// provider 가 nil 이면 panic — wire 누락 즉시 가시화.
-func NewLLMAdapter(provider llm.Provider) pathinfer.LLMClient {
+// provider 가 nil 이면 error — 호출자 (cmd/main) 가 boot fatal 처리 (이슈 #208).
+func NewLLMAdapter(provider llm.Provider) (pathinfer.LLMClient, error) {
 	if provider == nil {
-		panic("refiner: NewLLMAdapter requires non-nil provider")
+		return nil, errors.New("refiner: NewLLMAdapter requires non-nil provider")
 	}
-	return &providerAdapter{provider: provider}
+	return &providerAdapter{provider: provider}, nil
 }
 
 // Generate 는 llm.Provider.Generate 를 호출하고 응답 텍스트만 반환합니다.

--- a/internal/processor/parser/rule/refiner/refiner.go
+++ b/internal/processor/parser/rule/refiner/refiner.go
@@ -22,6 +22,7 @@ package refiner
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/url"
 	"strings"
@@ -103,26 +104,26 @@ func WithMetrics(m *Metrics) Option {
 	return func(r *Refiner) { r.metrics = m }
 }
 
-// New 는 Refiner 를 생성합니다. rules / samples / resolver / log 가 nil 이면 panic —
-// wire 누락 즉시 가시화. LLMClient 만 nil 허용 (algorithm-only 동작).
+// New 는 Refiner 를 생성합니다. rules / samples / resolver / log 가 nil 이면 error —
+// 호출자 (cmd/main) 가 boot fatal 처리 (이슈 #208). LLMClient 만 nil 허용 (algorithm-only 동작).
 func New(
 	rules storage.ParsingRuleRepository,
 	samples storage.SampleURLRepository,
 	resolver *rule.Resolver,
 	log *logger.Logger,
 	opts ...Option,
-) *Refiner {
+) (*Refiner, error) {
 	if rules == nil {
-		panic("refiner: New requires non-nil rules repo")
+		return nil, errors.New("refiner: New requires non-nil rules repo")
 	}
 	if samples == nil {
-		panic("refiner: New requires non-nil samples repo")
+		return nil, errors.New("refiner: New requires non-nil samples repo")
 	}
 	if resolver == nil {
-		panic("refiner: New requires non-nil resolver")
+		return nil, errors.New("refiner: New requires non-nil resolver")
 	}
 	if log == nil {
-		panic("refiner: New requires non-nil logger")
+		return nil, errors.New("refiner: New requires non-nil logger")
 	}
 	r := &Refiner{
 		rules:      rules,
@@ -135,7 +136,7 @@ func New(
 	for _, o := range opts {
 		o(r)
 	}
-	return r
+	return r, nil
 }
 
 // Start 는 background goroutine 으로 polling 을 시작하고 즉시 반환합니다 (PR #191 피드백).

--- a/internal/processor/parser/rule/resolver.go
+++ b/internal/processor/parser/rule/resolver.go
@@ -7,6 +7,7 @@ package rule
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/url"
 	"regexp"
@@ -105,10 +106,10 @@ func WithMaxCacheEntries(n int) Option {
 }
 
 // NewResolver 는 ParsingRuleRepository 를 사용하는 Resolver 를 생성합니다.
-// repo 가 nil 이면 panic — application 시작 시점 wire 누락 즉시 가시화.
-func NewResolver(repo storage.ParsingRuleRepository, opts ...Option) *Resolver {
+// repo 가 nil 이면 error — 호출자 (cmd/main) 가 boot fatal 처리 (이슈 #208).
+func NewResolver(repo storage.ParsingRuleRepository, opts ...Option) (*Resolver, error) {
 	if repo == nil {
-		panic("rule: NewResolver requires non-nil repo")
+		return nil, errors.New("rule: NewResolver requires non-nil repo")
 	}
 	r := &Resolver{
 		repo:             repo,
@@ -121,7 +122,7 @@ func NewResolver(repo storage.ParsingRuleRepository, opts ...Option) *Resolver {
 	for _, o := range opts {
 		o(r)
 	}
-	return r
+	return r, nil
 }
 
 // ResolveByURL 은 URL 에서 host + path 를 추출해 매칭 활성 규칙을 반환합니다.

--- a/internal/processor/parser/stage/stage.go
+++ b/internal/processor/parser/stage/stage.go
@@ -16,6 +16,7 @@ package stage
 
 import (
 	"context"
+	"errors"
 
 	"issuetracker/internal/processor"
 	"issuetracker/internal/processor/parser/rule/llmgen"
@@ -44,22 +45,22 @@ type Stage struct {
 }
 
 // NewStage 는 component 들을 받아 parser.Stage 를 반환합니다.
-// worker / cleaner 는 필수 (nil 이면 panic), llmGen / refiner 는 nil 허용.
+// worker / cleaner / log 는 필수 (nil 이면 error), llmGen / refiner 는 nil 허용 (이슈 #208).
 func NewStage(
 	pw *worker.ParserWorker,
 	cleaner *worker.RawContentCleaner,
 	llmGen *llmgen.Generator,
 	pathRefiner *refiner.Refiner,
 	log *logger.Logger,
-) *Stage {
+) (*Stage, error) {
 	if pw == nil {
-		panic("parser: NewStage requires non-nil ParserWorker")
+		return nil, errors.New("parser: NewStage requires non-nil ParserWorker")
 	}
 	if cleaner == nil {
-		panic("parser: NewStage requires non-nil RawContentCleaner")
+		return nil, errors.New("parser: NewStage requires non-nil RawContentCleaner")
 	}
 	if log == nil {
-		panic("parser: NewStage requires non-nil logger")
+		return nil, errors.New("parser: NewStage requires non-nil logger")
 	}
 	return &Stage{
 		worker:  pw,
@@ -67,7 +68,7 @@ func NewStage(
 		llmGen:  llmGen,
 		refiner: pathRefiner,
 		log:     log,
-	}
+	}, nil
 }
 
 // Name 은 stage 식별자 ("parser") 를 반환합니다.

--- a/internal/processor/validate/stage.go
+++ b/internal/processor/validate/stage.go
@@ -6,6 +6,7 @@ package validate
 
 import (
 	"context"
+	"errors"
 
 	"issuetracker/internal/processor"
 )
@@ -19,12 +20,12 @@ type Stage struct {
 }
 
 // NewStage 는 wired Worker 를 받아 validate.Stage 를 반환합니다.
-// worker 가 nil 이면 panic — wiring 누락 즉시 가시화.
-func NewStage(worker *Worker) *Stage {
+// worker 가 nil 이면 error — 호출자 (cmd/main) 가 boot fatal 처리 (이슈 #208).
+func NewStage(worker *Worker) (*Stage, error) {
 	if worker == nil {
-		panic("validate: NewStage requires non-nil Worker")
+		return nil, errors.New("validate: NewStage requires non-nil Worker")
 	}
-	return &Stage{worker: worker}
+	return &Stage{worker: worker}, nil
 }
 
 // Name 은 stage 식별자 ("validate") 를 반환합니다.

--- a/pkg/urlguard/gate.go
+++ b/pkg/urlguard/gate.go
@@ -2,6 +2,7 @@ package urlguard
 
 import (
 	"context"
+	"errors"
 
 	"issuetracker/pkg/logger"
 )
@@ -27,16 +28,17 @@ type Gate struct {
 }
 
 // NewGate 는 주어진 guard 와 log 로 새 Gate 를 생성합니다.
-// guard 가 nil 이면 panic — 비활성화는 AllowAllGuard{} 명시 주입으로 표현.
+// guard 가 nil 이면 error — 호출자 (cmd/main) 가 boot fatal 처리. 비활성화는 AllowAllGuard{}
+// 명시 주입으로 표현 (이슈 #208).
 // log 가 nil 이면 logger.FromContext(context.Background()) 의 기본 logger 를 사용.
-func NewGate(guard Guard, log *logger.Logger) *Gate {
+func NewGate(guard Guard, log *logger.Logger) (*Gate, error) {
 	if guard == nil {
-		panic("urlguard: NewGate requires non-nil Guard (use AllowAllGuard{} to disable)")
+		return nil, errors.New("urlguard: NewGate requires non-nil Guard (use AllowAllGuard{} to disable)")
 	}
 	if log == nil {
 		log = logger.FromContext(context.Background())
 	}
-	return &Gate{guard: guard, log: log}
+	return &Gate{guard: guard, log: log}, nil
 }
 
 // Allow 는 단일 URL 이 통과하는지 검사합니다.

--- a/test/internal/processor/fetcher/worker/pool_gate_test.go
+++ b/test/internal/processor/fetcher/worker/pool_gate_test.go
@@ -22,7 +22,8 @@ func TestKafkaConsumerPool_Gate_BlocksRSSURL_CommitsAndSkipsHandler(t *testing.T
 	contentSvc := new(mockContentService)
 
 	pool := worker.NewKafkaConsumerPool(consumer, producer, handler, contentSvc, 1)
-	pool.SetGate(urlguard.NewGate(urlguard.Default(), logger.New(logger.DefaultConfig())))
+	gate, _ := urlguard.NewGate(urlguard.Default(), logger.New(logger.DefaultConfig()))
+	pool.SetGate(gate)
 
 	// 차단될 RSS URL 을 가진 job 메시지
 	job := newTestJob()
@@ -49,7 +50,8 @@ func TestKafkaConsumerPool_Gate_AllowsArticleURL_DelegatesToHandler(t *testing.T
 	contentSvc := new(mockContentService)
 
 	pool := worker.NewKafkaConsumerPool(consumer, producer, handler, contentSvc, 1)
-	pool.SetGate(urlguard.NewGate(urlguard.Default(), logger.New(logger.DefaultConfig())))
+	gate, _ := urlguard.NewGate(urlguard.Default(), logger.New(logger.DefaultConfig()))
+	pool.SetGate(gate)
 
 	job := newTestJob()
 	job.Target.URL = "https://edition.cnn.com/health/article-123"
@@ -103,7 +105,8 @@ func TestKafkaConsumerPool_Gate_AllowAllGuard_DelegatesAll(t *testing.T) {
 	contentSvc := new(mockContentService)
 
 	pool := worker.NewKafkaConsumerPool(consumer, producer, handler, contentSvc, 1)
-	pool.SetGate(urlguard.NewGate(urlguard.AllowAllGuard{}, logger.New(logger.DefaultConfig())))
+	gate, _ := urlguard.NewGate(urlguard.AllowAllGuard{}, logger.New(logger.DefaultConfig()))
+	pool.SetGate(gate)
 
 	job := newTestJob()
 	job.Target.URL = "https://rss.cnn.com/rss/cnn_health.rss"
@@ -132,10 +135,9 @@ func TestKafkaConsumerPool_Gate_RaceFreeUpdate(t *testing.T) {
 	pool := worker.NewKafkaConsumerPool(consumer, producer, handler, contentSvc, 1)
 
 	// 동시에 여러 번 SetGate 호출 — atomic.Pointer 가 보장
-	guards := []*urlguard.Gate{
-		urlguard.NewGate(urlguard.Default(), nil),
-		urlguard.NewGate(urlguard.AllowAllGuard{}, nil),
-	}
+	g1, _ := urlguard.NewGate(urlguard.Default(), nil)
+	g2, _ := urlguard.NewGate(urlguard.AllowAllGuard{}, nil)
+	guards := []*urlguard.Gate{g1, g2}
 	for i := 0; i < 100; i++ {
 		pool.SetGate(guards[i%2])
 	}

--- a/test/internal/processor/parser/rule/discovery_test.go
+++ b/test/internal/processor/parser/rule/discovery_test.go
@@ -419,7 +419,8 @@ func TestParser_ParseLinks_RoutesToDiscoveryWhenPatternSet(t *testing.T) {
 		SameOriginOnly:    true,
 	}
 	repo := &fakeRepo{rules: []*storage.ParsingRuleRecord{discoveryRule(cfg)}}
-	p := rule.NewParser(rule.NewResolver(repo))
+	res, _ := rule.NewResolver(repo)
+	p, _ := rule.NewParser(res)
 
 	items, err := p.ParseLinks(context.Background(), makeRaw("https://news.example.com/category/politics", fullPageHTML))
 	require.NoError(t, err)
@@ -429,7 +430,8 @@ func TestParser_ParseLinks_RoutesToDiscoveryWhenPatternSet(t *testing.T) {
 func TestParser_ParseLinks_FallsBackToItemContainerWhenPatternEmpty(t *testing.T) {
 	// LinkDiscovery 가 nil → 기존 ItemContainer 경로 사용
 	repo := &fakeRepo{rules: []*storage.ParsingRuleRecord{listRule()}}
-	p := rule.NewParser(rule.NewResolver(repo))
+	res, _ := rule.NewResolver(repo)
+	p, _ := rule.NewParser(res)
 
 	items, err := p.ParseLinks(context.Background(), makeRaw("https://news.example.com/category", listHTML))
 	require.NoError(t, err)
@@ -452,7 +454,8 @@ func TestParser_ParseLinks_LinkDiscoveryWithEmptyPattern_AllPassDiscovery(t *tes
 	// ItemContainer 를 매칭 0건 selector 로 변경 — fallback 진입 시 ErrParseFailure 보장
 	r.Selectors.ItemContainer = &storage.FieldSelector{CSS: "div.no-such-class-anywhere"}
 	repo := &fakeRepo{rules: []*storage.ParsingRuleRecord{r}}
-	p := rule.NewParser(rule.NewResolver(repo))
+	res, _ := rule.NewResolver(repo)
+	p, _ := rule.NewParser(res)
 
 	items, err := p.ParseLinks(context.Background(), makeRaw("https://news.example.com/category", listHTML))
 	require.NoError(t, err, "discovery 경로가 동작 — fallback 진입 시 stale selector 로 에러였을 것")

--- a/test/internal/processor/parser/rule/llmgen/generator_test.go
+++ b/test/internal/processor/parser/rule/llmgen/generator_test.go
@@ -111,8 +111,9 @@ const sampleListHTML = `<!DOCTYPE html><html><body>
 
 func newGenerator(t *testing.T, provider llm.Provider, repo storage.ParsingRuleRepository) (*llmgen.Generator, *rule.Resolver) {
 	t.Helper()
-	resolver := rule.NewResolver(&noopFindRepo{}, rule.WithCacheTTL(time.Minute))
-	g := llmgen.New(provider, repo, resolver, logger.New(logger.DefaultConfig()))
+	resolver, _ := rule.NewResolver(&noopFindRepo{}, rule.WithCacheTTL(time.Minute))
+	g, err := llmgen.New(provider, repo, resolver, logger.New(logger.DefaultConfig()))
+	require.NoError(t, err)
 	return g, resolver
 }
 

--- a/test/internal/processor/parser/rule/parser_test.go
+++ b/test/internal/processor/parser/rule/parser_test.go
@@ -100,7 +100,8 @@ func makeRaw(url, html string) *core.RawContent {
 
 func TestParser_ParsePage_Success(t *testing.T) {
 	repo := &fakeRepo{rules: []*storage.ParsingRuleRecord{pageRule()}}
-	p := rule.NewParser(rule.NewResolver(repo))
+	res, _ := rule.NewResolver(repo)
+	p, _ := rule.NewParser(res)
 
 	page, err := p.ParsePage(context.Background(), makeRaw("https://news.example.com/article/1", articleHTML))
 	require.NoError(t, err)
@@ -118,7 +119,8 @@ func TestParser_ParsePage_Success(t *testing.T) {
 
 func TestParser_ParsePage_NoRule_ReturnsErrNoRule(t *testing.T) {
 	repo := &fakeRepo{notFound: true}
-	p := rule.NewParser(rule.NewResolver(repo))
+	res, _ := rule.NewResolver(repo)
+	p, _ := rule.NewParser(res)
 
 	_, err := p.ParsePage(context.Background(), makeRaw("https://nope.example.com/x", articleHTML))
 	require.Error(t, err)
@@ -129,7 +131,8 @@ func TestParser_ParsePage_MissingTitleSelector_EmptySelector(t *testing.T) {
 	r := pageRule()
 	r.Selectors.Title = nil
 	repo := &fakeRepo{rules: []*storage.ParsingRuleRecord{r}}
-	p := rule.NewParser(rule.NewResolver(repo))
+	res, _ := rule.NewResolver(repo)
+	p, _ := rule.NewParser(res)
 
 	_, err := p.ParsePage(context.Background(), makeRaw("https://news.example.com/x", articleHTML))
 	require.Error(t, err)
@@ -142,7 +145,8 @@ func TestParser_ParsePage_MainContentMatchesNothing_ParseFailure(t *testing.T) {
 	r := pageRule()
 	r.Selectors.MainContent = &storage.FieldSelector{CSS: "div.no-such-class", Multi: true}
 	repo := &fakeRepo{rules: []*storage.ParsingRuleRecord{r}}
-	p := rule.NewParser(rule.NewResolver(repo))
+	res, _ := rule.NewResolver(repo)
+	p, _ := rule.NewParser(res)
 
 	_, err := p.ParsePage(context.Background(), makeRaw("https://news.example.com/x", articleHTML))
 	require.Error(t, err)
@@ -153,7 +157,8 @@ func TestParser_ParsePage_MainContentMatchesNothing_ParseFailure(t *testing.T) {
 
 func TestParser_ParsePage_EmptyRaw_ParseFailure(t *testing.T) {
 	repo := &fakeRepo{rules: []*storage.ParsingRuleRecord{pageRule()}}
-	p := rule.NewParser(rule.NewResolver(repo))
+	res, _ := rule.NewResolver(repo)
+	p, _ := rule.NewParser(res)
 
 	_, err := p.ParsePage(context.Background(), &core.RawContent{URL: "https://news.example.com/x", HTML: ""})
 	require.Error(t, err)
@@ -168,7 +173,8 @@ func TestParser_ParsePage_EmptyRaw_ParseFailure(t *testing.T) {
 
 func TestParser_ParseLinks_Success_AbsolutizesURLs(t *testing.T) {
 	repo := &fakeRepo{rules: []*storage.ParsingRuleRecord{listRule()}}
-	p := rule.NewParser(rule.NewResolver(repo))
+	res, _ := rule.NewResolver(repo)
+	p, _ := rule.NewParser(res)
 
 	items, err := p.ParseLinks(context.Background(), makeRaw("https://news.example.com/category/politics", listHTML))
 	require.NoError(t, err)
@@ -186,7 +192,8 @@ func TestParser_ParseLinks_MissingItemContainer_EmptySelector(t *testing.T) {
 	r := listRule()
 	r.Selectors.ItemContainer = nil
 	repo := &fakeRepo{rules: []*storage.ParsingRuleRecord{r}}
-	p := rule.NewParser(rule.NewResolver(repo))
+	res, _ := rule.NewResolver(repo)
+	p, _ := rule.NewParser(res)
 
 	_, err := p.ParseLinks(context.Background(), makeRaw("https://news.example.com/x", listHTML))
 	require.Error(t, err)
@@ -199,7 +206,8 @@ func TestParser_ParseLinks_MissingItemLink_EmptySelector(t *testing.T) {
 	r := listRule()
 	r.Selectors.ItemLink = nil
 	repo := &fakeRepo{rules: []*storage.ParsingRuleRecord{r}}
-	p := rule.NewParser(rule.NewResolver(repo))
+	res, _ := rule.NewResolver(repo)
+	p, _ := rule.NewParser(res)
 
 	_, err := p.ParseLinks(context.Background(), makeRaw("https://news.example.com/x", listHTML))
 	require.Error(t, err)
@@ -210,15 +218,17 @@ func TestParser_ParseLinks_MissingItemLink_EmptySelector(t *testing.T) {
 
 func TestParser_ParseLinks_NoRule_ReturnsErrNoRule(t *testing.T) {
 	repo := &fakeRepo{notFound: true}
-	p := rule.NewParser(rule.NewResolver(repo))
+	res, _ := rule.NewResolver(repo)
+	p, _ := rule.NewParser(res)
 
 	_, err := p.ParseLinks(context.Background(), makeRaw("https://nope.example.com/list", listHTML))
 	require.Error(t, err)
 	assert.True(t, errors.Is(err, &rule.Error{Code: rule.ErrNoRule}))
 }
 
-func TestNewParser_NilResolver_Panics(t *testing.T) {
-	assert.PanicsWithValue(t, "rule: NewParser requires non-nil resolver", func() {
-		rule.NewParser(nil)
-	})
+func TestNewParser_NilResolver_ReturnsError(t *testing.T) {
+	p, err := rule.NewParser(nil)
+	assert.Nil(t, p)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "non-nil resolver")
 }

--- a/test/internal/processor/parser/rule/refiner/refiner_test.go
+++ b/test/internal/processor/parser/rule/refiner/refiner_test.go
@@ -189,12 +189,14 @@ func newCatchAllRule(id int64, host string) *storage.ParsingRuleRecord {
 
 func newRefiner(t *testing.T, rules storage.ParsingRuleRepository, samples storage.SampleURLRepository, opts ...refiner.Option) *refiner.Refiner {
 	t.Helper()
-	resolver := rule.NewResolver(rules)
+	resolver, _ := rule.NewResolver(rules)
 	log := logger.New(logger.DefaultConfig())
 	// minSamples 3 (테스트 가독성). interval 은 RunOnce 만 호출하면 무관.
 	defaults := []refiner.Option{refiner.WithMinSamples(3)}
 	defaults = append(defaults, opts...)
-	return refiner.New(rules, samples, resolver, log, defaults...)
+	r, err := refiner.New(rules, samples, resolver, log, defaults...)
+	require.NoError(t, err)
+	return r
 }
 
 // ─────────────────────────────────────────────────────────────────────────────

--- a/test/internal/processor/parser/rule/resolver_test.go
+++ b/test/internal/processor/parser/rule/resolver_test.go
@@ -99,7 +99,7 @@ func samplePageRule(host string) *storage.ParsingRuleRecord {
 
 func TestResolver_ResolveByURL_Success(t *testing.T) {
 	repo := &fakeRepo{rules: []*storage.ParsingRuleRecord{samplePageRule("news.example.com")}}
-	r := rule.NewResolver(repo)
+	r, _ := rule.NewResolver(repo)
 
 	got, err := r.ResolveByURL(context.Background(), "https://news.example.com/article/1", storage.TargetTypePage)
 	require.NoError(t, err)
@@ -109,7 +109,7 @@ func TestResolver_ResolveByURL_Success(t *testing.T) {
 
 func TestResolver_ResolveByURL_HostUppercaseNormalized(t *testing.T) {
 	repo := &fakeRepo{rules: []*storage.ParsingRuleRecord{samplePageRule("news.example.com")}}
-	r := rule.NewResolver(repo)
+	r, _ := rule.NewResolver(repo)
 
 	// URL host 가 대문자여도 lookup 은 lowercase 로 정규화되어 매칭
 	_, err := r.ResolveByURL(context.Background(), "https://NEWS.EXAMPLE.COM/x", storage.TargetTypePage)
@@ -118,7 +118,7 @@ func TestResolver_ResolveByURL_HostUppercaseNormalized(t *testing.T) {
 
 func TestResolver_ResolveByURL_InvalidURL_ReturnsError(t *testing.T) {
 	repo := &fakeRepo{}
-	r := rule.NewResolver(repo)
+	r, _ := rule.NewResolver(repo)
 
 	_, err := r.ResolveByURL(context.Background(), "://no-scheme", storage.TargetTypePage)
 	require.Error(t, err)
@@ -130,7 +130,7 @@ func TestResolver_ResolveByURL_InvalidURL_ReturnsError(t *testing.T) {
 
 func TestResolver_NoMatch_ReturnsErrNoRule(t *testing.T) {
 	repo := &fakeRepo{notFound: true}
-	r := rule.NewResolver(repo)
+	r, _ := rule.NewResolver(repo)
 
 	_, err := r.Resolve(context.Background(), "no-rule.example.com", "/", storage.TargetTypePage)
 	require.Error(t, err)
@@ -143,7 +143,7 @@ func TestResolver_NoMatch_ReturnsErrNoRule(t *testing.T) {
 
 func TestResolver_Cache_HitsAvoidRepoCall(t *testing.T) {
 	repo := &fakeRepo{rules: []*storage.ParsingRuleRecord{samplePageRule("news.example.com")}}
-	r := rule.NewResolver(repo)
+	r, _ := rule.NewResolver(repo)
 
 	// 첫 호출 → repo 1
 	_, err := r.Resolve(context.Background(), "news.example.com", "/", storage.TargetTypePage)
@@ -160,7 +160,7 @@ func TestResolver_Cache_HitsAvoidRepoCall(t *testing.T) {
 
 func TestResolver_NegativeCache_AvoidRepoCallForMissingHost(t *testing.T) {
 	repo := &fakeRepo{notFound: true}
-	r := rule.NewResolver(repo)
+	r, _ := rule.NewResolver(repo)
 
 	for i := 0; i < 5; i++ {
 		_, err := r.Resolve(context.Background(), "missing.example.com", "/", storage.TargetTypePage)
@@ -171,7 +171,7 @@ func TestResolver_NegativeCache_AvoidRepoCallForMissingHost(t *testing.T) {
 
 func TestResolver_Invalidate_ForcesRepoCall(t *testing.T) {
 	repo := &fakeRepo{rules: []*storage.ParsingRuleRecord{samplePageRule("news.example.com")}}
-	r := rule.NewResolver(repo)
+	r, _ := rule.NewResolver(repo)
 
 	_, err := r.Resolve(context.Background(), "news.example.com", "/", storage.TargetTypePage)
 	require.NoError(t, err)
@@ -191,7 +191,7 @@ func TestResolver_InvalidateAll_ClearsAllEntries(t *testing.T) {
 		samplePageRule("a.example.com"),
 		samplePageRule("b.example.com"),
 	}}
-	r := rule.NewResolver(repo)
+	r, _ := rule.NewResolver(repo)
 
 	_, err := r.Resolve(context.Background(), "a.example.com", "/", storage.TargetTypePage)
 	require.NoError(t, err)
@@ -211,7 +211,7 @@ func TestResolver_InvalidateAll_ClearsAllEntries(t *testing.T) {
 func TestResolver_CacheTTL_ExpiresAfterDuration(t *testing.T) {
 	repo := &fakeRepo{rules: []*storage.ParsingRuleRecord{samplePageRule("news.example.com")}}
 	// TTL 50ms — 테스트 친화적 짧은 시간
-	r := rule.NewResolver(repo, rule.WithCacheTTL(50*time.Millisecond))
+	r, _ := rule.NewResolver(repo, rule.WithCacheTTL(50*time.Millisecond))
 
 	_, err := r.Resolve(context.Background(), "news.example.com", "/", storage.TargetTypePage)
 	require.NoError(t, err)
@@ -224,10 +224,11 @@ func TestResolver_CacheTTL_ExpiresAfterDuration(t *testing.T) {
 	assert.Equal(t, 2, repo.calls(), "TTL 만료 후 repo 다시 호출")
 }
 
-func TestNewResolver_NilRepo_Panics(t *testing.T) {
-	assert.PanicsWithValue(t, "rule: NewResolver requires non-nil repo", func() {
-		rule.NewResolver(nil)
-	})
+func TestNewResolver_NilRepo_ReturnsError(t *testing.T) {
+	r, err := rule.NewResolver(nil)
+	assert.Nil(t, r)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "non-nil repo")
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -237,7 +238,7 @@ func TestNewResolver_NilRepo_Panics(t *testing.T) {
 // path_pattern=” (catch-all) rule 만 있을 때 어떤 path 든 매칭됨 — 기존 동작 보존.
 func TestResolver_PathPattern_EmptyMatchesAnyPath(t *testing.T) {
 	repo := &fakeRepo{rules: []*storage.ParsingRuleRecord{samplePageRule("news.example.com")}}
-	r := rule.NewResolver(repo)
+	r, _ := rule.NewResolver(repo)
 
 	for _, path := range []string{"/", "/article/1", "/sports/breaking-news", "/about"} {
 		got, err := r.Resolve(context.Background(), "news.example.com", path, storage.TargetTypePage)
@@ -258,7 +259,7 @@ func TestResolver_PathPattern_LongerPatternWinsOverCatchAll(t *testing.T) {
 	catchAll.Selectors.Title = &storage.FieldSelector{CSS: "h1.default"}
 
 	repo := &fakeRepo{rules: []*storage.ParsingRuleRecord{specific, catchAll}}
-	r := rule.NewResolver(repo)
+	r, _ := rule.NewResolver(repo)
 
 	// /sports/* path 는 specific rule 매칭 (LENGTH DESC 정렬상 우선)
 	got, err := r.Resolve(context.Background(), "news.example.com", "/sports/breaking", storage.TargetTypePage)
@@ -277,7 +278,7 @@ func TestResolver_PathPattern_NoMatchReturnsErrNoRule(t *testing.T) {
 	specific.PathPattern = "^/sports/.*$"
 
 	repo := &fakeRepo{rules: []*storage.ParsingRuleRecord{specific}}
-	r := rule.NewResolver(repo)
+	r, _ := rule.NewResolver(repo)
 
 	_, err := r.Resolve(context.Background(), "news.example.com", "/about", storage.TargetTypePage)
 	require.Error(t, err)
@@ -296,7 +297,7 @@ func TestResolver_PathPattern_InvalidRegexFallsThrough(t *testing.T) {
 	catchAll.Selectors.Title = &storage.FieldSelector{CSS: "h1.default"}
 
 	repo := &fakeRepo{rules: []*storage.ParsingRuleRecord{bad, catchAll}}
-	r := rule.NewResolver(repo)
+	r, _ := rule.NewResolver(repo)
 
 	got, err := r.Resolve(context.Background(), "news.example.com", "/article/1", storage.TargetTypePage)
 	require.NoError(t, err)
@@ -314,7 +315,7 @@ func TestResolver_PathPattern_RegexCacheReuseAcrossHosts(t *testing.T) {
 	b.PathPattern = pattern
 
 	repo := &fakeRepo{rules: []*storage.ParsingRuleRecord{a, b}}
-	r := rule.NewResolver(repo)
+	r, _ := rule.NewResolver(repo)
 
 	got, err := r.Resolve(context.Background(), "a.example.com", "/news/123", storage.TargetTypePage)
 	require.NoError(t, err)
@@ -332,7 +333,7 @@ func TestResolver_ResolveByURL_PathPatternMatching(t *testing.T) {
 	specific.Selectors.Title = &storage.FieldSelector{CSS: "h1.article"}
 
 	repo := &fakeRepo{rules: []*storage.ParsingRuleRecord{specific}}
-	r := rule.NewResolver(repo)
+	r, _ := rule.NewResolver(repo)
 
 	got, err := r.ResolveByURL(context.Background(), "https://news.example.com/article/12345?utm=x", storage.TargetTypePage)
 	require.NoError(t, err)

--- a/test/internal/publisher/publisher_gate_test.go
+++ b/test/internal/publisher/publisher_gate_test.go
@@ -59,7 +59,8 @@ func gateLog() *logger.Logger { return logger.New(logger.DefaultConfig()) }
 func TestPublisher_Gate_FiltersBlockedURLs(t *testing.T) {
 	prod := &gateMockProducer{}
 	pub := publisher.New(prod, noopResolver{}, gateLog())
-	pub.SetGate(urlguard.NewGate(urlguard.Default(), gateLog()))
+	gate, _ := urlguard.NewGate(urlguard.Default(), gateLog())
+	pub.SetGate(gate)
 
 	urls := []string{
 		"https://edition.cnn.com/article/1",      // pass
@@ -78,7 +79,8 @@ func TestPublisher_Gate_FiltersBlockedURLs(t *testing.T) {
 func TestPublisher_Gate_AllBlocked_NoPublish(t *testing.T) {
 	prod := &gateMockProducer{}
 	pub := publisher.New(prod, noopResolver{}, gateLog())
-	pub.SetGate(urlguard.NewGate(urlguard.Default(), gateLog()))
+	gate, _ := urlguard.NewGate(urlguard.Default(), gateLog())
+	pub.SetGate(gate)
 
 	err := pub.Publish(context.Background(), "cnn", []string{
 		"https://rss.cnn.com/rss/cnn_health.rss",
@@ -112,7 +114,8 @@ func TestPublisher_NoGate_LegacyBehavior(t *testing.T) {
 func TestPublisher_Gate_AllowAllGuard_NoFiltering(t *testing.T) {
 	prod := &gateMockProducer{}
 	pub := publisher.New(prod, noopResolver{}, gateLog())
-	pub.SetGate(urlguard.NewGate(urlguard.AllowAllGuard{}, gateLog()))
+	gate, _ := urlguard.NewGate(urlguard.AllowAllGuard{}, gateLog())
+	pub.SetGate(gate)
 
 	urls := []string{
 		"https://rss.cnn.com/rss/cnn_health.rss",

--- a/test/internal/scheduler/scheduler_gate_test.go
+++ b/test/internal/scheduler/scheduler_gate_test.go
@@ -107,7 +107,8 @@ func TestScheduler_Gate_BlocksRSSEntry(t *testing.T) {
 
 	sched := scheduler.New([]scheduler.ScheduleEntry{entry}, pub, gateTestLogger(), 3)
 	// Gate 의 logger 를 캡쳐 — 차단 시 'blocked by url guard' 로그가 buf 에 기록됨
-	sched.SetGate(urlguard.NewGate(urlguard.Default(), captureLogger(gateLogBuf)))
+	gate, _ := urlguard.NewGate(urlguard.Default(), captureLogger(gateLogBuf))
+	sched.SetGate(gate)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	sched.Start(ctx)
@@ -136,7 +137,8 @@ func TestScheduler_Gate_AllowsCategoryEntry(t *testing.T) {
 	}
 
 	sched := scheduler.New([]scheduler.ScheduleEntry{entry}, pub, gateTestLogger(), 3)
-	sched.SetGate(urlguard.NewGate(urlguard.Default(), gateTestLogger()))
+	gate, _ := urlguard.NewGate(urlguard.Default(), gateTestLogger())
+	sched.SetGate(gate)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	sched.Start(ctx)
@@ -182,7 +184,8 @@ func TestScheduler_Gate_AllowAllGuard_DelegatesAll(t *testing.T) {
 	}
 
 	sched := scheduler.New([]scheduler.ScheduleEntry{entry}, pub, gateTestLogger(), 3)
-	sched.SetGate(urlguard.NewGate(urlguard.AllowAllGuard{}, gateTestLogger()))
+	gate, _ := urlguard.NewGate(urlguard.AllowAllGuard{}, gateTestLogger())
+	sched.SetGate(gate)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	sched.Start(ctx)

--- a/test/pkg/urlguard/urlguard_test.go
+++ b/test/pkg/urlguard/urlguard_test.go
@@ -148,7 +148,7 @@ func extractLogEntries(t *testing.T, buf *bytes.Buffer) []map[string]interface{}
 
 func TestGate_Allow_Pass_NoLog(t *testing.T) {
 	buf := &bytes.Buffer{}
-	gate := urlguard.NewGate(urlguard.Default(), captureLogger(buf))
+	gate, _ := urlguard.NewGate(urlguard.Default(), captureLogger(buf))
 
 	ok := gate.Allow("https://edition.cnn.com/health", map[string]interface{}{"crawler": "cnn"})
 	assert.True(t, ok)
@@ -157,7 +157,7 @@ func TestGate_Allow_Pass_NoLog(t *testing.T) {
 
 func TestGate_Allow_Block_LogsWarn(t *testing.T) {
 	buf := &bytes.Buffer{}
-	gate := urlguard.NewGate(urlguard.Default(), captureLogger(buf))
+	gate, _ := urlguard.NewGate(urlguard.Default(), captureLogger(buf))
 
 	ok := gate.Allow("https://rss.cnn.com/rss/cnn_health.rss",
 		map[string]interface{}{"crawler": "cnn", "stage": "scheduler"})
@@ -175,7 +175,7 @@ func TestGate_Allow_Block_LogsWarn(t *testing.T) {
 
 func TestGate_Allow_NilFields_StillLogs(t *testing.T) {
 	buf := &bytes.Buffer{}
-	gate := urlguard.NewGate(urlguard.Default(), captureLogger(buf))
+	gate, _ := urlguard.NewGate(urlguard.Default(), captureLogger(buf))
 
 	ok := gate.Allow("https://rss.cnn.com/rss/foo.rss", nil)
 	assert.False(t, ok)
@@ -188,7 +188,7 @@ func TestGate_Allow_NilFields_StillLogs(t *testing.T) {
 
 func TestGate_Filter_PartialBlock(t *testing.T) {
 	buf := &bytes.Buffer{}
-	gate := urlguard.NewGate(urlguard.Default(), captureLogger(buf))
+	gate, _ := urlguard.NewGate(urlguard.Default(), captureLogger(buf))
 
 	urls := []string{
 		"https://edition.cnn.com/article/1",
@@ -209,7 +209,7 @@ func TestGate_Filter_PartialBlock(t *testing.T) {
 
 func TestGate_Filter_AllPass_NoLog(t *testing.T) {
 	buf := &bytes.Buffer{}
-	gate := urlguard.NewGate(urlguard.Default(), captureLogger(buf))
+	gate, _ := urlguard.NewGate(urlguard.Default(), captureLogger(buf))
 
 	urls := []string{"https://edition.cnn.com/a", "https://news.naver.com/b"}
 	allowed := gate.Filter(urls, nil)
@@ -218,7 +218,7 @@ func TestGate_Filter_AllPass_NoLog(t *testing.T) {
 }
 
 func TestGate_Filter_AllBlocked_ReturnsEmptyNotNil(t *testing.T) {
-	gate := urlguard.NewGate(urlguard.Default(), captureLogger(&bytes.Buffer{}))
+	gate, _ := urlguard.NewGate(urlguard.Default(), captureLogger(&bytes.Buffer{}))
 
 	allowed := gate.Filter([]string{
 		"https://rss.cnn.com/rss/a.rss",
@@ -229,14 +229,14 @@ func TestGate_Filter_AllBlocked_ReturnsEmptyNotNil(t *testing.T) {
 }
 
 func TestGate_Filter_EmptyInput(t *testing.T) {
-	gate := urlguard.NewGate(urlguard.Default(), captureLogger(&bytes.Buffer{}))
+	gate, _ := urlguard.NewGate(urlguard.Default(), captureLogger(&bytes.Buffer{}))
 
 	assert.Empty(t, gate.Filter(nil, nil))
 	assert.Empty(t, gate.Filter([]string{}, nil))
 }
 
 func TestGate_Filter_DoesNotMutateInput(t *testing.T) {
-	gate := urlguard.NewGate(urlguard.Default(), captureLogger(&bytes.Buffer{}))
+	gate, _ := urlguard.NewGate(urlguard.Default(), captureLogger(&bytes.Buffer{}))
 
 	input := []string{"https://edition.cnn.com/a", "https://rss.cnn.com/rss/b.rss"}
 	original := append([]string{}, input...)
@@ -245,15 +245,16 @@ func TestGate_Filter_DoesNotMutateInput(t *testing.T) {
 	assert.Equal(t, original, input, "Filter 가 입력 슬라이스를 변경하면 안 됨")
 }
 
-func TestNewGate_NilGuard_Panics(t *testing.T) {
-	assert.Panics(t, func() {
-		urlguard.NewGate(nil, nil)
-	})
+func TestNewGate_NilGuard_ReturnsError(t *testing.T) {
+	gate, err := urlguard.NewGate(nil, nil)
+	assert.Nil(t, gate)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "non-nil Guard")
 }
 
 func TestNewGate_NilLogger_UsesDefault(t *testing.T) {
 	// nil logger 는 panic 하지 않고 fallback 기본 logger 사용
-	gate := urlguard.NewGate(urlguard.Default(), nil)
+	gate, _ := urlguard.NewGate(urlguard.Default(), nil)
 	require.NotNil(t, gate)
 	// 호출이 panic 하지 않는지만 검증 (출력은 stdout 으로 흘러감)
 	assert.NotPanics(t, func() {


### PR DESCRIPTION
## 연관 이슈
- Closes #208

<br>

## 구현 내용

PR #207 CodeRabbit Major 피드백 follow-up — `.claude/rules/04-error-handling.md` "NEVER panic in production code" 원칙 준수. codebase 의 모든 panic-on-nil constructor 를 error 반환 패턴으로 통일.

### 코드 변경 (commit 1: source migration)

9개 파일의 constructor 시그니처 `func New*(...) *T` → `func New*(...) (*T, error)`. nil 입력 시 `errors.New(...)` 반환 (panic 제거):

| 파일 | 함수 | nil checks |
|---|---|---|
| `internal/processor/parser/rule/parser.go` | `NewParser` | 1 |
| `internal/processor/parser/rule/resolver.go` | `NewResolver` | 1 |
| `internal/processor/parser/rule/llmgen/generator.go` | `New` | 4 |
| `internal/processor/parser/rule/refiner/refiner.go` | `New` | 4 |
| `internal/processor/parser/rule/refiner/llm_adapter.go` | `NewLLMAdapter` | 1 |
| `internal/processor/fetcher/stage.go` | `NewStage` | 1 |
| `internal/processor/parser/stage/stage.go` | `NewStage` | 3 |
| `internal/processor/validate/stage.go` | `NewStage` | 1 |
| `pkg/urlguard/gate.go` | `NewGate` | 1 |

총 17개 panic 제거.

### 코드 변경 (commit 2: caller + tests)

**`cmd/issuetracker/main.go`:**
- 모든 caller 가 error 반환 처리 (`log.Fatal` on boot)
- `buildLLMGenerator` / `buildRefiner`: provider nil graceful degrade 유지하되, nil 아닐 때의 `New` 실패는 wiring 버그라 fatal 처리
- 신규 stage 변수 (`fetcherStage`, `parserStg`, `validateStage`) 도입

**Tests (9 파일):**
- 일반 호출 → `x, _ := X.New(...)` 패턴 (테스트 시나리오는 nil 입력 안 함)
- 헬퍼 함수 → `require.NoError(t, err)` 추가
- nil-input panic 검증 테스트 → error 반환 검증으로 전환:
  - `TestNewResolver_NilRepo_Panics` → `_ReturnsError`
  - `TestNewParser_NilResolver_Panics` → `_ReturnsError`
  - `TestNewGate_NilGuard_Panics` → `_ReturnsError`
- 인라인 `SetGate(NewGate(...))` 패턴 → 임시 변수로 split

### Out of scope (이슈 본문 명시)

- `internal/processor/parser/rule/refiner/metrics.go`: prometheus collector 충돌 panic
- `pkg/llm/measured.go:144,159`: prometheus collector 충돌 panic

→ wiring 시점이 아닌 prometheus 라이브러리 한계 (DescribedBy/AlreadyRegistered). 별도 정책 검토 필요 (다른 이슈).

<br>

## CI / 머지 게이트 점검

> [CI 운영 규약](docs/ci/conventions.md) 및 [Required Status Checks 단일 소스](docs/ci/status-checks.md)에 따라 작성합니다.

### 변경 영향 범위
- 영향 패키지/모듈: 9개 production 파일 (constructor 시그니처) + cmd/issuetracker/main.go (caller wiring) + 9개 테스트 파일
- 위험도(택1): `Low-Medium`
  - 동작 변경 없음 — wiring 누락은 panic 대신 `log.Fatal` 로 boot 차단 (효과 동일, 메시지가 더 명확)
  - DB / Kafka / Redis 영향 없음
  - 28개 패키지 race test 모두 통과 (failure 0)

### Required Status Checks
- 통과 확인 대상 (PR Checks 탭에서 확인):
  - [ ] `Commit Lint`
  - [ ] `PR Title Lint`
  - [ ] `Linked Issue Check`
  - [ ] `Format Check`
  - [ ] `Build`
  - [ ] `Test`
  - [ ] `Lint`

### 롤백 계획
- `git revert` 2개 commit. DB / 외부 시스템 영향 없음.

<br>

## TODO
- (선택, 후속 이슈) prometheus collector 충돌 panic 정책 검토 (`metrics.go`, `measured.go`) — `prometheus.AlreadyRegisteredError` 핸들링 패턴 표준화

<br>

## 논의 사항
- `04-error-handling.md` 의 "NEVER panic" 룰은 strict 유지. prometheus 충돌 같은 라이브러리 한계로 인한 panic 은 별도 정책 (이슈 #208 본문에 OUT OF SCOPE 명시).
- 모든 stage / generator / refiner / adapter / parser / resolver / gate 의 constructor 가 동일 패턴 — 향후 새 component 추가 시 동일 컨벤션 따르도록 코딩 가이드 정리 검토 가치.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
