### PR TITLE
[FEAT#221] 임계값 도달 시 chromedp 자동 전환 + 실패 raw republish (이슈 #175 단계 3)

### DIFF
--- a/cmd/issuetracker/main.go
+++ b/cmd/issuetracker/main.go
@@ -154,6 +154,12 @@ func main() {
 		log.WithError(err).Fatal("failed to construct fetcher rule resolver")
 	}
 
+	// 이슈 #221: process-local secret token — Upgrader 의 force_fetcher 부착과 ChainHandler 의
+	// 검증이 같은 token 공유. 외부 source 의 임의 force 차단.
+	if err := fetcherRule.InitForceFetcherToken(); err != nil {
+		log.WithError(err).Fatal("failed to init force_fetcher token")
+	}
+
 	// fetcher 측 등록 (이슈 #134 분리 후): chain handler 가 raw_contents 저장 + RawContentRef 발행만 수행.
 	if err := kr.Register(registry, core.DefaultConfig(), rawSvc, crawlerProducer, fetcherResolver, log); err != nil {
 		log.WithError(err).Fatal("failed to register kr crawlers")

--- a/cmd/issuetracker/main.go
+++ b/cmd/issuetracker/main.go
@@ -278,6 +278,24 @@ func main() {
 		log.Warn("redis unavailable, fetcher failure counter falls back to noop")
 	}
 
+	// 이슈 #221: host 단위 실패 raw_id 추적기 — 단계 3 의 chromedp 자동 전환 trigger 가 republish 대상 수집에 사용.
+	// 카운터와 같은 lifecycle (window TTL 동기화) — Redis 미연결 시 Noop.
+	var rawIDTracker fetcherRule.RawIDTracker = fetcherRule.NewNoopRawIDTracker()
+	if fetcherUpgradeCfg.Enabled && redisClientShared != nil {
+		t, tErr := fetcherRule.NewRedisRawIDTracker(
+			redisClientShared.Raw(),
+			fetcherUpgradeCfg.Window,
+			"", // default keyPrefix "fetcher:failed_raws"
+			log,
+		)
+		if tErr != nil {
+			log.WithError(tErr).Warn("failed to construct redis raw id tracker, falling back to noop")
+		} else {
+			rawIDTracker = t
+			log.Info("fetcher raw id tracker (redis set) enabled")
+		}
+	}
+
 	// ── Parser worker (이슈 #134) ──────────────────────────────────────────────
 	// fetcher 와 분리된 별도 consumer group (issuetracker-parsers) 으로 동작 — 인스턴스 수 독립 스케일.
 	// TopicFetched 의 RawContentRef 를 consume 하여 raw 로드 + 파싱 + content 저장 + raw 삭제.
@@ -300,6 +318,7 @@ func main() {
 		procLock,     // 이슈 #178: fetcher / parser / validator 가 동일 ProcessingLock 인스턴스 공유
 		llmGen,
 		failureCounter, // 이슈 #220: host 단위 fetcher 실패 카운터
+		rawIDTracker,   // 이슈 #221: host 별 실패 raw_id 추적기
 		fetcherUpgradeCfg.EmptyBodyTitleMin,
 		fetcherUpgradeCfg.EmptyBodyContentMin,
 		parserWorkerCount,

--- a/cmd/issuetracker/main.go
+++ b/cmd/issuetracker/main.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/prometheus/client_golang/prometheus"
 
+	goredis "github.com/redis/go-redis/v9"
 	"issuetracker/internal/locks"
 	"issuetracker/internal/processor"
 	"issuetracker/internal/processor/fetcher"
@@ -39,6 +40,7 @@ import (
 	"issuetracker/pkg/logger"
 	"issuetracker/pkg/metrics"
 	"issuetracker/pkg/queue"
+
 	"issuetracker/pkg/redis"
 )
 
@@ -296,6 +298,31 @@ func main() {
 		}
 	}
 
+	// 이슈 #221: 임계값 도달 시 chromedp 자동 전환 + 실패 raw republish trigger.
+	// ENABLED=false 또는 의존성 부재 시 nil — parser_worker 가 thresholdReached 신호만 받고 실제 전환 발생 안 함.
+	var fetcherUpgrader *fetcherRule.Upgrader
+	if fetcherUpgradeCfg.Enabled {
+		var redisRaw *goredis.Client
+		if redisClientShared != nil {
+			redisRaw = redisClientShared.Raw()
+		}
+		up, upErr := fetcherRule.NewUpgrader(
+			fetcherRuleRepo,
+			fetcherResolver,
+			rawIDTracker,
+			rawSvc,
+			crawlerProducer,
+			redisRaw, // nil 허용 — in-flight lock 비활성 (단일 인스턴스)
+			log,
+		)
+		if upErr != nil {
+			log.WithError(upErr).Warn("failed to construct fetcher upgrader, auto-upgrade disabled at runtime")
+		} else {
+			fetcherUpgrader = up
+			log.Info("fetcher auto-upgrade trigger (chromedp + republish) enabled")
+		}
+	}
+
 	// ── Parser worker (이슈 #134) ──────────────────────────────────────────────
 	// fetcher 와 분리된 별도 consumer group (issuetracker-parsers) 으로 동작 — 인스턴스 수 독립 스케일.
 	// TopicFetched 의 RawContentRef 를 consume 하여 raw 로드 + 파싱 + content 저장 + raw 삭제.
@@ -317,8 +344,9 @@ func main() {
 		sampleRepo,   // 이슈 #173 단계 4-1
 		procLock,     // 이슈 #178: fetcher / parser / validator 가 동일 ProcessingLock 인스턴스 공유
 		llmGen,
-		failureCounter, // 이슈 #220: host 단위 fetcher 실패 카운터
-		rawIDTracker,   // 이슈 #221: host 별 실패 raw_id 추적기
+		failureCounter,  // 이슈 #220: host 단위 fetcher 실패 카운터
+		rawIDTracker,    // 이슈 #221: host 별 실패 raw_id 추적기
+		fetcherUpgrader, // 이슈 #221: 임계값 도달 시 chromedp 자동 전환 + republish
 		fetcherUpgradeCfg.EmptyBodyTitleMin,
 		fetcherUpgradeCfg.EmptyBodyContentMin,
 		parserWorkerCount,

--- a/internal/processor/fetcher/domain/general/chain_handler.go
+++ b/internal/processor/fetcher/domain/general/chain_handler.go
@@ -70,14 +70,6 @@ func NewChainHandler(
 	}
 }
 
-// MetadataKeyForceFetcher 는 단계 3 의 자동 republish job 이 ChainHandler 에 chromedp 강제
-// 사용을 지시할 때 Target.Metadata 에 사용하는 키입니다 (이슈 #175 단계 3, sub-issue #221).
-//
-// 값 "chromedp" 가 설정되면 Resolver / fetcher_rules 조회를 건너뛰고 즉시 ChromedpChain 사용.
-// 외부 source 가 임의로 force 지정하지 못하도록 publisher 측에서 internal-only 로 제한해야 함
-// (이슈 #221 본문 안전망).
-const MetadataKeyForceFetcher = "force_fetcher"
-
 // selectChain 은 host 단위 fetcher 룰을 조회하여 사용할 chain 을 결정합니다.
 //
 // 우선순위 (위에서부터):
@@ -92,7 +84,7 @@ const MetadataKeyForceFetcher = "force_fetcher"
 func (h *ChainHandler) selectChain(ctx context.Context, job *core.CrawlJob) Handler {
 	// 단계 3 republish 경로 — Resolver 보다 우선. 자동 chromedp 전환 trigger 가 발행한
 	// 새 CrawlJob 이 즉시 chromedp 처리되도록 보장.
-	if v, ok := job.Target.Metadata[MetadataKeyForceFetcher]; ok {
+	if v, ok := job.Target.Metadata[rule.MetadataKeyForceFetcher]; ok {
 		if s, ok := v.(string); ok && s == string(storage.FetcherChromedp) {
 			if h.ChromedpChain != nil {
 				h.Log.WithFields(map[string]interface{}{

--- a/internal/processor/fetcher/domain/general/chain_handler.go
+++ b/internal/processor/fetcher/domain/general/chain_handler.go
@@ -70,13 +70,43 @@ func NewChainHandler(
 	}
 }
 
+// MetadataKeyForceFetcher 는 단계 3 의 자동 republish job 이 ChainHandler 에 chromedp 강제
+// 사용을 지시할 때 Target.Metadata 에 사용하는 키입니다 (이슈 #175 단계 3, sub-issue #221).
+//
+// 값 "chromedp" 가 설정되면 Resolver / fetcher_rules 조회를 건너뛰고 즉시 ChromedpChain 사용.
+// 외부 source 가 임의로 force 지정하지 못하도록 publisher 측에서 internal-only 로 제한해야 함
+// (이슈 #221 본문 안전망).
+const MetadataKeyForceFetcher = "force_fetcher"
+
 // selectChain 은 host 단위 fetcher 룰을 조회하여 사용할 chain 을 결정합니다.
+//
+// 우선순위 (위에서부터):
+//  1. Target.Metadata["force_fetcher"] == "chromedp" → ChromedpChain (단계 3 republish 경로)
+//  2. Resolver 의 host 룰 조회 결과
+//  3. fallback → DefaultChain
 //
 // Resolver 가 nil 이거나 host 추출 실패 또는 룰 조회 실패 시 DefaultChain 으로 fallback —
 // fetcher 정책이 부분적으로 망가져도 fetch 자체는 계속 진행 (graceful degrade).
 //
 // chain 선택 외에 룰 결과를 로그에 남겨 운영 가시성 확보.
 func (h *ChainHandler) selectChain(ctx context.Context, job *core.CrawlJob) Handler {
+	// 단계 3 republish 경로 — Resolver 보다 우선. 자동 chromedp 전환 trigger 가 발행한
+	// 새 CrawlJob 이 즉시 chromedp 처리되도록 보장.
+	if v, ok := job.Target.Metadata[MetadataKeyForceFetcher]; ok {
+		if s, ok := v.(string); ok && s == string(storage.FetcherChromedp) {
+			if h.ChromedpChain != nil {
+				h.Log.WithFields(map[string]interface{}{
+					"url":     job.Target.URL,
+					"fetcher": s,
+				}).Debug("force_fetcher metadata applied (republish path)")
+				return h.ChromedpChain
+			}
+			h.Log.WithFields(map[string]interface{}{
+				"url": job.Target.URL,
+			}).Warn("force_fetcher=chromedp but no ChromedpChain wired, using default chain")
+		}
+	}
+
 	if h.Resolver == nil {
 		return h.DefaultChain
 	}

--- a/internal/processor/fetcher/domain/general/chain_handler.go
+++ b/internal/processor/fetcher/domain/general/chain_handler.go
@@ -84,18 +84,28 @@ func NewChainHandler(
 func (h *ChainHandler) selectChain(ctx context.Context, job *core.CrawlJob) Handler {
 	// 단계 3 republish 경로 — Resolver 보다 우선. 자동 chromedp 전환 trigger 가 발행한
 	// 새 CrawlJob 이 즉시 chromedp 처리되도록 보장.
+	//
+	// Provenance 검증 (CodeRabbit 피드백): force_fetcher metadata 는 process-local secret token
+	// 과 함께 부착되어야만 honor. 외부 publisher (현재는 없으나 미래 확장 시) 가 token 추측 불가.
+	// token 부재 / 불일치 시 warn 후 default 분기 — fail-safe.
 	if v, ok := job.Target.Metadata[rule.MetadataKeyForceFetcher]; ok {
 		if s, ok := v.(string); ok && s == string(storage.FetcherChromedp) {
-			if h.ChromedpChain != nil {
+			tokenVal, _ := job.Target.Metadata[rule.MetadataKeyForceFetcherToken].(string)
+			if !rule.ValidateForceFetcherToken(tokenVal) {
+				h.Log.WithFields(map[string]interface{}{
+					"url": job.Target.URL,
+				}).Warn("force_fetcher metadata present but token invalid/absent — falling back to default chain")
+			} else if h.ChromedpChain != nil {
 				h.Log.WithFields(map[string]interface{}{
 					"url":     job.Target.URL,
 					"fetcher": s,
 				}).Debug("force_fetcher metadata applied (republish path)")
 				return h.ChromedpChain
+			} else {
+				h.Log.WithFields(map[string]interface{}{
+					"url": job.Target.URL,
+				}).Warn("force_fetcher=chromedp but no ChromedpChain wired, using default chain")
 			}
-			h.Log.WithFields(map[string]interface{}{
-				"url": job.Target.URL,
-			}).Warn("force_fetcher=chromedp but no ChromedpChain wired, using default chain")
 		}
 	}
 

--- a/internal/processor/fetcher/rule/force_fetcher_token.go
+++ b/internal/processor/fetcher/rule/force_fetcher_token.go
@@ -1,0 +1,58 @@
+package rule
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"fmt"
+	"sync"
+)
+
+// MetadataKeyForceFetcherToken 은 force_fetcher metadata 의 provenance 검증용 보조 키 (이슈 #221).
+//
+// Upgrader 가 process-local secret token 을 함께 부착, ChainHandler 가 검증 후에만 force_fetcher
+// 를 honor. 외부 publisher (현재는 없으나 미래 확장 시) 가 force_fetcher 임의 지정으로 chromedp
+// 를 강제하지 못하도록 internal-only 보장 (CodeRabbit 피드백).
+const MetadataKeyForceFetcherToken = "force_fetcher_token"
+
+var (
+	forceTokenMu sync.RWMutex
+	forceToken   string
+)
+
+// InitForceFetcherToken 은 process startup 시 1회 호출하여 force_fetcher token 을 초기화합니다.
+//
+// crypto/rand 16 bytes hex (32 char). 외부 source 가 추측 불가. 호출 후 ForceFetcherTokenValue /
+// ValidateForceFetcherToken 가 일관된 값으로 동작.
+//
+// 이미 초기화된 상태에서 재호출은 idempotent 하지 않음 — token 갱신 발생 (테스트용 외 운영 환경
+// 에서는 1회만 호출).
+func InitForceFetcherToken() error {
+	b := make([]byte, 16)
+	if _, err := rand.Read(b); err != nil {
+		return fmt.Errorf("init force_fetcher token: %w", err)
+	}
+	forceTokenMu.Lock()
+	forceToken = hex.EncodeToString(b)
+	forceTokenMu.Unlock()
+	return nil
+}
+
+// ForceFetcherTokenValue 는 현재 process token 을 반환합니다.
+//
+// Init 호출 전이면 빈 문자열 — Upgrader 가 metadata 에 빈 토큰 부착 → ChainHandler 의 검증
+// 자연 실패 → force_fetcher 무력화 (안전한 fallback).
+func ForceFetcherTokenValue() string {
+	forceTokenMu.RLock()
+	defer forceTokenMu.RUnlock()
+	return forceToken
+}
+
+// ValidateForceFetcherToken 는 provided 값이 process token 과 일치하는지 검증합니다.
+//
+// Init 안 된 상태 (forceToken="") 에서는 항상 false — 검증 자연 실패로 force_fetcher 무력화.
+// constant-time 비교는 token leakage 위협이 낮아 (process-local) 단순 == 사용.
+func ValidateForceFetcherToken(provided string) bool {
+	forceTokenMu.RLock()
+	defer forceTokenMu.RUnlock()
+	return forceToken != "" && provided == forceToken
+}

--- a/internal/processor/fetcher/rule/raw_id_tracker.go
+++ b/internal/processor/fetcher/rule/raw_id_tracker.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strconv"
 	"time"
 
 	goredis "github.com/redis/go-redis/v9"
@@ -11,23 +12,33 @@ import (
 	"issuetracker/pkg/logger"
 )
 
-// RawIDTracker 는 host 단위로 실패한 raw_id 를 추적합니다 (이슈 #221).
+// RawIDTracker 는 host 단위로 실패한 raw_id 를 timestamp 순으로 추적합니다 (이슈 #221).
 //
-// 단계 3 의 자동 chromedp 전환 트리거가 Pop 으로 같은 host 의 실패 raw_id 들을 가져와
-// 새 CrawlJob 으로 republish 합니다. raw_contents 테이블에 host 컬럼이 없어서 Redis Set
-// 으로 application 레이어에서 host → raw_id 관계를 추적.
+// 단계 3 의 자동 chromedp 전환 trigger 가 PeekByHost 로 가장 최근 실패 raw_id 들을 가져와
+// 새 CrawlJob 으로 republish 합니다. raw_contents 테이블에 host 컬럼이 없어서 Redis ZSET 으로
+// application 레이어에서 host → raw_id (recency 순) 관계를 추적.
 //
-// 본 인터페이스는 단계 2 의 FailureCounter 와 직교적 — 카운터는 host 단위 임계값 도달
-// 시점만 감지, Tracker 는 실제 republish 대상 raw_id 의 수집을 담당.
+// Peek-then-Remove 패턴 (CodeRabbit 피드백):
+//   - PeekByHost 는 최근 N 개를 조회만 — 실패 시 ID 가 손실되지 않음
+//   - 호출자 (Upgrader) 가 publish 성공 후 RemoveByHost 로 삭제
+//   - publish 실패 시 ID 가 잔존 → 다음 trigger 가 자연스럽게 재시도
+//
+// Set 대신 ZSET (score=timestamp) 채택 이유 (CodeRabbit 피드백):
+//   - "최근 실패 raw_ids" contract 보장 (Set 은 unordered 라 stale 항목 republish 위험)
+//   - ZREVRANGE 로 score DESC 순 (최근 우선) Peek 가능
 type RawIDTracker interface {
-	// Track 은 host 의 실패 raw_id 를 등록합니다. ttl 만료 시 자연 정리.
+	// Track 은 host 의 실패 raw_id 를 timestamp score 와 함께 등록합니다. ttl 만료 시 자연 정리.
 	// host 또는 rawID 가 빈 문자열이면 noop.
 	Track(ctx context.Context, host, rawID string) error
 
-	// PopByHost 는 host 의 실패 raw_id 를 최대 limit 개 가져오고 Set 에서 제거합니다.
-	// 단일 트리거 사이클에서 1회 호출 — 동일 raw_id 가 두 번 republish 되지 않도록 atomic.
-	// Set 비어있거나 host 매칭 entry 없으면 빈 슬라이스 + nil 에러.
-	PopByHost(ctx context.Context, host string, limit int) ([]string, error)
+	// PeekByHost 는 host 의 가장 최근 실패 raw_id 를 최대 limit 개 조회합니다 (제거 안 함).
+	// score DESC 순 — 가장 최근 항목이 첫 번째.
+	// 호출자가 republish 성공 후 RemoveByHost 로 명시적 제거.
+	PeekByHost(ctx context.Context, host string, limit int) ([]string, error)
+
+	// RemoveByHost 는 ZSET 에서 지정된 raw_id 들을 제거합니다. 존재하지 않는 ID 는 무시.
+	// 빈 슬라이스 / 빈 host 는 noop.
+	RemoveByHost(ctx context.Context, host string, rawIDs []string) error
 }
 
 // noopRawIDTracker 는 Redis 미연결 / FETCHER_AUTO_UPGRADE_ENABLED=false 시 fallback.
@@ -37,17 +48,20 @@ type noopRawIDTracker struct{}
 func NewNoopRawIDTracker() RawIDTracker { return noopRawIDTracker{} }
 
 func (noopRawIDTracker) Track(ctx context.Context, host, rawID string) error { return nil }
-func (noopRawIDTracker) PopByHost(ctx context.Context, host string, limit int) ([]string, error) {
+func (noopRawIDTracker) PeekByHost(ctx context.Context, host string, limit int) ([]string, error) {
 	return nil, nil
 }
+func (noopRawIDTracker) RemoveByHost(ctx context.Context, host string, rawIDs []string) error {
+	return nil
+}
 
-// redisRawIDTracker 는 Redis Set 기반 RawIDTracker 입니다.
+// redisRawIDTracker 는 Redis ZSET 기반 RawIDTracker 입니다.
 //
 // 알고리즘:
 //
-//   - Track: SADD key={prefix}:{host}, member=rawID + EXPIRE ttl (sliding)
-//   - PopByHost: SPOP key 가 atomic 으로 limit 개 pop — 동시 트리거가 같은 raw_id 를
-//     중복 republish 하는 race 를 SPOP 의 atomic 성으로 회피.
+//   - Track:        ZADD key={prefix}:{host}, score=now-unix-nano, member=rawID + EXPIRE ttl
+//   - PeekByHost:   ZREVRANGE key 0 limit-1 (score DESC = 최근 우선)
+//   - RemoveByHost: ZREM key member1 member2 ...
 type redisRawIDTracker struct {
 	client    *goredis.Client
 	keyPrefix string
@@ -55,11 +69,11 @@ type redisRawIDTracker struct {
 	log       *logger.Logger
 }
 
-// NewRedisRawIDTracker 는 Redis Set 기반 RawIDTracker 를 생성합니다.
+// NewRedisRawIDTracker 는 Redis ZSET 기반 RawIDTracker 를 생성합니다.
 //
 // client 가 nil 이거나 ttl 이 비정상이면 error 반환 (이슈 #208 정책).
 // keyPrefix 가 빈 문자열이면 "fetcher:failed_raws" 사용.
-// ttl 은 host 별 Set 의 자연 정리 시간 — FailureCounter 의 window 와 동기화 권장.
+// ttl 은 host 별 ZSET 의 자연 정리 시간 — FailureCounter 의 window 와 동기화 권장.
 func NewRedisRawIDTracker(client *goredis.Client, ttl time.Duration, keyPrefix string, log *logger.Logger) (RawIDTracker, error) {
 	if client == nil {
 		return nil, errors.New("rule: NewRedisRawIDTracker requires non-nil redis client")
@@ -87,28 +101,50 @@ func (r *redisRawIDTracker) Track(ctx context.Context, host, rawID string) error
 		return nil
 	}
 	key := r.keyFor(host)
+	score := float64(time.Now().UnixNano())
 
 	pipe := r.client.Pipeline()
-	pipe.SAdd(ctx, key, rawID)
+	pipe.ZAdd(ctx, key, goredis.Z{Score: score, Member: rawID})
 	pipe.Expire(ctx, key, r.ttl)
 	if _, err := pipe.Exec(ctx); err != nil {
-		return fmt.Errorf("redis raw id tracker SADD for host %s: %w", host, err)
+		return fmt.Errorf("redis raw id tracker ZADD for host %s: %w", host, err)
 	}
 	return nil
 }
 
-func (r *redisRawIDTracker) PopByHost(ctx context.Context, host string, limit int) ([]string, error) {
+func (r *redisRawIDTracker) PeekByHost(ctx context.Context, host string, limit int) ([]string, error) {
 	if host == "" || limit <= 0 {
 		return nil, nil
 	}
 	key := r.keyFor(host)
-	res, err := r.client.SPopN(ctx, key, int64(limit)).Result()
+	// ZREVRANGE 0 limit-1 — score DESC 순으로 N 개 (가장 최근 우선).
+	res, err := r.client.ZRevRange(ctx, key, 0, int64(limit-1)).Result()
 	if err != nil {
-		// 키 자체가 없을 때는 redis.Nil — 빈 슬라이스 + nil 로 정규화.
 		if errors.Is(err, goredis.Nil) {
 			return nil, nil
 		}
-		return nil, fmt.Errorf("redis raw id tracker SPOP for host %s: %w", host, err)
+		return nil, fmt.Errorf("redis raw id tracker ZREVRANGE for host %s: %w", host, err)
 	}
 	return res, nil
+}
+
+func (r *redisRawIDTracker) RemoveByHost(ctx context.Context, host string, rawIDs []string) error {
+	if host == "" || len(rawIDs) == 0 {
+		return nil
+	}
+	key := r.keyFor(host)
+	members := make([]interface{}, 0, len(rawIDs))
+	for _, id := range rawIDs {
+		if id == "" {
+			continue
+		}
+		members = append(members, id)
+	}
+	if len(members) == 0 {
+		return nil
+	}
+	if _, err := r.client.ZRem(ctx, key, members...).Result(); err != nil {
+		return fmt.Errorf("redis raw id tracker ZREM for host %s (count=%s): %w", host, strconv.Itoa(len(members)), err)
+	}
+	return nil
 }

--- a/internal/processor/fetcher/rule/raw_id_tracker.go
+++ b/internal/processor/fetcher/rule/raw_id_tracker.go
@@ -117,8 +117,14 @@ func (r *redisRawIDTracker) PeekByHost(ctx context.Context, host string, limit i
 		return nil, nil
 	}
 	key := r.keyFor(host)
-	// ZREVRANGE 0 limit-1 — score DESC 순으로 N 개 (가장 최근 우선).
-	res, err := r.client.ZRevRange(ctx, key, 0, int64(limit-1)).Result()
+	// ZRangeArgs with Rev — score DESC 순으로 N 개 (가장 최근 우선).
+	// ZRevRange 는 go-redis v9 에서 deprecated (Redis 6.2.0+ 권장 API).
+	res, err := r.client.ZRangeArgs(ctx, goredis.ZRangeArgs{
+		Key:   key,
+		Start: 0,
+		Stop:  int64(limit - 1),
+		Rev:   true,
+	}).Result()
 	if err != nil {
 		if errors.Is(err, goredis.Nil) {
 			return nil, nil

--- a/internal/processor/fetcher/rule/raw_id_tracker.go
+++ b/internal/processor/fetcher/rule/raw_id_tracker.go
@@ -1,0 +1,114 @@
+package rule
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	goredis "github.com/redis/go-redis/v9"
+
+	"issuetracker/pkg/logger"
+)
+
+// RawIDTracker 는 host 단위로 실패한 raw_id 를 추적합니다 (이슈 #221).
+//
+// 단계 3 의 자동 chromedp 전환 트리거가 Pop 으로 같은 host 의 실패 raw_id 들을 가져와
+// 새 CrawlJob 으로 republish 합니다. raw_contents 테이블에 host 컬럼이 없어서 Redis Set
+// 으로 application 레이어에서 host → raw_id 관계를 추적.
+//
+// 본 인터페이스는 단계 2 의 FailureCounter 와 직교적 — 카운터는 host 단위 임계값 도달
+// 시점만 감지, Tracker 는 실제 republish 대상 raw_id 의 수집을 담당.
+type RawIDTracker interface {
+	// Track 은 host 의 실패 raw_id 를 등록합니다. ttl 만료 시 자연 정리.
+	// host 또는 rawID 가 빈 문자열이면 noop.
+	Track(ctx context.Context, host, rawID string) error
+
+	// PopByHost 는 host 의 실패 raw_id 를 최대 limit 개 가져오고 Set 에서 제거합니다.
+	// 단일 트리거 사이클에서 1회 호출 — 동일 raw_id 가 두 번 republish 되지 않도록 atomic.
+	// Set 비어있거나 host 매칭 entry 없으면 빈 슬라이스 + nil 에러.
+	PopByHost(ctx context.Context, host string, limit int) ([]string, error)
+}
+
+// noopRawIDTracker 는 Redis 미연결 / FETCHER_AUTO_UPGRADE_ENABLED=false 시 fallback.
+type noopRawIDTracker struct{}
+
+// NewNoopRawIDTracker 는 항상 (nil, nil) 을 반환하는 RawIDTracker 를 반환합니다.
+func NewNoopRawIDTracker() RawIDTracker { return noopRawIDTracker{} }
+
+func (noopRawIDTracker) Track(ctx context.Context, host, rawID string) error { return nil }
+func (noopRawIDTracker) PopByHost(ctx context.Context, host string, limit int) ([]string, error) {
+	return nil, nil
+}
+
+// redisRawIDTracker 는 Redis Set 기반 RawIDTracker 입니다.
+//
+// 알고리즘:
+//
+//   - Track: SADD key={prefix}:{host}, member=rawID + EXPIRE ttl (sliding)
+//   - PopByHost: SPOP key 가 atomic 으로 limit 개 pop — 동시 트리거가 같은 raw_id 를
+//     중복 republish 하는 race 를 SPOP 의 atomic 성으로 회피.
+type redisRawIDTracker struct {
+	client    *goredis.Client
+	keyPrefix string
+	ttl       time.Duration
+	log       *logger.Logger
+}
+
+// NewRedisRawIDTracker 는 Redis Set 기반 RawIDTracker 를 생성합니다.
+//
+// client 가 nil 이거나 ttl 이 비정상이면 error 반환 (이슈 #208 정책).
+// keyPrefix 가 빈 문자열이면 "fetcher:failed_raws" 사용.
+// ttl 은 host 별 Set 의 자연 정리 시간 — FailureCounter 의 window 와 동기화 권장.
+func NewRedisRawIDTracker(client *goredis.Client, ttl time.Duration, keyPrefix string, log *logger.Logger) (RawIDTracker, error) {
+	if client == nil {
+		return nil, errors.New("rule: NewRedisRawIDTracker requires non-nil redis client")
+	}
+	if ttl <= 0 {
+		return nil, fmt.Errorf("rule: NewRedisRawIDTracker requires positive ttl, got %s", ttl)
+	}
+	if keyPrefix == "" {
+		keyPrefix = "fetcher:failed_raws"
+	}
+	return &redisRawIDTracker{
+		client:    client,
+		keyPrefix: keyPrefix,
+		ttl:       ttl,
+		log:       log,
+	}, nil
+}
+
+func (r *redisRawIDTracker) keyFor(host string) string {
+	return r.keyPrefix + ":" + host
+}
+
+func (r *redisRawIDTracker) Track(ctx context.Context, host, rawID string) error {
+	if host == "" || rawID == "" {
+		return nil
+	}
+	key := r.keyFor(host)
+
+	pipe := r.client.Pipeline()
+	pipe.SAdd(ctx, key, rawID)
+	pipe.Expire(ctx, key, r.ttl)
+	if _, err := pipe.Exec(ctx); err != nil {
+		return fmt.Errorf("redis raw id tracker SADD for host %s: %w", host, err)
+	}
+	return nil
+}
+
+func (r *redisRawIDTracker) PopByHost(ctx context.Context, host string, limit int) ([]string, error) {
+	if host == "" || limit <= 0 {
+		return nil, nil
+	}
+	key := r.keyFor(host)
+	res, err := r.client.SPopN(ctx, key, int64(limit)).Result()
+	if err != nil {
+		// 키 자체가 없을 때는 redis.Nil — 빈 슬라이스 + nil 로 정규화.
+		if errors.Is(err, goredis.Nil) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("redis raw id tracker SPOP for host %s: %w", host, err)
+	}
+	return res, nil
+}

--- a/internal/processor/fetcher/rule/upgrader.go
+++ b/internal/processor/fetcher/rule/upgrader.go
@@ -20,9 +20,7 @@ import (
 // MetadataKeyForceFetcher 는 단계 3 의 republish CrawlJob 이 ChainHandler 에 chromedp 강제
 // 사용을 지시할 때 Target.Metadata 에 사용하는 키 (이슈 #221).
 //
-// 같은 키가 internal/processor/fetcher/domain/general/chain_handler.go 에도 정의되어 있으나
-// import cycle 회피를 위해 본 패키지에 별도 const 유지. 두 값이 동일 문자열임을 두 패키지의
-// 경계에서 보장.
+// ChainHandler (general 패키지) 도 본 const 를 참조 — 단일 정의로 정합성 보장.
 const MetadataKeyForceFetcher = "force_fetcher"
 
 const (

--- a/internal/processor/fetcher/rule/upgrader.go
+++ b/internal/processor/fetcher/rule/upgrader.go
@@ -153,37 +153,48 @@ func (u *Upgrader) Trigger(ctx context.Context, host string) {
 		"reason": "auto_upgrade_validation",
 	})
 
-	// 실패 raw_id 수집 + republish
-	rawIDs, err := u.tracker.PopByHost(ctx, host, upgraderMaxRepublishPerCycle)
+	// 실패 raw_id 수집 + republish (Peek-then-Remove 패턴 — CodeRabbit 피드백):
+	//  - Peek: 제거 안 함 → publish 실패 시 잔존 (다음 trigger 가 자연 retry 가능)
+	//  - Publish 성공 후에만 RemoveByHost 로 명시적 제거
+	rawIDs, err := u.tracker.PeekByHost(ctx, host, upgraderMaxRepublishPerCycle)
 	if err != nil {
-		u.logWarn("upgrader tracker PopByHost failed, host upgraded but no raw republished", host, err)
+		u.logWarn("upgrader tracker PeekByHost failed, host upgraded but no raw republished", host, err)
 		return
 	}
 	if len(rawIDs) == 0 {
-		u.logDebug("upgrader: no failed raw to republish (already popped or expired)", host)
+		u.logDebug("upgrader: no failed raw to republish (none tracked or expired)", host)
 		return
 	}
 
 	u.republishRaws(ctx, host, rawIDs)
 }
 
-// republishRaws 는 PopByHost 결과의 raw_id 들을 새 CrawlJob 으로 발행합니다.
+// republishRaws 는 Peek 결과의 raw_id 들을 새 CrawlJob 으로 발행합니다 (Peek-then-Remove).
 //
 // 각 raw 에 대해:
-//   - rawSvc.GetByID 로 URL / Crawler 이름 추출 (실패 시 skip)
-//   - 새 CrawlJob 생성: Target.URL = raw.URL, Target.Metadata["force_fetcher"]="chromedp",
-//     Headers = {retry_reason: validation_upgrade, original_raw_id: ...}
-//   - 단일 PublishBatch 로 Kafka 발행 (priority normal)
+//   - rawSvc.GetByID 로 URL / Crawler 이름 추출
+//   - 성공 → CrawlJob 생성 (force_fetcher + token + retry 메타) → msgs append
+//   - 실패 (raw 없음 / URL 빈 상태) → staleIDs 누적 — publish 후 일괄 정리
+//
+// PublishBatch 결과:
+//   - 성공: republished + stale 모두 RemoveByHost 로 정리
+//   - 실패: RemoveByHost 호출 안 함 — 모든 ID 잔존, 다음 trigger 가 자연 retry (CodeRabbit 피드백)
+//
+// force_fetcher 는 process-local secret token 과 함께 부착 — 외부 source 의 임의 force 차단 (이슈 #221 안전망).
 func (u *Upgrader) republishRaws(ctx context.Context, host string, rawIDs []string) {
 	msgs := make([]queue.Message, 0, len(rawIDs))
+	republishedIDs := make([]string, 0, len(rawIDs))
+	staleIDs := make([]string, 0)
 
 	for _, rawID := range rawIDs {
 		raw, err := u.rawSvc.GetByID(ctx, rawID)
 		if err != nil {
-			u.logWarn("upgrader raw GetByID failed (skipping)", host, err)
+			u.logWarn("upgrader raw GetByID failed — marking stale", host, err)
+			staleIDs = append(staleIDs, rawID)
 			continue
 		}
 		if raw == nil || raw.URL == "" {
+			staleIDs = append(staleIDs, rawID)
 			continue
 		}
 
@@ -194,9 +205,10 @@ func (u *Upgrader) republishRaws(ctx context.Context, host string, rawIDs []stri
 				URL:  raw.URL,
 				Type: core.TargetTypeArticle,
 				Metadata: map[string]interface{}{
-					MetadataKeyForceFetcher: string(storage.FetcherChromedp),
-					"retry_reason":          "validation_upgrade",
-					"original_raw_id":       rawID,
+					MetadataKeyForceFetcher:      string(storage.FetcherChromedp),
+					MetadataKeyForceFetcherToken: ForceFetcherTokenValue(),
+					"retry_reason":               "validation_upgrade",
+					"original_raw_id":            rawID,
 				},
 			},
 			Priority:    core.PriorityNormal,
@@ -206,7 +218,8 @@ func (u *Upgrader) republishRaws(ctx context.Context, host string, rawIDs []stri
 		}
 		data, err := job.Marshal()
 		if err != nil {
-			u.logWarn("upgrader job Marshal failed (skipping)", host, err)
+			u.logWarn("upgrader job Marshal failed — marking stale", host, err)
+			staleIDs = append(staleIDs, rawID)
 			continue
 		}
 		msgs = append(msgs, queue.Message{
@@ -220,21 +233,36 @@ func (u *Upgrader) republishRaws(ctx context.Context, host string, rawIDs []stri
 				"original_raw_id": rawID,
 			},
 		})
+		republishedIDs = append(republishedIDs, rawID)
 	}
 
+	// 발행 대상 0건 — stale 만 정리.
 	if len(msgs) == 0 {
-		u.logDebug("upgrader: all republish candidates skipped (no valid raw)", host)
+		if len(staleIDs) > 0 {
+			if err := u.tracker.RemoveByHost(ctx, host, staleIDs); err != nil {
+				u.logWarn("upgrader RemoveByHost (stale only) failed", host, err)
+			}
+		}
+		u.logDebug("upgrader: no valid raw to publish (all stale)", host)
 		return
 	}
 
 	if err := u.producer.PublishBatch(ctx, msgs); err != nil {
-		u.logWarn("upgrader republish PublishBatch failed", host, err)
+		// Kafka 실패 — 모든 ID 잔존 (다음 trigger 가 자연 retry).
+		u.logWarn("upgrader republish PublishBatch failed, all ids retained for retry", host, err)
 		return
+	}
+
+	// 성공: republished + stale 모두 ZREM 으로 정리.
+	toRemove := append(append([]string{}, republishedIDs...), staleIDs...)
+	if err := u.tracker.RemoveByHost(ctx, host, toRemove); err != nil {
+		u.logWarn("upgrader RemoveByHost after publish failed (best-effort)", host, err)
 	}
 
 	u.logFields("upgrader republish completed", map[string]interface{}{
 		"host":            host,
 		"republish_count": len(msgs),
+		"stale_count":     len(staleIDs),
 	})
 }
 

--- a/internal/processor/fetcher/rule/upgrader.go
+++ b/internal/processor/fetcher/rule/upgrader.go
@@ -1,0 +1,270 @@
+package rule
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"time"
+
+	goredis "github.com/redis/go-redis/v9"
+
+	"issuetracker/internal/processor/fetcher/core"
+	"issuetracker/internal/storage"
+	"issuetracker/internal/storage/service"
+	"issuetracker/pkg/logger"
+	"issuetracker/pkg/queue"
+)
+
+// MetadataKeyForceFetcher 는 단계 3 의 republish CrawlJob 이 ChainHandler 에 chromedp 강제
+// 사용을 지시할 때 Target.Metadata 에 사용하는 키 (이슈 #221).
+//
+// 같은 키가 internal/processor/fetcher/domain/general/chain_handler.go 에도 정의되어 있으나
+// import cycle 회피를 위해 본 패키지에 별도 const 유지. 두 값이 동일 문자열임을 두 패키지의
+// 경계에서 보장.
+const MetadataKeyForceFetcher = "force_fetcher"
+
+const (
+	// upgraderInflightTTL: 같은 host 의 동시 trigger 가 1회만 실행되도록 잡는 SETNX lock 의 TTL.
+	// 너무 짧으면 trigger 중간에 lock 만료 → 중복 republish. 너무 길면 다음 정당한 trigger 가 차단됨.
+	// 단계 3 의 trigger 작업량 (fetcher_rules UPSERT + 최대 20건 republish) 에 충분한 5분.
+	upgraderInflightTTL = 5 * time.Minute
+
+	// upgraderMaxRepublishPerCycle: 단일 trigger 사이클의 max republish 수.
+	// 한 host 에 잔존 raw 100건이 있어도 일괄 republish 시 fetcher pool 폭주 회피.
+	// 나머지는 다음 trigger / 재카운팅 사이클이 자연스럽게 처리.
+	upgraderMaxRepublishPerCycle = 20
+
+	// republishedJobTimeout: republish 한 CrawlJob 의 fetch timeout. fetcher chromedp 의 일반값 (#146 설정).
+	republishedJobTimeout = 30 * time.Second
+)
+
+// Upgrader 는 임계값 도달 host 를 chromedp 로 자동 전환하고 실패 raw 를 republish 합니다 (이슈 #175 단계 3).
+//
+// 호출 흐름 (parser_worker 가 thresholdReached=true 받으면 Trigger 호출):
+//
+//  1. Redis SETNX 로 host 단위 in-flight lock — 동시 trigger 의 race / flooding 차단.
+//  2. fetcher_rules.GetByHost: 이미 chromedp 면 audit warn 후 skip (chromedp 도 실패하는 host 신호 — 운영자 개입 영역).
+//  3. fetcher_rules.Upsert(host, chromedp, "auto_upgrade_validation").
+//  4. Resolver.Invalidate(host) — cache 동기화.
+//  5. RawIDTracker.PopByHost(host, max=20) — 실패 raw 수집.
+//  6. 각 raw 에 대해: RawContentService.GetByID 로 URL 조회 → CrawlJob 생성 (Target.Metadata force_fetcher=chromedp, Headers={retry_reason, original_raw_id}) → Producer.PublishBatch.
+//  7. lock 자동 만료 (TTL).
+//
+// 안전망:
+//   - 이미 chromedp 인 host: UPSERT/republish 모두 skip + audit
+//   - 동시 trigger: SETNX dedup
+//   - max 20 cap: 단일 사이클 republish 폭주 회피
+//   - 모든 단계 실패는 non-fatal — best-effort. 다음 카운팅 사이클이 자연스러운 retry.
+type Upgrader struct {
+	repo     storage.FetcherRuleRepository
+	resolver Resolver
+	tracker  RawIDTracker
+	rawSvc   service.RawContentService
+	producer queue.Producer
+	redis    *goredis.Client // SETNX in-flight lock 용. nil 이면 lock 비활성 (단일 인스턴스 환경).
+	log      *logger.Logger
+}
+
+// NewUpgrader 는 Upgrader 를 생성합니다.
+//
+// 모든 인자는 nil 허용 안 함 (redis 만 nil 허용 — 단일 인스턴스 환경에서 lock 비활성).
+// nil 인자 발견 시 error (이슈 #208 정책).
+func NewUpgrader(
+	repo storage.FetcherRuleRepository,
+	resolver Resolver,
+	tracker RawIDTracker,
+	rawSvc service.RawContentService,
+	producer queue.Producer,
+	redisClient *goredis.Client,
+	log *logger.Logger,
+) (*Upgrader, error) {
+	if repo == nil {
+		return nil, errors.New("rule: NewUpgrader requires non-nil FetcherRuleRepository")
+	}
+	if resolver == nil {
+		return nil, errors.New("rule: NewUpgrader requires non-nil Resolver")
+	}
+	if tracker == nil {
+		return nil, errors.New("rule: NewUpgrader requires non-nil RawIDTracker")
+	}
+	if rawSvc == nil {
+		return nil, errors.New("rule: NewUpgrader requires non-nil RawContentService")
+	}
+	if producer == nil {
+		return nil, errors.New("rule: NewUpgrader requires non-nil Producer")
+	}
+	return &Upgrader{
+		repo:     repo,
+		resolver: resolver,
+		tracker:  tracker,
+		rawSvc:   rawSvc,
+		producer: producer,
+		redis:    redisClient,
+		log:      log,
+	}, nil
+}
+
+// Trigger 는 host 의 chromedp 자동 전환 + 실패 raw republish 를 1회 실행합니다.
+//
+// host 가 빈 문자열이면 noop. 모든 단계 실패는 non-fatal — best-effort.
+//
+// 본 메소드는 동기 — 호출자가 별도 goroutine 에서 실행하는 것을 권장 (parser_worker 의 처리 흐름을 차단하지 않도록).
+func (u *Upgrader) Trigger(ctx context.Context, host string) {
+	if host == "" || u == nil {
+		return
+	}
+
+	// in-flight dedup
+	if u.redis != nil {
+		key := "fetcher:upgrader:lock:" + host
+		ok, err := u.redis.SetNX(ctx, key, 1, upgraderInflightTTL).Result()
+		if err != nil {
+			u.logWarn("upgrader inflight lock failed, proceeding without dedup", host, err)
+		} else if !ok {
+			u.logDebug("upgrader skipped — another trigger in flight for host", host)
+			return
+		}
+	}
+
+	// 이미 chromedp 인 host 차단
+	if existing, err := u.repo.GetByHost(ctx, host); err == nil {
+		if existing.Fetcher == storage.FetcherChromedp {
+			u.logFields("upgrader skipped — host already on chromedp (audit: chromedp itself failing for this host)", map[string]interface{}{
+				"host":   host,
+				"reason": existing.Reason,
+			})
+			return
+		}
+	} else if !errors.Is(err, storage.ErrNotFound) {
+		u.logWarn("upgrader fetcher_rules GetByHost failed, aborting trigger", host, err)
+		return
+	}
+
+	// UPSERT chromedp + cache invalidate
+	if err := u.repo.Upsert(ctx, host, storage.FetcherChromedp, "auto_upgrade_validation"); err != nil {
+		u.logWarn("upgrader fetcher_rules Upsert failed", host, err)
+		return
+	}
+	u.resolver.Invalidate(host)
+	u.logFields("fetcher rule auto-upgraded to chromedp", map[string]interface{}{
+		"host":   host,
+		"reason": "auto_upgrade_validation",
+	})
+
+	// 실패 raw_id 수집 + republish
+	rawIDs, err := u.tracker.PopByHost(ctx, host, upgraderMaxRepublishPerCycle)
+	if err != nil {
+		u.logWarn("upgrader tracker PopByHost failed, host upgraded but no raw republished", host, err)
+		return
+	}
+	if len(rawIDs) == 0 {
+		u.logDebug("upgrader: no failed raw to republish (already popped or expired)", host)
+		return
+	}
+
+	u.republishRaws(ctx, host, rawIDs)
+}
+
+// republishRaws 는 PopByHost 결과의 raw_id 들을 새 CrawlJob 으로 발행합니다.
+//
+// 각 raw 에 대해:
+//   - rawSvc.GetByID 로 URL / Crawler 이름 추출 (실패 시 skip)
+//   - 새 CrawlJob 생성: Target.URL = raw.URL, Target.Metadata["force_fetcher"]="chromedp",
+//     Headers = {retry_reason: validation_upgrade, original_raw_id: ...}
+//   - 단일 PublishBatch 로 Kafka 발행 (priority normal)
+func (u *Upgrader) republishRaws(ctx context.Context, host string, rawIDs []string) {
+	msgs := make([]queue.Message, 0, len(rawIDs))
+
+	for _, rawID := range rawIDs {
+		raw, err := u.rawSvc.GetByID(ctx, rawID)
+		if err != nil {
+			u.logWarn("upgrader raw GetByID failed (skipping)", host, err)
+			continue
+		}
+		if raw == nil || raw.URL == "" {
+			continue
+		}
+
+		job := &core.CrawlJob{
+			ID:          newRepublishJobID(),
+			CrawlerName: raw.SourceInfo.Name,
+			Target: core.Target{
+				URL:  raw.URL,
+				Type: core.TargetTypeArticle,
+				Metadata: map[string]interface{}{
+					MetadataKeyForceFetcher: string(storage.FetcherChromedp),
+					"retry_reason":          "validation_upgrade",
+					"original_raw_id":       rawID,
+				},
+			},
+			Priority:    core.PriorityNormal,
+			ScheduledAt: time.Now(),
+			Timeout:     republishedJobTimeout,
+			MaxRetries:  3,
+		}
+		data, err := job.Marshal()
+		if err != nil {
+			u.logWarn("upgrader job Marshal failed (skipping)", host, err)
+			continue
+		}
+		msgs = append(msgs, queue.Message{
+			Topic: queue.TopicCrawlNormal,
+			Key:   []byte(job.ID),
+			Value: data,
+			Headers: map[string]string{
+				"crawler":         job.CrawlerName,
+				"priority":        fmt.Sprintf("%d", int(job.Priority)),
+				"retry_reason":    "validation_upgrade",
+				"original_raw_id": rawID,
+			},
+		})
+	}
+
+	if len(msgs) == 0 {
+		u.logDebug("upgrader: all republish candidates skipped (no valid raw)", host)
+		return
+	}
+
+	if err := u.producer.PublishBatch(ctx, msgs); err != nil {
+		u.logWarn("upgrader republish PublishBatch failed", host, err)
+		return
+	}
+
+	u.logFields("upgrader republish completed", map[string]interface{}{
+		"host":            host,
+		"republish_count": len(msgs),
+	})
+}
+
+func (u *Upgrader) logWarn(msg, host string, err error) {
+	if u.log == nil {
+		return
+	}
+	u.log.WithField("host", host).WithError(err).Warn(msg)
+}
+
+func (u *Upgrader) logDebug(msg, host string) {
+	if u.log == nil {
+		return
+	}
+	u.log.WithField("host", host).Debug(msg)
+}
+
+func (u *Upgrader) logFields(msg string, fields map[string]interface{}) {
+	if u.log == nil {
+		return
+	}
+	u.log.WithFields(fields).Info(msg)
+}
+
+// newRepublishJobID 는 republish CrawlJob 의 고유 ID 를 생성합니다 (publisher.newJobID 와 동일 패턴 — 32자 hex).
+func newRepublishJobID() string {
+	b := make([]byte, 16)
+	if _, err := rand.Read(b); err != nil {
+		// crypto/rand 실패는 매우 드물지만 발생 시 timestamp 기반 fallback.
+		return fmt.Sprintf("republish-%d", time.Now().UnixNano())
+	}
+	return "republish-" + hex.EncodeToString(b)
+}

--- a/internal/processor/fetcher/rule/upgrader.go
+++ b/internal/processor/fetcher/rule/upgrader.go
@@ -116,15 +116,17 @@ func (u *Upgrader) Trigger(ctx context.Context, host string) {
 		return
 	}
 
-	// in-flight dedup
+	// in-flight dedup — SetArgs(NX, TTL) 으로 atomic SET … NX PX. SetNX 는 go-redis v9 에서 deprecated.
+	// (goredis.Nil 은 NX 조건 불충족 = 이미 lock 보유 중을 의미하는 정상 신호.)
 	if u.redis != nil {
 		key := "fetcher:upgrader:lock:" + host
-		ok, err := u.redis.SetNX(ctx, key, 1, upgraderInflightTTL).Result()
-		if err != nil {
-			u.logWarn("upgrader inflight lock failed, proceeding without dedup", host, err)
-		} else if !ok {
+		err := u.redis.SetArgs(ctx, key, 1, goredis.SetArgs{Mode: "NX", TTL: upgraderInflightTTL}).Err()
+		if errors.Is(err, goredis.Nil) {
 			u.logDebug("upgrader skipped — another trigger in flight for host", host)
 			return
+		}
+		if err != nil {
+			u.logWarn("upgrader inflight lock failed, proceeding without dedup", host, err)
 		}
 	}
 

--- a/internal/processor/parser/worker/parser_worker.go
+++ b/internal/processor/parser/worker/parser_worker.go
@@ -71,6 +71,10 @@ type ParserWorker struct {
 	// nil 시 noopRawIDTracker — republish 비활성 (단계 3 trigger 가 빈 raw_id 받음).
 	rawIDTracker fetcherRule.RawIDTracker
 
+	// upgrader: 임계값 도달 시 chromedp 자동 전환 + 실패 raw republish 트리거 (이슈 #221).
+	// nil 허용 — nil 이면 thresholdReached 신호 발신만 (자동 전환 비활성).
+	upgrader *fetcherRule.Upgrader
+
 	emptyBodyTitleMin   int
 	emptyBodyContentMin int
 
@@ -107,6 +111,7 @@ func NewParserWorker(
 	llmGen *llmgen.Generator,
 	failureCounter fetcherRule.FailureCounter,
 	rawIDTracker fetcherRule.RawIDTracker,
+	upgrader *fetcherRule.Upgrader,
 	emptyBodyTitleMin int,
 	emptyBodyContentMin int,
 	workerCount int,
@@ -137,6 +142,7 @@ func NewParserWorker(
 		llmGen:              llmGen,
 		failureCounter:      failureCounter,
 		rawIDTracker:        rawIDTracker,
+		upgrader:            upgrader,
 		emptyBodyTitleMin:   emptyBodyTitleMin,
 		emptyBodyContentMin: emptyBodyContentMin,
 		workerCount:         workerCount,
@@ -386,13 +392,17 @@ func (w *ParserWorker) handleRuleError(ctx context.Context, raw *core.RawContent
 // 카운팅 / 트래킹 자체 실패는 non-fatal — warn 로그만 남기고 정상 흐름 유지 (Redis 장애가
 // parse 실패 처리 흐름을 막지 않도록).
 //
+// 이슈 #221: 카운터가 thresholdReached=true 반환하면 Upgrader.Trigger 를 별도 goroutine 으로
+// 비동기 호출 — parser 본 흐름의 latency 차단 회피. Upgrader 가 nil 이면 신호만 발신.
+//
 // rawID 는 단계 3 의 chromedp 자동 전환 trigger 가 republish 대상으로 사용. 빈 문자열이면
 // Tracker 가 noop.
 func (w *ParserWorker) recordHostFailure(ctx context.Context, host, rawID string, reason fetcherRule.FailureReason, mlog *logger.Logger) {
 	if w.failureCounter == nil {
 		return
 	}
-	if _, _, err := w.failureCounter.Record(ctx, host, reason); err != nil {
+	_, thresholdReached, err := w.failureCounter.Record(ctx, host, reason)
+	if err != nil {
 		mlog.WithFields(map[string]interface{}{
 			"host":   host,
 			"reason": string(reason),
@@ -405,6 +415,12 @@ func (w *ParserWorker) recordHostFailure(ctx context.Context, host, rawID string
 				"raw_id": rawID,
 			}).WithError(err).Warn("raw id tracker track failed (non-fatal)")
 		}
+	}
+	// 이슈 #221: 임계값 도달 시 자동 chromedp 전환 + 실패 raw republish trigger.
+	// 비동기 — parser 흐름의 latency 차단 회피. Upgrader 자체가 in-flight dedup / 이미 chromedp
+	// skip 등 안전망 보유.
+	if thresholdReached && w.upgrader != nil {
+		go w.upgrader.Trigger(context.Background(), host)
 	}
 }
 

--- a/internal/processor/parser/worker/parser_worker.go
+++ b/internal/processor/parser/worker/parser_worker.go
@@ -420,12 +420,16 @@ func (w *ParserWorker) recordHostFailure(ctx context.Context, host, rawID string
 	// 비동기 — parser 흐름의 latency 차단 회피. Upgrader 자체가 in-flight dedup / 이미 chromedp
 	// skip 등 안전망 보유.
 	//
-	// context.WithoutCancel: parent ctx 가 worker shutdown 으로 cancel 되어도 trigger 는 끝까지
-	// 실행 (5분 in-flight lock TTL 안에서 자연 종료). logger / trace_id 등 ctx value 는 보존되어
-	// 운영 가시성 확보 — context.Background() 보다 권장 (gemini 피드백).
+	// context.WithoutCancel + WithTimeout: parent ctx 의 logger / trace_id 등 value 는 보존하되
+	// (gemini 피드백) parent cancel 과 분리. 다만 unbounded 면 의존성 stall 시 goroutine leak 위험
+	// (CodeRabbit 피드백) — 30s timeout 으로 bound. Upgrader 의 5분 in-flight lock TTL 보다 짧지만
+	// Redis/DB/Kafka 호출 한 사이클은 30s 면 충분.
 	if thresholdReached && w.upgrader != nil {
-		triggerCtx := context.WithoutCancel(ctx)
-		go w.upgrader.Trigger(triggerCtx, host)
+		go func() {
+			triggerCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 30*time.Second)
+			defer cancel()
+			w.upgrader.Trigger(triggerCtx, host)
+		}()
 	}
 }
 

--- a/internal/processor/parser/worker/parser_worker.go
+++ b/internal/processor/parser/worker/parser_worker.go
@@ -65,7 +65,12 @@ type ParserWorker struct {
 	// failureCounter: host 단위 fetcher 실패 카운터 (이슈 #220).
 	// nil 시 noopFailureCounter 로 fallback — 카운팅 자체 비활성.
 	// rule.ErrParseFailure / rule.ErrEmptySelector 또는 빈본문 발생 시 Record 호출.
-	failureCounter      fetcherRule.FailureCounter
+	failureCounter fetcherRule.FailureCounter
+
+	// rawIDTracker: 같은 실패 시점에 host 별 raw_id 추적 (이슈 #221).
+	// nil 시 noopRawIDTracker — republish 비활성 (단계 3 trigger 가 빈 raw_id 받음).
+	rawIDTracker fetcherRule.RawIDTracker
+
 	emptyBodyTitleMin   int
 	emptyBodyContentMin int
 
@@ -82,6 +87,7 @@ type ParserWorker struct {
 //   - llmGen 은 nil 허용 — nil 이면 ErrNoRule 시 raw 잔존만 (LLM auto-rule 비활성, 이슈 #149)
 //   - resolver / sampleSvc 는 nil 허용 — nil 이면 sample 누적 skip (이슈 #173 단계 4-1, 정밀화 워크플로 비활성)
 //   - failureCounter 는 nil 허용 — nil 이면 NoopFailureCounter 로 fallback (이슈 #220 카운팅 비활성)
+//   - rawIDTracker 는 nil 허용 — nil 이면 NoopRawIDTracker 로 fallback (이슈 #221 republish 비활성)
 //
 // 이슈 #161 (도메인 중립화) 이후 news_articles 도메인 특화 보존은 제거됐습니다 — 모든 article
 // 결과는 contentSvc.Store 로 contents 단일 테이블에 저장됩니다.
@@ -100,6 +106,7 @@ func NewParserWorker(
 	procLock locks.ProcessingLock,
 	llmGen *llmgen.Generator,
 	failureCounter fetcherRule.FailureCounter,
+	rawIDTracker fetcherRule.RawIDTracker,
 	emptyBodyTitleMin int,
 	emptyBodyContentMin int,
 	workerCount int,
@@ -114,6 +121,9 @@ func NewParserWorker(
 	if failureCounter == nil {
 		failureCounter = fetcherRule.NewNoopFailureCounter()
 	}
+	if rawIDTracker == nil {
+		rawIDTracker = fetcherRule.NewNoopRawIDTracker()
+	}
 	return &ParserWorker{
 		consumer:            consumer,
 		producer:            producer,
@@ -126,6 +136,7 @@ func NewParserWorker(
 		procLock:            procLock,
 		llmGen:              llmGen,
 		failureCounter:      failureCounter,
+		rawIDTracker:        rawIDTracker,
 		emptyBodyTitleMin:   emptyBodyTitleMin,
 		emptyBodyContentMin: emptyBodyContentMin,
 		workerCount:         workerCount,
@@ -314,7 +325,7 @@ func (w *ParserWorker) processArticlePage(ctx context.Context, raw *core.RawCont
 	// 이슈 #220: parse 자체는 성공했지만 Title / MainContent 텍스트 길이가 임계값 미달이면
 	// 빈본문 신호로 host 카운터에 누적. 정상 흐름은 차단하지 않음 (downstream validator 가
 	// 별도 정책으로 처리).
-	w.recordEmptyBodyIfApplicable(ctx, raw, page, mlog)
+	w.recordEmptyBodyIfApplicable(ctx, raw, rawID, page, mlog)
 
 	content := general.ConvertPage(page, raw)
 	if err := w.publishContents(ctx, []*core.Content{content}, crawlerName); err != nil {
@@ -355,9 +366,10 @@ func (w *ParserWorker) handleRuleError(ctx context.Context, raw *core.RawContent
 
 		// 이슈 #220: page 단계의 ParseFailure / EmptySelector 만 host 카운터에 누적.
 		// list (category) 는 본질적으로 다른 selector 셋이라 chromedp 전환 신호로 부적절.
+		// 이슈 #221: 같은 시점에 raw_id 를 host 별 추적 — 단계 3 의 republish 대상 수집.
 		if targetType == storage.TargetTypePage &&
 			(rerr.Code == rule.ErrParseFailure || rerr.Code == rule.ErrEmptySelector) {
-			w.recordHostFailure(ctx, rerr.Host, fetcherRule.FailureReasonRuleParseFailure, mlog)
+			w.recordHostFailure(ctx, rerr.Host, rawID, fetcherRule.FailureReasonRuleParseFailure, mlog)
 		}
 
 		_ = rawID // 본 시그니처에선 rawID 직접 사용 안 함, 향후 audit log 에서 활용
@@ -368,10 +380,15 @@ func (w *ParserWorker) handleRuleError(ctx context.Context, raw *core.RawContent
 	return fmt.Errorf("%s: %w", stage, err)
 }
 
-// recordHostFailure 는 host 단위 fetcher 실패 카운터에 1건 누적합니다 (이슈 #220).
-// 카운팅 자체 실패는 non-fatal — warn 로그만 남기고 정상 흐름 유지 (Redis 장애가 parse 실패
-// 처리 흐름을 막지 않도록).
-func (w *ParserWorker) recordHostFailure(ctx context.Context, host string, reason fetcherRule.FailureReason, mlog *logger.Logger) {
+// recordHostFailure 는 host 단위 fetcher 실패 카운터에 1건 누적하고 raw_id 를 host Set 에
+// 추적합니다 (이슈 #220 + #221).
+//
+// 카운팅 / 트래킹 자체 실패는 non-fatal — warn 로그만 남기고 정상 흐름 유지 (Redis 장애가
+// parse 실패 처리 흐름을 막지 않도록).
+//
+// rawID 는 단계 3 의 chromedp 자동 전환 trigger 가 republish 대상으로 사용. 빈 문자열이면
+// Tracker 가 noop.
+func (w *ParserWorker) recordHostFailure(ctx context.Context, host, rawID string, reason fetcherRule.FailureReason, mlog *logger.Logger) {
 	if w.failureCounter == nil {
 		return
 	}
@@ -380,6 +397,14 @@ func (w *ParserWorker) recordHostFailure(ctx context.Context, host string, reaso
 			"host":   host,
 			"reason": string(reason),
 		}).WithError(err).Warn("failure counter record failed (non-fatal)")
+	}
+	if w.rawIDTracker != nil {
+		if err := w.rawIDTracker.Track(ctx, host, rawID); err != nil {
+			mlog.WithFields(map[string]interface{}{
+				"host":   host,
+				"raw_id": rawID,
+			}).WithError(err).Warn("raw id tracker track failed (non-fatal)")
+		}
 	}
 }
 
@@ -398,7 +423,9 @@ func hostOf(rawURL string) string {
 //
 // 임계값 어느 한쪽 미달이어도 신호 발신 — chromedp 전환 후 둘 다 정상 추출되는 케이스 가정.
 // 임계값이 0 이면 해당 필드 검증 비활성 (운영 옵션).
-func (w *ParserWorker) recordEmptyBodyIfApplicable(ctx context.Context, raw *core.RawContent, page *parser.Page, mlog *logger.Logger) {
+//
+// 이슈 #221: rawID 도 host 별 추적 — 단계 3 의 republish 대상 수집.
+func (w *ParserWorker) recordEmptyBodyIfApplicable(ctx context.Context, raw *core.RawContent, rawID string, page *parser.Page, mlog *logger.Logger) {
 	if w.emptyBodyTitleMin <= 0 && w.emptyBodyContentMin <= 0 {
 		return
 	}
@@ -421,7 +448,7 @@ func (w *ParserWorker) recordEmptyBodyIfApplicable(ctx context.Context, raw *cor
 		"body_length":  bodyLen,
 		"reason":       string(fetcherRule.FailureReasonEmptyBody),
 	}).Warn("empty body detected — recording host failure")
-	w.recordHostFailure(ctx, host, fetcherRule.FailureReasonEmptyBody, mlog)
+	w.recordHostFailure(ctx, host, rawID, fetcherRule.FailureReasonEmptyBody, mlog)
 }
 
 // publishContents 는 *core.Content 슬라이스를 contents 저장 + ContentRef 발행 (TopicNormalized).

--- a/internal/processor/parser/worker/parser_worker.go
+++ b/internal/processor/parser/worker/parser_worker.go
@@ -419,8 +419,13 @@ func (w *ParserWorker) recordHostFailure(ctx context.Context, host, rawID string
 	// 이슈 #221: 임계값 도달 시 자동 chromedp 전환 + 실패 raw republish trigger.
 	// 비동기 — parser 흐름의 latency 차단 회피. Upgrader 자체가 in-flight dedup / 이미 chromedp
 	// skip 등 안전망 보유.
+	//
+	// context.WithoutCancel: parent ctx 가 worker shutdown 으로 cancel 되어도 trigger 는 끝까지
+	// 실행 (5분 in-flight lock TTL 안에서 자연 종료). logger / trace_id 등 ctx value 는 보존되어
+	// 운영 가시성 확보 — context.Background() 보다 권장 (gemini 피드백).
 	if thresholdReached && w.upgrader != nil {
-		go w.upgrader.Trigger(context.Background(), host)
+		triggerCtx := context.WithoutCancel(ctx)
+		go w.upgrader.Trigger(triggerCtx, host)
 	}
 }
 

--- a/test/internal/processor/fetcher/rule/raw_id_tracker_test.go
+++ b/test/internal/processor/fetcher/rule/raw_id_tracker_test.go
@@ -26,9 +26,9 @@ func TestNewRedisRawIDTracker_BadTTL_ReturnsError(t *testing.T) {
 	assert.Error(t, err)
 }
 
-// TestRedisRawIDTracker_TrackAndPop_Basic:
-// 같은 host 에 N건 Track → PopByHost 가 N건 반환 + Set 비어짐.
-func TestRedisRawIDTracker_TrackAndPop_Basic(t *testing.T) {
+// TestRedisRawIDTracker_TrackAndPeek_Basic:
+// 같은 host 에 N건 Track → PeekByHost 가 N건 조회 (제거 안 함). 두 번째 Peek 도 같음.
+func TestRedisRawIDTracker_TrackAndPeek_Basic(t *testing.T) {
 	client := newTestRedisClient(t)
 	prefix := uniqueKeyPrefix(t)
 	tr, err := fetcherRule.NewRedisRawIDTracker(client.Raw(), time.Hour, prefix, nil)
@@ -40,25 +40,27 @@ func TestRedisRawIDTracker_TrackAndPop_Basic(t *testing.T) {
 
 	for _, id := range rawIDs {
 		require.NoError(t, tr.Track(ctx, host, id))
+		// 같은 timestamp 충돌 회피 + score 분산
+		time.Sleep(1 * time.Millisecond)
 	}
 
-	popped, err := tr.PopByHost(ctx, host, 10)
+	peeked, err := tr.PeekByHost(ctx, host, 10)
 	require.NoError(t, err)
-	assert.ElementsMatch(t, rawIDs, popped)
+	assert.ElementsMatch(t, rawIDs, peeked)
 
-	// 두 번째 Pop 은 비어있어야 함 — atomic SPOP
-	popped2, err := tr.PopByHost(ctx, host, 10)
+	// 두 번째 Peek 도 동일 — 제거 안 함 (Peek-then-Remove 의 핵심)
+	peeked2, err := tr.PeekByHost(ctx, host, 10)
 	require.NoError(t, err)
-	assert.Empty(t, popped2)
+	assert.ElementsMatch(t, rawIDs, peeked2)
 
 	t.Cleanup(func() {
 		client.Raw().Del(context.Background(), prefix+":"+host)
 	})
 }
 
-// TestRedisRawIDTracker_PopByHost_RespectsLimit:
-// limit 초과분은 Set 에 남음.
-func TestRedisRawIDTracker_PopByHost_RespectsLimit(t *testing.T) {
+// TestRedisRawIDTracker_PeekByHost_RecencyOrder:
+// ZREVRANGE 가 score DESC 순 → 가장 최근 추가가 첫 번째.
+func TestRedisRawIDTracker_PeekByHost_RecencyOrder(t *testing.T) {
 	client := newTestRedisClient(t)
 	prefix := uniqueKeyPrefix(t)
 	tr, err := fetcherRule.NewRedisRawIDTracker(client.Raw(), time.Hour, prefix, nil)
@@ -66,17 +68,66 @@ func TestRedisRawIDTracker_PopByHost_RespectsLimit(t *testing.T) {
 
 	host := "naver.com"
 	ctx := context.Background()
-	for i := 0; i < 5; i++ {
-		require.NoError(t, tr.Track(ctx, host, "raw-"+string(rune('a'+i))))
+	for _, id := range []string{"oldest", "middle", "newest"} {
+		require.NoError(t, tr.Track(ctx, host, id))
+		time.Sleep(1 * time.Millisecond)
 	}
 
-	popped, err := tr.PopByHost(ctx, host, 3)
+	peeked, err := tr.PeekByHost(ctx, host, 10)
 	require.NoError(t, err)
-	assert.Len(t, popped, 3)
+	require.Len(t, peeked, 3)
+	assert.Equal(t, "newest", peeked[0], "score DESC — most recent first")
+	assert.Equal(t, "oldest", peeked[2])
 
-	popped2, err := tr.PopByHost(ctx, host, 10)
+	t.Cleanup(func() {
+		client.Raw().Del(context.Background(), prefix+":"+host)
+	})
+}
+
+// TestRedisRawIDTracker_PeekByHost_RespectsLimit:
+// limit 적용 — N개 중 limit 만 반환.
+func TestRedisRawIDTracker_PeekByHost_RespectsLimit(t *testing.T) {
+	client := newTestRedisClient(t)
+	prefix := uniqueKeyPrefix(t)
+	tr, err := fetcherRule.NewRedisRawIDTracker(client.Raw(), time.Hour, prefix, nil)
 	require.NoError(t, err)
-	assert.Len(t, popped2, 2)
+
+	host := "yonhap.co.kr"
+	ctx := context.Background()
+	for i := 0; i < 5; i++ {
+		require.NoError(t, tr.Track(ctx, host, "raw-"+string(rune('a'+i))))
+		time.Sleep(1 * time.Millisecond)
+	}
+
+	peeked, err := tr.PeekByHost(ctx, host, 3)
+	require.NoError(t, err)
+	assert.Len(t, peeked, 3)
+
+	t.Cleanup(func() {
+		client.Raw().Del(context.Background(), prefix+":"+host)
+	})
+}
+
+// TestRedisRawIDTracker_RemoveByHost_RemovesOnlyListed:
+// RemoveByHost 가 지정된 raw_id 만 제거 — 나머지 잔존.
+func TestRedisRawIDTracker_RemoveByHost_RemovesOnlyListed(t *testing.T) {
+	client := newTestRedisClient(t)
+	prefix := uniqueKeyPrefix(t)
+	tr, err := fetcherRule.NewRedisRawIDTracker(client.Raw(), time.Hour, prefix, nil)
+	require.NoError(t, err)
+
+	host := "daum.net"
+	ctx := context.Background()
+	for _, id := range []string{"a", "b", "c", "d", "e"} {
+		require.NoError(t, tr.Track(ctx, host, id))
+		time.Sleep(1 * time.Millisecond)
+	}
+
+	require.NoError(t, tr.RemoveByHost(ctx, host, []string{"a", "c", "e"}))
+
+	peeked, err := tr.PeekByHost(ctx, host, 10)
+	require.NoError(t, err)
+	assert.ElementsMatch(t, []string{"b", "d"}, peeked)
 
 	t.Cleanup(func() {
 		client.Raw().Del(context.Background(), prefix+":"+host)
@@ -84,7 +135,7 @@ func TestRedisRawIDTracker_PopByHost_RespectsLimit(t *testing.T) {
 }
 
 // TestRedisRawIDTracker_EmptyArgs_NoOp:
-// 빈 host / 빈 rawID / limit<=0 모두 noop (Redis 호출 없음, 에러 없음).
+// 빈 host / 빈 rawID / limit<=0 모두 noop.
 func TestRedisRawIDTracker_EmptyArgs_NoOp(t *testing.T) {
 	client := newTestRedisClient(t)
 	tr, err := fetcherRule.NewRedisRawIDTracker(client.Raw(), time.Hour, "", nil)
@@ -95,40 +146,53 @@ func TestRedisRawIDTracker_EmptyArgs_NoOp(t *testing.T) {
 	require.NoError(t, tr.Track(ctx, "", "raw-1"))
 	require.NoError(t, tr.Track(ctx, "host.com", ""))
 
-	popped, err := tr.PopByHost(ctx, "", 10)
+	peeked, err := tr.PeekByHost(ctx, "", 10)
 	require.NoError(t, err)
-	assert.Empty(t, popped)
+	assert.Empty(t, peeked)
 
-	popped, err = tr.PopByHost(ctx, "host.com", 0)
+	peeked, err = tr.PeekByHost(ctx, "host.com", 0)
 	require.NoError(t, err)
-	assert.Empty(t, popped)
+	assert.Empty(t, peeked)
 
-	popped, err = tr.PopByHost(ctx, "host.com", -1)
-	require.NoError(t, err)
-	assert.Empty(t, popped)
+	require.NoError(t, tr.RemoveByHost(ctx, "", []string{"a"}))
+	require.NoError(t, tr.RemoveByHost(ctx, "host.com", []string{}))
 }
 
-// TestRedisRawIDTracker_PopByHost_NonexistentKey_ReturnsEmpty:
-// 키 자체가 없는 host 의 Pop 은 redis.Nil 정규화 → 빈 슬라이스.
-func TestRedisRawIDTracker_PopByHost_NonexistentKey_ReturnsEmpty(t *testing.T) {
+// TestRedisRawIDTracker_PeekByHost_NonexistentKey_ReturnsEmpty:
+// 키 없음 → 빈 슬라이스.
+func TestRedisRawIDTracker_PeekByHost_NonexistentKey_ReturnsEmpty(t *testing.T) {
 	client := newTestRedisClient(t)
 	tr, err := fetcherRule.NewRedisRawIDTracker(client.Raw(), time.Hour, "test:nonexistent:"+t.Name(), nil)
 	require.NoError(t, err)
 
-	popped, err := tr.PopByHost(context.Background(), "no-such-host", 10)
+	peeked, err := tr.PeekByHost(context.Background(), "no-such-host", 10)
 	require.NoError(t, err)
-	assert.Empty(t, popped)
+	assert.Empty(t, peeked)
 }
 
 // TestNoopRawIDTracker_AllNoop:
-// Noop tracker 는 Track / PopByHost 모두 nil 반환.
+// Noop tracker 의 모든 메소드 nil.
 func TestNoopRawIDTracker_AllNoop(t *testing.T) {
 	tr := fetcherRule.NewNoopRawIDTracker()
 	ctx := context.Background()
 
 	require.NoError(t, tr.Track(ctx, "host.com", "raw-1"))
 
-	popped, err := tr.PopByHost(ctx, "host.com", 10)
+	peeked, err := tr.PeekByHost(ctx, "host.com", 10)
 	require.NoError(t, err)
-	assert.Empty(t, popped)
+	assert.Empty(t, peeked)
+
+	require.NoError(t, tr.RemoveByHost(ctx, "host.com", []string{"raw-1"}))
+}
+
+// TestForceFetcherToken_InitAndValidate:
+// process-local token 초기화 후 ValidateForceFetcherToken 가 일치 시 true.
+func TestForceFetcherToken_InitAndValidate(t *testing.T) {
+	require.NoError(t, fetcherRule.InitForceFetcherToken())
+
+	tok := fetcherRule.ForceFetcherTokenValue()
+	assert.NotEmpty(t, tok)
+	assert.True(t, fetcherRule.ValidateForceFetcherToken(tok))
+	assert.False(t, fetcherRule.ValidateForceFetcherToken(""))
+	assert.False(t, fetcherRule.ValidateForceFetcherToken("wrong-token"))
 }

--- a/test/internal/processor/fetcher/rule/raw_id_tracker_test.go
+++ b/test/internal/processor/fetcher/rule/raw_id_tracker_test.go
@@ -1,0 +1,134 @@
+package rule_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	fetcherRule "issuetracker/internal/processor/fetcher/rule"
+)
+
+// TestNewRedisRawIDTracker_NilClient_ReturnsError:
+// 이슈 #208 panic-on-nil → error 정책.
+func TestNewRedisRawIDTracker_NilClient_ReturnsError(t *testing.T) {
+	_, err := fetcherRule.NewRedisRawIDTracker(nil, time.Hour, "", nil)
+	assert.Error(t, err)
+}
+
+// TestNewRedisRawIDTracker_BadTTL_ReturnsError:
+// ttl 0 또는 음수 → 의미 없음.
+func TestNewRedisRawIDTracker_BadTTL_ReturnsError(t *testing.T) {
+	client := newTestRedisClient(t)
+	_, err := fetcherRule.NewRedisRawIDTracker(client.Raw(), 0, "", nil)
+	assert.Error(t, err)
+}
+
+// TestRedisRawIDTracker_TrackAndPop_Basic:
+// 같은 host 에 N건 Track → PopByHost 가 N건 반환 + Set 비어짐.
+func TestRedisRawIDTracker_TrackAndPop_Basic(t *testing.T) {
+	client := newTestRedisClient(t)
+	prefix := uniqueKeyPrefix(t)
+	tr, err := fetcherRule.NewRedisRawIDTracker(client.Raw(), time.Hour, prefix, nil)
+	require.NoError(t, err)
+
+	host := "edition.cnn.com"
+	ctx := context.Background()
+	rawIDs := []string{"raw-1", "raw-2", "raw-3"}
+
+	for _, id := range rawIDs {
+		require.NoError(t, tr.Track(ctx, host, id))
+	}
+
+	popped, err := tr.PopByHost(ctx, host, 10)
+	require.NoError(t, err)
+	assert.ElementsMatch(t, rawIDs, popped)
+
+	// 두 번째 Pop 은 비어있어야 함 — atomic SPOP
+	popped2, err := tr.PopByHost(ctx, host, 10)
+	require.NoError(t, err)
+	assert.Empty(t, popped2)
+
+	t.Cleanup(func() {
+		client.Raw().Del(context.Background(), prefix+":"+host)
+	})
+}
+
+// TestRedisRawIDTracker_PopByHost_RespectsLimit:
+// limit 초과분은 Set 에 남음.
+func TestRedisRawIDTracker_PopByHost_RespectsLimit(t *testing.T) {
+	client := newTestRedisClient(t)
+	prefix := uniqueKeyPrefix(t)
+	tr, err := fetcherRule.NewRedisRawIDTracker(client.Raw(), time.Hour, prefix, nil)
+	require.NoError(t, err)
+
+	host := "naver.com"
+	ctx := context.Background()
+	for i := 0; i < 5; i++ {
+		require.NoError(t, tr.Track(ctx, host, "raw-"+string(rune('a'+i))))
+	}
+
+	popped, err := tr.PopByHost(ctx, host, 3)
+	require.NoError(t, err)
+	assert.Len(t, popped, 3)
+
+	popped2, err := tr.PopByHost(ctx, host, 10)
+	require.NoError(t, err)
+	assert.Len(t, popped2, 2)
+
+	t.Cleanup(func() {
+		client.Raw().Del(context.Background(), prefix+":"+host)
+	})
+}
+
+// TestRedisRawIDTracker_EmptyArgs_NoOp:
+// 빈 host / 빈 rawID / limit<=0 모두 noop (Redis 호출 없음, 에러 없음).
+func TestRedisRawIDTracker_EmptyArgs_NoOp(t *testing.T) {
+	client := newTestRedisClient(t)
+	tr, err := fetcherRule.NewRedisRawIDTracker(client.Raw(), time.Hour, "", nil)
+	require.NoError(t, err)
+
+	ctx := context.Background()
+
+	require.NoError(t, tr.Track(ctx, "", "raw-1"))
+	require.NoError(t, tr.Track(ctx, "host.com", ""))
+
+	popped, err := tr.PopByHost(ctx, "", 10)
+	require.NoError(t, err)
+	assert.Empty(t, popped)
+
+	popped, err = tr.PopByHost(ctx, "host.com", 0)
+	require.NoError(t, err)
+	assert.Empty(t, popped)
+
+	popped, err = tr.PopByHost(ctx, "host.com", -1)
+	require.NoError(t, err)
+	assert.Empty(t, popped)
+}
+
+// TestRedisRawIDTracker_PopByHost_NonexistentKey_ReturnsEmpty:
+// 키 자체가 없는 host 의 Pop 은 redis.Nil 정규화 → 빈 슬라이스.
+func TestRedisRawIDTracker_PopByHost_NonexistentKey_ReturnsEmpty(t *testing.T) {
+	client := newTestRedisClient(t)
+	tr, err := fetcherRule.NewRedisRawIDTracker(client.Raw(), time.Hour, "test:nonexistent:"+t.Name(), nil)
+	require.NoError(t, err)
+
+	popped, err := tr.PopByHost(context.Background(), "no-such-host", 10)
+	require.NoError(t, err)
+	assert.Empty(t, popped)
+}
+
+// TestNoopRawIDTracker_AllNoop:
+// Noop tracker 는 Track / PopByHost 모두 nil 반환.
+func TestNoopRawIDTracker_AllNoop(t *testing.T) {
+	tr := fetcherRule.NewNoopRawIDTracker()
+	ctx := context.Background()
+
+	require.NoError(t, tr.Track(ctx, "host.com", "raw-1"))
+
+	popped, err := tr.PopByHost(ctx, "host.com", 10)
+	require.NoError(t, err)
+	assert.Empty(t, popped)
+}

--- a/test/internal/processor/fetcher/rule/upgrader_test.go
+++ b/test/internal/processor/fetcher/rule/upgrader_test.go
@@ -1,0 +1,31 @@
+package rule_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	fetcherRule "issuetracker/internal/processor/fetcher/rule"
+)
+
+// TestNewUpgrader_NilDependencies_ReturnsError:
+// 이슈 #208 panic-on-nil → error 정책. 모든 필수 의존성이 nil 이면 즉시 error.
+//
+// 의존성 stub 만들기 비용이 크므로 (FetcherRuleRepository / Resolver / RawIDTracker /
+// RawContentService / Producer 모두 인터페이스) 핵심 invariant — 개별 nil 검증 — 만 검사.
+// 전체 흐름 검증은 통합 테스트 영역.
+func TestNewUpgrader_NilDependencies_ReturnsError(t *testing.T) {
+	// 모두 nil
+	_, err := fetcherRule.NewUpgrader(nil, nil, nil, nil, nil, nil, nil)
+	assert.Error(t, err)
+}
+
+// TestUpgrader_Trigger_NilReceiver_NoPanic:
+// nil Upgrader 에 Trigger 호출해도 panic 없음 — wiring 실패 시 graceful 보장.
+func TestUpgrader_Trigger_NilReceiver_NoPanic(t *testing.T) {
+	var u *fetcherRule.Upgrader
+	assert.NotPanics(t, func() {
+		u.Trigger(context.Background(), "host.com")
+	})
+}


### PR DESCRIPTION
## 연관 이슈
- Closes #221
- Closes #175 (단계 1 ~ 3 모두 완료 — 본 PR 머지 시 부모 이슈도 close)

<br>

## 구현 내용

이슈 #175 의 **단계 3** — 단계 2 의 thresholdReached=true 신호를 받아 fetcher_rules UPSERT (chromedp) + 같은 host 의 실패 raw 들을 새 CrawlJob 으로 republish. 본 PR 머지 시 #175 (host 단위 fetcher rule + validation 기반 자동 chromedp 전환 + 실패 raw republish) 가 완성.

### Commit 1: `[FEAT]:` RawIDTracker (Redis Set) + parser_worker 가 host 별 raw_id 추적

**`internal/processor/fetcher/rule/raw_id_tracker.go`** (신규):
- `RawIDTracker` 인터페이스: `Track(host, rawID)` + `PopByHost(host, limit)`
- `redisRawIDTracker`: Redis Set 기반
  - **Track**: `SADD key={prefix}:{host}, member=rawID` + `EXPIRE ttl` (sliding) — 단일 PIPELINE
  - **PopByHost**: `SPOPN key` atomic limit 개 pop — 동시 trigger 의 중복 republish 방지
- `noopRawIDTracker`: Redis 미연결 / ENABLED=false fallback
- `NewRedisRawIDTracker` 는 nil client / ttl<=0 시 error (이슈 #208 정책)

**parser_worker 통합**:
- `recordHostFailure` 시그니처에 `rawID` 추가 — 카운터 Record 와 동일 시점에 Tracker.Track 호출
- raw_contents 에 host 컬럼이 없어 application 레이어에서 host → raw_id 관계 유지

### Commit 2: `[FEAT]:` ChainHandler 가 `force_fetcher` Metadata 우선 처리

**`internal/processor/fetcher/domain/general/chain_handler.go`**:
- `MetadataKeyForceFetcher = "force_fetcher"` 상수 신설
- `selectChain` 우선순위 분기:
  1. `Target.Metadata["force_fetcher"] == "chromedp"` → ChromedpChain (Resolver 조회 skip)
  2. Resolver 의 host 룰 조회
  3. fallback → DefaultChain
- ChromedpChain 미wiring 사이트 (yonhap 등) 에 force 들어와도 graceful warn + DefaultChain fallback

### Commit 3: `[FEAT]:` Upgrader 모듈 + parser_worker 비동기 Trigger + wiring

**`internal/processor/fetcher/rule/upgrader.go`** (신규):

```
Trigger(ctx, host):
  1. Redis SETNX in-flight lock (TTL 5min) — 동시 trigger race 차단
  2. fetcher_rules.GetByHost: 이미 chromedp 면 audit warn + skip (chromedp 자체 실패 신호)
  3. fetcher_rules.Upsert(host, chromedp, "auto_upgrade_validation")
  4. Resolver.Invalidate(host) — cache 동기화
  5. RawIDTracker.PopByHost(host, max=20) — 실패 raw_id atomic 수집
  6. 각 raw: rawSvc.GetByID → URL → CrawlJob (force_fetcher metadata) → Producer.PublishBatch
```

**parser_worker**:
- `failureCounter.Record` 결과의 `thresholdReached=true` 시 `go w.upgrader.Trigger(context.Background(), host)` 비동기 호출 — parser 본 흐름 latency 차단 회피

**main.go wiring**:
- `goredis` import 추가 (Upgrader 의 Redis raw client 인자)
- `LoadFetcherAutoUpgrade.Enabled` 시 `NewUpgrader`, 그 외 nil — graceful degrade

### 안전망

| 위협 | 대응 |
|---|---|
| 동시 trigger | Redis SETNX in-flight lock (TTL 5min). Redis 미연결 시 lock 비활성 (단일 인스턴스 OK) |
| 이미 chromedp 인 host 재upgrade | `GetByHost` 후 분기 — UPSERT/republish 모두 skip + audit warn |
| republish flooding | `upgraderMaxRepublishPerCycle = 20` cap |
| chromedp 도 실패 시 무한 reprocess | (2) 분기로 skip, audit warn 만 — 운영자 개입 영역 |
| force_fetcher 외부 source 임의 지정 | publisher 측 정규 흐름은 metadata 비어있음, Upgrader 의 internal-only republish 만 채움 |
| parser 흐름 차단 | Trigger 비동기 (별도 goroutine) — Counter Record 의 latency 만 영향 |
| Redis 장애 | Counter / Tracker / SETNX 모두 noop 또는 warn 후 진행 — fetch/parse 흐름 중단 X |

### Commit 4: `[FEAT]:` 단위 테스트

**`test/internal/processor/fetcher/rule/raw_id_tracker_test.go`** (6 tests):
- nil client / bad ttl error / Track-Pop atomic / limit 준수 / 빈 인자 noop / 키 없음 → 빈 슬라이스 / Noop tracker

**`test/internal/processor/fetcher/rule/upgrader_test.go`** (2 tests):
- nil 의존성 wiring 거부 / nil receiver Trigger 호출 panic 없음

Upgrader 전체 흐름 검증은 의존성 5+ 종 stub 비용 대비 가치 낮음 — 통합 테스트 영역. 핵심 안전망만 단위 검증.

30개 패키지 race test 모두 통과 (failure 0).

<br>

## CI / 머지 게이트 점검

> [CI 운영 규약](docs/ci/conventions.md) 및 [Required Status Checks 단일 소스](docs/ci/status-checks.md)에 따라 작성합니다.

### 변경 영향 범위
- 영향 패키지: `internal/processor/fetcher/rule/` (RawIDTracker / Upgrader 신규), `internal/processor/fetcher/domain/general/` (ChainHandler force_fetcher 분기), `internal/processor/parser/worker/` (recordHostFailure 통합), `cmd/issuetracker/` (wiring)
- 위험도(택1): `Medium`
  - `FETCHER_AUTO_UPGRADE_ENABLED=true` (default) + Redis 가용 환경에서 **자동 동작**:
    - parser 가 host 단위 임계값 (default 5회/1h) 도달 감지
    - chromedp 로 자동 UPSERT + 최근 실패 raw 최대 20건 republish
  - 운영 모니터 필수: 첫 24-48h 동안 자동 upgrade 발생 host 의 분포 확인 — false positive (트래픽 spike 로 잘못 upgrade) 비율 측정
  - Chrome 자원 부담 ↑: upgrade 누적 시 chromedp 사용 비율 ↑ → #218 ERR_INSUFFICIENT_RESOURCES 재발 가능 → **#224 (주기적 downgrade) 후속 진행 권장**
  - DB 영향 작음 (fetcher_rules row 추가만)
- 30개 패키지 race test 모두 통과

### Required Status Checks
- 통과 확인 대상:
  - [ ] `Commit Lint`
  - [ ] `PR Title Lint`
  - [ ] `Linked Issue Check`
  - [ ] `Format Check`
  - [ ] `Build`
  - [ ] `Test`
  - [ ] `Lint`

### 롤백 계획
- `FETCHER_AUTO_UPGRADE_ENABLED=false` 즉시 비활성 (재시작 필요).
- `git revert` 4개 commit. 이미 자동 UPSERT 된 fetcher_rules row 가 있다면 운영자가 manual DELETE 또는 #224 (downgrade cron) 으로 정리.

<br>

## TODO
- (#224) 주기적 downgrade — 본 PR 의 upgrade-only 비대칭 보완. **머지 후 즉시 다음 작업 권장**
- (#218) fetcher 단계 분리 — Chrome 자원 격리 (semaphore). 본 PR 의 chromedp 사용 비율 ↑ 시 ERR_INSUFFICIENT_RESOURCES 재발 회피
- (운영) 라이브 1주일 모니터링: `fetcher rule auto-upgraded to chromedp` INFO 로그 발생 빈도 + host 분포

<br>

## 논의 사항
- **비동기 Trigger 호출의 context**: parser 의 `ctx` 가 worker stop 시 cancel 되면 Trigger 의 Redis/DB 호출도 중단됨. 본 commit 은 `context.Background()` 를 사용해 parser shutdown 과 trigger 의 lifecycle 분리 — Upgrader 가 끝까지 진행하도록 보장. trade-off: shutdown 시 trigger 가 잠깐 진행될 수 있음 (5분 in-flight lock TTL 안에서 자연 종료).
- **max 20 cap**: 한 host 에 잔존 raw 100건이 있어도 단일 사이클 republish 는 20건 — 다음 trigger / 재카운팅 사이클이 자연 처리. 운영 데이터로 부족하면 environment variable 화 검토.
- **force_fetcher 보안**: 본 PR 은 internal Upgrader 만 metadata 부착. publisher 의 정규 진입점 (`Publish(urls, ...)`) 은 metadata 를 받지 않으므로 외부 source 가 force 지정 못함. 향후 publisher API 가 확장될 때 internal-only validation 추가 검토.
- **#175 close**: 본 PR 머지 시 `Closes #221` + `Closes #175` 동시 적용. 단계 4 (#218 fetcher 단계 분리, #224 주기적 downgrade) 는 #175 의 후속 sub 이지만 독립 진행.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced automatic fetcher upgrading: when default fetching repeatedly fails for a host, the system automatically switches to an enhanced browser-based fetcher and retries failed content. Failed content IDs are tracked and republished for retry with the upgraded fetcher configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->