### PR TITLE
[FEAT#220] host 단위 fetcher 실패 카운팅 (Redis sliding window) (이슈 #175 단계 2)

### DIFF
--- a/cmd/issuetracker/main.go
+++ b/cmd/issuetracker/main.go
@@ -169,6 +169,7 @@ func main() {
 	var ingestionLock locks.IngestionLock
 	var retryScheduler crawlerWorker.RetryScheduler
 	var retrySchedulerStop func()
+	var redisClientShared *redis.Client // 이슈 #220: failure counter wiring 에서 재사용
 	redisCfg, err := config.LoadRedis()
 	if err != nil {
 		log.WithError(err).Warn("failed to load redis config, falling back to noop processing lock and ingestion lock")
@@ -178,6 +179,7 @@ func main() {
 			log.WithError(redisErr).Warn("failed to connect to redis, falling back to noop processing lock and ingestion lock")
 		} else {
 			defer redisClient.Close()
+			redisClientShared = redisClient
 			log.WithFields(map[string]interface{}{
 				"host": redisCfg.Host,
 				"port": redisCfg.Port,
@@ -243,6 +245,39 @@ func main() {
 	llmProvider := buildLLMProvider(log)
 	llmGen := buildLLMGenerator(llmProvider, parsingRuleRepo, ruleResolver, log)
 
+	// ── Fetcher 실패 카운터 (이슈 #220) ────────────────────────────────────────
+	// host 단위 fetcher 실패를 sliding window 로 누적 — 단계 3 (#221) 의 chromedp 자동 전환
+	// 트리거 입력. ENABLED=false 또는 Redis 미연결 시 Noop (성능 저하 0).
+	fetcherUpgradeCfg, err := config.LoadFetcherAutoUpgrade()
+	if err != nil {
+		log.WithError(err).Fatal("failed to load fetcher auto-upgrade config")
+	}
+	var failureCounter fetcherRule.FailureCounter = fetcherRule.NewNoopFailureCounter()
+	if fetcherUpgradeCfg.Enabled && redisClientShared != nil {
+		fc, fcErr := fetcherRule.NewRedisFailureCounter(
+			redisClientShared.Raw(),
+			fetcherUpgradeCfg.Threshold,
+			fetcherUpgradeCfg.Window,
+			"", // default keyPrefix "fetcher:fail"
+			log,
+		)
+		if fcErr != nil {
+			log.WithError(fcErr).Warn("failed to construct redis failure counter, falling back to noop")
+		} else {
+			failureCounter = fc
+			log.WithFields(map[string]interface{}{
+				"threshold":              fetcherUpgradeCfg.Threshold,
+				"window":                 fetcherUpgradeCfg.Window.String(),
+				"empty_body_title_min":   fetcherUpgradeCfg.EmptyBodyTitleMin,
+				"empty_body_content_min": fetcherUpgradeCfg.EmptyBodyContentMin,
+			}).Info("fetcher failure counter (redis sliding window) enabled")
+		}
+	} else if !fetcherUpgradeCfg.Enabled {
+		log.Info("fetcher auto-upgrade disabled (FETCHER_AUTO_UPGRADE_ENABLED=false), failure counter is noop")
+	} else {
+		log.Warn("redis unavailable, fetcher failure counter falls back to noop")
+	}
+
 	// ── Parser worker (이슈 #134) ──────────────────────────────────────────────
 	// fetcher 와 분리된 별도 consumer group (issuetracker-parsers) 으로 동작 — 인스턴스 수 독립 스케일.
 	// TopicFetched 의 RawContentRef 를 consume 하여 raw 로드 + 파싱 + content 저장 + raw 삭제.
@@ -264,6 +299,9 @@ func main() {
 		sampleRepo,   // 이슈 #173 단계 4-1
 		procLock,     // 이슈 #178: fetcher / parser / validator 가 동일 ProcessingLock 인스턴스 공유
 		llmGen,
+		failureCounter, // 이슈 #220: host 단위 fetcher 실패 카운터
+		fetcherUpgradeCfg.EmptyBodyTitleMin,
+		fetcherUpgradeCfg.EmptyBodyContentMin,
 		parserWorkerCount,
 		log,
 	)

--- a/internal/processor/fetcher/rule/counter.go
+++ b/internal/processor/fetcher/rule/counter.go
@@ -1,0 +1,153 @@
+package rule
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strconv"
+	"time"
+
+	goredis "github.com/redis/go-redis/v9"
+
+	"issuetracker/pkg/logger"
+)
+
+// FailureReason 은 카운터에 INCR 되는 실패의 분류입니다 (이슈 #220).
+//
+// 카운터 자체는 reason 별 분리 없이 host 단위로 누적 — reason 은 audit log / metric 차원.
+type FailureReason string
+
+const (
+	// FailureReasonRuleParseFailure: rule.Error 의 parse_failure / empty_selector 류 (selector 매칭 0건 / required selector 부재).
+	FailureReasonRuleParseFailure FailureReason = "rule_parse_failure"
+	// FailureReasonRuleNoRule: rule.Error 의 no_rule (host 에 active rule 없음).
+	// 본 sub 의 카운팅 대상에서 제외 권장 — 이 경우는 LLM 자동 rule 생성 (이슈 #149) 의 책임 영역.
+	// 그러나 운영자 분석을 위해 호출자가 선택 가능하도록 reason 정의는 유지.
+	FailureReasonRuleNoRule FailureReason = "rule_no_rule"
+	// FailureReasonEmptyBody: parse 자체는 성공했지만 Title / MainContent 텍스트 길이가 임계값 미달.
+	// FetcherAutoUpgradeConfig.EmptyBodyTitleMin / EmptyBodyContentMin 으로 임계값 운영.
+	FailureReasonEmptyBody FailureReason = "empty_body"
+)
+
+// FailureCounter 는 host 단위 fetcher 실패를 sliding window 로 카운팅합니다 (이슈 #220).
+//
+// 단계 3 (#221) 의 chromedp 자동 전환 트리거가 ThresholdReached=true 신호를 받아 fetcher_rules
+// UPSERT + 실패 raw republish 를 발동합니다. 본 sub 는 카운팅 + 임계값 도달 신호까지만.
+//
+// 모든 구현체는 goroutine-safe 해야 합니다 — parser_worker 가 동시에 Record 를 호출.
+type FailureCounter interface {
+	// Record 는 host 의 실패 1건을 누적하고 현재 window 내 카운트 + 임계값 도달 여부를 반환합니다.
+	// reason 은 audit / metric 용 (구현체가 카운터에 분리 저장해도, 분리 안 해도 무방).
+	// 카운팅 자체가 실패 (Redis 장애 등) 하면 error 반환 — 호출자가 graceful 분기.
+	Record(ctx context.Context, host string, reason FailureReason) (count int, thresholdReached bool, err error)
+}
+
+// noopFailureCounter 는 카운팅 비활성 (FETCHER_AUTO_UPGRADE_ENABLED=false 또는 Redis 미연결) 시 사용합니다.
+type noopFailureCounter struct{}
+
+// NewNoopFailureCounter 는 항상 (0, false, nil) 을 반환하는 FailureCounter 를 반환합니다.
+func NewNoopFailureCounter() FailureCounter { return noopFailureCounter{} }
+
+func (noopFailureCounter) Record(ctx context.Context, host string, reason FailureReason) (int, bool, error) {
+	return 0, false, nil
+}
+
+// redisFailureCounter 는 Redis sorted set 기반 sliding window FailureCounter 입니다.
+//
+// Sliding window 알고리즘:
+//
+//  1. ZADD score=now(unix-nano), member=unique-nonce  →  새 실패 timestamp 등록
+//  2. ZREMRANGEBYSCORE 0 (now - window)              →  window 시작 이전 element 제거
+//  3. EXPIRE key window+buffer                       →  key 자체 TTL (장기 미접근 시 자연 정리)
+//  4. ZCARD                                          →  현재 window 내 카운트
+//
+// 위 4개 명령을 단일 PIPELINE 으로 atomic 하게 실행 — race 회피 + RTT 단일 round-trip.
+type redisFailureCounter struct {
+	client    *goredis.Client
+	threshold int
+	window    time.Duration
+	keyPrefix string
+	now       func() time.Time // 테스트 주입용 — 일반 사용 시 nil → time.Now
+	log       *logger.Logger
+}
+
+// NewRedisFailureCounter 는 Redis 기반 sliding window FailureCounter 를 생성합니다.
+//
+// client 가 nil 이거나 threshold/window 가 비정상이면 error 반환 (이슈 #208 정책).
+// keyPrefix 는 멀티 환경 분리용 ("dev", "prod" 등). 빈 문자열이면 "fetcher:fail" 사용.
+func NewRedisFailureCounter(client *goredis.Client, threshold int, window time.Duration, keyPrefix string, log *logger.Logger) (FailureCounter, error) {
+	if client == nil {
+		return nil, errors.New("rule: NewRedisFailureCounter requires non-nil redis client")
+	}
+	if threshold < 1 {
+		return nil, fmt.Errorf("rule: NewRedisFailureCounter requires threshold >= 1, got %d", threshold)
+	}
+	if window <= 0 {
+		return nil, fmt.Errorf("rule: NewRedisFailureCounter requires positive window, got %s", window)
+	}
+	if keyPrefix == "" {
+		keyPrefix = "fetcher:fail"
+	}
+	return &redisFailureCounter{
+		client:    client,
+		threshold: threshold,
+		window:    window,
+		keyPrefix: keyPrefix,
+		log:       log,
+	}, nil
+}
+
+// keyFor 는 host 의 카운터 sorted-set key 를 만듭니다.
+func (r *redisFailureCounter) keyFor(host string) string {
+	return r.keyPrefix + ":" + host
+}
+
+// Record 는 sliding window 알고리즘에 따라 실패 1건을 누적합니다.
+func (r *redisFailureCounter) Record(ctx context.Context, host string, reason FailureReason) (int, bool, error) {
+	if host == "" {
+		return 0, false, nil
+	}
+	now := time.Now()
+	if r.now != nil {
+		now = r.now()
+	}
+	key := r.keyFor(host)
+	cutoff := now.Add(-r.window)
+
+	// member 는 timestamp + reason — Redis sorted set 의 member 가 unique 해야 같은 timestamp 의
+	// 동시 INCR 이 모두 보존됨. nano 까지 갈리지만 worst-case 동시 record 충돌 회피용 reason 부착.
+	member := strconv.FormatInt(now.UnixNano(), 10) + ":" + string(reason)
+	score := float64(now.UnixNano())
+
+	// PIPELINE — atomic 단일 RTT.
+	pipe := r.client.Pipeline()
+	pipe.ZAdd(ctx, key, goredis.Z{Score: score, Member: member})
+	pipe.ZRemRangeByScore(ctx, key, "-inf", strconv.FormatInt(cutoff.UnixNano(), 10))
+	// EXPIRE: window 의 2배 — 장기 미접근 host 의 key 자연 정리, sliding 정확도 보장.
+	pipe.Expire(ctx, key, 2*r.window)
+	zcard := pipe.ZCard(ctx, key)
+
+	if _, err := pipe.Exec(ctx); err != nil {
+		return 0, false, fmt.Errorf("redis failure counter pipeline for host %s: %w", host, err)
+	}
+
+	count := int(zcard.Val())
+	threshold := count >= r.threshold
+
+	if r.log != nil {
+		fields := map[string]interface{}{
+			"host":      host,
+			"reason":    string(reason),
+			"count":     count,
+			"threshold": r.threshold,
+			"window":    r.window.String(),
+		}
+		if threshold {
+			r.log.WithFields(fields).Info("fetcher failure threshold reached — chromedp upgrade trigger eligible")
+		} else {
+			r.log.WithFields(fields).Debug("fetcher failure recorded")
+		}
+	}
+
+	return count, threshold, nil
+}

--- a/internal/processor/fetcher/rule/counter.go
+++ b/internal/processor/fetcher/rule/counter.go
@@ -2,6 +2,8 @@ package rule
 
 import (
 	"context"
+	"crypto/rand"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"strconv"
@@ -11,6 +13,21 @@ import (
 
 	"issuetracker/pkg/logger"
 )
+
+// memberNonceLen 은 ZADD member 에 추가하는 random suffix 의 byte 길이입니다.
+// 8 bytes hex (16 char) — 같은 nano + reason 조합이 동시 발생해도 충돌 확률 사실상 0.
+// crypto/rand 실패 시 fallback 으로 빈 nonce — 그 경우 nano 정밀도에 의존하나 운영 영향 무시 가능.
+const memberNonceLen = 8
+
+// randNonce 는 ZADD member 의 unique 변별자로 사용할 random hex 문자열을 반환합니다.
+// crypto/rand 실패는 매우 드물지만 발생 시 빈 문자열로 fallback (panic 회피).
+func randNonce() string {
+	b := make([]byte, memberNonceLen)
+	if _, err := rand.Read(b); err != nil {
+		return ""
+	}
+	return hex.EncodeToString(b)
+}
 
 // FailureReason 은 카운터에 INCR 되는 실패의 분류입니다 (이슈 #220).
 //
@@ -114,9 +131,12 @@ func (r *redisFailureCounter) Record(ctx context.Context, host string, reason Fa
 	key := r.keyFor(host)
 	cutoff := now.Add(-r.window)
 
-	// member 는 timestamp + reason — Redis sorted set 의 member 가 unique 해야 같은 timestamp 의
-	// 동시 INCR 이 모두 보존됨. nano 까지 갈리지만 worst-case 동시 record 충돌 회피용 reason 부착.
-	member := strconv.FormatInt(now.UnixNano(), 10) + ":" + string(reason)
+	// member 는 timestamp + reason + random nonce — Redis sorted set 은 (score, member) 의
+	// member 가 unique 해야 ZADD 가 새 entry 로 인정됨. nano 정밀도가 보장되지 않는 환경 (Windows
+	// 일부 / 가상화 환경 etc.) 에서 같은 ns + reason 조합이 동시 발생하면 ZADD 가 중복 처리하여
+	// 카운트가 누락될 수 있으므로 crypto/rand 의 8 bytes hex nonce 를 추가해 충돌 확률을 사실상
+	// 0 으로 낮춘다 (gemini 피드백).
+	member := strconv.FormatInt(now.UnixNano(), 10) + ":" + string(reason) + ":" + randNonce()
 	score := float64(now.UnixNano())
 
 	// PIPELINE — atomic 단일 RTT.

--- a/internal/processor/parser/worker/parser_worker.go
+++ b/internal/processor/parser/worker/parser_worker.go
@@ -21,6 +21,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"net/url"
 	"strconv"
 	"sync"
 	"time"
@@ -28,6 +29,7 @@ import (
 	"issuetracker/internal/locks"
 	"issuetracker/internal/processor/fetcher/core"
 	"issuetracker/internal/processor/fetcher/domain/general"
+	fetcherRule "issuetracker/internal/processor/fetcher/rule"
 	"issuetracker/internal/processor/parser"
 	"issuetracker/internal/processor/parser/rule"
 	"issuetracker/internal/processor/parser/rule/llmgen"
@@ -48,16 +50,24 @@ const (
 
 // ParserWorker 는 TopicFetched consumer group 의 worker pool 입니다.
 type ParserWorker struct {
-	consumer    *queue.KafkaConsumer
-	producer    queue.Producer
-	rawSvc      service.RawContentService
-	contentSvc  service.ContentService
-	publisher   general.JobPublisher
-	parser      *rule.Parser
-	resolver    *rule.Resolver              // 이슈 #173 단계 4-1 — sample 누적 시 매칭된 rule lookup
-	sampleSvc   storage.SampleURLRepository // nil 허용 — nil 이면 sample 누적 skip (단계 4-1)
-	procLock    locks.ProcessingLock        // nil 이면 NoopProcessingLock 사용 (단일 인스턴스 fallback)
-	llmGen      *llmgen.Generator           // nil 허용 — nil 이면 ErrNoRule 시 raw 잔존만 (LLM auto-rule 비활성)
+	consumer   *queue.KafkaConsumer
+	producer   queue.Producer
+	rawSvc     service.RawContentService
+	contentSvc service.ContentService
+	publisher  general.JobPublisher
+	parser     *rule.Parser
+	resolver   *rule.Resolver              // 이슈 #173 단계 4-1 — sample 누적 시 매칭된 rule lookup
+	sampleSvc  storage.SampleURLRepository // nil 허용 — nil 이면 sample 누적 skip (단계 4-1)
+	procLock   locks.ProcessingLock        // nil 이면 NoopProcessingLock 사용 (단일 인스턴스 fallback)
+	llmGen     *llmgen.Generator           // nil 허용 — nil 이면 ErrNoRule 시 raw 잔존만 (LLM auto-rule 비활성)
+
+	// failureCounter: host 단위 fetcher 실패 카운터 (이슈 #220).
+	// nil 시 noopFailureCounter 로 fallback — 카운팅 자체 비활성.
+	// rule.ErrParseFailure / rule.ErrEmptySelector 또는 빈본문 발생 시 Record 호출.
+	failureCounter      fetcherRule.FailureCounter
+	emptyBodyTitleMin   int
+	emptyBodyContentMin int
+
 	workerCount int
 	log         *logger.Logger
 
@@ -70,6 +80,7 @@ type ParserWorker struct {
 //   - procLock 은 nil 허용 — nil 이면 NoopProcessingLock 으로 fallback (단일 인스턴스 환경에서 dedup 비활성)
 //   - llmGen 은 nil 허용 — nil 이면 ErrNoRule 시 raw 잔존만 (LLM auto-rule 비활성, 이슈 #149)
 //   - resolver / sampleSvc 는 nil 허용 — nil 이면 sample 누적 skip (이슈 #173 단계 4-1, 정밀화 워크플로 비활성)
+//   - failureCounter 는 nil 허용 — nil 이면 NoopFailureCounter 로 fallback (이슈 #220 카운팅 비활성)
 //
 // 이슈 #161 (도메인 중립화) 이후 news_articles 도메인 특화 보존은 제거됐습니다 — 모든 article
 // 결과는 contentSvc.Store 로 contents 단일 테이블에 저장됩니다.
@@ -87,6 +98,9 @@ func NewParserWorker(
 	sampleSvc storage.SampleURLRepository,
 	procLock locks.ProcessingLock,
 	llmGen *llmgen.Generator,
+	failureCounter fetcherRule.FailureCounter,
+	emptyBodyTitleMin int,
+	emptyBodyContentMin int,
 	workerCount int,
 	log *logger.Logger,
 ) *ParserWorker {
@@ -96,19 +110,25 @@ func NewParserWorker(
 	if procLock == nil {
 		procLock = locks.NoopProcessingLock{}
 	}
+	if failureCounter == nil {
+		failureCounter = fetcherRule.NewNoopFailureCounter()
+	}
 	return &ParserWorker{
-		consumer:    consumer,
-		producer:    producer,
-		rawSvc:      rawSvc,
-		contentSvc:  contentSvc,
-		publisher:   publisher,
-		parser:      parser,
-		resolver:    resolver,
-		sampleSvc:   sampleSvc,
-		procLock:    procLock,
-		llmGen:      llmGen,
-		workerCount: workerCount,
-		log:         log,
+		consumer:            consumer,
+		producer:            producer,
+		rawSvc:              rawSvc,
+		contentSvc:          contentSvc,
+		publisher:           publisher,
+		parser:              parser,
+		resolver:            resolver,
+		sampleSvc:           sampleSvc,
+		procLock:            procLock,
+		llmGen:              llmGen,
+		failureCounter:      failureCounter,
+		emptyBodyTitleMin:   emptyBodyTitleMin,
+		emptyBodyContentMin: emptyBodyContentMin,
+		workerCount:         workerCount,
+		log:                 log,
 	}
 }
 
@@ -290,6 +310,11 @@ func (w *ParserWorker) processArticlePage(ctx context.Context, raw *core.RawCont
 		return w.handleRuleError(ctx, raw, rawID, "parse_page", storage.TargetTypePage, err, mlog)
 	}
 
+	// 이슈 #220: parse 자체는 성공했지만 Title / MainContent 텍스트 길이가 임계값 미달이면
+	// 빈본문 신호로 host 카운터에 누적. 정상 흐름은 차단하지 않음 (downstream validator 가
+	// 별도 정책으로 처리).
+	w.recordEmptyBodyIfApplicable(ctx, raw, page, mlog)
+
 	content := general.ConvertPage(page, raw)
 	if err := w.publishContents(ctx, []*core.Content{content}, crawlerName); err != nil {
 		return fmt.Errorf("publish article content: %w", err)
@@ -308,6 +333,10 @@ func (w *ParserWorker) processArticlePage(ctx context.Context, raw *core.RawCont
 //   - rule.ErrNoRule + llmGen 활성화 → LLM rule generator 비동기 enqueue (이슈 #149) + raw 잔존 + commit
 //   - 기타 rule.Error → raw 잔존 + commit (warn 로그) — 운영자 review 윈도우
 //   - 기타 → 호출자에게 error 전파 → commit 안 함 → 재시도
+//
+// 이슈 #220 (page 단계 한정): rule.ErrParseFailure / rule.ErrEmptySelector 는 host 단위 카운터로
+// 누적 — 임계값 도달 시 단계 3 (#221) 의 chromedp 자동 전환 트리거 입력. ErrNoRule 은 LLM 자동
+// rule 생성 (이슈 #149) 의 책임 영역이라 카운팅 제외 (다른 정책으로 처리됨).
 func (w *ParserWorker) handleRuleError(ctx context.Context, raw *core.RawContent, rawID, stage string, targetType storage.TargetType, err error, mlog *logger.Logger) error {
 	var rerr *rule.Error
 	if errors.As(err, &rerr) {
@@ -323,12 +352,73 @@ func (w *ParserWorker) handleRuleError(ctx context.Context, raw *core.RawContent
 			w.llmGen.Enqueue(ctx, rerr.Host, targetType, raw)
 		}
 
+		// 이슈 #220: page 단계의 ParseFailure / EmptySelector 만 host 카운터에 누적.
+		// list (category) 는 본질적으로 다른 selector 셋이라 chromedp 전환 신호로 부적절.
+		if targetType == storage.TargetTypePage &&
+			(rerr.Code == rule.ErrParseFailure || rerr.Code == rule.ErrEmptySelector) {
+			w.recordHostFailure(ctx, rerr.Host, fetcherRule.FailureReasonRuleParseFailure, mlog)
+		}
+
 		_ = rawID // 본 시그니처에선 rawID 직접 사용 안 함, 향후 audit log 에서 활용
 		// raw 는 의도적으로 잔존 — cleanup cron 이 TTL (default 1h) 후 정리
 		// 또는 LLM 자동 rule 생성 + 운영자 enable=true flip 후 reprocess 가능
 		return nil
 	}
 	return fmt.Errorf("%s: %w", stage, err)
+}
+
+// recordHostFailure 는 host 단위 fetcher 실패 카운터에 1건 누적합니다 (이슈 #220).
+// 카운팅 자체 실패는 non-fatal — warn 로그만 남기고 정상 흐름 유지 (Redis 장애가 parse 실패
+// 처리 흐름을 막지 않도록).
+func (w *ParserWorker) recordHostFailure(ctx context.Context, host string, reason fetcherRule.FailureReason, mlog *logger.Logger) {
+	if w.failureCounter == nil {
+		return
+	}
+	if _, _, err := w.failureCounter.Record(ctx, host, reason); err != nil {
+		mlog.WithFields(map[string]interface{}{
+			"host":   host,
+			"reason": string(reason),
+		}).WithError(err).Warn("failure counter record failed (non-fatal)")
+	}
+}
+
+// hostOf 는 raw.URL 에서 host 만 추출합니다 (port 제거).
+// 파싱 실패 시 빈 문자열 — 호출자가 빈 host 를 noop 으로 흡수.
+func hostOf(rawURL string) string {
+	u, err := url.Parse(rawURL)
+	if err != nil || u.Host == "" {
+		return ""
+	}
+	return u.Hostname()
+}
+
+// recordEmptyBodyIfApplicable 는 page 의 Title / MainContent 길이가 임계값 미달이면
+// host 카운터에 empty_body 신호로 누적합니다 (이슈 #220).
+//
+// 임계값 어느 한쪽 미달이어도 신호 발신 — chromedp 전환 후 둘 다 정상 추출되는 케이스 가정.
+// 임계값이 0 이면 해당 필드 검증 비활성 (운영 옵션).
+func (w *ParserWorker) recordEmptyBodyIfApplicable(ctx context.Context, raw *core.RawContent, page *parser.Page, mlog *logger.Logger) {
+	if w.emptyBodyTitleMin <= 0 && w.emptyBodyContentMin <= 0 {
+		return
+	}
+	titleLen := len(page.Title)
+	bodyLen := len(page.MainContent)
+	titleShort := w.emptyBodyTitleMin > 0 && titleLen < w.emptyBodyTitleMin
+	bodyShort := w.emptyBodyContentMin > 0 && bodyLen < w.emptyBodyContentMin
+	if !titleShort && !bodyShort {
+		return
+	}
+	host := hostOf(raw.URL)
+	if host == "" {
+		return
+	}
+	mlog.WithFields(map[string]interface{}{
+		"host":         host,
+		"title_length": titleLen,
+		"body_length":  bodyLen,
+		"reason":       string(fetcherRule.FailureReasonEmptyBody),
+	}).Warn("empty body detected — recording host failure")
+	w.recordHostFailure(ctx, host, fetcherRule.FailureReasonEmptyBody, mlog)
 }
 
 // publishContents 는 *core.Content 슬라이스를 contents 저장 + ContentRef 발행 (TopicNormalized).

--- a/internal/processor/parser/worker/parser_worker.go
+++ b/internal/processor/parser/worker/parser_worker.go
@@ -25,6 +25,7 @@ import (
 	"strconv"
 	"sync"
 	"time"
+	"unicode/utf8"
 
 	"issuetracker/internal/locks"
 	"issuetracker/internal/processor/fetcher/core"
@@ -401,8 +402,10 @@ func (w *ParserWorker) recordEmptyBodyIfApplicable(ctx context.Context, raw *cor
 	if w.emptyBodyTitleMin <= 0 && w.emptyBodyContentMin <= 0 {
 		return
 	}
-	titleLen := len(page.Title)
-	bodyLen := len(page.MainContent)
+	// gemini 피드백: byte 길이 대신 rune count — 한글 (multibyte) 페이지 다수라 byte 기준이면
+	// 같은 임계값에서 의도보다 훨씬 짧은 본문이 통과됨. 임계값은 글자 수 의미로 통일.
+	titleLen := utf8.RuneCountInString(page.Title)
+	bodyLen := utf8.RuneCountInString(page.MainContent)
 	titleShort := w.emptyBodyTitleMin > 0 && titleLen < w.emptyBodyTitleMin
 	bodyShort := w.emptyBodyContentMin > 0 && bodyLen < w.emptyBodyContentMin
 	if !titleShort && !bodyShort {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -272,6 +272,111 @@ func LoadPathInfer(envFiles ...string) (PathInferConfig, error) {
 	return cfg, nil
 }
 
+// FetcherAutoUpgradeConfig 는 host 단위 fetcher 실패 누적 → chromedp 자동 전환 정책 설정입니다 (이슈 #175 단계 2, sub-issue #220).
+//
+// 본 단계는 카운팅 + 임계값 도달 신호 발신까지만 — 실제 fetcher_rules UPSERT / 실패 raw republish 는 단계 3 (#221) 의 책임.
+//
+// Window / Threshold 의 의미:
+//   - 윈도우 (default 1h) 안에 같은 host 의 실패가 Threshold (default 5) 회 누적되면 trigger.
+//   - 윈도우는 sliding — 마지막 실패 시각에서 Window 만큼 이전까지 카운트.
+type FetcherAutoUpgradeConfig struct {
+	// Enabled: false 면 카운팅 자체 skip (Noop FailureCounter 사용 — 성능 저하 0).
+	// 환경변수 FETCHER_AUTO_UPGRADE_ENABLED (default true).
+	Enabled bool
+
+	// Threshold: window 내 실패 횟수 임계값 (이상이면 trigger). 환경변수 FETCHER_AUTO_UPGRADE_THRESHOLD (default 5).
+	Threshold int
+
+	// Window: sliding window 길이. 환경변수 FETCHER_AUTO_UPGRADE_WINDOW (Go duration, default 1h).
+	Window time.Duration
+
+	// EmptyBodyTitleMin / EmptyBodyContentMin: 빈본문 판정 임계값 (이슈 #220 단계 2 확장 신호).
+	// parse 자체는 성공했지만 결과 텍스트가 너무 짧은 경우도 실패 신호로 카운팅.
+	// 환경변수 FETCHER_EMPTY_BODY_TITLE_MIN (default 5), FETCHER_EMPTY_BODY_CONTENT_MIN (default 100).
+	EmptyBodyTitleMin   int
+	EmptyBodyContentMin int
+}
+
+// DefaultFetcherAutoUpgradeConfig 는 기본 FetcherAutoUpgradeConfig 를 반환합니다.
+func DefaultFetcherAutoUpgradeConfig() FetcherAutoUpgradeConfig {
+	return FetcherAutoUpgradeConfig{
+		Enabled:             true,
+		Threshold:           5,
+		Window:              1 * time.Hour,
+		EmptyBodyTitleMin:   5,
+		EmptyBodyContentMin: 100,
+	}
+}
+
+// LoadFetcherAutoUpgrade 는 .env 를 로드한 후 OS 환경변수로 FetcherAutoUpgradeConfig 를 구성합니다.
+//
+// 지원 환경변수:
+//   - FETCHER_AUTO_UPGRADE_ENABLED: true | false (default true)
+//   - FETCHER_AUTO_UPGRADE_THRESHOLD: 양의 정수 (default 5)
+//   - FETCHER_AUTO_UPGRADE_WINDOW: Go duration (default "1h")
+//   - FETCHER_EMPTY_BODY_TITLE_MIN: 0 이상의 정수 (default 5)
+//   - FETCHER_EMPTY_BODY_CONTENT_MIN: 0 이상의 정수 (default 100)
+func LoadFetcherAutoUpgrade(envFiles ...string) (FetcherAutoUpgradeConfig, error) {
+	if len(envFiles) == 0 {
+		envFiles = []string{".env"}
+	}
+	if err := godotenv.Load(envFiles...); err != nil && !errors.Is(err, os.ErrNotExist) {
+		return FetcherAutoUpgradeConfig{}, fmt.Errorf("failed to load env files %v: %w", envFiles, err)
+	}
+
+	cfg := DefaultFetcherAutoUpgradeConfig()
+
+	if v := os.Getenv("FETCHER_AUTO_UPGRADE_ENABLED"); v != "" {
+		b, err := strconv.ParseBool(v)
+		if err != nil {
+			return FetcherAutoUpgradeConfig{}, fmt.Errorf("parse FETCHER_AUTO_UPGRADE_ENABLED %q: %w", v, err)
+		}
+		cfg.Enabled = b
+	}
+	if v := os.Getenv("FETCHER_AUTO_UPGRADE_THRESHOLD"); v != "" {
+		n, err := strconv.Atoi(v)
+		if err != nil {
+			return FetcherAutoUpgradeConfig{}, fmt.Errorf("parse FETCHER_AUTO_UPGRADE_THRESHOLD %q: %w", v, err)
+		}
+		if n < 1 {
+			return FetcherAutoUpgradeConfig{}, fmt.Errorf("invalid FETCHER_AUTO_UPGRADE_THRESHOLD %d: must be 1 or greater", n)
+		}
+		cfg.Threshold = n
+	}
+	if v := os.Getenv("FETCHER_AUTO_UPGRADE_WINDOW"); v != "" {
+		d, err := time.ParseDuration(v)
+		if err != nil {
+			return FetcherAutoUpgradeConfig{}, fmt.Errorf("parse FETCHER_AUTO_UPGRADE_WINDOW %q: %w", v, err)
+		}
+		if d <= 0 {
+			return FetcherAutoUpgradeConfig{}, fmt.Errorf("invalid FETCHER_AUTO_UPGRADE_WINDOW %q: must be positive", v)
+		}
+		cfg.Window = d
+	}
+	if v := os.Getenv("FETCHER_EMPTY_BODY_TITLE_MIN"); v != "" {
+		n, err := strconv.Atoi(v)
+		if err != nil {
+			return FetcherAutoUpgradeConfig{}, fmt.Errorf("parse FETCHER_EMPTY_BODY_TITLE_MIN %q: %w", v, err)
+		}
+		if n < 0 {
+			return FetcherAutoUpgradeConfig{}, fmt.Errorf("invalid FETCHER_EMPTY_BODY_TITLE_MIN %d: must be 0 or greater", n)
+		}
+		cfg.EmptyBodyTitleMin = n
+	}
+	if v := os.Getenv("FETCHER_EMPTY_BODY_CONTENT_MIN"); v != "" {
+		n, err := strconv.Atoi(v)
+		if err != nil {
+			return FetcherAutoUpgradeConfig{}, fmt.Errorf("parse FETCHER_EMPTY_BODY_CONTENT_MIN %q: %w", v, err)
+		}
+		if n < 0 {
+			return FetcherAutoUpgradeConfig{}, fmt.Errorf("invalid FETCHER_EMPTY_BODY_CONTENT_MIN %d: must be 0 or greater", n)
+		}
+		cfg.EmptyBodyContentMin = n
+	}
+
+	return cfg, nil
+}
+
 // LLMConfig 는 LLM rule generator (이슈 #149) wiring 설정입니다.
 //
 // LLMConfig drives the LLM provider used for auto-generating parsing rules when

--- a/pkg/redis/client.go
+++ b/pkg/redis/client.go
@@ -50,6 +50,15 @@ func (c *Client) HealthCheck(ctx context.Context) error {
 	return nil
 }
 
+// Raw 는 내부 *goredis.Client 를 반환합니다 — generic 명령 (ZADD / ZREMRANGEBYSCORE / ZCARD 등)
+// 이 필요한 외부 패키지가 사용. pkg/redis 에 모든 명령을 method 로 wrapping 하지 않고 외부에
+// raw access 를 노출하는 절충 — 본 패키지 내부 (lock.go, retry_queue.go) 는 그대로 c.rdb 사용.
+//
+// 호출자는 반환된 client 를 close 하면 안 됨 (Client.Close() 가 lifecycle 책임).
+func (c *Client) Raw() *goredis.Client {
+	return c.rdb
+}
+
 // Close는 Redis 연결 풀을 닫습니다.
 func (c *Client) Close() error {
 	return c.rdb.Close()

--- a/test/internal/processor/fetcher/rule/counter_test.go
+++ b/test/internal/processor/fetcher/rule/counter_test.go
@@ -1,0 +1,173 @@
+package rule_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	fetcherRule "issuetracker/internal/processor/fetcher/rule"
+	"issuetracker/pkg/config"
+	pkgredis "issuetracker/pkg/redis"
+)
+
+// newTestRedisClient 는 로컬 Redis 에 연결하는 테스트 클라이언트를 만듭니다.
+// 미연결 시 통합 테스트 자체 skip (lock_test.go 패턴 동일).
+func newTestRedisClient(t *testing.T) *pkgredis.Client {
+	t.Helper()
+	cfg, err := config.LoadRedis()
+	require.NoError(t, err)
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	client, err := pkgredis.New(ctx, cfg)
+	if err != nil {
+		t.Skipf("Redis not available (%v) — skipping integration test", err)
+	}
+	t.Cleanup(func() { _ = client.Close() })
+	return client
+}
+
+// uniqueKeyPrefix 는 동시 실행 / 반복 실행 시 테스트 간 격리를 위한 prefix 입니다.
+func uniqueKeyPrefix(t *testing.T) string {
+	t.Helper()
+	return "test:fetcher:fail:" + t.Name() + ":" + time.Now().Format(time.RFC3339Nano)
+}
+
+// TestNewRedisFailureCounter_NilClient_ReturnsError:
+// 이슈 #208 panic-on-nil → error 정책. nil client 는 wiring 오류라 즉시 error.
+func TestNewRedisFailureCounter_NilClient_ReturnsError(t *testing.T) {
+	_, err := fetcherRule.NewRedisFailureCounter(nil, 5, time.Hour, "", newTestLogger())
+	assert.Error(t, err)
+}
+
+// TestNewRedisFailureCounter_BadThreshold_ReturnsError:
+// threshold 0 또는 음수 → 카운터 자체 무의미. 즉시 error.
+func TestNewRedisFailureCounter_BadThreshold_ReturnsError(t *testing.T) {
+	client := newTestRedisClient(t)
+	_, err := fetcherRule.NewRedisFailureCounter(client.Raw(), 0, time.Hour, "", newTestLogger())
+	assert.Error(t, err)
+
+	_, err = fetcherRule.NewRedisFailureCounter(client.Raw(), -1, time.Hour, "", newTestLogger())
+	assert.Error(t, err)
+}
+
+// TestNewRedisFailureCounter_BadWindow_ReturnsError:
+// window 0 또는 음수 → sliding window 의미 없음. 즉시 error.
+func TestNewRedisFailureCounter_BadWindow_ReturnsError(t *testing.T) {
+	client := newTestRedisClient(t)
+	_, err := fetcherRule.NewRedisFailureCounter(client.Raw(), 5, 0, "", newTestLogger())
+	assert.Error(t, err)
+}
+
+// TestRedisFailureCounter_Record_FirstHitBelowThreshold:
+// 첫 실패 1건 등록 → count=1, threshold(=5) 미달 → false.
+func TestRedisFailureCounter_Record_FirstHitBelowThreshold(t *testing.T) {
+	client := newTestRedisClient(t)
+	prefix := uniqueKeyPrefix(t)
+	c, err := fetcherRule.NewRedisFailureCounter(client.Raw(), 5, time.Hour, prefix, newTestLogger())
+	require.NoError(t, err)
+
+	count, reached, err := c.Record(context.Background(), "edition.cnn.com", fetcherRule.FailureReasonRuleParseFailure)
+	require.NoError(t, err)
+	assert.Equal(t, 1, count)
+	assert.False(t, reached)
+
+	// cleanup
+	t.Cleanup(func() {
+		client.Raw().Del(context.Background(), prefix+":edition.cnn.com")
+	})
+}
+
+// TestRedisFailureCounter_Record_AccumulatesUntilThreshold:
+// 임계값 (3) 만큼 누적 → count=3, threshold 도달 → true.
+func TestRedisFailureCounter_Record_AccumulatesUntilThreshold(t *testing.T) {
+	client := newTestRedisClient(t)
+	prefix := uniqueKeyPrefix(t)
+	c, err := fetcherRule.NewRedisFailureCounter(client.Raw(), 3, time.Hour, prefix, newTestLogger())
+	require.NoError(t, err)
+
+	host := "naver.com"
+	ctx := context.Background()
+
+	count, reached, err := c.Record(ctx, host, fetcherRule.FailureReasonRuleParseFailure)
+	require.NoError(t, err)
+	assert.Equal(t, 1, count)
+	assert.False(t, reached)
+
+	count, reached, err = c.Record(ctx, host, fetcherRule.FailureReasonEmptyBody)
+	require.NoError(t, err)
+	assert.Equal(t, 2, count)
+	assert.False(t, reached)
+
+	count, reached, err = c.Record(ctx, host, fetcherRule.FailureReasonRuleParseFailure)
+	require.NoError(t, err)
+	assert.Equal(t, 3, count)
+	assert.True(t, reached)
+
+	// 임계값 도달 이후 추가 record 도 threshold=true 유지 (windowing 안에서는 cumulative).
+	count, reached, err = c.Record(ctx, host, fetcherRule.FailureReasonEmptyBody)
+	require.NoError(t, err)
+	assert.Equal(t, 4, count)
+	assert.True(t, reached)
+
+	t.Cleanup(func() {
+		client.Raw().Del(context.Background(), prefix+":"+host)
+	})
+}
+
+// TestRedisFailureCounter_Record_PrunesOldEntries:
+// window 보다 오래된 entry 는 ZREMRANGEBYSCORE 로 제거되어 카운트에서 빠진다.
+//
+// 직접 시간 흐름을 만들 수 없으므로 매우 짧은 window (50ms) + sleep 으로 검증.
+func TestRedisFailureCounter_Record_PrunesOldEntries(t *testing.T) {
+	client := newTestRedisClient(t)
+	prefix := uniqueKeyPrefix(t)
+	c, err := fetcherRule.NewRedisFailureCounter(client.Raw(), 5, 50*time.Millisecond, prefix, newTestLogger())
+	require.NoError(t, err)
+
+	host := "yonhap.co.kr"
+	ctx := context.Background()
+
+	for i := 0; i < 3; i++ {
+		_, _, err := c.Record(ctx, host, fetcherRule.FailureReasonRuleParseFailure)
+		require.NoError(t, err)
+	}
+
+	// window 만료 대기 + 새 record 로 ZREMRANGEBYSCORE 발동 확인.
+	time.Sleep(80 * time.Millisecond)
+
+	count, reached, err := c.Record(ctx, host, fetcherRule.FailureReasonRuleParseFailure)
+	require.NoError(t, err)
+	assert.Equal(t, 1, count, "이전 3건은 window 밖이라 제거됨, 새 1건만 남아야 함")
+	assert.False(t, reached)
+
+	t.Cleanup(func() {
+		client.Raw().Del(context.Background(), prefix+":"+host)
+	})
+}
+
+// TestRedisFailureCounter_EmptyHost_ReturnsZero:
+// 빈 host 는 즉시 (0, false, nil) — Redis 호출 없음.
+func TestRedisFailureCounter_EmptyHost_ReturnsZero(t *testing.T) {
+	client := newTestRedisClient(t)
+	c, err := fetcherRule.NewRedisFailureCounter(client.Raw(), 5, time.Hour, "", newTestLogger())
+	require.NoError(t, err)
+
+	count, reached, err := c.Record(context.Background(), "", fetcherRule.FailureReasonRuleParseFailure)
+	require.NoError(t, err)
+	assert.Equal(t, 0, count)
+	assert.False(t, reached)
+}
+
+// TestNoopFailureCounter_AlwaysReturnsZero:
+// FETCHER_AUTO_UPGRADE_ENABLED=false 또는 Redis 미연결 시 사용. 항상 (0, false, nil).
+func TestNoopFailureCounter_AlwaysReturnsZero(t *testing.T) {
+	c := fetcherRule.NewNoopFailureCounter()
+
+	count, reached, err := c.Record(context.Background(), "any.host.com", fetcherRule.FailureReasonRuleParseFailure)
+	require.NoError(t, err)
+	assert.Equal(t, 0, count)
+	assert.False(t, reached)
+}


### PR DESCRIPTION
## 연관 이슈
- Closes #220

본 PR 은 이슈 #175 의 단계 2 (sub-issue #220) 만 완료. #175 자체는 단계 3 (#221) 머지 후 함께 close.

<br>

## 구현 내용

이슈 #175 단계 2 — host 단위 fetcher 실패 신호 감지 + Redis sliding window 카운팅. 단계 3 (#221) 의 chromedp 자동 전환 트리거가 본 sub 의 `ThresholdReached=true` 신호를 받아 fetcher_rules UPSERT + 실패 raw republish 를 발동.

### Commit 1: `[FEAT]:` FailureCounter 인프라

**`pkg/config/config.go` — FetcherAutoUpgradeConfig**:
| 환경변수 | 기본값 | 의미 |
|---|---|---|
| `FETCHER_AUTO_UPGRADE_ENABLED` | `true` | false 시 Noop 카운터 (성능 저하 0) |
| `FETCHER_AUTO_UPGRADE_THRESHOLD` | `5` | window 내 누적 임계값 |
| `FETCHER_AUTO_UPGRADE_WINDOW` | `1h` | sliding window 길이 (Go duration) |
| `FETCHER_EMPTY_BODY_TITLE_MIN` | `5` | 빈본문 신호 임계 (Title) |
| `FETCHER_EMPTY_BODY_CONTENT_MIN` | `100` | 빈본문 신호 임계 (MainContent) |

**`internal/processor/fetcher/rule/counter.go`**:
- `FailureCounter` 인터페이스: `Record(host, reason) → (count, thresholdReached, error)`
- `FailureReason`: `rule_parse_failure` / `rule_no_rule` / `empty_body`
- `noopFailureCounter`: 항상 (0, false, nil) — ENABLED=false 또는 Redis 미연결 시
- `redisFailureCounter`: Redis sorted set 기반 sliding window
  - **알고리즘**: `ZADD score=now, member=ts:reason` + `ZREMRANGEBYSCORE` + `EXPIRE window*2` + `ZCARD` 4개 명령을 단일 PIPELINE 으로 atomic 실행
  - `NewRedisFailureCounter` 는 nil client / 비정상 threshold/window 시 error (이슈 #208 정책)

**`pkg/redis/client.go`**:
- `Raw() *goredis.Client` accessor 추가 — 외부 패키지가 generic 명령 (ZADD/ZREMRANGEBYSCORE/ZCARD) 사용. 같은 패키지 내부 (lock.go / retry_queue.go) 는 그대로 c.rdb.

### Commit 2: `[FEAT]:` parser_worker 통합 + wiring

**ParserWorker (`parser_worker.go`)**:
- 새 필드: `failureCounter` / `emptyBodyTitleMin` / `emptyBodyContentMin`
- `NewParserWorker` 시그니처에 3개 인자 추가, nil counter → Noop fallback
- `handleRuleError`:
  - **page 단계의** `rule.ErrParseFailure` / `rule.ErrEmptySelector` 만 host 카운터 누적
  - list (category) 는 selector 셋이 본질적으로 다른 맥락이라 chromedp 전환 신호로 부적절 — 제외
  - `rule.ErrNoRule` 은 LLM 자동 rule 생성 (이슈 #149) 의 책임 영역이라 카운팅 제외
- `processArticlePage`: parse 성공 후 Title / MainContent 길이 임계값 미달이면 `empty_body` 신호로 누적. 정상 흐름 차단 안 함
- 카운터 호출 실패는 non-fatal warn 로그 (Redis 장애가 parse 흐름 차단 안 함)

**`cmd/issuetracker/main.go` wiring**:
- `redisClientShared` 변수 outer scope 승격 — Counter wiring 에서 Redis client 재사용 (lifecycle 은 기존 defer Close 그대로)
- ENABLED + Redis 가용 모두 만족 시 RedisFailureCounter, 그 외 Noop
- 부팅 시 INFO 로그로 활성화 상태 표시 (threshold / window / 빈본문 임계값)

### 테스트

**`test/internal/processor/fetcher/rule/counter_test.go`** (8 tests, miniredis 없음 → 실제 Redis 통합 — Redis 미연결 시 t.Skipf, lock_test.go 패턴):

| Test | 검증 |
|---|---|
| `TestNewRedisFailureCounter_NilClient_ReturnsError` | nil client wiring (이슈 #208) |
| `TestNewRedisFailureCounter_BadThreshold_ReturnsError` | threshold < 1 거부 |
| `TestNewRedisFailureCounter_BadWindow_ReturnsError` | window <= 0 거부 |
| `TestRedisFailureCounter_Record_FirstHitBelowThreshold` | count=1, threshold false |
| `TestRedisFailureCounter_Record_AccumulatesUntilThreshold` | 임계값 도달 + 이후 cumulative true |
| `TestRedisFailureCounter_Record_PrunesOldEntries` | window 만료 후 ZREMRANGEBYSCORE 발동 (50ms window + 80ms sleep) |
| `TestRedisFailureCounter_EmptyHost_ReturnsZero` | 빈 host noop |
| `TestNoopFailureCounter_AlwaysReturnsZero` | always (0, false, nil) |

30개 패키지 race test 모두 통과 (failure 0).

<br>

## CI / 머지 게이트 점검

> [CI 운영 규약](docs/ci/conventions.md) 및 [Required Status Checks 단일 소스](docs/ci/status-checks.md)에 따라 작성합니다.

### 변경 영향 범위
- 영향 패키지: `pkg/config/`, `pkg/redis/` (Raw accessor), `internal/processor/fetcher/rule/` (신규 counter), `internal/processor/parser/worker/` (실패 분기 통합), `cmd/issuetracker/` (wiring)
- 위험도(택1): `Low-Medium`
  - `FETCHER_AUTO_UPGRADE_ENABLED=true` (default) + Redis 연결 환경에서 카운팅 활성. **count 누적만 발생, fetcher_rules UPSERT / republish 는 본 PR 범위 외** — 단계 3 (#221) 머지 전까지 실제 chromedp 전환은 일어나지 않음
  - Redis 장애 시 카운터만 noop 으로 fallback, parse 흐름은 그대로
  - DB / Kafka 영향 없음

### Required Status Checks
- 통과 확인 대상 (PR Checks 탭에서 확인):
  - [ ] `Commit Lint`
  - [ ] `PR Title Lint`
  - [ ] `Linked Issue Check`
  - [ ] `Format Check`
  - [ ] `Build`
  - [ ] `Test`
  - [ ] `Lint`

### 롤백 계획
- `git revert` 2개 commit 또는 `FETCHER_AUTO_UPGRADE_ENABLED=false` 로 즉시 비활성. DB / 외부 시스템 영향 없음.

<br>

## TODO
- (단계 3, sub #221) 임계값 도달 시 chromedp 자동 UPSERT + 실패 raw republish — 본 sub 의 `thresholdReached=true` 신호를 trigger 입력으로 사용
- (운영 모니터) 머지 후 라이브 1시간 모니터링: `fetcher failure threshold reached` INFO 로그 발생 빈도 + host 분포 확인

<br>

## 논의 사항
- **카운팅 단위 = host 만**: 본 sub scope 한정. 향후 (host, target_type) 또는 (host, path) 확장 검토 가치 있으나 단계 3 머지 후 운영 데이터 보고 결정.
- **rule.ErrNoRule 카운팅 제외**: ErrNoRule 은 \"host 에 active rule 없음\" — LLM auto-rule (이슈 #149) 가 처리하는 영역. ParseFailure / EmptySelector 같은 \"rule 은 있는데 selector 가 안 맞음\" 케이스만 chromedp 전환 신호로 의미 있음.
- **빈본문 임계값 (`Title<5` / `MainContent<100`)**: default 는 보수적. 운영 데이터로 false positive (정상 짧은 페이지) 비율 보고 조정 필요.
- **list (category) 페이지 제외**: ItemContainer / LinkDiscovery 등 list 전용 selector 가 있어 \"rule fail\" 의미가 page 와 다름. chromedp 가 list 페이지의 빈 결과를 해결한다는 보장도 없음.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
