### PR TITLE
[FIX#146] chromedp graceful timeout 강화 — 폴링 미종료 페이지에서 부분 DOM 무조건 반환

### DIFF
--- a/internal/processor/fetcher/implementation/chromedp/fetch.go
+++ b/internal/processor/fetcher/implementation/chromedp/fetch.go
@@ -140,6 +140,14 @@ func (c *ChromedpCrawler) Fetch(ctx context.Context, target core.Target) (*core.
 		preCheckStatus := statusCode
 		statusMu.Unlock()
 		if preCheckStatus == 0 && partialHTML == "" {
+			// gemini 피드백: shutdown 으로 인한 cancel 과 일반 timeout 실패를 구분.
+			// browserCtx 는 c.allocCtx 의 child 이므로, allocCtx 가 cancel 된 셧다운
+			// 상황에서는 browserCtx.Err() 가 non-nil. 이 경우 false-positive alert 회피를
+			// 위해 raw context error 그대로 반환 (Retryable 분류 안 함, 다운스트림이 자체
+			// 종료 흐름에서 처리).
+			if browserErr := browserCtx.Err(); browserErr != nil {
+				return nil, browserErr
+			}
 			return nil, &core.CrawlerError{
 				Category:  core.ErrCategoryNetwork,
 				Code:      "CDP_002",

--- a/internal/processor/fetcher/implementation/chromedp/fetch.go
+++ b/internal/processor/fetcher/implementation/chromedp/fetch.go
@@ -132,6 +132,25 @@ func (c *ChromedpCrawler) Fetch(ctx context.Context, target core.Target) (*core.
 			}).Warn("partial DOM did not meet validation threshold, retaining anyway")
 		}
 
+		// Navigate 자체 실패 가드 (CodeRabbit 피드백): main-document 응답이 한 번도
+		// 도착하지 않았고 (statusCode == 0) 캡처도 빈 결과면 페이지가 사실상 미응답.
+		// 이슈 #146 acceptance criteria "Navigate 자체 실패 (네트워크 오류) 는 기존대로
+		// CDP_002 에러" 를 충족하기 위해 명시적으로 CDP_002 에러로 분류한다.
+		statusMu.Lock()
+		preCheckStatus := statusCode
+		statusMu.Unlock()
+		if preCheckStatus == 0 && partialHTML == "" {
+			return nil, &core.CrawlerError{
+				Category:  core.ErrCategoryNetwork,
+				Code:      "CDP_002",
+				Message:   "failed to render page: navigation produced no main-document response",
+				Source:    c.name,
+				URL:       target.URL,
+				Retryable: true,
+				Err:       runErr,
+			}
+		}
+
 		html = partialHTML
 		partialLoad = true
 		log.WithFields(map[string]interface{}{

--- a/internal/processor/fetcher/implementation/chromedp/fetch.go
+++ b/internal/processor/fetcher/implementation/chromedp/fetch.go
@@ -115,7 +115,7 @@ func (c *ChromedpCrawler) Fetch(ctx context.Context, target core.Target) (*core.
 			"timeout_ms": c.config.Timeout.Milliseconds(),
 		}).Warn("page render timed out, attempting graceful capture")
 
-		partialHTML, captureErr := captureOuterHTML(browserCtx)
+		partialHTML, captureErr := captureOuterHTML(browserCtx, c.opts.GracefulCaptureTimeout)
 		if captureErr != nil {
 			// 부분 캡처 자체가 실패 → 빈 페이지/네트워크 불가와 동등한 완전 실패로 분류
 			// runErr(원인 timeout)와 captureErr(캡처 실패 사유 — target closed,

--- a/internal/processor/fetcher/implementation/chromedp/fetch.go
+++ b/internal/processor/fetcher/implementation/chromedp/fetch.go
@@ -2,8 +2,6 @@ package chromedp
 
 import (
 	"context"
-	"errors"
-	"fmt"
 	"sync"
 	"time"
 
@@ -115,36 +113,23 @@ func (c *ChromedpCrawler) Fetch(ctx context.Context, target core.Target) (*core.
 			"timeout_ms": c.config.Timeout.Milliseconds(),
 		}).Warn("page render timed out, attempting graceful capture")
 
+		// 이슈 #146: timeout = 정상 종료 시그널로 취급. 캡처 실패/검증 실패해도
+		// 에러로 끌어올리지 않고 partial_load=true 의 (가능하면 빈 HTML) 응답으로
+		// downgrade. 호출자(parser)는 빈 HTML 을 받으면 자연스럽게 링크 0건 처리하므로
+		// 시스템이 안정적으로 흘러간다. Navigate 자체가 한 번도 응답을 못 받은 케이스
+		// (statusCode == 0 이면서 capturedHTML 도 빈 상태) 만 진짜 실패로 분류한다.
 		partialHTML, captureErr := captureOuterHTML(browserCtx, c.opts.GracefulCaptureTimeout)
 		if captureErr != nil {
-			// 부분 캡처 자체가 실패 → 빈 페이지/네트워크 불가와 동등한 완전 실패로 분류
-			// runErr(원인 timeout)와 captureErr(캡처 실패 사유 — target closed,
-			// context canceled, CDP 오류 등)를 모두 보존하여 디버깅 가능성 유지
-			return nil, &core.CrawlerError{
-				Category:  core.ErrCategoryTimeout,
-				Code:      "CDP_006",
-				Message:   "render timeout and graceful capture failed",
-				Source:    c.name,
-				URL:       target.URL,
-				Retryable: true,
-				Err:       errors.Join(runErr, captureErr),
-			}
-		}
-
-		// 부분 로드 DOM 유효성 검증 (최소 body + 길이 충족)
-		if !IsValidPartialDOM(partialHTML) {
-			// runErr(timeout) + DOM 검증 실패 사유(길이 정보 포함)를 함께 보존하여
-			// 에러 체인에서 "어떤 검증이 실패했는지"를 추적할 수 있도록 한다
-			validationErr := fmt.Errorf("partial DOM failed validation: length=%d", len(partialHTML))
-			return nil, &core.CrawlerError{
-				Category:  core.ErrCategoryTimeout,
-				Code:      "CDP_007",
-				Message:   "render timeout and partial DOM invalid",
-				Source:    c.name,
-				URL:       target.URL,
-				Retryable: true,
-				Err:       errors.Join(runErr, validationErr),
-			}
+			log.WithFields(map[string]interface{}{
+				"url":        target.URL,
+				"timeout_ms": c.config.Timeout.Milliseconds(),
+			}).WithError(captureErr).Warn("graceful capture failed, proceeding with empty partial body")
+			partialHTML = ""
+		} else if !IsValidPartialDOM(partialHTML) {
+			log.WithFields(map[string]interface{}{
+				"url":    target.URL,
+				"length": len(partialHTML),
+			}).Warn("partial DOM did not meet validation threshold, retaining anyway")
 		}
 
 		html = partialHTML
@@ -152,7 +137,7 @@ func (c *ChromedpCrawler) Fetch(ctx context.Context, target core.Target) (*core.
 		log.WithFields(map[string]interface{}{
 			"url":  target.URL,
 			"size": len(html),
-		}).Info("graceful timeout capture succeeded")
+		}).Info("graceful timeout capture completed")
 	}
 
 	elapsed := time.Since(start)

--- a/internal/processor/fetcher/implementation/chromedp/graceful_timeout.go
+++ b/internal/processor/fetcher/implementation/chromedp/graceful_timeout.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/chromedp/cdproto/page"
 	"github.com/chromedp/chromedp"
 )
 
@@ -13,11 +14,6 @@ import (
 // timeout 발생으로 graceful capture가 적용된 경우 true가 설정되어,
 // 다운스트림 파이프라인에서 데이터의 완전성 수준을 판단할 수 있다.
 const MetadataKeyPartialLoad = "partial_load"
-
-// gracefulCaptureTimeout: timeout 발생 시 부분 DOM 캡처에 허용하는 최대 시간
-// 너무 길면 전체 응답 시간이 늘어나고, 너무 짧으면 캡처 실패 빈도가 증가하므로
-// 실험적으로 3초가 적정 수준임을 가정한다 (chromedp OuterHTML 평균 < 1초).
-const gracefulCaptureTimeout = 3 * time.Second
 
 // minPartialDOMLength: 부분 로드 DOM으로 인정할 최소 HTML 길이 (바이트)
 // 빈 페이지(`<html><head></head><body></body></html>`)는 약 45바이트이므로
@@ -50,15 +46,28 @@ func IsValidPartialDOM(html string) bool {
 	return strings.Contains(html, "<body") || strings.Contains(html, "<BODY")
 }
 
-// captureOuterHTML: timeout 이후 별도 context로 OuterHTML 추출 시도
+// captureOuterHTML: timeout 이후 별도 context로 OuterHTML 추출 시도 (이슈 #146).
 // browserCtx는 timeout으로 cancel되지 않은 tab context여야 하며,
 // chromedp가 동일 탭에 새 명령을 발행할 수 있어야 한다.
-func captureOuterHTML(browserCtx context.Context) (string, error) {
-	rescueCtx, cancel := context.WithTimeout(browserCtx, gracefulCaptureTimeout)
+//
+// page.StopLoading() 을 OuterHTML 직전에 발행하여 navigation polling 을 즉시 중단,
+// CDP 가 응답할 여유를 확보. analytics / SSE / long-poll 페이지처럼 navigation 이
+// 끝나지 않는 케이스에서 OuterHTML 만 호출하면 응답이 안 와서 context canceled 로
+// 끝나는 현상을 회피한다.
+//
+// captureTimeout 가 0 이하이면 DefaultGracefulCaptureTimeout 을 사용한다.
+func captureOuterHTML(browserCtx context.Context, captureTimeout time.Duration) (string, error) {
+	if captureTimeout <= 0 {
+		captureTimeout = DefaultGracefulCaptureTimeout
+	}
+	rescueCtx, cancel := context.WithTimeout(browserCtx, captureTimeout)
 	defer cancel()
 
 	var html string
-	if err := chromedp.Run(rescueCtx, chromedp.OuterHTML("html", &html)); err != nil {
+	if err := chromedp.Run(rescueCtx,
+		page.StopLoading(),
+		chromedp.OuterHTML("html", &html),
+	); err != nil {
 		return "", err
 	}
 	return html, nil

--- a/internal/processor/fetcher/implementation/chromedp/parse.go
+++ b/internal/processor/fetcher/implementation/chromedp/parse.go
@@ -37,6 +37,16 @@ func (c *ChromedpCrawler) FetchAndParse(ctx context.Context, target core.Target,
 		}
 	}
 
+	// Fetch 단계의 partial_load 마킹을 Content 로 전파 (이슈 #146 + CodeRabbit 피드백).
+	// timeout 발생 시 raw.Metadata 에 MetadataKeyPartialLoad=true 가 채워져 있으며,
+	// 해당 정보를 다운스트림 (validator/parser) 가 신뢰도 분기에 활용할 수 있도록 함.
+	partialLoad := false
+	if v, ok := raw.Metadata[MetadataKeyPartialLoad]; ok {
+		if b, ok2 := v.(bool); ok2 && b {
+			partialLoad = true
+		}
+	}
+
 	content := &core.Content{
 		ID:           raw.ID,
 		SourceID:     c.sourceInfo.Name,
@@ -48,6 +58,9 @@ func (c *ChromedpCrawler) FetchAndParse(ctx context.Context, target core.Target,
 		Reliability:  0.0,
 		Extra:        make(map[string]interface{}),
 		CreatedAt:    time.Now(),
+	}
+	if partialLoad {
+		content.Extra[MetadataKeyPartialLoad] = true
 	}
 
 	// Extract title
@@ -88,6 +101,19 @@ func (c *ChromedpCrawler) FetchAndParse(ctx context.Context, target core.Target,
 	}).Info("content parsed successfully with chromedp")
 
 	if content.Title == "" || content.Body == "" {
+		// 이슈 #146 + CodeRabbit 피드백: partial_load 인 경우 timeout 시점의 부분 DOM 이라
+		// title/body 가 비어 있을 수 있다. "timeout = 정상 종료 시그널" 계약을 유지하기 위해
+		// CDP_004 를 던지지 않고 빈 필드의 Content 를 그대로 반환 — 다운스트림 (validator)
+		// 가 빈 필드 정책으로 처리. partial_load=false 인데 비어 있으면 진짜 파싱 실패라
+		// 기존대로 CDP_004 에러 유지.
+		if partialLoad {
+			log.WithFields(map[string]interface{}{
+				"url":          target.URL,
+				"title_length": len(content.Title),
+				"body_length":  len(content.Body),
+			}).Warn("partial-load content missing required fields, returning as partial")
+			return content, nil
+		}
 		return nil, &core.CrawlerError{
 			Category: core.ErrCategoryParse,
 			Code:     "CDP_004",

--- a/internal/processor/fetcher/implementation/chromedp/types.go
+++ b/internal/processor/fetcher/implementation/chromedp/types.go
@@ -2,6 +2,7 @@ package chromedp
 
 import (
 	"context"
+	"time"
 
 	"issuetracker/internal/processor/fetcher/core"
 )
@@ -51,18 +52,29 @@ type ChromedpOptions struct {
 	// RemoteURL: 원격 Chrome WebSocket 주소 (기본값: ws://localhost:9222)
 	// Docker 실행 예시: docker run -d -p 9222:9222 chromedp/headless-shell
 	RemoteURL string
+
+	// GracefulCaptureTimeout: navigation timeout 발생 후 별도 context 로 OuterHTML 을
+	// 재캡처할 때 허용하는 최대 시간 (이슈 #146).
+	// 0 또는 음수면 DefaultGracefulCaptureTimeout (10s) 사용.
+	// 부하 상태의 CDP 응답 + page.StopLoading() 후 OuterHTML 회수까지 시간이 필요해
+	// 기존 3s 는 너무 짧았음. 운영 튜닝 가능하도록 옵션화.
+	GracefulCaptureTimeout time.Duration
 }
+
+// DefaultGracefulCaptureTimeout: GracefulCaptureTimeout 미지정 시 기본값 (이슈 #146).
+const DefaultGracefulCaptureTimeout = 10 * time.Second
 
 // DefaultOptions: 로컬 Chrome 실행 기본 옵션
 func DefaultOptions() ChromedpOptions {
 	return ChromedpOptions{
-		Headless:        true,
-		WaitStable:      true,
-		WaitSelector:    "",
-		WaitNetworkIdle: false,
-		ViewportWidth:   1920,
-		ViewportHeight:  1080,
-		UseRemote:       false,
+		Headless:               true,
+		WaitStable:             true,
+		WaitSelector:           "",
+		WaitNetworkIdle:        false,
+		ViewportWidth:          1920,
+		ViewportHeight:         1080,
+		UseRemote:              false,
+		GracefulCaptureTimeout: DefaultGracefulCaptureTimeout,
 	}
 }
 
@@ -70,13 +82,14 @@ func DefaultOptions() ChromedpOptions {
 // chromedp/headless-shell 컨테이너를 ws://localhost:9222 에서 연결
 func DefaultRemoteOptions() ChromedpOptions {
 	return ChromedpOptions{
-		Headless:        true,
-		WaitStable:      true,
-		WaitSelector:    "",
-		WaitNetworkIdle: false,
-		ViewportWidth:   1920,
-		ViewportHeight:  1080,
-		UseRemote:       true,
-		RemoteURL:       "ws://localhost:9222",
+		Headless:               true,
+		WaitStable:             true,
+		WaitSelector:           "",
+		WaitNetworkIdle:        false,
+		ViewportWidth:          1920,
+		ViewportHeight:         1080,
+		UseRemote:              true,
+		RemoteURL:              "ws://localhost:9222",
+		GracefulCaptureTimeout: DefaultGracefulCaptureTimeout,
 	}
 }

--- a/test/internal/processor/fetcher/implementation/chromedp/graceful_timeout_test.go
+++ b/test/internal/processor/fetcher/implementation/chromedp/graceful_timeout_test.go
@@ -1,0 +1,115 @@
+package chromedp_test
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	cdpimpl "issuetracker/internal/processor/fetcher/implementation/chromedp"
+)
+
+// TestIsTimeoutError_DeadlineExceeded_True:
+// chromedp.Run 이 timeout 으로 종료되면 context.DeadlineExceeded 를 wrap 하여 반환.
+// 본 helper 가 그 케이스를 정확히 식별해야 graceful capture 분기로 진입 가능.
+func TestIsTimeoutError_DeadlineExceeded_True(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Nanosecond)
+	defer cancel()
+	<-ctx.Done()
+
+	assert.True(t, cdpimpl.IsTimeoutError(ctx.Err()))
+	assert.True(t, cdpimpl.IsTimeoutError(context.DeadlineExceeded))
+}
+
+// TestIsTimeoutError_Canceled_False:
+// 사용자/상위 호출자가 context 를 cancel 한 케이스는 graceful capture 대상이 아니다.
+// IsTimeoutError 는 false 를 반환하여 호출자가 즉시 에러로 분류하도록 한다.
+func TestIsTimeoutError_Canceled_False(t *testing.T) {
+	assert.False(t, cdpimpl.IsTimeoutError(context.Canceled))
+}
+
+// TestIsTimeoutError_Nil_False:
+// nil 에러는 timeout 이 아니다.
+func TestIsTimeoutError_Nil_False(t *testing.T) {
+	assert.False(t, cdpimpl.IsTimeoutError(nil))
+}
+
+// TestIsTimeoutError_OtherError_False:
+// 일반 에러는 timeout 이 아니다 — graceful capture 분기 미진입.
+func TestIsTimeoutError_OtherError_False(t *testing.T) {
+	assert.False(t, cdpimpl.IsTimeoutError(errors.New("network refused")))
+}
+
+// TestIsValidPartialDOM_Cases:
+// 부분 DOM 검증의 핵심 두 조건 — 길이 (>= 512) + body 태그 존재 — 을 케이스로 검증.
+// 본 검증은 이슈 #146 이후 "검증 실패해도 partial 로 진행" 정책이지만, helper 자체는
+// 다운스트림이 partial 신뢰도를 판단할 때 활용하므로 동작은 유지.
+func TestIsValidPartialDOM_Cases(t *testing.T) {
+	body := strings.Repeat("a", 600)
+
+	tests := []struct {
+		name string
+		html string
+		want bool
+	}{
+		{
+			name: "valid lowercase body tag",
+			html: "<html><head></head><body>" + body + "</body></html>",
+			want: true,
+		},
+		{
+			name: "valid uppercase body tag",
+			html: "<HTML><HEAD></HEAD><BODY>" + body + "</BODY></HTML>",
+			want: true,
+		},
+		{
+			name: "below minimum length",
+			html: "<html><body>tiny</body></html>",
+			want: false,
+		},
+		{
+			name: "long enough but no body tag",
+			html: strings.Repeat("<div>filler</div>", 100),
+			want: false,
+		},
+		{
+			name: "empty html",
+			html: "",
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, cdpimpl.IsValidPartialDOM(tt.html))
+		})
+	}
+}
+
+// TestDefaultGracefulCaptureTimeout_Value:
+// 이슈 #146 의 기본값 합의: 부하 상태 CDP 응답 + page.StopLoading 후 OuterHTML 회수까지
+// 충분한 여유를 위해 10s 채택. 의도치 않은 변경 방지 차원의 sentinel 테스트.
+func TestDefaultGracefulCaptureTimeout_Value(t *testing.T) {
+	assert.Equal(t, 10*time.Second, cdpimpl.DefaultGracefulCaptureTimeout)
+}
+
+// TestDefaultOptions_GracefulCaptureTimeoutPopulated:
+// DefaultOptions / DefaultRemoteOptions 모두 GracefulCaptureTimeout 가 채워져
+// captureOuterHTML 호출 시 0 fallback 분기를 타지 않도록 보장.
+func TestDefaultOptions_GracefulCaptureTimeoutPopulated(t *testing.T) {
+	local := cdpimpl.DefaultOptions()
+	assert.Equal(t, cdpimpl.DefaultGracefulCaptureTimeout, local.GracefulCaptureTimeout)
+
+	remote := cdpimpl.DefaultRemoteOptions()
+	assert.Equal(t, cdpimpl.DefaultGracefulCaptureTimeout, remote.GracefulCaptureTimeout)
+}
+
+// TestMetadataKeyPartialLoad_Stable:
+// 다운스트림 (parser, validator) 이 metadata 에서 partial 식별 시 의존하는 키.
+// 외부 계약이라 변경 시 다운스트림에도 영향 — sentinel 로 보호.
+func TestMetadataKeyPartialLoad_Stable(t *testing.T) {
+	assert.Equal(t, "partial_load", cdpimpl.MetadataKeyPartialLoad)
+}


### PR DESCRIPTION
## 연관 이슈
- Closes #146

<br>

## 구현 내용

이슈 #146 의 핵심 요구사항: **"타임아웃이 발생하더라도 에러로 처리하지 말고, 폴링 중단된 상태의 렌더링된 결과를 도출"** 을 충족하기 위해 chromedp graceful timeout 경로를 강화.

CNN entertainment 등 analytics / SSE / long-poll 페이지에서 navigation polling 이 끝나지 않아 30s timeout 후 graceful capture 도 3s 안에 응답 못해 `CDP_006` 에러로 종료, 워커 재큐잉 폭주가 반복되던 문제 해소.

### Commit 1: `[REFAC]:` graceful capture timeout 옵션화 + `page.StopLoading()` 통합

**`internal/processor/fetcher/implementation/chromedp/types.go`**:
- `ChromedpOptions.GracefulCaptureTimeout time.Duration` 신규 필드
- `DefaultGracefulCaptureTimeout = 10 * time.Second` (기존 상수 3s → 10s)
- `DefaultOptions` / `DefaultRemoteOptions` 둘 다 기본값 주입

**`internal/processor/fetcher/implementation/chromedp/graceful_timeout.go`**:
- `captureOuterHTML(browserCtx, captureTimeout)` 시그니처에 timeout 인자 추가, 0 이하면 기본값 사용
- 내부에서 `OuterHTML` 직전 `page.StopLoading()` 발행 — analytics/SSE/long-poll 페이지의 navigation polling 을 즉시 중단해 CDP 응답 회수 가능
- 상수 `gracefulCaptureTimeout` 제거

**`internal/processor/fetcher/implementation/chromedp/fetch.go`**:
- `captureOuterHTML(browserCtx, c.opts.GracefulCaptureTimeout)` 호출처 갱신

### Commit 2: `[FIX]:` CDP_006/CDP_007 다운그레이드 — timeout 시 부분 DOM 무조건 반환

**`internal/processor/fetcher/implementation/chromedp/fetch.go`**:
- `captureOuterHTML` 실패 (구 CDP_006) → 에러 반환 대신 `partialHTML=""` + warn 로그 + `partial_load=true` 로 fallthrough
- `IsValidPartialDOM` 검증 실패 (구 CDP_007) → 에러 반환 대신 그대로 partial 반환 + warn 로그
- 두 케이스 모두 호출자 (parser) 가 빈/짧은 HTML 을 받으면 자연스럽게 링크 0건 처리 → 시스템 안정
- `Navigate` 자체 실패 (`runErr` 가 timeout 이 아닌 케이스) 는 기존대로 `CDP_002` 에러 유지 — 진짜 실패만 에러 분류
- 부수: `errors.Join` / `fmt.Errorf` 사용처 사라져 imports 정리

### Commit 3: `[FEAT]:` chromedp graceful timeout helper 단위 테스트 추가

**`test/internal/processor/fetcher/implementation/chromedp/graceful_timeout_test.go`** (신규, 7 tests):
- `TestIsTimeoutError_*` 4종 — DeadlineExceeded / Canceled / nil / 일반 에러 분류
- `TestIsValidPartialDOM_Cases` — lowercase/uppercase body, 길이 미달, body 누락, 빈 html (5 시나리오)
- `TestDefaultGracefulCaptureTimeout_Value` — 10s sentinel
- `TestDefaultOptions_GracefulCaptureTimeoutPopulated` — Default* 둘 다 채움 보장
- `TestMetadataKeyPartialLoad_Stable` — 다운스트림 계약 키 sentinel

29개 패키지 race test 모두 통과 (failure 0).

<br>

## CI / 머지 게이트 점검

> [CI 운영 규약](docs/ci/conventions.md) 및 [Required Status Checks 단일 소스](docs/ci/status-checks.md)에 따라 작성합니다.

### 변경 영향 범위
- 영향 패키지: `internal/processor/fetcher/implementation/chromedp/` (fetch.go, graceful_timeout.go, types.go) + 신규 테스트
- 위험도(택1): `Medium`
  - timeout 동작이 에러 → partial 반환으로 변경되므로 호출자 (parser) 의 빈 HTML 처리 검증 필요
  - DB / Kafka / Redis 직접 영향 없음. 다만 timeout 후 빈 RawContent 가 storage / parser 로 전파되므로 다운스트림 정상 동작 (링크 0건 처리) 확인 필요
- 29개 패키지 race test 모두 통과

### Required Status Checks
- 통과 확인 대상 (PR Checks 탭에서 확인):
  - [ ] `Commit Lint`
  - [ ] `PR Title Lint`
  - [ ] `Linked Issue Check`
  - [ ] `Format Check`
  - [ ] `Build`
  - [ ] `Test`
  - [ ] `Lint`

### 롤백 계획
- `git revert` 3개 commit. DB / 외부 시스템 영향 없음.

<br>

## TODO
- (별도 이슈) 같은 URL 재시도 억제 — 이슈 본문 "5. 회로 차단" 항목, 부분 로드 결과 cache 화. 본 PR 범위 외.
- (운영 모니터링) 머지 후 24h 라이브 로그에서 `graceful capture failed, proceeding with empty partial body` warn 발생 빈도 확인 — 너무 잦으면 GracefulCaptureTimeout 더 늘리는 운영 튜닝 검토.

<br>

## 논의 사항
- `IsValidPartialDOM` 검증 실패 시에도 partial 반환하는 정책은 이슈 본문 요구사항 "검증으로 다시 막지 않아야 함" 충족. 다운스트림이 빈/짧은 HTML 도 안전 처리해야 함 (parser 가 링크 0건 → 자연 종결).
- `partial_load=true` metadata 는 다운스트림이 신뢰도 분기에 활용 가능 — 본 PR 은 marker 만 설정, 분기 로직은 호출자 책임.
- chromedp 통합 테스트는 실제 브라우저 통신이 필요해 본 PR 범위에 포함하지 않음. helper invariants + 운영 검증으로 커버.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Changed timeout behavior to return partial page content instead of failing completely when navigation exceeds limits.
  * Improved error recovery by logging warnings and continuing with captured content when validation issues occur.

* **Tests**
  * Added test coverage for timeout error detection and partial DOM validation logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->