### PR TITLE
[DOCS#212] 규약 6 의 prefix 표기 체계 3분리 (commit / PR / 이슈) 명문화

### DIFF
--- a/.claude/rules/07-workflow.md
+++ b/.claude/rules/07-workflow.md
@@ -184,8 +184,8 @@ fc95aec [FIX]: 피드백 반영, all-pass 모드 PathPrefixes 검증 + discovery
 
 | 위치 | 형식 | 예시 | 강제 |
 |---|---|---|---|
-| Commit message | `[FEAT]:` / `[FIX]:` / `[REFAC]:` / `[DOCS]:` / `[CHORE]:` (축약 + 콜론) | `[FIX]: 인덱스 누락 보정` | CI Commit Lint |
-| PR title | `[FEAT#N]` / `[FIX#N]` / `[REFAC#N]` / `[DOCS#N]` / `[CHORE#N]` (commit prefix + #이슈번호) | `[DOCS#212] 규약 6 정정` | CI PR Title Lint |
+| Commit message | `[FEAT]:` / `[FIX]:` / `[REFAC]:` / `[DOCS]:` / `[CHORE]:` (축약 + 콜론) | `[FIX]: 인덱스 누락 보정` | GitHub Actions Commit Lint |
+| PR title | `[FEAT#N]` / `[FIX#N]` / `[REFAC#N]` / `[DOCS#N]` / `[CHORE#N]` (commit 카테고리 + #이슈번호, 콜론 없음) | `[DOCS#212] 규약 6 정정` | GitHub Actions PR Title Lint |
 | **Issue title** | **`[FEATURE]` / `[FIX]` / `[REFACTOR]` / `[DOCS]` / `[CHORE]` / `[HOTFIX]`** (full-word, 콜론 없음) | `[FEATURE] 새 크롤러 추가` | (lint 미강제, 규약 6 운영) |
 
 **핵심 차이**: 이슈 prefix 는 commit prefix 의 축약형이 아니라 **원본 단어** 를 그대로 쓴다. 또한 commit/PR 에는 없는 `[HOTFIX]` 가 이슈 prefix 에만 존재 — 배포 중 긴급 대응이라는 별도 카테고리. 이 표기 차이는 의도된 설계이며, 본 규약 6 의 매핑 표는 **이슈 prefix → Label/Type** 매핑이다.

--- a/.claude/rules/07-workflow.md
+++ b/.claude/rules/07-workflow.md
@@ -178,9 +178,21 @@ fc95aec [FIX]: 피드백 반영, all-pass 모드 PathPrefixes 검증 + discovery
 이슈 / PR 생성 시 **항상 Label 부여** (필수). 이슈는 추가로 **Issue Type 부여** (필수).
 분류·필터링·자동화 (예: hotfix 라벨로 우선순위 알림) 가 누락되지 않도록 일관 매핑 적용.
 
-#### Label 매핑 (이슈 + PR 공통)
+#### Prefix 표기 체계 (commit / PR / 이슈 — 3 분리 설계)
 
-| Commit prefix | 기본 Label | 추가 Label (조건부) |
+본 repo 는 commit / PR / 이슈 제목의 prefix 를 **의도적으로 다른 표기** 로 운용한다.
+
+| 위치 | 형식 | 예시 | 강제 |
+|---|---|---|---|
+| Commit message | `[FEAT]:` / `[FIX]:` / `[REFAC]:` / `[DOCS]:` / `[CHORE]:` (축약 + 콜론) | `[FIX]: 인덱스 누락 보정` | CI Commit Lint |
+| PR title | `[FEAT#N]` / `[FIX#N]` / `[REFAC#N]` / `[DOCS#N]` / `[CHORE#N]` (commit prefix + #이슈번호) | `[DOCS#212] 규약 6 정정` | CI PR Title Lint |
+| **Issue title** | **`[FEATURE]` / `[FIX]` / `[REFACTOR]` / `[DOCS]` / `[CHORE]` / `[HOTFIX]`** (full-word, 콜론 없음) | `[FEATURE] 새 크롤러 추가` | (lint 미강제, 규약 6 운영) |
+
+**핵심 차이**: 이슈 prefix 는 commit prefix 의 축약형이 아니라 **원본 단어** 를 그대로 쓴다. 또한 commit/PR 에는 없는 `[HOTFIX]` 가 이슈 prefix 에만 존재 — 배포 중 긴급 대응이라는 별도 카테고리. 이 표기 차이는 의도된 설계이며, 본 규약 6 의 매핑 표는 **이슈 prefix → Label/Type** 매핑이다.
+
+#### Label 매핑 (이슈 prefix 기준)
+
+| Issue prefix | 기본 Label | 추가 Label (조건부) |
 |---|---|---|
 | `[FEATURE]` | `enhancement` | — |
 | `[REFACTOR]` | `refactor` | — |
@@ -189,14 +201,16 @@ fc95aec [FIX]: 피드백 반영, all-pass 모드 PathPrefixes 검증 + discovery
 | `[FIX]` (일반 에러 이슈) | `bug` | — |
 | `[HOTFIX]` (배포 중 긴급) | `bug` | + `hotfix` |
 
+PR 의 Label 은 그 PR 이 닫는 이슈 (`Closes #N`) 의 Label 과 동일하게 부여한다.
+
 #### Issue Type 매핑 (이슈 전용)
 
 GitHub Issue Type 은 라벨과 별개의 native 분류 — `gh api graphql` 의 `updateIssueIssueType` mutation 으로 부여.
 
-| Commit prefix | Issue Type |
+| Issue prefix | Issue Type |
 |---|---|
 | `[FEATURE]` | `Feature` |
-| `[FIX]` | `Bug` |
+| `[FIX]` / `[HOTFIX]` | `Bug` |
 | `[REFACTOR]` / `[CHORE]` / `[DOCS]` | `Task` |
 
 본 repo 의 Issue Type ID:
@@ -206,13 +220,15 @@ GitHub Issue Type 은 라벨과 별개의 native 분류 — `gh api graphql` 의
 
 #### 부여 명령 예시
 
-**이슈 생성 시 Label**:
+**이슈 생성 시 Label** (title 은 issue prefix 사용 — full-word, 콜론 없음):
 ```bash
 gh issue create --repo EinSofINTEREST/IssueTracker \
   --title "[DOCS] 제목" \
   --label documentation \
   --body "..."
 ```
+
+다른 issue prefix 예: `[FEATURE] 새 크롤러`, `[REFACTOR] 모듈 분리`, `[HOTFIX] 배포 직후 데드락`.
 
 **이슈 Type 부여 (생성 직후)**:
 ```bash
@@ -270,4 +286,5 @@ gh pr edit <PR_NUMBER> --add-label documentation
   - 이슈 #129 — PR 생성 직후 cron 자동 등록
   - 이슈 #199 — 이슈 먼저 (issue-first) 워크플로 명문화 (규약 1 도입)
   - 이슈 #210 — Label · Issue Type · Sub-issue Relation 정책 명문화 (규약 6 도입)
+  - 이슈 #212 — 규약 6 의 prefix 표기 체계 3분리 (commit / PR / 이슈) 명문화
 - 관련 문서: [.github/PULL_REQUEST_TEMPLATE.md](../../.github/PULL_REQUEST_TEMPLATE.md)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,7 +70,7 @@ docs/ci/        → CI 운영 규약, status check 단일 소스
 3. **Commit-per-TODO** — 별 언급 없으면 논리적 변경 단위마다 commit (메시지 컨벤션 준수).
 4. **PR 자동 생성** — 작업 완료 직후 컨벤션 + 템플릿 준수해서 `Closes #<sub-issue>` 포함 PR 자동 생성. 마지막 sub-issue PR 에서 메인 이슈도 close.
 5. **권한 사용 최소화** — 새 permission / 외부 도구 / 의존성은 작업 완수에 불가피한 경우에만.
-6. **Label · Issue Type 부여 필수** (이슈 #210) — 이슈/PR 생성 시 commit prefix 기준 Label (`[FEAT]:→enhancement`, `[REFAC]:→refactor`, `[CHORE]:→chore`, `[DOCS]:→documentation`, `[FIX]:→bug` (+ 배포 긴급은 `hotfix`)). 이슈는 추가로 Issue Type (`[FEAT]:→Feature`, `[FIX]:→Bug`, 그 외 `Task`).
+6. **Label · Issue Type 부여 필수** (이슈 #210, #212) — 이슈는 **issue prefix** 기준 Label + Type (`[FEATURE]→enhancement/Feature`, `[REFACTOR]→refactor/Task`, `[CHORE]→chore/Task`, `[DOCS]→documentation/Task`, `[FIX]→bug/Bug`, `[HOTFIX]→bug+hotfix/Bug`). PR Label 은 그 PR 이 닫는 이슈의 Label 과 동일. 표기 체계 3분리 (commit `[FEAT]:` / PR `[FEAT#N]` / issue `[FEATURE]`) 는 [규약 6](.claude/rules/07-workflow.md) 참조.
 
 ## PR 생성 후 자동 동작 (이슈 #129)
 


### PR DESCRIPTION
## 연관 이슈
- Closes #212

<br>

## 구현 내용

PR #211 머지 후 사용자 commit \`54fe1ca\` 로 매핑 표가 \`[FEATURE]\` / \`[REFACTOR]\` / \`[HOTFIX]\` 표기로 정정되었으나, 표 헤더가 여전히 \`Commit prefix\` 였고 CLAUDE.md 6규약 요약도 commit prefix 기준 표기를 사용해 commit 컨벤션과 혼동될 여지가 있었음. 본 PR 은 사용자 의도 (commit/PR/이슈 prefix 3분리 설계) 를 명문화.

### \`.claude/rules/07-workflow.md\` 변경

1. **Prefix 표기 체계 표 신설** (규약 6 도입부) — 3가지 위치별 형식·예시·강제 출처:
   | 위치 | 형식 | 예시 | 강제 |
   |---|---|---|---|
   | Commit message | \`[FEAT]:\` 등 (축약 + 콜론) | \`[FIX]: 인덱스 누락 보정\` | CI Commit Lint |
   | PR title | \`[FEAT#N]\` 등 (commit + #이슈번호) | \`[DOCS#212] 규약 6 정정\` | CI PR Title Lint |
   | Issue title | \`[FEATURE]\` / \`[FIX]\` / \`[REFACTOR]\` / \`[DOCS]\` / \`[CHORE]\` / \`[HOTFIX]\` (full-word, 콜론 없음) | \`[FEATURE] 새 크롤러 추가\` | (lint 미강제, 규약 6 운영) |

2. **Label / Issue Type 매핑 표 헤더 정정**: \`Commit prefix\` → \`Issue prefix\`
3. **Issue Type 매핑 보완**: \`[HOTFIX]\` → \`Bug\` 추가 (누락 보강)
4. **PR Label 부여 원칙 명시**: PR Label 은 그 PR 이 닫는 이슈 (\`Closes #N\`) 의 Label 과 동일
5. **이슈 생성 예시 보강**: 다른 issue prefix (\`[FEATURE]\`, \`[REFACTOR]\`, \`[HOTFIX]\`) 예시 추가
6. 참고 자료에 본 이슈 #212 추가

### \`CLAUDE.md\` 변경

6규약 요약을 issue prefix 표기로 재작성 + 3분리 설계 안내 추가.

<br>

## CI / 머지 게이트 점검

> [CI 운영 규약](docs/ci/conventions.md) 및 [Required Status Checks 단일 소스](docs/ci/status-checks.md)에 따라 작성합니다.

### 변경 영향 범위
- 영향 파일: \`.claude/rules/07-workflow.md\`, \`CLAUDE.md\` (문서만)
- 위험도(택1): \`Low\` — 코드 변경 없음, 문서 명문화만
- DB / Kafka / Redis / 빌드 영향 없음

### Required Status Checks
- 통과 확인 대상 (PR Checks 탭에서 확인):
  - [ ] \`Commit Lint\`
  - [ ] \`PR Title Lint\`
  - [ ] \`Linked Issue Check\`
  - [ ] \`Format Check\`
  - [ ] \`Build\`
  - [ ] \`Test\`
  - [ ] \`Lint\`

### 롤백 계획
- \`git revert\` 단일 commit. 코드/시스템 영향 없음.

<br>

## TODO
- 본 PR 머지 후, 기존 이슈들의 prefix 가 새 표기 (\`[FEATURE]\` / \`[REFACTOR]\` / \`[HOTFIX]\`) 와 다른 경우 점진적 정리 가능 (별도 chore)

<br>

## 논의 사항
- 본 PR 의 자체 prefix 적용:
  - 이슈 #212 title: \`[DOCS] ...\` (issue prefix 규약 준수)
  - PR title: \`[DOCS#212] ...\` (commit/PR title 규약 준수)
  - commit prefix: \`[DOCS]:\` (commit lint 통과 확인)

🤖 Generated with [Claude Code](https://claude.com/claude-code)