### PR TITLE
[FEAT#218] fetcher 단계 분리 — chromedp 전용 worker pool + semaphore

### DIFF
--- a/cmd/issuetracker/main.go
+++ b/cmd/issuetracker/main.go
@@ -234,6 +234,37 @@ func main() {
 		RetryScheduler: retryScheduler,
 	}
 
+	// 이슈 #218: chromedp 전용 worker pool — semaphore 로 Chrome 동시 호출 제한.
+	chromedpPoolCfg, err := config.LoadFetcherChromedpPool()
+	if err != nil {
+		log.WithError(err).Fatal("failed to load fetcher chromedp pool config")
+	}
+	if chromedpPoolCfg.Enabled {
+		chromedpKafkaCfg := queue.DefaultConfig()
+		chromedpKafkaCfg.GroupID = queue.GroupChromedpFetchers
+		chromedpConsumer := queue.NewConsumer(chromedpKafkaCfg, queue.TopicCrawlChromedp)
+		defer chromedpConsumer.Close()
+
+		sem, err := crawlerWorker.NewSemaphore(chromedpPoolCfg.SemaphoreCapacity)
+		if err != nil {
+			log.WithError(err).Fatal("failed to construct chromedp semaphore")
+		}
+		chromedpHandler, err := crawlerWorker.NewChromedpJobHandler(registry, sem, log)
+		if err != nil {
+			log.WithError(err).Fatal("failed to construct chromedp job handler")
+		}
+
+		managerCfg.Chromedp = crawlerWorker.PoolConfig{Consumer: chromedpConsumer, WorkerCount: chromedpPoolCfg.WorkerCount}
+		managerCfg.ChromedpHandler = chromedpHandler
+
+		log.WithFields(map[string]interface{}{
+			"worker_count":       chromedpPoolCfg.WorkerCount,
+			"semaphore_capacity": chromedpPoolCfg.SemaphoreCapacity,
+		}).Info("chromedp pool wiring enabled")
+	} else {
+		log.Info("chromedp pool disabled (FETCHER_CHROMEDP_POOL_ENABLED=false), republished jobs will accumulate")
+	}
+
 	manager := crawlerWorker.NewPoolManager(managerCfg, crawlerProducer, registry, contentSvc, resolver, log)
 
 	log.WithFields(map[string]interface{}{

--- a/cmd/issuetracker/main.go
+++ b/cmd/issuetracker/main.go
@@ -262,7 +262,10 @@ func main() {
 			"semaphore_capacity": chromedpPoolCfg.SemaphoreCapacity,
 		}).Info("chromedp pool wiring enabled")
 	} else {
-		log.Info("chromedp pool disabled (FETCHER_CHROMEDP_POOL_ENABLED=false), republished jobs will accumulate")
+		// 이슈 #218 (CodeRabbit 피드백): goquery worker 의 ChainHandler 가 lazy detect / chromedp
+		// 룰 / force_fetcher 분기에서 항상 TopicCrawlChromedp 로 republish 함. consumer 가 없으면
+		// 메시지가 영구 누적되어 운영 장애로 이어짐 — fail-fast 로 운영자가 명시적 의사결정 강제.
+		log.Fatal("chromedp pool disabled (FETCHER_CHROMEDP_POOL_ENABLED=false) but goquery republish path is unconditional — enable pool or fork republish behavior in chain_handler")
 	}
 
 	manager := crawlerWorker.NewPoolManager(managerCfg, crawlerProducer, registry, contentSvc, resolver, log)

--- a/deployments/docker/docker-compose.yml
+++ b/deployments/docker/docker-compose.yml
@@ -120,9 +120,10 @@ services:
         echo '=== IssueTracker Kafka Topic Initialization ==='
 
         echo '[crawl topics]'
-        $$T --bootstrap-server $$KAFKA --create --if-not-exists --topic issuetracker.crawl.high   --partitions ${KAFKA_PARTITIONS_HIGH:-6} --replication-factor 1
-        $$T --bootstrap-server $$KAFKA --create --if-not-exists --topic issuetracker.crawl.normal --partitions ${KAFKA_PARTITIONS_NORMAL:-8} --replication-factor 1
-        $$T --bootstrap-server $$KAFKA --create --if-not-exists --topic issuetracker.crawl.low    --partitions ${KAFKA_PARTITIONS_LOW:-4} --replication-factor 1
+        $$T --bootstrap-server $$KAFKA --create --if-not-exists --topic issuetracker.crawl.high     --partitions ${KAFKA_PARTITIONS_HIGH:-6} --replication-factor 1
+        $$T --bootstrap-server $$KAFKA --create --if-not-exists --topic issuetracker.crawl.normal   --partitions ${KAFKA_PARTITIONS_NORMAL:-8} --replication-factor 1
+        $$T --bootstrap-server $$KAFKA --create --if-not-exists --topic issuetracker.crawl.low      --partitions ${KAFKA_PARTITIONS_LOW:-4} --replication-factor 1
+        $$T --bootstrap-server $$KAFKA --create --if-not-exists --topic issuetracker.crawl.chromedp --partitions ${KAFKA_PARTITIONS_CHROMEDP:-4} --replication-factor 1
 
         echo '[raw topics]'
         $$T --bootstrap-server $$KAFKA --create --if-not-exists --topic issuetracker.raw.us       --partitions 8 --replication-factor 1

--- a/internal/processor/fetcher/domain/general/chain_handler.go
+++ b/internal/processor/fetcher/domain/general/chain_handler.go
@@ -3,6 +3,7 @@ package general
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/url"
 
@@ -159,14 +160,35 @@ func extractHost(rawURL string) string {
 // Handle 은 chain 통과로 raw HTML 을 fetch 하고 raw_contents 저장 + RawContentRef 발행을 수행합니다.
 //
 // 항상 nil Content slice 를 반환 — 파싱은 parser worker 가 TopicFetched 를 consume 하여 처리.
+//
+// 이슈 #218: chromedp 처리는 별도 worker pool 로 격리. selectChain 결과가 ChromedpChain 이거나
+// DefaultChain 의 GoQuery 가 lazy detect 시 sentinel 반환하면 직접 호출 대신 TopicCrawlChromedp
+// 로 republish — Chrome 자원 동시 호출량을 chromedp pool 의 semaphore 로 제어.
 func (h *ChainHandler) Handle(ctx context.Context, job *core.CrawlJob) ([]*core.Content, error) {
 	if h.DefaultChain == nil || h.Log == nil || h.RawSvc == nil || h.Producer == nil {
 		return nil, fmt.Errorf("chain handler is not properly initialized")
 	}
 
 	chain := h.selectChain(ctx, job)
+
+	// 이슈 #218: ChromedpChain 매칭 (force_fetcher 또는 Resolver 룰) → 직접 호출 안 하고 republish.
+	// 같은 인스턴스 비교 (포인터 ID) 로 selectChain 의 ChromedpChain 분기 식별.
+	if h.ChromedpChain != nil && chain == h.ChromedpChain {
+		if err := h.republishToChromedpQueue(ctx, job); err != nil {
+			return nil, fmt.Errorf("republish to chromedp queue for %s: %w", job.Target.URL, err)
+		}
+		return nil, nil
+	}
+
 	raw, err := chain.Handle(ctx, job)
 	if err != nil {
+		// 이슈 #218: GoQuery 의 lazy detect sentinel — chromedp pool 로 republish 후 정상 종료.
+		if errors.Is(err, ErrLazyContentNeedsBrowser) {
+			if pubErr := h.republishToChromedpQueue(ctx, job); pubErr != nil {
+				return nil, fmt.Errorf("republish to chromedp queue (lazy detect) for %s: %w", job.Target.URL, pubErr)
+			}
+			return nil, nil
+		}
 		return nil, err
 	}
 	if raw == nil {
@@ -201,6 +223,38 @@ func (h *ChainHandler) Handle(ctx context.Context, job *core.CrawlJob) ([]*core.
 	}).Debug("raw content stored, fetched ref published")
 
 	return nil, nil
+}
+
+// republishToChromedpQueue 는 본 job 을 TopicCrawlChromedp 로 다시 발행합니다 (이슈 #218).
+//
+// chromedp 처리 책임을 본 worker (goquery pool) 에서 분리 — 별도 chromedp worker pool 이 receive
+// 후 semaphore 로 Chrome 자원 보호. force_fetcher metadata + token 은 보존하여 chromedp pool 의
+// ChainHandler 가 분기 일관성 유지.
+//
+// CrawlJob 페이로드는 그대로 재직렬화 — Marshal 실패는 가능한 fatal 이라 caller 에 전파.
+func (h *ChainHandler) republishToChromedpQueue(ctx context.Context, job *core.CrawlJob) error {
+	data, err := job.Marshal()
+	if err != nil {
+		return fmt.Errorf("marshal job %s: %w", job.ID, err)
+	}
+	msg := queue.Message{
+		Topic: queue.TopicCrawlChromedp,
+		Key:   []byte(job.ID),
+		Value: data,
+		Headers: map[string]string{
+			"crawler":  job.CrawlerName,
+			"job_id":   job.ID,
+			"original": "goquery_pool",
+		},
+	}
+	if err := h.Producer.Publish(ctx, msg); err != nil {
+		return fmt.Errorf("publish chromedp queue: %w", err)
+	}
+	h.Log.WithFields(map[string]interface{}{
+		"crawler": job.CrawlerName,
+		"url":     job.Target.URL,
+	}).Info("job republished to chromedp queue")
+	return nil
 }
 
 // publishFetchedRef 는 RawContentRef 를 TopicFetched 에 발행합니다.

--- a/internal/processor/fetcher/domain/general/chain_handler.go
+++ b/internal/processor/fetcher/domain/general/chain_handler.go
@@ -195,10 +195,17 @@ func (h *ChainHandler) Handle(ctx context.Context, job *core.CrawlJob) ([]*core.
 		return nil, fmt.Errorf("chain returned nil raw content for %s", job.Target.URL)
 	}
 
-	// raw_contents 저장 (중복 시 기존 ID 재사용 — RawContentService 책임)
+	return nil, h.processFetchedRaw(ctx, job, raw, "default")
+}
+
+// processFetchedRaw 는 fetch 된 raw 를 raw_contents 에 저장하고 RawContentRef 를 TopicFetched 에
+// 발행하는 공통 흐름입니다 (gemini 피드백 — Handle / HandleChromedpOnly 중복 추출).
+//
+// pool 인자는 로그 차원의 식별자 ("default" / "chromedp") — 운영 가시성용.
+func (h *ChainHandler) processFetchedRaw(ctx context.Context, job *core.CrawlJob, raw *core.RawContent, pool string) error {
 	rawID, dup, err := h.RawSvc.Store(ctx, raw)
 	if err != nil {
-		return nil, fmt.Errorf("store raw content for %s: %w", job.Target.URL, err)
+		return fmt.Errorf("store raw content for %s: %w", job.Target.URL, err)
 	}
 	if dup {
 		// 동일 URL 의 이전 raw 가 이미 존재 — 새 fetch 가 의미 없음 (parser 가 이전 raw 를 처리 중이거나 처리 완료).
@@ -208,11 +215,12 @@ func (h *ChainHandler) Handle(ctx context.Context, job *core.CrawlJob) ([]*core.
 			"crawler":     job.CrawlerName,
 			"url":         raw.URL,
 			"existing_id": rawID,
+			"pool":        pool,
 		}).Debug("raw content already exists for url, republishing ref")
 	}
 
 	if err := h.publishFetchedRef(ctx, job, raw, rawID); err != nil {
-		return nil, fmt.Errorf("publish fetched ref for %s: %w", job.Target.URL, err)
+		return fmt.Errorf("publish fetched ref for %s: %w", job.Target.URL, err)
 	}
 
 	h.Log.WithFields(map[string]interface{}{
@@ -220,9 +228,9 @@ func (h *ChainHandler) Handle(ctx context.Context, job *core.CrawlJob) ([]*core.
 		"url":         raw.URL,
 		"raw_id":      rawID,
 		"target_type": string(job.Target.Type),
+		"pool":        pool,
 	}).Debug("raw content stored, fetched ref published")
-
-	return nil, nil
+	return nil
 }
 
 // HandleChromedpOnly 는 ChromedpChain 만 호출하여 chromedp 단독 fetch 를 수행합니다 (이슈 #218).
@@ -249,31 +257,7 @@ func (h *ChainHandler) HandleChromedpOnly(ctx context.Context, job *core.CrawlJo
 		return nil, fmt.Errorf("chromedp chain returned nil raw content for %s", job.Target.URL)
 	}
 
-	rawID, dup, err := h.RawSvc.Store(ctx, raw)
-	if err != nil {
-		return nil, fmt.Errorf("store raw content for %s: %w", job.Target.URL, err)
-	}
-	if dup {
-		h.Log.WithFields(map[string]interface{}{
-			"crawler":     job.CrawlerName,
-			"url":         raw.URL,
-			"existing_id": rawID,
-		}).Debug("raw content already exists for url, republishing ref")
-	}
-
-	if err := h.publishFetchedRef(ctx, job, raw, rawID); err != nil {
-		return nil, fmt.Errorf("publish fetched ref for %s: %w", job.Target.URL, err)
-	}
-
-	h.Log.WithFields(map[string]interface{}{
-		"crawler":     job.CrawlerName,
-		"url":         raw.URL,
-		"raw_id":      rawID,
-		"target_type": string(job.Target.Type),
-		"pool":        "chromedp",
-	}).Debug("raw content stored via chromedp pool, fetched ref published")
-
-	return nil, nil
+	return nil, h.processFetchedRaw(ctx, job, raw, "chromedp")
 }
 
 // republishToChromedpQueue 는 본 job 을 TopicCrawlChromedp 로 다시 발행합니다 (이슈 #218).

