### PR TITLE
[FEAT#219] fetcher_rules 테이블 + Resolver 인프라 (이슈 #175 단계 1)

### DIFF
--- a/cmd/issuetracker/main.go
+++ b/cmd/issuetracker/main.go
@@ -17,6 +17,7 @@ import (
 	"issuetracker/internal/processor/fetcher/domain/general/sources/kr"
 	"issuetracker/internal/processor/fetcher/domain/general/sources/us"
 	"issuetracker/internal/processor/fetcher/handler"
+	fetcherRule "issuetracker/internal/processor/fetcher/rule"
 	crawlerWorker "issuetracker/internal/processor/fetcher/worker"
 	"issuetracker/internal/processor/parser/rule"
 	"issuetracker/internal/processor/parser/rule/llmgen"
@@ -140,11 +141,22 @@ func main() {
 	contentRepo := pgstore.NewContentRepository(pool, log)
 	contentSvc := service.NewContentService(contentRepo, log)
 
+	// host 단위 fetcher 룰 (이슈 #175 단계 1) — fetcher_rules 테이블 + Resolver wiring.
+	// 룰 부재 host 는 default chain (현재 동작 100% 보존).
+	fetcherRuleRepo, err := pgstore.NewFetcherRuleRepository(pool, log)
+	if err != nil {
+		log.WithError(err).Fatal("failed to construct fetcher rule repository")
+	}
+	fetcherResolver, err := fetcherRule.NewResolver(fetcherRuleRepo, log, 0)
+	if err != nil {
+		log.WithError(err).Fatal("failed to construct fetcher rule resolver")
+	}
+
 	// fetcher 측 등록 (이슈 #134 분리 후): chain handler 가 raw_contents 저장 + RawContentRef 발행만 수행.
-	if err := kr.Register(registry, core.DefaultConfig(), rawSvc, crawlerProducer, log); err != nil {
+	if err := kr.Register(registry, core.DefaultConfig(), rawSvc, crawlerProducer, fetcherResolver, log); err != nil {
 		log.WithError(err).Fatal("failed to register kr crawlers")
 	}
-	if err := us.Register(registry, core.DefaultConfig(), rawSvc, crawlerProducer, log); err != nil {
+	if err := us.Register(registry, core.DefaultConfig(), rawSvc, crawlerProducer, fetcherResolver, log); err != nil {
 		log.WithError(err).Fatal("failed to register us crawlers")
 	}
 

--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/segmentio/kafka-go v0.4.50
 	github.com/stretchr/testify v1.11.1
 	golang.org/x/net v0.48.0
+	golang.org/x/sync v0.19.0
 	google.golang.org/grpc v1.79.1
 	google.golang.org/protobuf v1.36.11
 )
@@ -48,7 +49,6 @@ require (
 	github.com/stretchr/objx v0.5.2 // indirect
 	go.uber.org/atomic v1.11.0 // indirect
 	go.yaml.in/yaml/v2 v2.4.2 // indirect
-	golang.org/x/sync v0.19.0 // indirect
 	golang.org/x/sys v0.39.0 // indirect
 	golang.org/x/text v0.32.0 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20251202230838-ff82c1b0f217 // indirect

--- a/internal/processor/fetcher/domain/general/chain_handler.go
+++ b/internal/processor/fetcher/domain/general/chain_handler.go
@@ -4,8 +4,11 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net/url"
 
 	"issuetracker/internal/processor/fetcher/core"
+	"issuetracker/internal/processor/fetcher/rule"
+	"issuetracker/internal/storage"
 	"issuetracker/internal/storage/service"
 	"issuetracker/pkg/logger"
 	"issuetracker/pkg/queue"
@@ -22,46 +25,115 @@ import (
 // consumer group) 의 책임으로 이전됨. 본 핸들러는 nil Content slice 를 반환하여 worker pool 의
 // publishNormalized 단계를 스킵하도록 함.
 //
+// host 단위 fetcher 정책 (이슈 #175 단계 1):
+//   - Resolver 가 nil 이거나 룰 미등록 host: DefaultChain 사용 (gq → browser fallback)
+//   - 룰 = 'chromedp': ChromedpChain 사용 (browser only) — goquery 시도 skip
+//   - 룰 = 'goquery':  DefaultChain 사용 (gq → browser fallback) — 현재로선 default 와 동일.
+//     단계 3 의 자동 downgrade 정책이 도입되면 GoQueryOnly chain 으로 분기 가능.
+//
 // 본 분리의 핵심 가치:
 //   - parser 가 무거워져도 (chromedp 가 큰 HTML 처리, LLM 호출 등) fetcher worker 슬롯 점유 X
 //   - parser worker 인스턴스 수를 fetcher 와 독립으로 스케일 가능
 //   - raw HTML 이 DB 에 보존되어 worker crash 시에도 복구 가능
 //   - 파싱 실패한 raw 가 잔존 → LLM 으로 새 rule 생성 (이슈 #149) 후 재처리 가능
 type ChainHandler struct {
-	Crawler  SourceCrawler
-	Chain    Handler
-	RawSvc   service.RawContentService
-	Producer queue.Producer
-	Log      *logger.Logger
+	Crawler       SourceCrawler
+	DefaultChain  Handler       // gq → browser (현재 동작 — 룰 미등록 host 의 기본)
+	ChromedpChain Handler       // browser only (룰 = chromedp 인 host 전용)
+	Resolver      rule.Resolver // optional. nil 이면 항상 DefaultChain 사용
+	RawSvc        service.RawContentService
+	Producer      queue.Producer
+	Log           *logger.Logger
 }
 
 // NewChainHandler 는 새 ChainHandler 를 생성합니다.
-// Chain / RawSvc / Producer / Log 모두 비-nil 필수.
+// DefaultChain / RawSvc / Producer / Log 모두 비-nil 필수.
+// ChromedpChain 이 nil 이면 룰 = 'chromedp' 매칭이어도 DefaultChain fallback (warn 로그).
+// Resolver 가 nil 이면 룰 조회 없이 항상 DefaultChain — 기존 동작 100% 보존.
 func NewChainHandler(
 	crawler SourceCrawler,
-	chain Handler,
+	defaultChain Handler,
+	chromedpChain Handler,
+	resolver rule.Resolver,
 	rawSvc service.RawContentService,
 	producer queue.Producer,
 	log *logger.Logger,
 ) *ChainHandler {
 	return &ChainHandler{
-		Crawler:  crawler,
-		Chain:    chain,
-		RawSvc:   rawSvc,
-		Producer: producer,
-		Log:      log,
+		Crawler:       crawler,
+		DefaultChain:  defaultChain,
+		ChromedpChain: chromedpChain,
+		Resolver:      resolver,
+		RawSvc:        rawSvc,
+		Producer:      producer,
+		Log:           log,
 	}
+}
+
+// selectChain 은 host 단위 fetcher 룰을 조회하여 사용할 chain 을 결정합니다.
+//
+// Resolver 가 nil 이거나 host 추출 실패 또는 룰 조회 실패 시 DefaultChain 으로 fallback —
+// fetcher 정책이 부분적으로 망가져도 fetch 자체는 계속 진행 (graceful degrade).
+//
+// chain 선택 외에 룰 결과를 로그에 남겨 운영 가시성 확보.
+func (h *ChainHandler) selectChain(ctx context.Context, job *core.CrawlJob) Handler {
+	if h.Resolver == nil {
+		return h.DefaultChain
+	}
+	host := extractHost(job.Target.URL)
+	if host == "" {
+		return h.DefaultChain
+	}
+	res, err := h.Resolver.Resolve(ctx, host)
+	if err != nil {
+		h.Log.WithFields(map[string]interface{}{
+			"url":  job.Target.URL,
+			"host": host,
+		}).WithError(err).Warn("fetcher rule resolve failed, falling back to default chain")
+		return h.DefaultChain
+	}
+	if !res.Found {
+		return h.DefaultChain
+	}
+	if res.Fetcher == storage.FetcherChromedp {
+		if h.ChromedpChain == nil {
+			h.Log.WithFields(map[string]interface{}{
+				"url":  job.Target.URL,
+				"host": host,
+			}).Warn("rule selected chromedp but no ChromedpChain wired, using default chain")
+			return h.DefaultChain
+		}
+		h.Log.WithFields(map[string]interface{}{
+			"url":     job.Target.URL,
+			"host":    host,
+			"fetcher": string(res.Fetcher),
+		}).Debug("fetcher rule applied")
+		return h.ChromedpChain
+	}
+	// FetcherGoQuery — 현재는 DefaultChain 과 동작이 같음. 단계 3 자동 downgrade 도입 시 분기.
+	return h.DefaultChain
+}
+
+// extractHost 는 URL 에서 host 만 뽑습니다 (port 제거 포함).
+// 파싱 실패 시 빈 문자열 — 호출자가 default chain 으로 fallback 분기.
+func extractHost(rawURL string) string {
+	u, err := url.Parse(rawURL)
+	if err != nil || u.Host == "" {
+		return ""
+	}
+	return u.Hostname()
 }
 
 // Handle 은 chain 통과로 raw HTML 을 fetch 하고 raw_contents 저장 + RawContentRef 발행을 수행합니다.
 //
 // 항상 nil Content slice 를 반환 — 파싱은 parser worker 가 TopicFetched 를 consume 하여 처리.
 func (h *ChainHandler) Handle(ctx context.Context, job *core.CrawlJob) ([]*core.Content, error) {
-	if h.Chain == nil || h.Log == nil || h.RawSvc == nil || h.Producer == nil {
+	if h.DefaultChain == nil || h.Log == nil || h.RawSvc == nil || h.Producer == nil {
 		return nil, fmt.Errorf("chain handler is not properly initialized")
 	}
 
-	raw, err := h.Chain.Handle(ctx, job)
+	chain := h.selectChain(ctx, job)
+	raw, err := chain.Handle(ctx, job)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/processor/fetcher/domain/general/sources/kr/registry.go
+++ b/internal/processor/fetcher/domain/general/sources/kr/registry.go
@@ -16,6 +16,7 @@ import (
 	"issuetracker/internal/processor/fetcher/handler"
 	cdp "issuetracker/internal/processor/fetcher/implementation/chromedp"
 	"issuetracker/internal/processor/fetcher/implementation/goquery"
+	"issuetracker/internal/processor/fetcher/rule"
 	"issuetracker/internal/storage/service"
 	"issuetracker/pkg/logger"
 	"issuetracker/pkg/queue"
@@ -24,6 +25,7 @@ import (
 // Register 는 모든 한국 사이트 크롤러를 registry 에 등록합니다 (이슈 #134 — fetcher/parser 분리 후).
 //
 // rawSvc + producer 는 ChainHandler (fetcher 측) 가 raw_contents 저장 + RawContentRef 발행에 사용.
+// resolver 는 호스트 단위 fetcher 룰 (이슈 #175) 적용. nil 이면 항상 default chain.
 // parser worker 는 본 함수 외부에서 별도 wiring (cmd/issuetracker/main.go).
 //
 // 등록 중 wiring 실패 (BuildChain misconfig 등) 시 error 반환 — 호출자가 fail-fast 결정.
@@ -32,15 +34,16 @@ func Register(
 	config core.Config,
 	rawSvc service.RawContentService,
 	producer queue.Producer,
+	resolver rule.Resolver,
 	log *logger.Logger,
 ) error {
-	if err := registerNaver(registry, config, rawSvc, producer, log); err != nil {
+	if err := registerNaver(registry, config, rawSvc, producer, resolver, log); err != nil {
 		return err
 	}
-	if err := registerYonhap(registry, config, rawSvc, producer, log); err != nil {
+	if err := registerYonhap(registry, config, rawSvc, producer, resolver, log); err != nil {
 		return err
 	}
-	if err := registerDaum(registry, config, rawSvc, producer, log); err != nil {
+	if err := registerDaum(registry, config, rawSvc, producer, resolver, log); err != nil {
 		return err
 	}
 	return nil
@@ -51,7 +54,7 @@ func Register(
 //   - 호출자가 넘긴 config 는 사용하지 않음 (사이트별 디테일 덮어쓰기 회피)
 //   - ChainHandler 는 fetch + raw store + RawContentRef publish 만 수행 — 파싱은 parser worker 책임
 
-func registerNaver(registry *handler.Registry, _ core.Config, rawSvc service.RawContentService, producer queue.Producer, log *logger.Logger) error {
+func registerNaver(registry *handler.Registry, _ core.Config, rawSvc service.RawContentService, producer queue.Producer, resolver rule.Resolver, log *logger.Logger) error {
 	cfg := naver.Default()
 
 	gqCrawler := goquery.NewGoqueryCrawler("naver-goquery", cfg.CrawlerConfig.SourceInfo, cfg.CrawlerConfig)
@@ -61,36 +64,42 @@ func registerNaver(registry *handler.Registry, _ core.Config, rawSvc service.Raw
 	brFetcher := fetcher.NewBrowserFetcher(cdpCrawler, cfg.CrawlerConfig)
 
 	crawler := general.NewGenericCrawler("naver", cfg.CrawlerConfig.SourceInfo, gqFetcher, cfg.BaseURL, cfg.CrawlerConfig)
-	chain, err := general.BuildChain(gqFetcher, brFetcher, log,
+	defaultChain, err := general.BuildChain(gqFetcher, brFetcher, log,
 		"data-lazy-src", "lazyload", "data-lazy",
 	)
 	if err != nil {
-		return fmt.Errorf("naver chain wiring: %w", err)
+		return fmt.Errorf("naver default chain wiring: %w", err)
+	}
+	chromedpChain, err := general.BuildChain(nil, brFetcher, log)
+	if err != nil {
+		return fmt.Errorf("naver chromedp chain wiring: %w", err)
 	}
 
-	registry.Register("naver", general.NewChainHandler(crawler, chain, rawSvc, producer, log))
+	registry.Register("naver", general.NewChainHandler(crawler, defaultChain, chromedpChain, resolver, rawSvc, producer, log))
 	log.WithField("crawler", "naver").Info("naver crawler registered")
 	return nil
 }
 
-func registerYonhap(registry *handler.Registry, _ core.Config, rawSvc service.RawContentService, producer queue.Producer, log *logger.Logger) error {
+func registerYonhap(registry *handler.Registry, _ core.Config, rawSvc service.RawContentService, producer queue.Producer, resolver rule.Resolver, log *logger.Logger) error {
 	cfg := yonhap.Default()
 
 	gqCrawler := goquery.NewGoqueryCrawler("yonhap-goquery", cfg.CrawlerConfig.SourceInfo, cfg.CrawlerConfig)
 	gqFetcher := fetcher.NewGoqueryFetcher(gqCrawler)
 
 	crawler := general.NewGenericCrawler("yonhap", cfg.CrawlerConfig.SourceInfo, gqFetcher, cfg.BaseURL, cfg.CrawlerConfig)
-	chain, err := general.BuildChain(gqFetcher, nil, log)
+	defaultChain, err := general.BuildChain(gqFetcher, nil, log)
 	if err != nil {
 		return fmt.Errorf("yonhap chain wiring: %w", err)
 	}
 
-	registry.Register("yonhap", general.NewChainHandler(crawler, chain, rawSvc, producer, log))
+	// yonhap 은 browser fetcher 미설정 — chromedpChain=nil. 룰=chromedp 매칭 시 ChainHandler 가
+	// warn 로그 + DefaultChain 으로 fallback.
+	registry.Register("yonhap", general.NewChainHandler(crawler, defaultChain, nil, resolver, rawSvc, producer, log))
 	log.WithField("crawler", "yonhap").Info("yonhap crawler registered")
 	return nil
 }
 
-func registerDaum(registry *handler.Registry, _ core.Config, rawSvc service.RawContentService, producer queue.Producer, log *logger.Logger) error {
+func registerDaum(registry *handler.Registry, _ core.Config, rawSvc service.RawContentService, producer queue.Producer, resolver rule.Resolver, log *logger.Logger) error {
 	cfg := daum.Default()
 
 	gqCrawler := goquery.NewGoqueryCrawler("daum-goquery", cfg.CrawlerConfig.SourceInfo, cfg.CrawlerConfig)
@@ -100,14 +109,18 @@ func registerDaum(registry *handler.Registry, _ core.Config, rawSvc service.RawC
 	brFetcher := fetcher.NewBrowserFetcher(cdpCrawler, cfg.CrawlerConfig)
 
 	crawler := general.NewGenericCrawler("daum", cfg.CrawlerConfig.SourceInfo, gqFetcher, cfg.BaseURL, cfg.CrawlerConfig)
-	chain, err := general.BuildChain(gqFetcher, brFetcher, log,
+	defaultChain, err := general.BuildChain(gqFetcher, brFetcher, log,
 		"data-lazy-src", "lazyload", "data-lazy",
 	)
 	if err != nil {
-		return fmt.Errorf("daum chain wiring: %w", err)
+		return fmt.Errorf("daum default chain wiring: %w", err)
+	}
+	chromedpChain, err := general.BuildChain(nil, brFetcher, log)
+	if err != nil {
+		return fmt.Errorf("daum chromedp chain wiring: %w", err)
 	}
 
-	registry.Register("daum", general.NewChainHandler(crawler, chain, rawSvc, producer, log))
+	registry.Register("daum", general.NewChainHandler(crawler, defaultChain, chromedpChain, resolver, rawSvc, producer, log))
 	log.WithField("crawler", "daum").Info("daum crawler registered")
 	return nil
 }

--- a/internal/processor/fetcher/domain/general/sources/us/registry.go
+++ b/internal/processor/fetcher/domain/general/sources/us/registry.go
@@ -13,25 +13,28 @@ import (
 	"issuetracker/internal/processor/fetcher/handler"
 	cdp "issuetracker/internal/processor/fetcher/implementation/chromedp"
 	"issuetracker/internal/processor/fetcher/implementation/goquery"
+	"issuetracker/internal/processor/fetcher/rule"
 	"issuetracker/internal/storage/service"
 	"issuetracker/pkg/logger"
 	"issuetracker/pkg/queue"
 )
 
 // Register 는 모든 미국 사이트 크롤러를 registry 에 등록합니다 (이슈 #134 — fetcher/parser 분리 후).
+// resolver 는 호스트 단위 fetcher 룰 (이슈 #175) 적용. nil 이면 항상 default chain.
 // 등록 중 wiring 실패 시 error 반환 — 호출자가 fail-fast 결정.
 func Register(
 	registry *handler.Registry,
 	config core.Config,
 	rawSvc service.RawContentService,
 	producer queue.Producer,
+	resolver rule.Resolver,
 	log *logger.Logger,
 ) error {
-	return registerCNN(registry, config, rawSvc, producer, log)
+	return registerCNN(registry, config, rawSvc, producer, resolver, log)
 }
 
 // 사이트별 등록 패턴은 kr/registry.go 와 동일.
-func registerCNN(registry *handler.Registry, _ core.Config, rawSvc service.RawContentService, producer queue.Producer, log *logger.Logger) error {
+func registerCNN(registry *handler.Registry, _ core.Config, rawSvc service.RawContentService, producer queue.Producer, resolver rule.Resolver, log *logger.Logger) error {
 	cfg := cnn.Default()
 
 	gqCrawler := goquery.NewGoqueryCrawler("cnn-goquery", cfg.CrawlerConfig.SourceInfo, cfg.CrawlerConfig)
@@ -41,14 +44,18 @@ func registerCNN(registry *handler.Registry, _ core.Config, rawSvc service.RawCo
 	brFetcher := fetcher.NewBrowserFetcher(cdpCrawler, cfg.CrawlerConfig)
 
 	crawler := general.NewGenericCrawler("cnn", cfg.CrawlerConfig.SourceInfo, gqFetcher, cfg.BaseURL, cfg.CrawlerConfig)
-	chain, err := general.BuildChain(gqFetcher, brFetcher, log,
+	defaultChain, err := general.BuildChain(gqFetcher, brFetcher, log,
 		"data-lazy-src", "lazyload", "data-lazy",
 	)
 	if err != nil {
-		return fmt.Errorf("cnn chain wiring: %w", err)
+		return fmt.Errorf("cnn default chain wiring: %w", err)
+	}
+	chromedpChain, err := general.BuildChain(nil, brFetcher, log)
+	if err != nil {
+		return fmt.Errorf("cnn chromedp chain wiring: %w", err)
 	}
 
-	registry.Register("cnn", general.NewChainHandler(crawler, chain, rawSvc, producer, log))
+	registry.Register("cnn", general.NewChainHandler(crawler, defaultChain, chromedpChain, resolver, rawSvc, producer, log))
 	log.WithField("crawler", "cnn").Info("cnn crawler registered")
 	return nil
 }

--- a/internal/processor/fetcher/rule/resolver.go
+++ b/internal/processor/fetcher/rule/resolver.go
@@ -1,0 +1,108 @@
+// Package rule 는 fetcher 단계의 host 단위 정책 (fetcher_rules) 을 매핑하는 Resolver 를 제공합니다 (이슈 #175 단계 1, sub-issue #219).
+//
+// fetcher_rules 테이블에 등록된 host 는 본 Resolver 가 해당 fetcher (goquery / chromedp) 를
+// 반환합니다. 미등록 host 는 ResolveResult{Found: false} 가 되어 호출자 (ChainHandler) 가
+// default chain (현재 동작) 을 사용합니다.
+//
+// 핫패스 호출 빈도가 높아 sync.Map 기반 in-memory cache + TTL 로 DB 부하를 흡수합니다.
+// 캐시 entry 는 negative (not found) 도 보관 — 동일 host 의 반복 조회가 매번 DB 까지 가지
+// 않도록.
+package rule
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"time"
+
+	"issuetracker/internal/storage"
+	"issuetracker/pkg/logger"
+)
+
+// DefaultCacheTTL 은 cache entry 의 기본 유효기간입니다.
+//
+// 운영자 manual UPSERT 또는 단계 3 의 자동 UPSERT 가 적용되기까지의 최대 지연.
+// 너무 짧으면 DB 부하 ↑, 너무 길면 운영 변경 반영 지연 ↑. 5분이 일반적 trade-off.
+const DefaultCacheTTL = 5 * time.Minute
+
+// ResolveResult 는 host 단위 fetcher 룰 조회 결과입니다.
+//
+// Found=false 면 매칭 룰 없음 — 호출자는 default chain 동작.
+// Found=true 면 Fetcher 가 'goquery' 또는 'chromedp'.
+type ResolveResult struct {
+	Found   bool
+	Fetcher storage.FetcherKind
+}
+
+// Resolver 는 host → fetcher 매핑을 조회합니다.
+//
+// 모든 구현체는 goroutine-safe 해야 합니다 — fetcher worker 가 동시에 Resolve 를 호출.
+type Resolver interface {
+	Resolve(ctx context.Context, host string) (ResolveResult, error)
+
+	// Invalidate 는 host 의 cache entry 를 즉시 만료시킵니다 (단계 3 의 자동 UPSERT 직후 호출).
+	Invalidate(host string)
+}
+
+// cacheEntry 는 sync.Map 의 value — Resolve 결과 + cached 시각.
+type cacheEntry struct {
+	result   ResolveResult
+	cachedAt time.Time
+}
+
+// dbResolver 는 fetcher_rules 테이블을 source of truth 로 사용하는 Resolver 입니다.
+type dbResolver struct {
+	repo  storage.FetcherRuleRepository
+	log   *logger.Logger
+	ttl   time.Duration
+	cache sync.Map // map[string]cacheEntry
+}
+
+// NewResolver 는 새 dbResolver 를 생성합니다.
+//
+// repo 가 nil 이면 wiring 오류 — error 반환 (이슈 #208 panic-on-nil 정책).
+// ttl 이 0 이하이면 DefaultCacheTTL 사용.
+func NewResolver(repo storage.FetcherRuleRepository, log *logger.Logger, ttl time.Duration) (Resolver, error) {
+	if repo == nil {
+		return nil, errors.New("rule: NewResolver requires non-nil FetcherRuleRepository")
+	}
+	if ttl <= 0 {
+		ttl = DefaultCacheTTL
+	}
+	return &dbResolver{repo: repo, log: log, ttl: ttl}, nil
+}
+
+// Resolve 는 host 의 fetcher_rules row 를 조회합니다.
+//
+// cache hit 시 즉시 반환. miss / 만료 시 DB 조회 후 결과 (positive / negative) 모두 cache.
+// 빈 host 는 ResolveResult{Found: false}, nil 에러 — 핫패스에서 빈 host 도 default 분기.
+func (r *dbResolver) Resolve(ctx context.Context, host string) (ResolveResult, error) {
+	if host == "" {
+		return ResolveResult{}, nil
+	}
+
+	if cached, ok := r.cache.Load(host); ok {
+		if e, ok := cached.(cacheEntry); ok && time.Since(e.cachedAt) < r.ttl {
+			return e.result, nil
+		}
+	}
+
+	rec, err := r.repo.GetByHost(ctx, host)
+	if err != nil {
+		if errors.Is(err, storage.ErrNotFound) {
+			result := ResolveResult{Found: false}
+			r.cache.Store(host, cacheEntry{result: result, cachedAt: time.Now()})
+			return result, nil
+		}
+		return ResolveResult{}, err
+	}
+
+	result := ResolveResult{Found: true, Fetcher: rec.Fetcher}
+	r.cache.Store(host, cacheEntry{result: result, cachedAt: time.Now()})
+	return result, nil
+}
+
+// Invalidate 는 host 의 cache entry 를 즉시 제거합니다.
+func (r *dbResolver) Invalidate(host string) {
+	r.cache.Delete(host)
+}

--- a/internal/processor/fetcher/rule/resolver.go
+++ b/internal/processor/fetcher/rule/resolver.go
@@ -15,6 +15,8 @@ import (
 	"sync"
 	"time"
 
+	"golang.org/x/sync/singleflight"
+
 	"issuetracker/internal/storage"
 	"issuetracker/pkg/logger"
 )
@@ -51,11 +53,16 @@ type cacheEntry struct {
 }
 
 // dbResolver 는 fetcher_rules 테이블을 source of truth 로 사용하는 Resolver 입니다.
+//
+// singleflight 로 thundering herd 방지 (gemini 피드백): cache miss / 만료 시점에 동일 host 에
+// 대해 여러 goroutine 이 동시에 진입해도 DB 조회는 단 1회만 발생하고 모든 caller 가 같은 결과를
+// 공유함.
 type dbResolver struct {
-	repo  storage.FetcherRuleRepository
-	log   *logger.Logger
-	ttl   time.Duration
-	cache sync.Map // map[string]cacheEntry
+	repo   storage.FetcherRuleRepository
+	log    *logger.Logger
+	ttl    time.Duration
+	cache  sync.Map // map[string]cacheEntry
+	flight singleflight.Group
 }
 
 // NewResolver 는 새 dbResolver 를 생성합니다.
@@ -74,8 +81,9 @@ func NewResolver(repo storage.FetcherRuleRepository, log *logger.Logger, ttl tim
 
 // Resolve 는 host 의 fetcher_rules row 를 조회합니다.
 //
-// cache hit 시 즉시 반환. miss / 만료 시 DB 조회 후 결과 (positive / negative) 모두 cache.
-// 빈 host 는 ResolveResult{Found: false}, nil 에러 — 핫패스에서 빈 host 도 default 분기.
+// cache hit 시 즉시 반환. miss / 만료 시 singleflight 로 DB 조회를 단일화 (동일 host 동시 진입
+// 시 1회만 hit), 결과 (positive / negative) 모두 cache. 빈 host 는 ResolveResult{Found: false},
+// nil 에러 — 핫패스에서 빈 host 도 default 분기.
 func (r *dbResolver) Resolve(ctx context.Context, host string) (ResolveResult, error) {
 	if host == "" {
 		return ResolveResult{}, nil
@@ -87,19 +95,30 @@ func (r *dbResolver) Resolve(ctx context.Context, host string) (ResolveResult, e
 		}
 	}
 
-	rec, err := r.repo.GetByHost(ctx, host)
-	if err != nil {
-		if errors.Is(err, storage.ErrNotFound) {
-			result := ResolveResult{Found: false}
-			r.cache.Store(host, cacheEntry{result: result, cachedAt: time.Now()})
-			return result, nil
+	v, err, _ := r.flight.Do(host, func() (interface{}, error) {
+		// double-check: singleflight leader 가 진입한 사이 다른 leader 가 cache 채웠을 수 있음.
+		if cached, ok := r.cache.Load(host); ok {
+			if e, ok := cached.(cacheEntry); ok && time.Since(e.cachedAt) < r.ttl {
+				return e.result, nil
+			}
 		}
+		rec, err := r.repo.GetByHost(ctx, host)
+		if err != nil {
+			if errors.Is(err, storage.ErrNotFound) {
+				result := ResolveResult{Found: false}
+				r.cache.Store(host, cacheEntry{result: result, cachedAt: time.Now()})
+				return result, nil
+			}
+			return ResolveResult{}, err
+		}
+		result := ResolveResult{Found: true, Fetcher: rec.Fetcher}
+		r.cache.Store(host, cacheEntry{result: result, cachedAt: time.Now()})
+		return result, nil
+	})
+	if err != nil {
 		return ResolveResult{}, err
 	}
-
-	result := ResolveResult{Found: true, Fetcher: rec.Fetcher}
-	r.cache.Store(host, cacheEntry{result: result, cachedAt: time.Now()})
-	return result, nil
+	return v.(ResolveResult), nil
 }
 
 // Invalidate 는 host 의 cache entry 를 즉시 제거합니다.

--- a/internal/storage/fetcher_rule.go
+++ b/internal/storage/fetcher_rule.go
@@ -1,0 +1,56 @@
+package storage
+
+import (
+	"context"
+	"time"
+)
+
+// FetcherKind 는 fetch 단계에서 사용할 도구 식별자입니다 (이슈 #175 단계 1, sub-issue #219).
+//
+// FetcherKind discriminates between the static-HTML fetcher (goquery) and the headless
+// browser fetcher (chromedp). host 단위로 어느 fetcher 가 우선인지 결정하는 단일 키.
+type FetcherKind string
+
+const (
+	// FetcherGoQuery: 정적 HTML fetch (가벼움, 기본). lazy-load / SPA 가 아닌 일반 페이지에 적합.
+	FetcherGoQuery FetcherKind = "goquery"
+	// FetcherChromedp: 헤드리스 브라우저 fetch (무거움). SPA / dynamic content 사이트에 적용.
+	FetcherChromedp FetcherKind = "chromedp"
+)
+
+// IsValid 는 fetcher_rules.fetcher CHECK 제약과 동일한 검증을 application 측에서 수행합니다.
+func (k FetcherKind) IsValid() bool {
+	return k == FetcherGoQuery || k == FetcherChromedp
+}
+
+// FetcherRuleRecord 는 fetcher_rules 테이블의 단일 행입니다.
+//
+// FetcherRuleRecord represents a single row of the fetcher_rules table.
+type FetcherRuleRecord struct {
+	ID          int64
+	HostPattern string      // exact host (예: "edition.cnn.com")
+	Fetcher     FetcherKind // "goquery" | "chromedp"
+	Reason      string      // "manual" | "auto_upgrade_validation" | ...
+	CreatedAt   time.Time
+	UpdatedAt   time.Time
+}
+
+// FetcherRuleRepository 는 fetcher_rules 테이블에 대한 데이터 접근 인터페이스입니다.
+//
+// 모든 구현체는 goroutine-safe 해야 합니다 — Resolver 가 핫패스에서 GetByHost 를 호출.
+type FetcherRuleRepository interface {
+	// Upsert 는 host_pattern 단위 UPSERT 입니다. 새 row 면 INSERT, 기존이면 fetcher / reason / updated_at
+	// 갱신. host_pattern 의 빈 문자열은 storage.ErrInvalid 반환. fetcher 가 IsValid 가 아니면 동일.
+	Upsert(ctx context.Context, host string, fetcher FetcherKind, reason string) error
+
+	// GetByHost 는 host_pattern 으로 단일 row 를 조회합니다.
+	// 매칭 없으면 storage.ErrNotFound 반환 — Resolver 가 errors.Is 로 분기.
+	GetByHost(ctx context.Context, host string) (*FetcherRuleRecord, error)
+
+	// List 는 모든 fetcher_rules 를 host_pattern ASC 로 반환합니다 (운영 도구용).
+	// 본 단계에서는 페이지네이션 미도입 — host 수가 수백 단위 까지는 단일 응답 충분.
+	List(ctx context.Context) ([]*FetcherRuleRecord, error)
+
+	// Delete 는 host_pattern 으로 row 를 제거합니다. 존재하지 않아도 nil 반환 (idempotent).
+	Delete(ctx context.Context, host string) error
+}

--- a/internal/storage/postgres/fetcher_rule.go
+++ b/internal/storage/postgres/fetcher_rule.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
@@ -11,6 +12,13 @@ import (
 	"issuetracker/internal/storage"
 	"issuetracker/pkg/logger"
 )
+
+// canonicalizeHost 는 host_pattern 의 표준형을 강제합니다 (CodeRabbit 피드백).
+// migration 013 의 CHECK 제약 (LOWER(BTRIM(...))) 과 동일한 정규화를 application 측에서 적용해
+// 대소문자 / padding 차이로 인한 silent miss 를 회피.
+func canonicalizeHost(host string) string {
+	return strings.ToLower(strings.TrimSpace(host))
+}
 
 // pgFetcherRuleRepository 는 pgx/v5 기반 FetcherRuleRepository 구현체입니다 (이슈 #175 단계 1).
 type pgFetcherRuleRepository struct {
@@ -46,6 +54,7 @@ DO UPDATE SET
 // Upsert 는 host_pattern 단위 UPSERT 를 수행합니다.
 // host 가 빈 문자열이거나 fetcher 가 유효하지 않으면 storage.ErrInvalid 반환 — DB CHECK 제약과 application 측 검증 이중화.
 func (r *pgFetcherRuleRepository) Upsert(ctx context.Context, host string, fetcher storage.FetcherKind, reason string) error {
+	host = canonicalizeHost(host)
 	if host == "" {
 		return fmt.Errorf("upsert fetcher rule: %w: empty host_pattern", storage.ErrInvalid)
 	}
@@ -67,6 +76,7 @@ WHERE host_pattern = $1
 // GetByHost 는 host_pattern exact match 로 단일 row 를 반환합니다.
 // 매칭 없으면 storage.ErrNotFound — Resolver 가 errors.Is 로 분기 (캐시 negative entry 등).
 func (r *pgFetcherRuleRepository) GetByHost(ctx context.Context, host string) (*storage.FetcherRuleRecord, error) {
+	host = canonicalizeHost(host)
 	rec := &storage.FetcherRuleRecord{}
 	var fetcher string
 	err := r.pool.QueryRow(ctx, sqlGetFetcherRuleByHost, host).Scan(
@@ -116,6 +126,7 @@ const sqlDeleteFetcherRule = `DELETE FROM fetcher_rules WHERE host_pattern = $1`
 
 // Delete 는 host_pattern 으로 row 를 제거합니다. 존재 여부와 무관하게 nil 반환 (idempotent).
 func (r *pgFetcherRuleRepository) Delete(ctx context.Context, host string) error {
+	host = canonicalizeHost(host)
 	if _, err := r.pool.Exec(ctx, sqlDeleteFetcherRule, host); err != nil {
 		return fmt.Errorf("delete fetcher rule %s: %w", host, err)
 	}

--- a/internal/storage/postgres/fetcher_rule.go
+++ b/internal/storage/postgres/fetcher_rule.go
@@ -1,0 +1,123 @@
+package postgres
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"issuetracker/internal/storage"
+	"issuetracker/pkg/logger"
+)
+
+// pgFetcherRuleRepository 는 pgx/v5 기반 FetcherRuleRepository 구현체입니다 (이슈 #175 단계 1).
+type pgFetcherRuleRepository struct {
+	pool *pgxpool.Pool
+}
+
+// NewFetcherRuleRepository 는 pgxpool 을 사용하는 FetcherRuleRepository 를 생성합니다.
+//
+// log 인자는 향후 query latency / error log 등 운영 가시성 추가를 대비해 시그니처에 유지하되,
+// 현재 구현에서는 사용하지 않습니다 — 다른 Repository 들과 일관된 시그니처.
+//
+// pool 이 nil 이면 error 반환 (이슈 #208 의 panic-on-nil → error 마이그레이션 정책).
+func NewFetcherRuleRepository(pool *pgxpool.Pool, log *logger.Logger) (storage.FetcherRuleRepository, error) {
+	if pool == nil {
+		return nil, errors.New("postgres: NewFetcherRuleRepository requires non-nil pool")
+	}
+	_ = log
+	return &pgFetcherRuleRepository{pool: pool}, nil
+}
+
+// sqlUpsertFetcherRule 는 host_pattern 단위 UPSERT 입니다 — 신규 INSERT 또는 fetcher / reason 갱신.
+// updated_at 은 ON CONFLICT 분기에서 NOW() 로 명시 갱신.
+const sqlUpsertFetcherRule = `
+INSERT INTO fetcher_rules (host_pattern, fetcher, reason)
+VALUES ($1, $2, $3)
+ON CONFLICT (host_pattern)
+DO UPDATE SET
+  fetcher    = EXCLUDED.fetcher,
+  reason     = EXCLUDED.reason,
+  updated_at = NOW()
+`
+
+// Upsert 는 host_pattern 단위 UPSERT 를 수행합니다.
+// host 가 빈 문자열이거나 fetcher 가 유효하지 않으면 storage.ErrInvalid 반환 — DB CHECK 제약과 application 측 검증 이중화.
+func (r *pgFetcherRuleRepository) Upsert(ctx context.Context, host string, fetcher storage.FetcherKind, reason string) error {
+	if host == "" {
+		return fmt.Errorf("upsert fetcher rule: %w: empty host_pattern", storage.ErrInvalid)
+	}
+	if !fetcher.IsValid() {
+		return fmt.Errorf("upsert fetcher rule: %w: invalid fetcher %q", storage.ErrInvalid, fetcher)
+	}
+	if _, err := r.pool.Exec(ctx, sqlUpsertFetcherRule, host, string(fetcher), reason); err != nil {
+		return fmt.Errorf("upsert fetcher rule for %s: %w", host, err)
+	}
+	return nil
+}
+
+const sqlGetFetcherRuleByHost = `
+SELECT id, host_pattern, fetcher, COALESCE(reason, ''), created_at, updated_at
+FROM fetcher_rules
+WHERE host_pattern = $1
+`
+
+// GetByHost 는 host_pattern exact match 로 단일 row 를 반환합니다.
+// 매칭 없으면 storage.ErrNotFound — Resolver 가 errors.Is 로 분기 (캐시 negative entry 등).
+func (r *pgFetcherRuleRepository) GetByHost(ctx context.Context, host string) (*storage.FetcherRuleRecord, error) {
+	rec := &storage.FetcherRuleRecord{}
+	var fetcher string
+	err := r.pool.QueryRow(ctx, sqlGetFetcherRuleByHost, host).Scan(
+		&rec.ID, &rec.HostPattern, &fetcher, &rec.Reason, &rec.CreatedAt, &rec.UpdatedAt,
+	)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, storage.ErrNotFound
+		}
+		return nil, fmt.Errorf("get fetcher rule by host %s: %w", host, err)
+	}
+	rec.Fetcher = storage.FetcherKind(fetcher)
+	return rec, nil
+}
+
+const sqlListFetcherRules = `
+SELECT id, host_pattern, fetcher, COALESCE(reason, ''), created_at, updated_at
+FROM fetcher_rules
+ORDER BY host_pattern ASC
+`
+
+// List 는 모든 fetcher_rules 를 host_pattern ASC 로 반환합니다.
+func (r *pgFetcherRuleRepository) List(ctx context.Context) ([]*storage.FetcherRuleRecord, error) {
+	rows, err := r.pool.Query(ctx, sqlListFetcherRules)
+	if err != nil {
+		return nil, fmt.Errorf("list fetcher rules: %w", err)
+	}
+	defer rows.Close()
+
+	var out []*storage.FetcherRuleRecord
+	for rows.Next() {
+		rec := &storage.FetcherRuleRecord{}
+		var fetcher string
+		if err := rows.Scan(&rec.ID, &rec.HostPattern, &fetcher, &rec.Reason, &rec.CreatedAt, &rec.UpdatedAt); err != nil {
+			return nil, fmt.Errorf("scan fetcher rule: %w", err)
+		}
+		rec.Fetcher = storage.FetcherKind(fetcher)
+		out = append(out, rec)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("list fetcher rules iter: %w", err)
+	}
+	return out, nil
+}
+
+const sqlDeleteFetcherRule = `DELETE FROM fetcher_rules WHERE host_pattern = $1`
+
+// Delete 는 host_pattern 으로 row 를 제거합니다. 존재 여부와 무관하게 nil 반환 (idempotent).
+func (r *pgFetcherRuleRepository) Delete(ctx context.Context, host string) error {
+	if _, err := r.pool.Exec(ctx, sqlDeleteFetcherRule, host); err != nil {
+		return fmt.Errorf("delete fetcher rule %s: %w", host, err)
+	}
+	return nil
+}

--- a/migrations/down/013_fetcher_rules.sql
+++ b/migrations/down/013_fetcher_rules.sql
@@ -1,0 +1,3 @@
+-- 013_fetcher_rules down: 호스트 단위 fetcher 선택 정책 테이블 제거.
+DROP INDEX IF EXISTS idx_fetcher_rules_host;
+DROP TABLE IF EXISTS fetcher_rules;

--- a/migrations/up/013_fetcher_rules.sql
+++ b/migrations/up/013_fetcher_rules.sql
@@ -1,0 +1,30 @@
+-- 013_fetcher_rules: 호스트 단위 fetcher 선택 정책 테이블 (이슈 #175 단계 1, sub-issue #219)
+--
+-- 배경:
+--   기존 fetcher 파이프라인은 모든 host 에 동일 chain (goquery 우선 + lazy-load 시 chromedp fallback)
+--   적용. SPA / dynamic content 사이트는 \"형식적으로는 받아왔으나 본문이 비어있는\" 상태로 통과해
+--   parsing 까지 가서야 빈 본문 발견. 본 테이블은 host 단위로 fetcher 선택을 강제할 수 있는 base 를
+--   마련한다.
+--
+-- 자동 전환은 별도 sub-issue (#220 카운팅 + #221 자동 UPSERT) 의 책임. 본 단계에서는 운영자
+-- manual UPSERT + Resolver 의 조회만 동작.
+--
+-- 호환성:
+--   - fetcher_rules 부재 host 는 default chain (현재 동작 100% 보존)
+--   - parsing_rules 와 별도 테이블 — lifecycle / 정책 다름
+
+CREATE TABLE IF NOT EXISTS fetcher_rules (
+  id           BIGSERIAL PRIMARY KEY,
+  host_pattern TEXT      NOT NULL UNIQUE,
+  fetcher      TEXT      NOT NULL CHECK (fetcher IN ('goquery', 'chromedp')),
+  reason       TEXT,
+  created_at   TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at   TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_fetcher_rules_host ON fetcher_rules(host_pattern);
+
+COMMENT ON TABLE  fetcher_rules               IS 'host 단위 fetcher 선택 정책 (이슈 #175 단계 1).';
+COMMENT ON COLUMN fetcher_rules.host_pattern  IS 'exact host match (예: ''edition.cnn.com''). path 단위 매칭은 본 단계 scope 외.';
+COMMENT ON COLUMN fetcher_rules.fetcher       IS 'goquery | chromedp — Resolver 가 host 매칭 시 반환할 fetcher 식별자.';
+COMMENT ON COLUMN fetcher_rules.reason        IS 'manual | auto_upgrade_validation | ... — UPSERT 사유 audit.';

--- a/migrations/up/013_fetcher_rules.sql
+++ b/migrations/up/013_fetcher_rules.sql
@@ -15,7 +15,9 @@
 
 CREATE TABLE IF NOT EXISTS fetcher_rules (
   id           BIGSERIAL PRIMARY KEY,
-  host_pattern TEXT      NOT NULL UNIQUE,
+  host_pattern TEXT      NOT NULL UNIQUE
+              CHECK (host_pattern = LOWER(BTRIM(host_pattern)))
+              CHECK (BTRIM(host_pattern) <> ''),
   fetcher      TEXT      NOT NULL CHECK (fetcher IN ('goquery', 'chromedp')),
   reason       TEXT,
   created_at   TIMESTAMPTZ NOT NULL DEFAULT NOW(),

--- a/test/internal/processor/fetcher/rule/resolver_test.go
+++ b/test/internal/processor/fetcher/rule/resolver_test.go
@@ -1,0 +1,194 @@
+package rule_test
+
+import (
+	"context"
+	"errors"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	fetcherRule "issuetracker/internal/processor/fetcher/rule"
+	"issuetracker/internal/storage"
+	"issuetracker/pkg/logger"
+)
+
+// stubFetcherRuleRepo 는 FetcherRuleRepository 의 in-memory 스텁입니다.
+//
+// repo 동작 자체는 본 sub 의 검증 대상이 아니라 (Postgres 통합 테스트 영역) Resolver 의
+// cache / fallback / Invalidate 동작을 격리 검증하기 위한 stub.
+type stubFetcherRuleRepo struct {
+	rules map[string]*storage.FetcherRuleRecord
+	err   error
+	calls atomic.Int32
+}
+
+func (s *stubFetcherRuleRepo) Upsert(ctx context.Context, host string, fetcher storage.FetcherKind, reason string) error {
+	if s.rules == nil {
+		s.rules = make(map[string]*storage.FetcherRuleRecord)
+	}
+	s.rules[host] = &storage.FetcherRuleRecord{HostPattern: host, Fetcher: fetcher, Reason: reason}
+	return nil
+}
+func (s *stubFetcherRuleRepo) GetByHost(ctx context.Context, host string) (*storage.FetcherRuleRecord, error) {
+	s.calls.Add(1)
+	if s.err != nil {
+		return nil, s.err
+	}
+	if r, ok := s.rules[host]; ok {
+		return r, nil
+	}
+	return nil, storage.ErrNotFound
+}
+func (s *stubFetcherRuleRepo) List(ctx context.Context) ([]*storage.FetcherRuleRecord, error) {
+	out := make([]*storage.FetcherRuleRecord, 0, len(s.rules))
+	for _, r := range s.rules {
+		out = append(out, r)
+	}
+	return out, nil
+}
+func (s *stubFetcherRuleRepo) Delete(ctx context.Context, host string) error {
+	delete(s.rules, host)
+	return nil
+}
+
+func newTestLogger() *logger.Logger {
+	return logger.New(logger.DefaultConfig())
+}
+
+// TestNewResolver_NilRepo_ReturnsError:
+// 이슈 #208 panic-on-nil → error 정책 — wiring 시 nil repo 는 즉시 error.
+func TestNewResolver_NilRepo_ReturnsError(t *testing.T) {
+	_, err := fetcherRule.NewResolver(nil, newTestLogger(), 0)
+	assert.Error(t, err)
+}
+
+// TestResolver_HostNotFound_ReturnsFalse:
+// fetcher_rules 부재 host 는 ResolveResult{Found: false} — 호출자가 default chain 사용 분기.
+func TestResolver_HostNotFound_ReturnsFalse(t *testing.T) {
+	repo := &stubFetcherRuleRepo{}
+	r, err := fetcherRule.NewResolver(repo, newTestLogger(), 0)
+	require.NoError(t, err)
+
+	res, err := r.Resolve(context.Background(), "unknown.example.com")
+	require.NoError(t, err)
+	assert.False(t, res.Found)
+}
+
+// TestResolver_HostMatched_ReturnsFetcher:
+// 매칭 host 는 등록된 fetcher 그대로 반환.
+func TestResolver_HostMatched_ReturnsFetcher(t *testing.T) {
+	repo := &stubFetcherRuleRepo{
+		rules: map[string]*storage.FetcherRuleRecord{
+			"edition.cnn.com": {HostPattern: "edition.cnn.com", Fetcher: storage.FetcherChromedp},
+		},
+	}
+	r, err := fetcherRule.NewResolver(repo, newTestLogger(), 0)
+	require.NoError(t, err)
+
+	res, err := r.Resolve(context.Background(), "edition.cnn.com")
+	require.NoError(t, err)
+	assert.True(t, res.Found)
+	assert.Equal(t, storage.FetcherChromedp, res.Fetcher)
+}
+
+// TestResolver_CachesPositiveResult:
+// 같은 host 의 반복 조회는 cache hit — repo.GetByHost 가 1회만 호출.
+func TestResolver_CachesPositiveResult(t *testing.T) {
+	repo := &stubFetcherRuleRepo{
+		rules: map[string]*storage.FetcherRuleRecord{
+			"edition.cnn.com": {HostPattern: "edition.cnn.com", Fetcher: storage.FetcherChromedp},
+		},
+	}
+	r, err := fetcherRule.NewResolver(repo, newTestLogger(), 1*time.Hour)
+	require.NoError(t, err)
+
+	for i := 0; i < 5; i++ {
+		_, _ = r.Resolve(context.Background(), "edition.cnn.com")
+	}
+	assert.Equal(t, int32(1), repo.calls.Load())
+}
+
+// TestResolver_CachesNegativeResult:
+// not-found 도 cache — 동일 host 의 반복 조회가 매번 DB 까지 가지 않도록.
+func TestResolver_CachesNegativeResult(t *testing.T) {
+	repo := &stubFetcherRuleRepo{}
+	r, err := fetcherRule.NewResolver(repo, newTestLogger(), 1*time.Hour)
+	require.NoError(t, err)
+
+	for i := 0; i < 5; i++ {
+		_, _ = r.Resolve(context.Background(), "unknown.example.com")
+	}
+	assert.Equal(t, int32(1), repo.calls.Load())
+}
+
+// TestResolver_RepoError_PropagatesNoCache:
+// repo 가 ErrNotFound 가 아닌 에러를 반환하면 caller 에 전파 + cache 미저장 (다음 호출에 재시도).
+func TestResolver_RepoError_PropagatesNoCache(t *testing.T) {
+	repo := &stubFetcherRuleRepo{err: errors.New("connection lost")}
+	r, err := fetcherRule.NewResolver(repo, newTestLogger(), 1*time.Hour)
+	require.NoError(t, err)
+
+	_, err = r.Resolve(context.Background(), "edition.cnn.com")
+	assert.Error(t, err)
+
+	// 동일 host 의 다음 호출도 repo 까지 도달해야 함.
+	_, err = r.Resolve(context.Background(), "edition.cnn.com")
+	assert.Error(t, err)
+	assert.Equal(t, int32(2), repo.calls.Load())
+}
+
+// TestResolver_TTLExpiry_RefetchesFromRepo:
+// TTL 만료 후 재조회는 repo 로 다시 hit.
+func TestResolver_TTLExpiry_RefetchesFromRepo(t *testing.T) {
+	repo := &stubFetcherRuleRepo{
+		rules: map[string]*storage.FetcherRuleRecord{
+			"edition.cnn.com": {HostPattern: "edition.cnn.com", Fetcher: storage.FetcherChromedp},
+		},
+	}
+	r, err := fetcherRule.NewResolver(repo, newTestLogger(), 5*time.Millisecond)
+	require.NoError(t, err)
+
+	_, _ = r.Resolve(context.Background(), "edition.cnn.com")
+	assert.Equal(t, int32(1), repo.calls.Load())
+
+	time.Sleep(20 * time.Millisecond)
+
+	_, _ = r.Resolve(context.Background(), "edition.cnn.com")
+	assert.Equal(t, int32(2), repo.calls.Load())
+}
+
+// TestResolver_Invalidate_ForcesRefetch:
+// Invalidate 호출 후 같은 host 조회는 cache miss → repo hit.
+func TestResolver_Invalidate_ForcesRefetch(t *testing.T) {
+	repo := &stubFetcherRuleRepo{
+		rules: map[string]*storage.FetcherRuleRecord{
+			"edition.cnn.com": {HostPattern: "edition.cnn.com", Fetcher: storage.FetcherChromedp},
+		},
+	}
+	r, err := fetcherRule.NewResolver(repo, newTestLogger(), 1*time.Hour)
+	require.NoError(t, err)
+
+	_, _ = r.Resolve(context.Background(), "edition.cnn.com")
+	assert.Equal(t, int32(1), repo.calls.Load())
+
+	r.Invalidate("edition.cnn.com")
+
+	_, _ = r.Resolve(context.Background(), "edition.cnn.com")
+	assert.Equal(t, int32(2), repo.calls.Load())
+}
+
+// TestResolver_EmptyHost_ReturnsFalseWithoutRepoCall:
+// 빈 host 는 핫패스에서 즉시 default 분기 — repo 호출 없음.
+func TestResolver_EmptyHost_ReturnsFalseWithoutRepoCall(t *testing.T) {
+	repo := &stubFetcherRuleRepo{}
+	r, err := fetcherRule.NewResolver(repo, newTestLogger(), 0)
+	require.NoError(t, err)
+
+	res, err := r.Resolve(context.Background(), "")
+	require.NoError(t, err)
+	assert.False(t, res.Found)
+	assert.Equal(t, int32(0), repo.calls.Load())
+}


### PR DESCRIPTION
## 연관 이슈
- Closes #219

본 PR 은 이슈 #175 의 단계 1 (sub-issue #219) 만 완료. #175 자체는 단계 2 (#220) / 단계 3 (#221) 머지 후 함께 close.

<br>

## 구현 내용

이슈 #175 의 단계 1 인프라 — host 단위 fetcher 선택 정책. 자동 전환 (단계 3) / 카운팅 (단계 2) 의 base 가 되며, 본 PR 자체는 운영자 manual UPSERT + Resolver 조회까지만 동작.

### Commit 1: `[FEAT]:` 테이블 + Repository

**`migrations/up/013_fetcher_rules.sql`** (+ down):
```sql
CREATE TABLE IF NOT EXISTS fetcher_rules (
  id           BIGSERIAL PRIMARY KEY,
  host_pattern TEXT      NOT NULL UNIQUE,
  fetcher      TEXT      NOT NULL CHECK (fetcher IN ('goquery', 'chromedp')),
  reason       TEXT,
  created_at   TIMESTAMPTZ NOT NULL DEFAULT NOW(),
  updated_at   TIMESTAMPTZ NOT NULL DEFAULT NOW()
);
CREATE INDEX IF NOT EXISTS idx_fetcher_rules_host ON fetcher_rules(host_pattern);
```

**`internal/storage/fetcher_rule.go`**:
- `FetcherKind` (goquery / chromedp) + `IsValid()`
- `FetcherRuleRecord` / `FetcherRuleRepository` 인터페이스 (`Upsert` / `GetByHost` / `List` / `Delete`)

**`internal/storage/postgres/fetcher_rule.go`**:
- pgx/v5 구현
- `Upsert` 는 `ON CONFLICT (host_pattern) DO UPDATE`
- `GetByHost` 는 `pgx.ErrNoRows` → `storage.ErrNotFound` 정규화
- `NewFetcherRuleRepository` 는 nil pool 시 error 반환 (이슈 #208 정책)

### Commit 2: `[FEAT]:` Resolver + ChainHandler 분기

**`internal/processor/fetcher/rule/resolver.go`** (신규 패키지):
- `Resolver` 인터페이스 + `dbResolver` 구현
- `sync.Map` 기반 in-memory cache + TTL (default 5분)
- positive / negative 양쪽 cache — 반복 조회 DB 부하 차단
- `Invalidate(host)` — 단계 3 의 자동 UPSERT 직후 cache 동기화 hook (현재는 호출자 없음)

**ChainHandler 변경 (`internal/processor/fetcher/domain/general/chain_handler.go`)**:
- 단일 `Chain` → 두 chain 보유:
  - `DefaultChain` (gq → browser fallback) — 룰 미등록 host 의 기본
  - `ChromedpChain` (browser only) — 룰 = `'chromedp'` 인 host 전용
- `Resolver` optional — nil 이면 항상 Default (기존 동작 100% 보존)
- `selectChain()`: 룰 결과로 분기. Resolver 에러 / 빈 host 는 Default fallback (graceful degrade)
- `extractHost()`: URL → Hostname (port 제거)

**Registry wiring (`sources/kr/registry.go`, `sources/us/registry.go`)**:
- `Register` / `register*` 시그니처에 `resolver rule.Resolver` 추가
- 각 사이트별 `chromedpChain = BuildChain(nil, brFetcher, log)` 추가 조립
- yonhap 은 browser fetcher 미설정 → `chromedpChain=nil`. 룰=chromedp 매칭 시 warn + Default fallback

**`cmd/issuetracker/main.go`**:
- `pgstore.NewFetcherRuleRepository` + `fetcherRule.NewResolver` wiring
- `kr.Register` / `us.Register` 호출에 `fetcherResolver` 전달

### 테스트

**`test/internal/processor/fetcher/rule/resolver_test.go`** (9 tests):

| Test | 검증 |
|---|---|
| `TestNewResolver_NilRepo_ReturnsError` | nil repo wiring 시 error (이슈 #208 정책) |
| `TestResolver_HostNotFound_ReturnsFalse` | 룰 부재 host → `Found=false` |
| `TestResolver_HostMatched_ReturnsFetcher` | 매칭 host → 등록된 fetcher 반환 |
| `TestResolver_CachesPositiveResult` | positive cache hit (5회 호출, repo 1회) |
| `TestResolver_CachesNegativeResult` | negative cache hit |
| `TestResolver_RepoError_PropagatesNoCache` | ErrNotFound 외 에러는 전파 + 미저장 |
| `TestResolver_TTLExpiry_RefetchesFromRepo` | TTL 만료 후 refetch |
| `TestResolver_Invalidate_ForcesRefetch` | Invalidate 후 cache miss |
| `TestResolver_EmptyHost_ReturnsFalseWithoutRepoCall` | 빈 host 는 즉시 default 분기 |

30개 패키지 race test 모두 통과 (failure 0).

<br>

## CI / 머지 게이트 점검

> [CI 운영 규약](docs/ci/conventions.md) 및 [Required Status Checks 단일 소스](docs/ci/status-checks.md)에 따라 작성합니다.

### 변경 영향 범위
- 영향 패키지: `internal/storage/` (신규 fetcher_rule), `internal/storage/postgres/` (신규 구현), `internal/processor/fetcher/rule/` (신규), `internal/processor/fetcher/domain/general/` (ChainHandler + Registry), `cmd/issuetracker/` (wiring), 신규 migration
- 위험도(택1): `Low-Medium`
  - **fetcher_rules 빈 상태**: 모든 호스트가 `Found=false` → DefaultChain → 현재 동작 100% 보존
  - 운영자가 직접 `INSERT` 하지 않는 한 동작 변화 없음. 안전망: Resolver 에러 시 Default fallback
  - migration 013 은 신규 테이블만 추가 (기존 스키마 영향 없음)

### Required Status Checks
- 통과 확인 대상 (PR Checks 탭에서 확인):
  - [ ] `Commit Lint`
  - [ ] `PR Title Lint`
  - [ ] `Linked Issue Check`
  - [ ] `Format Check`
  - [ ] `Build`
  - [ ] `Test`
  - [ ] `Lint`

### 롤백 계획
- `git revert` 2개 commit + migration 013 down 적용 (`bin/migrate-down`).
- DB 영향: `fetcher_rules` 테이블만 추가, drop 시 데이터 손실 없음 (운영 데이터 미보유).

<br>

## TODO
- (단계 2, sub #220) host 단위 실패 카운팅 (Redis sliding window)
- (단계 3, sub #221) 임계값 도달 시 chromedp 자동 UPSERT + 실패 raw republish
- (운영) 수동 검증: `INSERT INTO fetcher_rules (host_pattern, fetcher, reason) VALUES ('edition.cnn.com', 'chromedp', 'manual');` 후 라이브에서 cnn 호스트가 chromedp chain 으로 직행하는지 debug.log 확인

<br>

## 논의 사항
- `FetcherRuleRepository` 의 통합 테스트는 본 PR 에 미포함 — Postgres testcontainer 통합 테스트 패턴은 본 repo 에서 일반화 미완. 단위 레벨에서 stub repo 로 Resolver 동작 검증으로 갈음.
- 단계 3 의 자동 UPSERT 후 Resolver cache 동기화는 `Invalidate()` 사용 — 단계 3 PR 에서 호출 wiring 추가 예정.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced host-level fetcher selection policies that allow configuring which fetching method (standard or browser-based) is used for each website.
  * Crawler registration now supports rule-based fetching behavior based on target host.

* **Database**
  * Added `fetcher_rules` table to store host-specific fetching preferences with associated metadata.

* **Tests**
  * Added comprehensive test suite for rule resolution and caching behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->