--- a/internal/processor/fetcher/domain/general/chain_handler.go
+++ b/internal/processor/fetcher/domain/general/chain_handler.go
@@ -225,6 +225,57 @@ func (h *ChainHandler) Handle(ctx context.Context, job *core.CrawlJob) ([]*core.
 	return nil, nil
 }
 
+// HandleChromedpOnly 는 ChromedpChain 만 호출하여 chromedp 단독 fetch 를 수행합니다 (이슈 #218).
+//
+// chromedp pool 의 ChromedpJobHandler 가 같은 ChainHandler 인스턴스를 Registry 에서 lookup 하여
+// 본 메소드 호출 — Resolver / force_fetcher / republish 분기 skip 하고 ChromedpChain 직접 호출.
+// 그 외 처리 흐름 (raw_contents 저장 + RawContentRef publish) 은 일반 Handle 과 동일.
+//
+// ChromedpChain 미wiring 사이트 (예: yonhap) 에 대해서는 정의상 chromedp pool 이 큐 메시지를
+// 받지 않아야 하지만, 안전장치로 nil 일 때 graceful error.
+func (h *ChainHandler) HandleChromedpOnly(ctx context.Context, job *core.CrawlJob) ([]*core.Content, error) {
+	if h.Log == nil || h.RawSvc == nil || h.Producer == nil {
+		return nil, fmt.Errorf("chain handler is not properly initialized")
+	}
+	if h.ChromedpChain == nil {
+		return nil, fmt.Errorf("crawler %s has no chromedp chain wired", job.CrawlerName)
+	}
+
+	raw, err := h.ChromedpChain.Handle(ctx, job)
+	if err != nil {
+		return nil, err
+	}
+	if raw == nil {
+		return nil, fmt.Errorf("chromedp chain returned nil raw content for %s", job.Target.URL)
+	}
+
+	rawID, dup, err := h.RawSvc.Store(ctx, raw)
+	if err != nil {
+		return nil, fmt.Errorf("store raw content for %s: %w", job.Target.URL, err)
+	}
+	if dup {
+		h.Log.WithFields(map[string]interface{}{
+			"crawler":     job.CrawlerName,
+			"url":         raw.URL,
+			"existing_id": rawID,
+		}).Debug("raw content already exists for url, republishing ref")
+	}
+
+	if err := h.publishFetchedRef(ctx, job, raw, rawID); err != nil {
+		return nil, fmt.Errorf("publish fetched ref for %s: %w", job.Target.URL, err)
+	}
+
+	h.Log.WithFields(map[string]interface{}{
+		"crawler":     job.CrawlerName,
+		"url":         raw.URL,
+		"raw_id":      rawID,
+		"target_type": string(job.Target.Type),
+		"pool":        "chromedp",
+	}).Debug("raw content stored via chromedp pool, fetched ref published")
+
+	return nil, nil
+}
+
 // republishToChromedpQueue 는 본 job 을 TopicCrawlChromedp 로 다시 발행합니다 (이슈 #218).
 //
 // chromedp 처리 책임을 본 worker (goquery pool) 에서 분리 — 별도 chromedp worker pool 이 receive

--- a/internal/processor/fetcher/domain/general/handler.go
+++ b/internal/processor/fetcher/domain/general/handler.go
@@ -19,6 +19,13 @@ type Handler interface {
 	SetNext(h Handler)
 }
 
+// ErrLazyContentNeedsBrowser 는 GoQueryFetchHandler 가 lazy-load 감지 시 반환하는 sentinel 입니다 (이슈 #218).
+//
+// 기존 동작 — chain next 위임으로 같은 worker 에서 chromedp 호출 — 은 단일 Chrome 자원 풀
+// 고갈을 초래. 본 sentinel 을 받은 ChainHandler 는 next 위임 대신 TopicCrawlChromedp 로
+// republish — chromedp 호출이 별도 worker pool 에서 격리.
+var ErrLazyContentNeedsBrowser = errors.New("lazy loading content detected — chromedp pool republish required")
+
 // baseHandler 는 체인 위임 메커니즘을 제공하는 공통 구조체입니다.
 type baseHandler struct {
 	next Handler
@@ -68,11 +75,13 @@ func (h *GoQueryFetchHandler) Handle(ctx context.Context, job *core.CrawlJob) (*
 	}
 
 	if h.hasLazyContent(raw.HTML) {
+		// 이슈 #218: chain next 위임 대신 sentinel 반환. ChainHandler 가 받아 TopicCrawlChromedp
+		// 로 republish — chromedp 호출이 별도 worker pool 에서 격리되어 Chrome 자원 안정.
 		h.log.WithFields(map[string]interface{}{
 			"handler": "goquery",
 			"url":     job.Target.URL,
-		}).Warn("lazy loading detected, delegating to browser handler")
-		return h.delegateToNext(ctx, job, fmt.Errorf("lazy loading content detected"))
+		}).Warn("lazy loading detected, signaling chromedp republish")
+		return nil, ErrLazyContentNeedsBrowser
 	}
 
 	h.log.WithFields(map[string]interface{}{

--- a/internal/processor/fetcher/domain/general/sources/kr/registry.go
+++ b/internal/processor/fetcher/domain/general/sources/kr/registry.go
@@ -64,7 +64,8 @@ func registerNaver(registry *handler.Registry, _ core.Config, rawSvc service.Raw
 	brFetcher := fetcher.NewBrowserFetcher(cdpCrawler, cfg.CrawlerConfig)
 
 	crawler := general.NewGenericCrawler("naver", cfg.CrawlerConfig.SourceInfo, gqFetcher, cfg.BaseURL, cfg.CrawlerConfig)
-	defaultChain, err := general.BuildChain(gqFetcher, brFetcher, log,
+	// 이슈 #218: DefaultChain 은 goquery only — lazy detect 시 sentinel 반환 → ChainHandler 가 chromedp pool 로 republish.
+	defaultChain, err := general.BuildChain(gqFetcher, nil, log,
 		"data-lazy-src", "lazyload", "data-lazy",
 	)
 	if err != nil {
@@ -109,7 +110,8 @@ func registerDaum(registry *handler.Registry, _ core.Config, rawSvc service.RawC
 	brFetcher := fetcher.NewBrowserFetcher(cdpCrawler, cfg.CrawlerConfig)
 
 	crawler := general.NewGenericCrawler("daum", cfg.CrawlerConfig.SourceInfo, gqFetcher, cfg.BaseURL, cfg.CrawlerConfig)
-	defaultChain, err := general.BuildChain(gqFetcher, brFetcher, log,
+	// 이슈 #218: DefaultChain = goquery only.
+	defaultChain, err := general.BuildChain(gqFetcher, nil, log,
 		"data-lazy-src", "lazyload", "data-lazy",
 	)
 	if err != nil {

--- a/internal/processor/fetcher/domain/general/sources/us/registry.go
+++ b/internal/processor/fetcher/domain/general/sources/us/registry.go
@@ -44,7 +44,8 @@ func registerCNN(registry *handler.Registry, _ core.Config, rawSvc service.RawCo
 	brFetcher := fetcher.NewBrowserFetcher(cdpCrawler, cfg.CrawlerConfig)
 
 	crawler := general.NewGenericCrawler("cnn", cfg.CrawlerConfig.SourceInfo, gqFetcher, cfg.BaseURL, cfg.CrawlerConfig)
-	defaultChain, err := general.BuildChain(gqFetcher, brFetcher, log,
+	// 이슈 #218: DefaultChain = goquery only.
+	defaultChain, err := general.BuildChain(gqFetcher, nil, log,
 		"data-lazy-src", "lazyload", "data-lazy",
 	)
 	if err != nil {

--- a/internal/processor/fetcher/handler/handler.go
+++ b/internal/processor/fetcher/handler/handler.go
@@ -56,6 +56,18 @@ func (r *Registry) Register(name string, h Handler) {
 	r.handlers[name] = h
 }
 
+// Lookup 은 crawler name 으로 등록된 Handler 를 반환합니다.
+//
+// Lookup returns the registered Handler for crawler name. ok=false 면 미등록 — 호출자는
+// fallback (예: 별도 에러 처리) 결정. Handle 과 달리 noop fallback 자동 적용 안 함.
+//
+// 이슈 #218: ChromedpJobHandler 가 Registry 에서 *ChainHandler 를 직접 가져와
+// HandleChromedpOnly 호출하기 위해 사용.
+func (r *Registry) Lookup(name string) (Handler, bool) {
+	h, ok := r.handlers[name]
+	return h, ok
+}
+
 // Handle은 job.CrawlerName에 등록된 Handler를 찾아 실행합니다.
 // 등록된 Handler가 없으면 noop fallback을 실행합니다.
 //

--- a/internal/processor/fetcher/worker/chromedp_handler.go
+++ b/internal/processor/fetcher/worker/chromedp_handler.go
@@ -1,0 +1,79 @@
+package worker
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"issuetracker/internal/processor/fetcher/core"
+	"issuetracker/internal/processor/fetcher/domain/general"
+	"issuetracker/internal/processor/fetcher/handler"
+	"issuetracker/pkg/logger"
+)
+
+// ChromedpJobHandler 는 TopicCrawlChromedp 의 CrawlJob 을 처리하는 JobHandler 입니다 (이슈 #218).
+//
+// 책임:
+//
+//  1. Semaphore.Acquire — Chrome 인스턴스의 동시 navigation 수 제한
+//  2. handler.Registry 에서 crawler_name 으로 ChainHandler lookup
+//  3. ChainHandler.HandleChromedpOnly 호출 — ChromedpChain 으로 raw fetch + 저장 + RawContentRef publish
+//  4. Semaphore.Release (defer)
+//
+// goquery worker pool 의 ChainHandler.republishToChromedpQueue 가 발행한 메시지가 본 핸들러로
+// 흐름. ChromedpChain 이 같은 인스턴스라 chromedp 호출 자체는 동일 — 격리된 worker pool 에서
+// semaphore 로 동시성만 제한.
+type ChromedpJobHandler struct {
+	registry *handler.Registry
+	sem      Semaphore
+	log      *logger.Logger
+}
+
+// NewChromedpJobHandler 는 새 ChromedpJobHandler 를 생성합니다.
+//
+// registry / sem 은 nil 허용 안 함 (이슈 #208 정책).
+func NewChromedpJobHandler(registry *handler.Registry, sem Semaphore, log *logger.Logger) (*ChromedpJobHandler, error) {
+	if registry == nil {
+		return nil, errors.New("worker: NewChromedpJobHandler requires non-nil handler Registry")
+	}
+	if sem == nil {
+		return nil, errors.New("worker: NewChromedpJobHandler requires non-nil Semaphore")
+	}
+	return &ChromedpJobHandler{
+		registry: registry,
+		sem:      sem,
+		log:      log,
+	}, nil
+}
+
+// Handle 은 semaphore 보호 하에 chromedp fetch 를 실행합니다.
+//
+// Registry 에서 crawler_name 으로 등록된 Handler 를 lookup. 등록된 Handler 가 *general.ChainHandler
+// 가 아니면 (테스트/noop fallback 등) error — chromedp pool 은 정의상 ChainHandler 만 처리.
+//
+// Semaphore Acquire 가 ctx 만료로 실패하면 ctx.Err 반환 — KafkaConsumerPool 이 재시도 정책 적용.
+func (h *ChromedpJobHandler) Handle(ctx context.Context, job *core.CrawlJob) ([]*core.Content, error) {
+	if err := h.sem.Acquire(ctx); err != nil {
+		return nil, fmt.Errorf("chromedp semaphore acquire: %w", err)
+	}
+	defer h.sem.Release()
+
+	regHandler, ok := h.registry.Lookup(job.CrawlerName)
+	if !ok {
+		return nil, fmt.Errorf("no chain handler registered for crawler %s", job.CrawlerName)
+	}
+	chain, ok := regHandler.(*general.ChainHandler)
+	if !ok {
+		return nil, fmt.Errorf("registered handler for crawler %s is not *ChainHandler", job.CrawlerName)
+	}
+
+	if h.log != nil {
+		h.log.WithFields(map[string]interface{}{
+			"crawler":  job.CrawlerName,
+			"url":      job.Target.URL,
+			"capacity": h.sem.Capacity(),
+		}).Debug("chromedp pool handling job")
+	}
+
+	return chain.HandleChromedpOnly(ctx, job)
+}

--- a/internal/processor/fetcher/worker/chromedp_handler.go
+++ b/internal/processor/fetcher/worker/chromedp_handler.go
@@ -53,10 +53,17 @@ func NewChromedpJobHandler(registry *handler.Registry, sem Semaphore, log *logge
 //
 // Semaphore Acquire 가 ctx 만료로 실패하면 ctx.Err 반환 — KafkaConsumerPool 이 재시도 정책 적용.
 func (h *ChromedpJobHandler) Handle(ctx context.Context, job *core.CrawlJob) ([]*core.Content, error) {
+	if job == nil {
+		return nil, errors.New("chromedp handler received nil job")
+	}
 	if err := h.sem.Acquire(ctx); err != nil {
 		return nil, fmt.Errorf("chromedp semaphore acquire: %w", err)
 	}
-	defer h.sem.Release()
+	defer func() {
+		if relErr := h.sem.Release(); relErr != nil && h.log != nil {
+			h.log.WithError(relErr).Warn("chromedp semaphore release contract violation (non-fatal)")
+		}
+	}()
 
 	regHandler, ok := h.registry.Lookup(job.CrawlerName)
 	if !ok {

--- a/internal/processor/fetcher/worker/manager.go
+++ b/internal/processor/fetcher/worker/manager.go
@@ -33,12 +33,22 @@ type PoolConfig struct {
 //
 // URL dedup 은 이슈 #178 의 Ingestion Lock (Publisher 단) 으로 단일화 — worker 측 별도 cache 없음.
 // 단계별 worker 간 동시처리 차단은 ProcessingLock 으로 일원화 (구 JobLocker 의 명칭 변경).
+//
+// 이슈 #218: Chromedp 필드는 chromedp 전용 worker pool 의 PoolConfig + ChromedpHandler.
+// nil 이면 chromedp pool 미기동 (fetcher pool split 비활성 — 기존 동작 유지). Consumer 와
+// Handler 둘 다 non-nil 이어야 wiring 됨.
 type ManagerConfig struct {
 	High           PoolConfig
 	Normal         PoolConfig
 	Low            PoolConfig
 	ProcessingLock locks.ProcessingLock
 	RetryScheduler RetryScheduler
+
+	// Chromedp 는 chromedp 전용 pool 의 Consumer + WorkerCount.
+	// Consumer.nil 이면 chromedp pool 비활성.
+	Chromedp PoolConfig
+	// ChromedpHandler 는 chromedp pool 의 JobHandler. nil 이면 chromedp pool 비활성.
+	ChromedpHandler JobHandler
 }
 
 // ─────────────────────────────────────────────────────────────────────────
@@ -61,6 +71,9 @@ type PoolManager struct {
 	producer queue.Producer
 	resolver PriorityResolver
 	log      *logger.Logger
+
+	// chromedpPool 은 chromedp 전용 worker pool (이슈 #218). nil 이면 비활성.
+	chromedpPool *KafkaConsumerPool
 }
 
 // NewPoolManager는 설정에 따라 우선순위별 KafkaConsumerPool을 생성하고 PoolManager를 반환합니다.
@@ -99,7 +112,7 @@ func NewPoolManager(
 		return pool
 	}
 
-	return &PoolManager{
+	mgr := &PoolManager{
 		pools: map[core.Priority]*KafkaConsumerPool{
 			core.PriorityHigh:   newPool(cfg.High, "high"),
 			core.PriorityNormal: newPool(cfg.Normal, "normal"),
@@ -109,6 +122,21 @@ func NewPoolManager(
 		resolver: resolver,
 		log:      log,
 	}
+
+	// 이슈 #218: chromedp 전용 pool wiring (Consumer + Handler 둘 다 있을 때만 활성).
+	if cfg.Chromedp.Consumer != nil && cfg.ChromedpHandler != nil {
+		chromedpPool := NewKafkaConsumerPoolWithOptions(
+			cfg.Chromedp.Consumer, producer, cfg.ChromedpHandler, contentSvc, cfg.Chromedp.WorkerCount,
+			cbRegistry, procLock,
+		)
+		chromedpPool.SetPriority("chromedp")
+		if cfg.RetryScheduler != nil {
+			chromedpPool.SetRetryScheduler(cfg.RetryScheduler)
+		}
+		mgr.chromedpPool = chromedpPool
+	}
+
+	return mgr
 }
 
 // Publish는 CrawlJob을 PriorityResolver로 우선순위를 결정한 후 해당 Kafka crawl 토픽에 발행합니다.
@@ -148,6 +176,7 @@ func (m *PoolManager) Publish(ctx context.Context, job *core.CrawlJob) error {
 }
 
 // Start는 high/normal/low 모든 Pool의 goroutine을 시작합니다.
+// chromedp pool 이 wiring 되어 있으면 함께 시작 (이슈 #218).
 func (m *PoolManager) Start(ctx context.Context) {
 	// 우선순위 순서대로 시작 (로그 가독성)
 	for _, p := range []core.Priority{core.PriorityHigh, core.PriorityNormal, core.PriorityLow} {
@@ -157,12 +186,20 @@ func (m *PoolManager) Start(ctx context.Context) {
 		}).Info("starting worker pool")
 		m.pools[p].Start(ctx)
 	}
+	if m.chromedpPool != nil {
+		m.log.WithFields(map[string]interface{}{
+			"priority":     "chromedp",
+			"worker_count": m.chromedpPool.workerCount,
+		}).Info("starting worker pool")
+		m.chromedpPool.Start(ctx)
+	}
 }
 
 // Stop은 모든 Pool을 동시에 graceful shutdown합니다.
 //
 // Stop stops all pools concurrently so they drain in parallel within the
 // shared context timeout. 첫 번째로 발생한 에러를 반환하며 나머지 Pool 종료도 계속 시도합니다.
+// chromedp pool 이 wiring 되어 있으면 함께 종료 (이슈 #218).
 func (m *PoolManager) Stop(ctx context.Context) error {
 	var (
 		mu       sync.Mutex
@@ -170,22 +207,25 @@ func (m *PoolManager) Stop(ctx context.Context) error {
 		wg       sync.WaitGroup
 	)
 
+	stopPool := func(name string, pool *KafkaConsumerPool) {
+		defer wg.Done()
+		if err := pool.Stop(ctx); err != nil {
+			m.log.WithField("pool", name).WithError(err).Error("pool stop error")
+			mu.Lock()
+			if firstErr == nil {
+				firstErr = err
+			}
+			mu.Unlock()
+		}
+	}
+
 	for p, pool := range m.pools {
 		wg.Add(1)
-		go func(priority core.Priority, pool *KafkaConsumerPool) {
-			defer wg.Done()
-			if err := pool.Stop(ctx); err != nil {
-				m.log.WithFields(map[string]interface{}{
-					"priority": priority,
-				}).WithError(err).Error("pool stop error")
-
-				mu.Lock()
-				if firstErr == nil {
-					firstErr = err
-				}
-				mu.Unlock()
-			}
-		}(p, pool)
+		go stopPool(fmt.Sprintf("priority_%d", p), pool)
+	}
+	if m.chromedpPool != nil {
+		wg.Add(1)
+		go stopPool("chromedp", m.chromedpPool)
 	}
 
 	wg.Wait()

--- a/internal/processor/fetcher/worker/semaphore.go
+++ b/internal/processor/fetcher/worker/semaphore.go
@@ -1,0 +1,69 @@
+package worker
+
+import (
+	"context"
+	"errors"
+)
+
+// Semaphore 는 N 개의 동시 진입을 허용하는 counting semaphore 입니다 (이슈 #218).
+//
+// chromedp worker pool 이 Chrome 인스턴스의 동시 navigation 수를 제한하기 위해 사용 — 같은
+// Chrome 의 URLLoader / ResourceScheduler 가 ERR_INSUFFICIENT_RESOURCES 로 거부되는 빈도를
+// 직접 차단. capacity 는 운영 시 Chrome 의 동시 처리 한계 (보통 4-6) 에 맞춰 조정.
+//
+// 동시 사용 안전 — channel 기반 구현이라 lock-free.
+type Semaphore interface {
+	// Acquire 는 슬롯 1개를 점유합니다. 슬롯 부족 시 대기. ctx 가 cancel 되면 ctx.Err() 반환.
+	// 성공 시 nil — 호출자는 작업 완료 후 반드시 Release 호출 (defer 권장).
+	Acquire(ctx context.Context) error
+
+	// Release 는 슬롯 1개를 반납합니다. Acquire 와 1:1 매핑.
+	Release()
+
+	// Capacity 는 동시 보유 가능한 최대 슬롯 수를 반환합니다.
+	Capacity() int
+}
+
+// chanSemaphore 는 buffered channel 기반 Semaphore 구현입니다.
+type chanSemaphore struct {
+	slots    chan struct{}
+	capacity int
+}
+
+// NewSemaphore 는 capacity 만큼의 동시 진입을 허용하는 Semaphore 를 생성합니다.
+//
+// capacity <= 0 이면 error (이슈 #208 정책).
+func NewSemaphore(capacity int) (Semaphore, error) {
+	if capacity <= 0 {
+		return nil, errors.New("worker: NewSemaphore requires positive capacity")
+	}
+	return &chanSemaphore{
+		slots:    make(chan struct{}, capacity),
+		capacity: capacity,
+	}, nil
+}
+
+// Acquire 는 ctx 만료 전까지 슬롯을 대기합니다.
+func (s *chanSemaphore) Acquire(ctx context.Context) error {
+	select {
+	case s.slots <- struct{}{}:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+// Release 는 슬롯 1개를 반납합니다 (Acquire 후 1:1 매핑).
+//
+// 슬롯 반납 시 점유 중이지 않으면 panic — 호출자가 Acquire 와 1:1 매칭 보장 책임.
+// (Go 의 nil send-on-closed-channel 같은 panic 보다 일찍 발견 가능.)
+func (s *chanSemaphore) Release() {
+	select {
+	case <-s.slots:
+	default:
+		panic("worker: Semaphore.Release called without matching Acquire")
+	}
+}
+
+// Capacity 는 동시 보유 가능한 최대 슬롯 수를 반환합니다.
+func (s *chanSemaphore) Capacity() int { return s.capacity }

--- a/internal/processor/fetcher/worker/semaphore.go
+++ b/internal/processor/fetcher/worker/semaphore.go
@@ -18,11 +18,19 @@ type Semaphore interface {
 	Acquire(ctx context.Context) error
 
 	// Release 는 슬롯 1개를 반납합니다. Acquire 와 1:1 매핑.
-	Release()
+	// 매칭 Acquire 없이 호출 시 ErrReleaseWithoutAcquire — 호출자가 contract 위반을 log/audit.
+	// (production panic 금지 정책 — 이슈 #208 / 04-error-handling.md.)
+	Release() error
 
 	// Capacity 는 동시 보유 가능한 최대 슬롯 수를 반환합니다.
 	Capacity() int
 }
+
+// ErrReleaseWithoutAcquire 는 Release() 가 매칭 Acquire 없이 호출됐을 때 반환됩니다.
+//
+// production panic 금지 (이슈 #208) 에 따라 panic 대신 sentinel error — 호출자가 sentry / log 로
+// contract 위반 알림. 정상 흐름에서는 발생 안 함 (defer Release 패턴 사용).
+var ErrReleaseWithoutAcquire = errors.New("worker: Semaphore.Release called without matching Acquire")
 
 // chanSemaphore 는 buffered channel 기반 Semaphore 구현입니다.
 type chanSemaphore struct {
@@ -55,13 +63,14 @@ func (s *chanSemaphore) Acquire(ctx context.Context) error {
 
 // Release 는 슬롯 1개를 반납합니다 (Acquire 후 1:1 매핑).
 //
-// 슬롯 반납 시 점유 중이지 않으면 panic — 호출자가 Acquire 와 1:1 매칭 보장 책임.
-// (Go 의 nil send-on-closed-channel 같은 panic 보다 일찍 발견 가능.)
-func (s *chanSemaphore) Release() {
+// 매칭 Acquire 없이 호출되면 ErrReleaseWithoutAcquire 반환 — 호출자가 log 로 contract 위반
+// 알림. production panic 금지 (이슈 #208) 에 따라 panic 대신 error.
+func (s *chanSemaphore) Release() error {
 	select {
 	case <-s.slots:
+		return nil
 	default:
-		panic("worker: Semaphore.Release called without matching Acquire")
+		return ErrReleaseWithoutAcquire
 	}
 }
 

--- a/internal/processor/fetcher/worker/semaphore.go
+++ b/internal/processor/fetcher/worker/semaphore.go
@@ -30,7 +30,7 @@ type Semaphore interface {
 //
 // production panic 금지 (이슈 #208) 에 따라 panic 대신 sentinel error — 호출자가 sentry / log 로
 // contract 위반 알림. 정상 흐름에서는 발생 안 함 (defer Release 패턴 사용).
-var ErrReleaseWithoutAcquire = errors.New("worker: Semaphore.Release called without matching Acquire")
+var ErrReleaseWithoutAcquire = errors.New("worker: release called without matching acquire")
 
 // chanSemaphore 는 buffered channel 기반 Semaphore 구현입니다.
 type chanSemaphore struct {
@@ -43,7 +43,7 @@ type chanSemaphore struct {
 // capacity <= 0 이면 error (이슈 #208 정책).
 func NewSemaphore(capacity int) (Semaphore, error) {
 	if capacity <= 0 {
-		return nil, errors.New("worker: NewSemaphore requires positive capacity")
+		return nil, errors.New("worker: semaphore requires positive capacity")
 	}
 	return &chanSemaphore{
 		slots:    make(chan struct{}, capacity),
@@ -52,7 +52,13 @@ func NewSemaphore(capacity int) (Semaphore, error) {
 }
 
 // Acquire 는 ctx 만료 전까지 슬롯을 대기합니다.
+//
+// ctx 가 이미 cancel 된 상태면 슬롯 가용성과 무관하게 ctx.Err() 즉시 반환 (CodeRabbit 피드백) —
+// 호출자가 give-up 한 후에 슬롯을 소비하지 않도록 deterministic.
 func (s *chanSemaphore) Acquire(ctx context.Context) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
 	select {
 	case s.slots <- struct{}{}:
 		return nil

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -278,8 +278,12 @@ func LoadPathInfer(envFiles ...string) (PathInferConfig, error) {
 // 직전에 Semaphore.Acquire 로 Chrome 인스턴스의 동시 navigation 수를 제한해 ResourceScheduler
 // 큐 고갈 (ERR_INSUFFICIENT_RESOURCES) 을 차단.
 type FetcherChromedpPoolConfig struct {
-	// Enabled: false 면 chromedp pool 미기동 — 기존 흐름 (chromedp 호출이 goquery worker 안에서
-	// 발생) 유지. 환경변수 FETCHER_CHROMEDP_POOL_ENABLED (default true).
+	// Enabled: false 면 chromedp pool 미기동. **주의**: goquery worker 의 ChainHandler 가 lazy
+	// detect / chromedp 룰 / force_fetcher 분기에서 항상 TopicCrawlChromedp 로 republish 하므로
+	// pool 미기동 상태에서는 그 메시지가 처리되지 않고 누적된다 — main.go 가 fail-fast.
+	// 운영자가 chromedp 처리를 진정으로 비활성화하려면 chain_handler 의 republish 분기도 함께
+	// fork 해야 함 (별도 PR).
+	// 환경변수 FETCHER_CHROMEDP_POOL_ENABLED (default true).
 	Enabled bool
 
 	// WorkerCount: chromedp pool 의 worker goroutine 수.

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -272,6 +272,81 @@ func LoadPathInfer(envFiles ...string) (PathInferConfig, error) {
 	return cfg, nil
 }
 
+// FetcherChromedpPoolConfig 는 chromedp 전용 worker pool 의 wiring 설정입니다 (이슈 #218).
+//
+// goquery worker pool 과 분리된 별도 Kafka consumer group 을 운영하며, worker 의 chromedp 호출
+// 직전에 Semaphore.Acquire 로 Chrome 인스턴스의 동시 navigation 수를 제한해 ResourceScheduler
+// 큐 고갈 (ERR_INSUFFICIENT_RESOURCES) 을 차단.
+type FetcherChromedpPoolConfig struct {
+	// Enabled: false 면 chromedp pool 미기동 — 기존 흐름 (chromedp 호출이 goquery worker 안에서
+	// 발생) 유지. 환경변수 FETCHER_CHROMEDP_POOL_ENABLED (default true).
+	Enabled bool
+
+	// WorkerCount: chromedp pool 의 worker goroutine 수.
+	// 환경변수 FETCHER_CHROMEDP_WORKER_COUNT (default 2).
+	WorkerCount int
+
+	// SemaphoreCapacity: 동시 chromedp 호출 수 상한 — Chrome URLLoader 한계 (보통 30 미만) 의
+	// 안전 마진. 환경변수 FETCHER_CHROMEDP_SEMAPHORE_CAPACITY (default 4).
+	SemaphoreCapacity int
+}
+
+// DefaultFetcherChromedpPoolConfig 는 기본 FetcherChromedpPoolConfig 를 반환합니다.
+func DefaultFetcherChromedpPoolConfig() FetcherChromedpPoolConfig {
+	return FetcherChromedpPoolConfig{
+		Enabled:           true,
+		WorkerCount:       2,
+		SemaphoreCapacity: 4,
+	}
+}
+
+// LoadFetcherChromedpPool 는 .env 를 로드한 후 OS 환경변수로 FetcherChromedpPoolConfig 를 구성합니다.
+//
+// 지원 환경변수:
+//   - FETCHER_CHROMEDP_POOL_ENABLED: true | false (default true)
+//   - FETCHER_CHROMEDP_WORKER_COUNT: 양의 정수 (default 2)
+//   - FETCHER_CHROMEDP_SEMAPHORE_CAPACITY: 양의 정수 (default 4)
+func LoadFetcherChromedpPool(envFiles ...string) (FetcherChromedpPoolConfig, error) {
+	if len(envFiles) == 0 {
+		envFiles = []string{".env"}
+	}
+	if err := godotenv.Load(envFiles...); err != nil && !errors.Is(err, os.ErrNotExist) {
+		return FetcherChromedpPoolConfig{}, fmt.Errorf("failed to load env files %v: %w", envFiles, err)
+	}
+
+	cfg := DefaultFetcherChromedpPoolConfig()
+
+	if v := os.Getenv("FETCHER_CHROMEDP_POOL_ENABLED"); v != "" {
+		b, err := strconv.ParseBool(v)
+		if err != nil {
+			return FetcherChromedpPoolConfig{}, fmt.Errorf("parse FETCHER_CHROMEDP_POOL_ENABLED %q: %w", v, err)
+		}
+		cfg.Enabled = b
+	}
+	if v := os.Getenv("FETCHER_CHROMEDP_WORKER_COUNT"); v != "" {
+		n, err := strconv.Atoi(v)
+		if err != nil {
+			return FetcherChromedpPoolConfig{}, fmt.Errorf("parse FETCHER_CHROMEDP_WORKER_COUNT %q: %w", v, err)
+		}
+		if n < 1 {
+			return FetcherChromedpPoolConfig{}, fmt.Errorf("invalid FETCHER_CHROMEDP_WORKER_COUNT %d: must be 1 or greater", n)
+		}
+		cfg.WorkerCount = n
+	}
+	if v := os.Getenv("FETCHER_CHROMEDP_SEMAPHORE_CAPACITY"); v != "" {
+		n, err := strconv.Atoi(v)
+		if err != nil {
+			return FetcherChromedpPoolConfig{}, fmt.Errorf("parse FETCHER_CHROMEDP_SEMAPHORE_CAPACITY %q: %w", v, err)
+		}
+		if n < 1 {
+			return FetcherChromedpPoolConfig{}, fmt.Errorf("invalid FETCHER_CHROMEDP_SEMAPHORE_CAPACITY %d: must be 1 or greater", n)
+		}
+		cfg.SemaphoreCapacity = n
+	}
+
+	return cfg, nil
+}
+
 // FetcherAutoDowngradeConfig 는 자동 upgrade 된 host 를 주기적으로 goquery 로 되돌리는 안전장치 설정입니다 (이슈 #175 후속, sub-issue #224).
 //
 // upgrade-only 비대칭으로 인해 일시적 트래픽 에러로 잘못 upgrade 된 host 가 영원히 chromedp 로

--- a/pkg/queue/config.go
+++ b/pkg/queue/config.go
@@ -9,6 +9,13 @@ const (
 	TopicCrawlNormal = "issuetracker.crawl.normal"
 	TopicCrawlLow    = "issuetracker.crawl.low"
 
+	// TopicCrawlChromedp: chromedp 전용 fetch 큐 (이슈 #218).
+	// goquery worker 가 lazy-load 감지 / fetch 실패 시 재발행하거나, 단계 3 의 자동 upgrade
+	// trigger / force_fetcher metadata path 가 직접 enqueue. 별도 consumer group
+	// (GroupChromedpFetchers) 의 chromedp worker 가 consume 하여 worker 단위 semaphore 로
+	// Chrome 인스턴스 동시 호출 수를 제어. 우선순위 분리는 본 sub scope 외 (단일 토픽).
+	TopicCrawlChromedp = "issuetracker.crawl.chromedp"
+
 	// 원본 데이터 토픽 (국가별)
 	TopicRawUS = "issuetracker.raw.us"
 	TopicRawKR = "issuetracker.raw.kr"
@@ -32,6 +39,10 @@ const (
 // Consumer group 상수
 const (
 	GroupCrawlerWorkers = "issuetracker-crawler-workers"
+	// GroupChromedpFetchers: TopicCrawlChromedp 를 consume 하여 chromedp 만 사용하는 fetcher worker
+	// pool 의 consumer group (이슈 #218). 일반 crawler worker (GroupCrawlerWorkers) 와 분리되어
+	// Chrome 자원과 1:1 매핑된 worker 수 + semaphore 로 동시 호출량 제한.
+	GroupChromedpFetchers = "issuetracker-chromedp-fetchers"
 	// GroupParsers: TopicFetched 를 consume 하여 raw 로드 + 파싱 + content 저장 + raw 삭제 (이슈 #134).
 	GroupParsers     = "issuetracker-parsers"
 	GroupNormalizers = "issuetracker-normalizers"

--- a/test/internal/processor/fetcher/worker/semaphore_test.go
+++ b/test/internal/processor/fetcher/worker/semaphore_test.go
@@ -47,10 +47,10 @@ func TestSemaphore_Acquire_BlocksUntilRelease(t *testing.T) {
 	assert.Error(t, err, "3번째 Acquire 는 슬롯 부족으로 timeout")
 
 	// Release 후 Acquire 통과
-	s.Release()
+	require.NoError(t, s.Release())
 	require.NoError(t, s.Acquire(ctx))
-	s.Release()
-	s.Release()
+	require.NoError(t, s.Release())
+	require.NoError(t, s.Release())
 }
 
 // TestSemaphore_Concurrent_RespectsCapacity:
@@ -72,7 +72,7 @@ func TestSemaphore_Concurrent_RespectsCapacity(t *testing.T) {
 		go func() {
 			defer wg.Done()
 			require.NoError(t, s.Acquire(context.Background()))
-			defer s.Release()
+			defer func() { _ = s.Release() }()
 
 			n := current.Add(1)
 			defer current.Add(-1)
@@ -108,7 +108,7 @@ func TestSemaphore_Acquire_ContextCanceled_ReturnsError(t *testing.T) {
 	assert.ErrorIs(t, err, context.Canceled)
 
 	// 점유 안 됐으니 Release 1번만 가능.
-	s.Release()
+	require.NoError(t, s.Release())
 }
 
 // TestSemaphore_Release_WithoutAcquire_ReturnsError:

--- a/test/internal/processor/fetcher/worker/semaphore_test.go
+++ b/test/internal/processor/fetcher/worker/semaphore_test.go
@@ -1,0 +1,123 @@
+package worker_test
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"issuetracker/internal/processor/fetcher/worker"
+)
+
+// TestNewSemaphore_BadCapacity_ReturnsError:
+// 이슈 #208 panic-on-nil → error 정책. capacity <= 0 거부.
+func TestNewSemaphore_BadCapacity_ReturnsError(t *testing.T) {
+	_, err := worker.NewSemaphore(0)
+	assert.Error(t, err)
+	_, err = worker.NewSemaphore(-1)
+	assert.Error(t, err)
+}
+
+// TestSemaphore_Capacity_Reports:
+// Capacity() 가 생성 시 받은 값과 일치.
+func TestSemaphore_Capacity_Reports(t *testing.T) {
+	s, err := worker.NewSemaphore(5)
+	require.NoError(t, err)
+	assert.Equal(t, 5, s.Capacity())
+}
+
+// TestSemaphore_Acquire_BlocksUntilRelease:
+// capacity=2 이면 3번째 Acquire 는 첫 두 Release 중 하나가 일어나야 통과.
+func TestSemaphore_Acquire_BlocksUntilRelease(t *testing.T) {
+	s, err := worker.NewSemaphore(2)
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	require.NoError(t, s.Acquire(ctx))
+	require.NoError(t, s.Acquire(ctx))
+
+	// 3번째 Acquire 는 timeout context 로 차단 검증
+	timeoutCtx, cancel := context.WithTimeout(ctx, 50*time.Millisecond)
+	defer cancel()
+	err = s.Acquire(timeoutCtx)
+	assert.Error(t, err, "3번째 Acquire 는 슬롯 부족으로 timeout")
+
+	// Release 후 Acquire 통과
+	s.Release()
+	require.NoError(t, s.Acquire(ctx))
+	s.Release()
+	s.Release()
+}
+
+// TestSemaphore_Concurrent_RespectsCapacity:
+// goroutine N (>capacity) 동시 Acquire 시 동시 점유 수가 capacity 초과 안 함.
+func TestSemaphore_Concurrent_RespectsCapacity(t *testing.T) {
+	const capacity = 3
+	const goroutines = 20
+	s, err := worker.NewSemaphore(capacity)
+	require.NoError(t, err)
+
+	var (
+		current atomic.Int32
+		maxSeen atomic.Int32
+		wg      sync.WaitGroup
+	)
+
+	for i := 0; i < goroutines; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			require.NoError(t, s.Acquire(context.Background()))
+			defer s.Release()
+
+			n := current.Add(1)
+			defer current.Add(-1)
+
+			// max 추적
+			for {
+				m := maxSeen.Load()
+				if n <= m || maxSeen.CompareAndSwap(m, n) {
+					break
+				}
+			}
+
+			time.Sleep(10 * time.Millisecond)
+		}()
+	}
+
+	wg.Wait()
+	assert.LessOrEqual(t, int(maxSeen.Load()), capacity, "동시 점유 수가 capacity 초과 안 됨")
+	assert.GreaterOrEqual(t, int(maxSeen.Load()), 1)
+}
+
+// TestSemaphore_Acquire_ContextCanceled_ReturnsError:
+// Acquire 대기 중 ctx cancel → ctx.Err 반환 + 슬롯 점유 안 함.
+func TestSemaphore_Acquire_ContextCanceled_ReturnsError(t *testing.T) {
+	s, err := worker.NewSemaphore(1)
+	require.NoError(t, err)
+
+	require.NoError(t, s.Acquire(context.Background()))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	err = s.Acquire(ctx)
+	assert.ErrorIs(t, err, context.Canceled)
+
+	// 점유 안 됐으니 Release 1번만 가능.
+	s.Release()
+}
+
+// TestSemaphore_Release_WithoutAcquire_Panics:
+// 매칭 Acquire 없이 Release 호출 시 panic — 호출자 contract 위반 조기 발견.
+func TestSemaphore_Release_WithoutAcquire_Panics(t *testing.T) {
+	s, err := worker.NewSemaphore(2)
+	require.NoError(t, err)
+
+	assert.Panics(t, func() {
+		s.Release()
+	})
+}

--- a/test/internal/processor/fetcher/worker/semaphore_test.go
+++ b/test/internal/processor/fetcher/worker/semaphore_test.go
@@ -72,7 +72,11 @@ func TestSemaphore_Concurrent_RespectsCapacity(t *testing.T) {
 		go func() {
 			defer wg.Done()
 			require.NoError(t, s.Acquire(context.Background()))
-			defer func() { _ = s.Release() }()
+			defer func() {
+				if err := s.Release(); err != nil {
+					t.Errorf("release failed: %v", err)
+				}
+			}()
 
 			n := current.Add(1)
 			defer current.Add(-1)

--- a/test/internal/processor/fetcher/worker/semaphore_test.go
+++ b/test/internal/processor/fetcher/worker/semaphore_test.go
@@ -111,13 +111,12 @@ func TestSemaphore_Acquire_ContextCanceled_ReturnsError(t *testing.T) {
 	s.Release()
 }
 
-// TestSemaphore_Release_WithoutAcquire_Panics:
-// 매칭 Acquire 없이 Release 호출 시 panic — 호출자 contract 위반 조기 발견.
-func TestSemaphore_Release_WithoutAcquire_Panics(t *testing.T) {
+// TestSemaphore_Release_WithoutAcquire_ReturnsError:
+// 매칭 Acquire 없이 Release 호출 시 ErrReleaseWithoutAcquire — production panic 금지 (이슈 #208).
+func TestSemaphore_Release_WithoutAcquire_ReturnsError(t *testing.T) {
 	s, err := worker.NewSemaphore(2)
 	require.NoError(t, err)
 
-	assert.Panics(t, func() {
-		s.Release()
-	})
+	err = s.Release()
+	assert.ErrorIs(t, err, worker.ErrReleaseWithoutAcquire)
 }


### PR DESCRIPTION
## 연관 이슈
- Closes #218

<br>

## 구현 내용

이슈 #218 — fetcher 단계 분리. chromedp 호출이 같은 worker pool 에서 일어나는 fallback 흐름을 제거하고, 별도 worker pool + Kafka 큐 + Semaphore 로 Chrome 자원 보호.

### Commit 1: `[FEAT]:` 큐 상수 + Semaphore 인프라

- `pkg/queue/config.go`: `TopicCrawlChromedp` + `GroupChromedpFetchers`
- `internal/processor/fetcher/worker/semaphore.go`: channel-based Semaphore (Acquire/Release/Capacity, ctx 만료 지원, Release without Acquire panic)
- 단위 테스트 6건 (capacity / 동시성 / ctx canceled / panic)

### Commit 2: `[REFAC]:` GoQuery lazy 분기 + DefaultChain 단순화

- `general/handler.go`: `ErrLazyContentNeedsBrowser` sentinel — lazy detect 시 next 위임 대신 sentinel 반환
- `sources/{kr,us}/registry.go`: `DefaultChain = BuildChain(gqFetcher, nil, log, ...)` — goquery only. ChromedpChain 은 그대로 (별도 chromedp pool 이 호출).

### Commit 3: `[REFAC]:` ChainHandler republish 분기

- `chain_handler.go`:
  - `republishToChromedpQueue(ctx, job)` — CrawlJob 그대로 재직렬화 후 `TopicCrawlChromedp` 로 publish
  - Handle: `selectChain == ChromedpChain` (force_fetcher / Resolver 룰) → republish, sentinel 받으면 republish

### Commit 4: `[FEAT]:` ChromedpJobHandler + PoolManager 확장

- `handler.Registry.Lookup(name)` — `ChromedpJobHandler` 가 *ChainHandler 직접 가져오기
- `general.ChainHandler.HandleChromedpOnly(ctx, job)` — ChromedpChain 만 호출 + raw 저장 + RawContentRef publish
- `worker/chromedp_handler.go`: `ChromedpJobHandler` (sem.Acquire → registry.Lookup → ChainHandler.HandleChromedpOnly → sem.Release)
- `worker/manager.go`:
  - `ManagerConfig.Chromedp` + `ChromedpHandler` 필드
  - `PoolManager.chromedpPool` 신설
  - Start/Stop 에 chromedp pool lifecycle 통합

### Commit 5: `[FEAT]:` config + main.go wiring

- `pkg/config/config.go`: `FetcherChromedpPoolConfig`
  - `FETCHER_CHROMEDP_POOL_ENABLED` (default `true`)
  - `FETCHER_CHROMEDP_WORKER_COUNT` (default `2`)
  - `FETCHER_CHROMEDP_SEMAPHORE_CAPACITY` (default `4`)
- `cmd/issuetracker/main.go`: ENABLED 시 chromedp consumer + Semaphore + ChromedpJobHandler wiring 후 `ManagerConfig` 에 주입

<br>

## 흐름

```
[goquery worker pool] (TopicCrawl* consume)
  ChainHandler.Handle:
    selectChain == ChromedpChain (force_fetcher / 룰)  →  TopicCrawlChromedp republish
    DefaultChain.Handle:
      성공                   → raw 저장 + TopicFetched (parser 로 위임)
      ErrLazyContentNeedsBrowser → TopicCrawlChromedp republish
      일반 에러               → 재시도 (기존 흐름)

[chromedp worker pool] (TopicCrawlChromedp consume, GroupChromedpFetchers)
  ChromedpJobHandler.Handle:
    sem.Acquire (capacity 4)
    Registry.Lookup(crawler) → *ChainHandler
    ChainHandler.HandleChromedpOnly:
      ChromedpChain.Handle (browser only) → raw 저장 + TopicFetched
    sem.Release (defer)
```

<br>

## 효과

| 항목 | 효과 |
|---|---|
| Chrome `ERR_INSUFFICIENT_RESOURCES` 빈도 | semaphore (capacity 4) 로 직접 차단 → 큰 폭 감소 |
| 자원 1:1 매핑 | chromedp worker 수 ↔ Chrome 인스턴스 부하 명확 |
| 가시성 | chromedp consumer lag 만 보면 부하 식별 가능 |
| 스케일링 독립성 | goquery 처리량은 그대로, chromedp 만 별도 증설 가능 |

<br>

## CI / 머지 게이트 점검

> [CI 운영 규약](docs/ci/conventions.md) 및 [Required Status Checks 단일 소스](docs/ci/status-checks.md)에 따라 작성합니다.

### 변경 영향 범위
- 영향 패키지: `pkg/queue/`, `pkg/config/`, `internal/processor/fetcher/worker/` (Semaphore + ChromedpJobHandler + PoolManager 확장), `internal/processor/fetcher/handler/` (Registry.Lookup), `internal/processor/fetcher/domain/general/` (sentinel + ChainHandler republish/HandleChromedpOnly), site registries (kr / us), `cmd/issuetracker/`
- 위험도(택1): `Medium`
  - 신규 Kafka topic / consumer group — 첫 부팅 시 자동 생성 (Kafka 설정에 따라)
  - chain 흐름 변경 — DefaultChain 의 browser fallback 제거. 기존에 same-worker 에서 처리되던 chromedp 메시지가 신규 topic 으로 routing
  - DLQ 발행 정책 등 후속 운영 정책은 별도 (chromedp pool 의 retry / DLQ 는 기존 KafkaConsumerPool 의 정책 그대로)
  - 30개 패키지 race test 모두 통과

### Required Status Checks
- 통과 확인 대상:
  - [ ] `Commit Lint`
  - [ ] `PR Title Lint`
  - [ ] `Linked Issue Check`
  - [ ] `Format Check`
  - [ ] `Build`
  - [ ] `Test`
  - [ ] `Lint`

### 롤백 계획
- `FETCHER_CHROMEDP_POOL_ENABLED=false` 즉시 비활성. 단, chain 의 republish 분기는 그대로라 메시지가 chromedp 큐에 쌓임 (재시작 후 ENABLED=true 시 정상 처리).
- `git revert` 5개 commit. 신규 Kafka topic 은 정리 (수동 `kafka-topics --delete`).

<br>

## TODO
- (운영 검증) 머지 후 라이브 모니터링: Chrome `ERR_INSUFFICIENT_RESOURCES` 빈도 감소 확인 + chromedp consumer lag / sem 점유율 추적
- (후속) Kafka topic 의 partition 수 / replication factor 운영 표준 정의 (현재는 자동 생성 default)
- (후속) chromedp pool 의 worker count / sem capacity 운영 데이터로 튜닝 (default 2 worker / capacity 4 는 보수적)

<br>

## 논의 사항
- **chain 분리 vs 같은 인스턴스 공유**: ChromedpChain (BrowserFetchHandler) 이 goquery pool / chromedp pool 양쪽에 wiring 가능. 본 PR 은 의도적으로 chromedp pool 만 호출 (republish 우회) — 같은 인스턴스라도 호출 경로가 1개라 자원 추적 가시성 ↑.
- **republish 비용**: chromedp 처리 요청이 추가 Kafka 라운드트립을 거침 (1회 publish + 1회 consume). 평균 latency 약 10-100ms 증가 — Chrome 자원 안정의 trade-off.
- **force_fetcher metadata 보존**: republish 시 CrawlJob 그대로 재직렬화 — Target.Metadata 의 token + retry_reason 등 모두 보존. chromedp pool 의 ChainHandler.HandleChromedpOnly 가 Resolver 분기 skip 하므로 token 검증은 영향 없음.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Dedicated browser-backed crawl pool and queue for improved handling of JS/lazy-loaded pages.
  * Automatic detection of lazy-loaded content and automatic rerouting to the browser crawl pool.
  * New config options to enable the browser pool and tune worker count and semaphore capacity.

* **Improvements**
  * Safer semaphore implementation with capacity validation and error-returning release to prevent panics.

* **Tests**
  * Comprehensive semaphore tests for capacity, concurrency, cancellation, and release behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->