### PR TITLE
[REFAC#229] chromedp pool — per-worker Semaphore + worker_id context 도입

### DIFF
--- a/cmd/issuetracker/main.go
+++ b/cmd/issuetracker/main.go
@@ -245,11 +245,18 @@ func main() {
 		chromedpConsumer := queue.NewConsumer(chromedpKafkaCfg, queue.TopicCrawlChromedp)
 		defer chromedpConsumer.Close()
 
-		sem, err := crawlerWorker.NewSemaphore(chromedpPoolCfg.SemaphoreCapacity)
-		if err != nil {
-			log.WithError(err).Fatal("failed to construct chromedp semaphore")
+		// 이슈 #229: per-worker Semaphore 모델 — worker_id 별 1 개씩, 길이 = WorkerCount.
+		// 한 worker 가 자기 전용 Chrome 에 동시 띄울 tab 수만 제한 (글로벌이 아님).
+		// 다음 sub-issue (#230) 에서 worker_id 별 RemoteURL 까지 매핑하면 1:1 활성화.
+		sems := make([]crawlerWorker.Semaphore, chromedpPoolCfg.WorkerCount)
+		for i := 0; i < chromedpPoolCfg.WorkerCount; i++ {
+			sem, semErr := crawlerWorker.NewSemaphore(chromedpPoolCfg.SemaphoreCapacity)
+			if semErr != nil {
+				log.WithError(semErr).Fatal("failed to construct chromedp semaphore")
+			}
+			sems[i] = sem
 		}
-		chromedpHandler, err := crawlerWorker.NewChromedpJobHandler(registry, sem, log)
+		chromedpHandler, err := crawlerWorker.NewChromedpJobHandler(registry, sems, log)
 		if err != nil {
 			log.WithError(err).Fatal("failed to construct chromedp job handler")
 		}
@@ -258,9 +265,9 @@ func main() {
 		managerCfg.ChromedpHandler = chromedpHandler
 
 		log.WithFields(map[string]interface{}{
-			"worker_count":       chromedpPoolCfg.WorkerCount,
-			"semaphore_capacity": chromedpPoolCfg.SemaphoreCapacity,
-		}).Info("chromedp pool wiring enabled")
+			"worker_count":                  chromedpPoolCfg.WorkerCount,
+			"per_worker_semaphore_capacity": chromedpPoolCfg.SemaphoreCapacity,
+		}).Info("chromedp pool wiring enabled (per-worker semaphores)")
 	} else {
 		// 이슈 #218 (CodeRabbit 피드백): goquery worker 의 ChainHandler 가 lazy detect / chromedp
 		// 룰 / force_fetcher 분기에서 항상 TopicCrawlChromedp 로 republish 함. consumer 가 없으면

--- a/cmd/issuetracker/main.go
+++ b/cmd/issuetracker/main.go
@@ -246,8 +246,10 @@ func main() {
 		defer chromedpConsumer.Close()
 
 		// 이슈 #229: per-worker Semaphore 모델 — worker_id 별 1 개씩, 길이 = WorkerCount.
-		// 한 worker 가 자기 전용 Chrome 에 동시 띄울 tab 수만 제한 (글로벌이 아님).
-		// 다음 sub-issue (#230) 에서 worker_id 별 RemoteURL 까지 매핑하면 1:1 활성화.
+		// 본 Semaphore 는 worker 자원 격리 guard 역할 — KafkaConsumerPool 의 worker 는 메시지를
+		// 순차 처리하므로 capacity > 1 은 현 모델에서 추가 동시성 이득 없음 (gemini 피드백).
+		// 실질 전체 동시 navigate 수 = WorkerCount. 다음 sub-issue (#230) 에서 worker_id 별
+		// RemoteURL 까지 매핑하면 worker:Chrome 1:1 활성화.
 		sems := make([]crawlerWorker.Semaphore, chromedpPoolCfg.WorkerCount)
 		for i := 0; i < chromedpPoolCfg.WorkerCount; i++ {
 			sem, semErr := crawlerWorker.NewSemaphore(chromedpPoolCfg.SemaphoreCapacity)
@@ -267,7 +269,8 @@ func main() {
 		log.WithFields(map[string]interface{}{
 			"worker_count":                  chromedpPoolCfg.WorkerCount,
 			"per_worker_semaphore_capacity": chromedpPoolCfg.SemaphoreCapacity,
-		}).Info("chromedp pool wiring enabled (per-worker semaphores)")
+			"effective_concurrency":         chromedpPoolCfg.WorkerCount,
+		}).Info("chromedp pool wiring enabled (per-worker semaphores; effective concurrency = worker_count)")
 	} else {
 		// 이슈 #218 (CodeRabbit 피드백): goquery worker 의 ChainHandler 가 lazy detect / chromedp
 		// 룰 / force_fetcher 분기에서 항상 TopicCrawlChromedp 로 republish 함. consumer 가 없으면

--- a/internal/processor/fetcher/worker/chromedp_handler.go
+++ b/internal/processor/fetcher/worker/chromedp_handler.go
@@ -15,38 +15,69 @@ import (
 //
 // 책임:
 //
-//  1. Semaphore.Acquire — Chrome 인스턴스의 동시 navigation 수 제한
+//  1. worker_id 별 Semaphore.Acquire — 같은 Chrome 인스턴스에 동시 띄울 tab 수 제한
 //  2. handler.Registry 에서 crawler_name 으로 ChainHandler lookup
 //  3. ChainHandler.HandleChromedpOnly 호출 — ChromedpChain 으로 raw fetch + 저장 + RawContentRef publish
 //  4. Semaphore.Release (defer)
 //
+// 이슈 #229 — per-worker Semaphore 모델:
+// 글로벌 Semaphore 1 개를 모든 worker 가 공유하던 PR #227 의 모델을, worker_id 별 Semaphore
+// 1 개로 분리. 한 worker 가 자기 전용 Chrome 에 동시 띄울 tab 수만 제한 — 이후 sub-issue
+// #230 에서 RemoteURL 매핑까지 N 개로 확장하면 worker:Chrome 1:1 활성화.
+//
 // goquery worker pool 의 ChainHandler.republishToChromedpQueue 가 발행한 메시지가 본 핸들러로
-// 흐름. ChromedpChain 이 같은 인스턴스라 chromedp 호출 자체는 동일 — 격리된 worker pool 에서
-// semaphore 로 동시성만 제한.
+// 흐름.
 type ChromedpJobHandler struct {
 	registry *handler.Registry
-	sem      Semaphore
-	log      *logger.Logger
+	// sems 는 worker_id 별 Semaphore. 길이 N — KafkaConsumerPool 의 chromedp pool worker 수와 동일.
+	// Handle 진입 시 ctx 의 worker_id 로 슬롯 선택. ID 가 범위 밖이면 0번 슬롯 fallback (방어).
+	sems []Semaphore
+	log  *logger.Logger
 }
 
-// NewChromedpJobHandler 는 새 ChromedpJobHandler 를 생성합니다.
+// NewChromedpJobHandler 는 새 ChromedpJobHandler 를 생성합니다 (이슈 #229).
 //
-// registry / sem 은 nil 허용 안 함 (이슈 #208 정책).
-func NewChromedpJobHandler(registry *handler.Registry, sem Semaphore, log *logger.Logger) (*ChromedpJobHandler, error) {
+// sems 는 worker_id 인덱스의 Semaphore slice — 길이는 chromedp pool 의 worker 수와 동일해야
+// 합니다. 호출자(main.go) 가 cfg.WorkerCount 만큼 NewSemaphore 를 만들어 전달합니다.
+//
+// registry / sems 는 nil/empty 허용 안 함 (이슈 #208 정책).
+func NewChromedpJobHandler(registry *handler.Registry, sems []Semaphore, log *logger.Logger) (*ChromedpJobHandler, error) {
 	if registry == nil {
 		return nil, errors.New("worker: NewChromedpJobHandler requires non-nil handler Registry")
 	}
-	if sem == nil {
-		return nil, errors.New("worker: NewChromedpJobHandler requires non-nil Semaphore")
+	if len(sems) == 0 {
+		return nil, errors.New("worker: NewChromedpJobHandler requires at least one Semaphore")
+	}
+	for i, s := range sems {
+		if s == nil {
+			return nil, fmt.Errorf("worker: NewChromedpJobHandler sems[%d] is nil", i)
+		}
 	}
 	return &ChromedpJobHandler{
 		registry: registry,
-		sem:      sem,
+		sems:     sems,
 		log:      log,
 	}, nil
 }
 
-// Handle 은 semaphore 보호 하에 chromedp fetch 를 실행합니다.
+// resolveSemaphore 는 ctx 의 worker_id 로 자기 전용 Semaphore 를 반환합니다.
+// worker_id 미설정 또는 범위 밖이면 0번 슬롯 fallback + WARN 로그 (방어 + 가시성).
+func (h *ChromedpJobHandler) resolveSemaphore(ctx context.Context) (Semaphore, int) {
+	id := WorkerIDFromContext(ctx)
+	if id < 0 || id >= len(h.sems) {
+		if h.log != nil {
+			h.log.WithFields(map[string]interface{}{
+				"worker_id":   id,
+				"slot_count":  len(h.sems),
+				"fallback_id": 0,
+			}).Warn("chromedp handler received out-of-range worker_id, using slot 0 fallback")
+		}
+		return h.sems[0], 0
+	}
+	return h.sems[id], id
+}
+
+// Handle 은 per-worker semaphore 보호 하에 chromedp fetch 를 실행합니다.
 //
 // Registry 에서 crawler_name 으로 등록된 Handler 를 lookup. 등록된 Handler 가 *general.ChainHandler
 // 가 아니면 (테스트/noop fallback 등) error — chromedp pool 은 정의상 ChainHandler 만 처리.
@@ -56,12 +87,16 @@ func (h *ChromedpJobHandler) Handle(ctx context.Context, job *core.CrawlJob) ([]
 	if job == nil {
 		return nil, errors.New("chromedp handler received nil job")
 	}
-	if err := h.sem.Acquire(ctx); err != nil {
-		return nil, fmt.Errorf("chromedp semaphore acquire: %w", err)
+
+	sem, workerID := h.resolveSemaphore(ctx)
+	if err := sem.Acquire(ctx); err != nil {
+		return nil, fmt.Errorf("chromedp semaphore acquire (worker_id=%d): %w", workerID, err)
 	}
 	defer func() {
-		if relErr := h.sem.Release(); relErr != nil && h.log != nil {
-			h.log.WithError(relErr).Warn("chromedp semaphore release contract violation (non-fatal)")
+		if relErr := sem.Release(); relErr != nil && h.log != nil {
+			h.log.WithFields(map[string]interface{}{
+				"worker_id": workerID,
+			}).WithError(relErr).Warn("chromedp semaphore release contract violation (non-fatal)")
 		}
 	}()
 
@@ -76,9 +111,10 @@ func (h *ChromedpJobHandler) Handle(ctx context.Context, job *core.CrawlJob) ([]
 
 	if h.log != nil {
 		h.log.WithFields(map[string]interface{}{
-			"crawler":  job.CrawlerName,
-			"url":      job.Target.URL,
-			"capacity": h.sem.Capacity(),
+			"crawler":   job.CrawlerName,
+			"url":       job.Target.URL,
+			"worker_id": workerID,
+			"capacity":  sem.Capacity(),
 		}).Debug("chromedp pool handling job")
 	}
 

--- a/internal/processor/fetcher/worker/chromedp_handler.go
+++ b/internal/processor/fetcher/worker/chromedp_handler.go
@@ -15,15 +15,20 @@ import (
 //
 // 책임:
 //
-//  1. worker_id 별 Semaphore.Acquire — 같은 Chrome 인스턴스에 동시 띄울 tab 수 제한
+//  1. worker_id 별 Semaphore.Acquire — worker 자원 격리 guard
 //  2. handler.Registry 에서 crawler_name 으로 ChainHandler lookup
 //  3. ChainHandler.HandleChromedpOnly 호출 — ChromedpChain 으로 raw fetch + 저장 + RawContentRef publish
 //  4. Semaphore.Release (defer)
 //
-// 이슈 #229 — per-worker Semaphore 모델:
+// 이슈 #229 — per-worker Semaphore 모델 + 실효 동시성 정정 (gemini 피드백):
 // 글로벌 Semaphore 1 개를 모든 worker 가 공유하던 PR #227 의 모델을, worker_id 별 Semaphore
-// 1 개로 분리. 한 worker 가 자기 전용 Chrome 에 동시 띄울 tab 수만 제한 — 이후 sub-issue
-// #230 에서 RemoteURL 매핑까지 N 개로 확장하면 worker:Chrome 1:1 활성화.
+// 1 개로 분리. **단, KafkaConsumerPool 의 worker goroutine 은 메시지를 순차 처리** 하므로 같은
+// worker 가 동시 2 개 이상의 Handle 을 호출할 수 없음 → per-worker Semaphore 의 capacity > 1 은
+// 현 모델에서 추가 동시성 이득 없음 (default 1 권장).
+//
+// 본 핸들러의 Semaphore 는 처리량 throttle 이 아닌 worker 자원 격리 guard 역할 — 다음 sub-issue
+// #230 에서 worker_id 별 Chrome RemoteURL 까지 매핑하면 worker:Chrome 1:1 활성화. 처리량 조정은
+// WorkerCount + RemoteURLs 수로 수행.
 //
 // goquery worker pool 의 ChainHandler.republishToChromedpQueue 가 발행한 메시지가 본 핸들러로
 // 흐름.

--- a/internal/processor/fetcher/worker/pool.go
+++ b/internal/processor/fetcher/worker/pool.go
@@ -231,10 +231,16 @@ func (p *KafkaConsumerPool) SetPriority(name string) {
 
 // Start는 worker goroutine들과 message polling goroutine을 시작합니다.
 // context가 cancel되면 polling이 중단되고 진행 중인 작업이 완료됩니다.
+//
+// 각 worker goroutine 은 0..workerCount-1 의 worker_id 를 부여받아 ctx 에 실어 전달합니다
+// (이슈 #229). 다운스트림 JobHandler — 특히 ChromedpJobHandler — 는 worker_id 로 per-worker
+// 자원 (Semaphore, 추후 RemoteURL) 을 lookup 합니다. priority pool (high/normal/low) 의 worker_id
+// 는 의미가 없지만 (handler 가 무시) 모든 pool 이 동일 wiring 을 갖도록 일관성 보장.
 func (p *KafkaConsumerPool) Start(ctx context.Context) {
 	for i := 0; i < p.workerCount; i++ {
+		workerID := i
 		p.wg.Add(1)
-		go p.worker(ctx)
+		go p.worker(ctx, workerID)
 	}
 
 	// pollDone은 pollMessages가 완전히 종료된 후 닫힙니다.
@@ -364,8 +370,12 @@ func (p *KafkaConsumerPool) pollMessages(ctx context.Context) {
 	}
 }
 
-func (p *KafkaConsumerPool) worker(ctx context.Context) {
+func (p *KafkaConsumerPool) worker(ctx context.Context, workerID int) {
 	defer p.wg.Done()
+
+	// 이슈 #229 — worker_id 를 ctx 에 첨부. ChromedpJobHandler 가 per-worker Semaphore
+	// 슬롯을 선택하는 데 사용. priority pool 에서는 handler 가 ID 를 무시.
+	ctx = WithWorkerID(ctx, workerID)
 
 	log := logger.FromContext(ctx)
 

--- a/internal/processor/fetcher/worker/worker_id.go
+++ b/internal/processor/fetcher/worker/worker_id.go
@@ -1,0 +1,37 @@
+package worker
+
+import "context"
+
+// 이슈 #229 — KafkaConsumerPool 의 worker goroutine 별 인덱스를 ctx 로 전달하기 위한
+// helper. ChromedpJobHandler 가 per-worker Semaphore 슬롯을 lookup 하는 데 사용 (이슈 #228 의
+// 1:1 매핑 모델 — sub-issue #230 에서 RemoteURL 매핑까지 확장).
+//
+// 컨텍스트 키 노출 정책: unexported type + sentinel — context.WithValue 충돌 회피 표준 패턴.
+// 외부 패키지는 WithWorkerID / WorkerIDFromContext 만 사용.
+
+type workerIDKey struct{}
+
+// noWorkerID 는 WorkerIDFromContext 가 worker_id 미설정을 나타낼 때 반환하는 값입니다.
+// pool 외 호출 경로 (테스트, 다른 worker 종류) 에서 안전하게 fallback 분기할 수 있도록
+// 음수 sentinel 을 사용합니다.
+const noWorkerID = -1
+
+// WithWorkerID 는 ctx 에 worker_id (0..N-1) 를 첨부하여 반환합니다.
+// KafkaConsumerPool 의 worker goroutine 이 처리 진입 시 1회 호출.
+func WithWorkerID(ctx context.Context, workerID int) context.Context {
+	return context.WithValue(ctx, workerIDKey{}, workerID)
+}
+
+// WorkerIDFromContext 는 ctx 에서 worker_id 를 추출합니다.
+// 미설정 / 타입 불일치 시 noWorkerID (-1) 반환 — 호출자는 fallback 분기 책임.
+func WorkerIDFromContext(ctx context.Context) int {
+	if ctx == nil {
+		return noWorkerID
+	}
+	v := ctx.Value(workerIDKey{})
+	id, ok := v.(int)
+	if !ok {
+		return noWorkerID
+	}
+	return id
+}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -278,11 +278,17 @@ func LoadPathInfer(envFiles ...string) (PathInferConfig, error) {
 // 직전에 Semaphore.Acquire 로 Chrome 인스턴스의 동시 navigation 수를 제한해 ResourceScheduler
 // 큐 고갈 (ERR_INSUFFICIENT_RESOURCES) 을 차단.
 //
-// 이슈 #229 — Semaphore 의미 변경:
-// PR #227 의 글로벌 Semaphore 1 개 (전체 worker 공유) 모델에서, worker_id 별 Semaphore 1 개
-// (per-worker capacity) 로 분리. SemaphoreCapacity 는 한 worker 가 같은 Chrome 에 동시 띄울
-// tab 수 — 다음 sub-issue (#230) 에서 RemoteURL 매핑까지 N 개로 확장하면 worker:Chrome 1:1
-// 모델 활성화.
+// 이슈 #229 — Semaphore 의미 변경 + 실효 동시성 정정 (gemini 피드백):
+// PR #227 의 글로벌 Semaphore 1 개 (전체 worker 공유) 모델에서, worker_id 별 Semaphore 1 개로
+// 분리. **단, KafkaConsumerPool 의 worker goroutine 은 jobs 채널에서 메시지를 1 개씩 꺼내
+// 순차 처리** 하므로 (pool.go 의 worker 루프 참조), 같은 worker 가 동시 2 개 이상의 Handle 을
+// 호출할 수 없음 → per-worker SemaphoreCapacity > 1 은 현 모델에서 추가 동시성 이득 없음.
+//
+// 실질 전체 동시성 = WorkerCount (NOT WorkerCount × SemaphoreCapacity).
+// SemaphoreCapacity > 1 옵션은 미래 worker-내 동시 분기 (예: 한 워커가 받은 메시지를 여러 tab
+// 으로 분할 처리) 시나리오 대비 보존 — 현 운영에서는 default 1 권장.
+//
+// 다음 sub-issue (#230) 에서 RemoteURL 매핑까지 N 개로 확장하면 worker:Chrome 1:1 모델 활성화.
 type FetcherChromedpPoolConfig struct {
 	// Enabled: false 면 chromedp pool 미기동. **주의**: goquery worker 의 ChainHandler 가 lazy
 	// detect / chromedp 룰 / force_fetcher 분기에서 항상 TopicCrawlChromedp 로 republish 하므로
@@ -293,28 +299,33 @@ type FetcherChromedpPoolConfig struct {
 	Enabled bool
 
 	// WorkerCount: chromedp pool 의 worker goroutine 수.
+	// **실질 전체 동시 navigate 수 = WorkerCount** (per-worker 순차 처리 모델). 처리량 튜닝의
+	// 단일 lever 이므로 운영 부하에 맞춰 조정 — sub-issue #230 머지 후에는 RemoteURLs 수와
+	// 일치시켜야 함 (worker:Chrome 1:1 매핑 보장).
 	// 환경변수 FETCHER_CHROMEDP_WORKER_COUNT (default 2).
 	WorkerCount int
 
-	// SemaphoreCapacity: per-worker 동시 chromedp 호출 수 상한 (이슈 #229).
-	// 의미: 한 worker 가 자기 전용 Chrome 에 동시 띄울 tab 수.
-	// 글로벌 capacity 가 아님 — 전체 동시성은 WorkerCount × SemaphoreCapacity.
-	// Chrome URLLoader 한계 (보통 6 미만 권장) 안에서 운영 튜닝.
-	// 환경변수 FETCHER_CHROMEDP_SEMAPHORE_CAPACITY (default 2).
+	// SemaphoreCapacity: per-worker Semaphore 슬롯 수 (이슈 #229).
+	// **현 KafkaConsumerPool 모델에서는 1 이상 의미 없음** — worker 가 메시지를 순차 처리하므로
+	// 같은 worker 의 동시 Acquire 가 발생하지 않음. 옵션은 미래 worker-내 동시 분기 시나리오
+	// (예: 한 worker 가 메시지 1건을 여러 sub-tab 으로 분할) 대비 보존.
+	// 운영 처리량 조정은 SemaphoreCapacity 가 아닌 WorkerCount 로 수행.
+	// 환경변수 FETCHER_CHROMEDP_SEMAPHORE_CAPACITY (default 1).
 	SemaphoreCapacity int
 }
 
 // DefaultFetcherChromedpPoolConfig 는 기본 FetcherChromedpPoolConfig 를 반환합니다.
 //
-// 이슈 #229 — default 재조정:
-// SemaphoreCapacity 의미가 글로벌 → per-worker 로 변경되었으므로 기본값을 4 → 2 로 낮춤.
-// 기존 운영자가 환경변수로 4 를 명시했다면 worker 당 4 tab → worker 2 × 4 = 8 tab 동시
-// 호출이 됨 — 명시적 의사결정으로 처리. default 운영자는 4 → 2 × 2 = 4 tab 으로 동일 수준.
+// 이슈 #229 — default 재조정 (gemini 피드백 반영):
+// SemaphoreCapacity 가 현 KafkaConsumerPool 순차 처리 모델에서 1 이상 의미 없으므로 default 1.
+// 기존 운영자가 환경변수로 4 를 명시했다면 — 그 값은 무시되지 않고 그대로 적용되지만 (slot 수
+// 4 의 sem 이 worker 별로 만들어짐) 실효 동시성은 변하지 않음 (worker 1 + slot 4 = 동시 1건).
+// 처리량 변경은 WorkerCount 환경변수로만 조정 가능.
 func DefaultFetcherChromedpPoolConfig() FetcherChromedpPoolConfig {
 	return FetcherChromedpPoolConfig{
 		Enabled:           true,
 		WorkerCount:       2,
-		SemaphoreCapacity: 2,
+		SemaphoreCapacity: 1,
 	}
 }
 
@@ -322,8 +333,8 @@ func DefaultFetcherChromedpPoolConfig() FetcherChromedpPoolConfig {
 //
 // 지원 환경변수:
 //   - FETCHER_CHROMEDP_POOL_ENABLED: true | false (default true)
-//   - FETCHER_CHROMEDP_WORKER_COUNT: 양의 정수 (default 2)
-//   - FETCHER_CHROMEDP_SEMAPHORE_CAPACITY: 양의 정수, per-worker (default 2)
+//   - FETCHER_CHROMEDP_WORKER_COUNT: 양의 정수 (default 2) — 실질 전체 동시 navigate 수
+//   - FETCHER_CHROMEDP_SEMAPHORE_CAPACITY: 양의 정수, per-worker (default 1, 1 이상 의미 없음)
 func LoadFetcherChromedpPool(envFiles ...string) (FetcherChromedpPoolConfig, error) {
 	if len(envFiles) == 0 {
 		envFiles = []string{".env"}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -277,6 +277,12 @@ func LoadPathInfer(envFiles ...string) (PathInferConfig, error) {
 // goquery worker pool 과 분리된 별도 Kafka consumer group 을 운영하며, worker 의 chromedp 호출
 // 직전에 Semaphore.Acquire 로 Chrome 인스턴스의 동시 navigation 수를 제한해 ResourceScheduler
 // 큐 고갈 (ERR_INSUFFICIENT_RESOURCES) 을 차단.
+//
+// 이슈 #229 — Semaphore 의미 변경:
+// PR #227 의 글로벌 Semaphore 1 개 (전체 worker 공유) 모델에서, worker_id 별 Semaphore 1 개
+// (per-worker capacity) 로 분리. SemaphoreCapacity 는 한 worker 가 같은 Chrome 에 동시 띄울
+// tab 수 — 다음 sub-issue (#230) 에서 RemoteURL 매핑까지 N 개로 확장하면 worker:Chrome 1:1
+// 모델 활성화.
 type FetcherChromedpPoolConfig struct {
 	// Enabled: false 면 chromedp pool 미기동. **주의**: goquery worker 의 ChainHandler 가 lazy
 	// detect / chromedp 룰 / force_fetcher 분기에서 항상 TopicCrawlChromedp 로 republish 하므로
@@ -290,17 +296,25 @@ type FetcherChromedpPoolConfig struct {
 	// 환경변수 FETCHER_CHROMEDP_WORKER_COUNT (default 2).
 	WorkerCount int
 
-	// SemaphoreCapacity: 동시 chromedp 호출 수 상한 — Chrome URLLoader 한계 (보통 30 미만) 의
-	// 안전 마진. 환경변수 FETCHER_CHROMEDP_SEMAPHORE_CAPACITY (default 4).
+	// SemaphoreCapacity: per-worker 동시 chromedp 호출 수 상한 (이슈 #229).
+	// 의미: 한 worker 가 자기 전용 Chrome 에 동시 띄울 tab 수.
+	// 글로벌 capacity 가 아님 — 전체 동시성은 WorkerCount × SemaphoreCapacity.
+	// Chrome URLLoader 한계 (보통 6 미만 권장) 안에서 운영 튜닝.
+	// 환경변수 FETCHER_CHROMEDP_SEMAPHORE_CAPACITY (default 2).
 	SemaphoreCapacity int
 }
 
 // DefaultFetcherChromedpPoolConfig 는 기본 FetcherChromedpPoolConfig 를 반환합니다.
+//
+// 이슈 #229 — default 재조정:
+// SemaphoreCapacity 의미가 글로벌 → per-worker 로 변경되었으므로 기본값을 4 → 2 로 낮춤.
+// 기존 운영자가 환경변수로 4 를 명시했다면 worker 당 4 tab → worker 2 × 4 = 8 tab 동시
+// 호출이 됨 — 명시적 의사결정으로 처리. default 운영자는 4 → 2 × 2 = 4 tab 으로 동일 수준.
 func DefaultFetcherChromedpPoolConfig() FetcherChromedpPoolConfig {
 	return FetcherChromedpPoolConfig{
 		Enabled:           true,
 		WorkerCount:       2,
-		SemaphoreCapacity: 4,
+		SemaphoreCapacity: 2,
 	}
 }
 
@@ -309,7 +323,7 @@ func DefaultFetcherChromedpPoolConfig() FetcherChromedpPoolConfig {
 // 지원 환경변수:
 //   - FETCHER_CHROMEDP_POOL_ENABLED: true | false (default true)
 //   - FETCHER_CHROMEDP_WORKER_COUNT: 양의 정수 (default 2)
-//   - FETCHER_CHROMEDP_SEMAPHORE_CAPACITY: 양의 정수 (default 4)
+//   - FETCHER_CHROMEDP_SEMAPHORE_CAPACITY: 양의 정수, per-worker (default 2)
 func LoadFetcherChromedpPool(envFiles ...string) (FetcherChromedpPoolConfig, error) {
 	if len(envFiles) == 0 {
 		envFiles = []string{".env"}

--- a/test/internal/processor/fetcher/worker/chromedp_handler_test.go
+++ b/test/internal/processor/fetcher/worker/chromedp_handler_test.go
@@ -1,0 +1,182 @@
+package worker_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"issuetracker/internal/processor/fetcher/core"
+	"issuetracker/internal/processor/fetcher/handler"
+	"issuetracker/internal/processor/fetcher/worker"
+)
+
+// fakeHandler 는 chromedp pool 의 *general.ChainHandler 가 아닌 임의 Handler 구현체를
+// Registry 에 등록하여 ChromedpJobHandler 의 type assertion 실패 경로를 검증합니다.
+// 실제 ChainHandler 는 chromedp 의존성이 있어 본 unit test 에서는 다루지 않습니다.
+type fakeHandler struct{}
+
+func (fakeHandler) Handle(_ context.Context, _ *core.CrawlJob) ([]*core.Content, error) {
+	return nil, nil
+}
+
+// TestNewChromedpJobHandler_NilRegistry_ReturnsError 는 Registry nil 거부를 검증합니다 (이슈 #208).
+func TestNewChromedpJobHandler_NilRegistry_ReturnsError(t *testing.T) {
+	sem, err := worker.NewSemaphore(1)
+	require.NoError(t, err)
+
+	_, err = worker.NewChromedpJobHandler(nil, []worker.Semaphore{sem}, nil)
+	assert.Error(t, err)
+}
+
+// TestNewChromedpJobHandler_EmptySems_ReturnsError 는 빈 Semaphore slice 거부를 검증합니다
+// (이슈 #229 — per-worker 모델은 최소 1 슬롯 필요).
+func TestNewChromedpJobHandler_EmptySems_ReturnsError(t *testing.T) {
+	reg := handler.NewRegistry(nil)
+
+	_, err := worker.NewChromedpJobHandler(reg, nil, nil)
+	assert.Error(t, err)
+
+	_, err = worker.NewChromedpJobHandler(reg, []worker.Semaphore{}, nil)
+	assert.Error(t, err)
+}
+
+// TestNewChromedpJobHandler_NilSemInSlice_ReturnsError 는 sems slice 안 nil 원소 거부를 검증합니다.
+func TestNewChromedpJobHandler_NilSemInSlice_ReturnsError(t *testing.T) {
+	reg := handler.NewRegistry(nil)
+	sem, err := worker.NewSemaphore(1)
+	require.NoError(t, err)
+
+	_, err = worker.NewChromedpJobHandler(reg, []worker.Semaphore{sem, nil}, nil)
+	assert.Error(t, err)
+}
+
+// TestChromedpJobHandler_NilJob_ReturnsError 는 nil job 방어를 검증합니다.
+func TestChromedpJobHandler_NilJob_ReturnsError(t *testing.T) {
+	reg := handler.NewRegistry(nil)
+	sem, err := worker.NewSemaphore(1)
+	require.NoError(t, err)
+
+	h, err := worker.NewChromedpJobHandler(reg, []worker.Semaphore{sem}, nil)
+	require.NoError(t, err)
+
+	_, err = h.Handle(context.Background(), nil)
+	assert.Error(t, err)
+}
+
+// TestChromedpJobHandler_UnregisteredCrawler_ReturnsError 는 Registry 에 등록되지 않은
+// crawler_name 에 대해 error 를 반환하면서 Semaphore 는 정상 Acquire/Release 되는지 검증합니다.
+func TestChromedpJobHandler_UnregisteredCrawler_ReturnsError(t *testing.T) {
+	reg := handler.NewRegistry(nil)
+	sem, err := worker.NewSemaphore(1)
+	require.NoError(t, err)
+
+	h, err := worker.NewChromedpJobHandler(reg, []worker.Semaphore{sem}, nil)
+	require.NoError(t, err)
+
+	job := &core.CrawlJob{ID: "j1", CrawlerName: "missing", Target: core.Target{URL: "https://example.com"}}
+	_, err = h.Handle(context.Background(), job)
+	assert.Error(t, err)
+
+	// Acquire/Release 가 짝을 이뤘다면 슬롯이 빈 상태 — 이어 Acquire 즉시 성공해야 함.
+	require.NoError(t, sem.Acquire(context.Background()))
+	require.NoError(t, sem.Release())
+}
+
+// TestChromedpJobHandler_NonChainHandler_ReturnsError 는 등록 Handler 가 *general.ChainHandler
+// 가 아닐 때 error 를 반환하면서 Semaphore 는 정상 정리되는지 검증합니다.
+func TestChromedpJobHandler_NonChainHandler_ReturnsError(t *testing.T) {
+	reg := handler.NewRegistry(nil)
+	reg.Register("noncha", fakeHandler{})
+
+	sem, err := worker.NewSemaphore(1)
+	require.NoError(t, err)
+
+	h, err := worker.NewChromedpJobHandler(reg, []worker.Semaphore{sem}, nil)
+	require.NoError(t, err)
+
+	job := &core.CrawlJob{ID: "j1", CrawlerName: "noncha", Target: core.Target{URL: "https://example.com"}}
+	_, err = h.Handle(context.Background(), job)
+	assert.Error(t, err)
+
+	require.NoError(t, sem.Acquire(context.Background()))
+	require.NoError(t, sem.Release())
+}
+
+// TestChromedpJobHandler_PerWorkerSemaphores_AcquireOnlyAssignedSlot 는 worker_id 가
+// 자기 슬롯의 Semaphore 만 점유하고 다른 슬롯에 영향이 없는지 검증합니다 (이슈 #229 의 핵심 모델).
+//
+// 검증: worker 0 이 자기 슬롯 (capacity=1) 을 점유한 상태에서, worker 1 의 슬롯은 여전히 가용.
+func TestChromedpJobHandler_PerWorkerSemaphores_AcquireOnlyAssignedSlot(t *testing.T) {
+	reg := handler.NewRegistry(nil)
+
+	sem0, err := worker.NewSemaphore(1)
+	require.NoError(t, err)
+	sem1, err := worker.NewSemaphore(1)
+	require.NoError(t, err)
+
+	// worker 0 의 슬롯을 외부에서 미리 점유 — 글로벌 모델이라면 worker 1 도 차단되었어야 함.
+	require.NoError(t, sem0.Acquire(context.Background()))
+
+	h, err := worker.NewChromedpJobHandler(reg, []worker.Semaphore{sem0, sem1}, nil)
+	require.NoError(t, err)
+
+	// worker 1 ctx 로 Handle 호출 — Registry 미등록이라 lookup 단계에서 실패하지만,
+	// 그 전에 sem1 은 정상 Acquire 후 Release 되어야 함.
+	ctx := worker.WithWorkerID(context.Background(), 1)
+	job := &core.CrawlJob{ID: "j1", CrawlerName: "missing", Target: core.Target{URL: "https://example.com"}}
+	_, err = h.Handle(ctx, job)
+	assert.Error(t, err) // unregistered → error
+
+	// worker 1 의 슬롯이 deferred Release 로 빈 상태 — Acquire 즉시 성공.
+	timeoutCtx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+	assert.NoError(t, sem1.Acquire(timeoutCtx))
+	require.NoError(t, sem1.Release())
+
+	// worker 0 의 슬롯은 여전히 외부 점유 상태 그대로.
+	require.NoError(t, sem0.Release())
+}
+
+// TestChromedpJobHandler_OutOfRangeWorkerID_FallbackToSlot0 는 worker_id 가 sems 범위를 벗어날 때
+// 0번 슬롯으로 fallback 되는지 검증합니다 (방어 — out-of-range 면 0번 슬롯 점유 후 진행).
+func TestChromedpJobHandler_OutOfRangeWorkerID_FallbackToSlot0(t *testing.T) {
+	reg := handler.NewRegistry(nil)
+
+	sem0, err := worker.NewSemaphore(1)
+	require.NoError(t, err)
+
+	h, err := worker.NewChromedpJobHandler(reg, []worker.Semaphore{sem0}, nil)
+	require.NoError(t, err)
+
+	// worker_id=99 → sems 길이 1 → fallback to slot 0
+	ctx := worker.WithWorkerID(context.Background(), 99)
+	job := &core.CrawlJob{ID: "j1", CrawlerName: "missing", Target: core.Target{URL: "https://example.com"}}
+	_, err = h.Handle(ctx, job)
+	assert.Error(t, err) // unregistered → error
+
+	// 0번 슬롯이 정상 정리되었는지 확인.
+	require.NoError(t, sem0.Acquire(context.Background()))
+	require.NoError(t, sem0.Release())
+}
+
+// TestChromedpJobHandler_NoWorkerID_FallbackToSlot0 는 ctx 에 worker_id 가 없을 때
+// 0번 슬롯으로 fallback 되는지 검증합니다 (테스트 / 비-pool 호출 경로 호환성).
+func TestChromedpJobHandler_NoWorkerID_FallbackToSlot0(t *testing.T) {
+	reg := handler.NewRegistry(nil)
+
+	sem0, err := worker.NewSemaphore(1)
+	require.NoError(t, err)
+
+	h, err := worker.NewChromedpJobHandler(reg, []worker.Semaphore{sem0}, nil)
+	require.NoError(t, err)
+
+	job := &core.CrawlJob{ID: "j1", CrawlerName: "missing", Target: core.Target{URL: "https://example.com"}}
+	_, err = h.Handle(context.Background(), job) // worker_id 미설정
+	assert.Error(t, err)
+
+	require.NoError(t, sem0.Acquire(context.Background()))
+	require.NoError(t, sem0.Release())
+}

--- a/test/internal/processor/fetcher/worker/worker_id_test.go
+++ b/test/internal/processor/fetcher/worker/worker_id_test.go
@@ -1,0 +1,42 @@
+package worker_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"issuetracker/internal/processor/fetcher/worker"
+)
+
+// TestWorkerIDFromContext_Unset_ReturnsNegative 는 worker_id 미설정 ctx 가
+// sentinel (-1) 을 반환하는지 검증합니다 (이슈 #229).
+func TestWorkerIDFromContext_Unset_ReturnsNegative(t *testing.T) {
+	id := worker.WorkerIDFromContext(context.Background())
+	assert.Equal(t, -1, id)
+}
+
+// TestWorkerIDFromContext_NilContext_ReturnsNegative 는 nil ctx 도 panic 없이
+// sentinel (-1) 을 반환하는지 검증합니다.
+func TestWorkerIDFromContext_NilContext_ReturnsNegative(t *testing.T) {
+	id := worker.WorkerIDFromContext(nil) //nolint:staticcheck // 의도적 nil 검증
+	assert.Equal(t, -1, id)
+}
+
+// TestWithWorkerID_RoundTrip 는 WithWorkerID 로 주입한 값이 동일하게 추출되는지 검증합니다.
+func TestWithWorkerID_RoundTrip(t *testing.T) {
+	cases := []int{0, 1, 5, 99}
+	for _, want := range cases {
+		ctx := worker.WithWorkerID(context.Background(), want)
+		got := worker.WorkerIDFromContext(ctx)
+		assert.Equal(t, want, got)
+	}
+}
+
+// TestWithWorkerID_Override 는 마지막 WithWorkerID 호출이 우선하는지 검증합니다
+// (context.WithValue chain 동작).
+func TestWithWorkerID_Override(t *testing.T) {
+	ctx := worker.WithWorkerID(context.Background(), 0)
+	ctx = worker.WithWorkerID(ctx, 7)
+	assert.Equal(t, 7, worker.WorkerIDFromContext(ctx))
+}

--- a/test/pkg/config/config_test.go
+++ b/test/pkg/config/config_test.go
@@ -508,3 +508,89 @@ func TestLoadPathInfer_InvalidZeroOrNegative(t *testing.T) {
 		})
 	}
 }
+
+// 이슈 #229 — chromedp pool config 테스트.
+// SemaphoreCapacity 의미가 글로벌 → per-worker 로 변경되었으며 default 가 4 → 2 로 조정됨.
+
+func unsetFetcherChromedpPoolEnvVars(t *testing.T) {
+	t.Helper()
+	vars := []string{
+		"FETCHER_CHROMEDP_POOL_ENABLED",
+		"FETCHER_CHROMEDP_WORKER_COUNT",
+		"FETCHER_CHROMEDP_SEMAPHORE_CAPACITY",
+	}
+	for _, v := range vars {
+		t.Setenv(v, "")
+	}
+}
+
+func TestLoadFetcherChromedpPool_DefaultValues(t *testing.T) {
+	unsetFetcherChromedpPoolEnvVars(t)
+
+	cfg, err := config.LoadFetcherChromedpPool("/tmp/nonexistent-env-file.env")
+	if err != nil {
+		t.Fatalf("기본값 로드 실패: %v", err)
+	}
+
+	def := config.DefaultFetcherChromedpPoolConfig()
+	if cfg.Enabled != def.Enabled {
+		t.Errorf("Enabled: got %v, want %v", cfg.Enabled, def.Enabled)
+	}
+	if cfg.WorkerCount != def.WorkerCount {
+		t.Errorf("WorkerCount: got %d, want %d", cfg.WorkerCount, def.WorkerCount)
+	}
+	// 이슈 #229 — per-worker 의미 변경에 맞춰 default 2 로 낮춤.
+	if def.SemaphoreCapacity != 2 {
+		t.Errorf("DefaultFetcherChromedpPoolConfig.SemaphoreCapacity: got %d, want 2 (per-worker 의미 default)", def.SemaphoreCapacity)
+	}
+	if cfg.SemaphoreCapacity != def.SemaphoreCapacity {
+		t.Errorf("SemaphoreCapacity: got %d, want %d", cfg.SemaphoreCapacity, def.SemaphoreCapacity)
+	}
+}
+
+func TestLoadFetcherChromedpPool_EnvOverride(t *testing.T) {
+	unsetFetcherChromedpPoolEnvVars(t)
+	t.Setenv("FETCHER_CHROMEDP_POOL_ENABLED", "true")
+	t.Setenv("FETCHER_CHROMEDP_WORKER_COUNT", "4")
+	t.Setenv("FETCHER_CHROMEDP_SEMAPHORE_CAPACITY", "3")
+
+	cfg, err := config.LoadFetcherChromedpPool("/tmp/nonexistent-env-file.env")
+	if err != nil {
+		t.Fatalf("환경변수 override 실패: %v", err)
+	}
+	if !cfg.Enabled {
+		t.Errorf("Enabled: got false, want true")
+	}
+	if cfg.WorkerCount != 4 {
+		t.Errorf("WorkerCount: got %d, want 4", cfg.WorkerCount)
+	}
+	if cfg.SemaphoreCapacity != 3 {
+		t.Errorf("SemaphoreCapacity: got %d, want 3", cfg.SemaphoreCapacity)
+	}
+}
+
+func TestLoadFetcherChromedpPool_InvalidWorkerCount(t *testing.T) {
+	for _, v := range []string{"0", "-1", "abc"} {
+		t.Run(v, func(t *testing.T) {
+			unsetFetcherChromedpPoolEnvVars(t)
+			t.Setenv("FETCHER_CHROMEDP_WORKER_COUNT", v)
+			_, err := config.LoadFetcherChromedpPool("/tmp/nonexistent-env-file.env")
+			if err == nil {
+				t.Fatalf("FETCHER_CHROMEDP_WORKER_COUNT=%q 는 거부되어야 함", v)
+			}
+		})
+	}
+}
+
+func TestLoadFetcherChromedpPool_InvalidSemaphoreCapacity(t *testing.T) {
+	for _, v := range []string{"0", "-1", "abc"} {
+		t.Run(v, func(t *testing.T) {
+			unsetFetcherChromedpPoolEnvVars(t)
+			t.Setenv("FETCHER_CHROMEDP_SEMAPHORE_CAPACITY", v)
+			_, err := config.LoadFetcherChromedpPool("/tmp/nonexistent-env-file.env")
+			if err == nil {
+				t.Fatalf("FETCHER_CHROMEDP_SEMAPHORE_CAPACITY=%q 는 거부되어야 함", v)
+			}
+		})
+	}
+}

--- a/test/pkg/config/config_test.go
+++ b/test/pkg/config/config_test.go
@@ -539,9 +539,10 @@ func TestLoadFetcherChromedpPool_DefaultValues(t *testing.T) {
 	if cfg.WorkerCount != def.WorkerCount {
 		t.Errorf("WorkerCount: got %d, want %d", cfg.WorkerCount, def.WorkerCount)
 	}
-	// 이슈 #229 — per-worker 의미 변경에 맞춰 default 2 로 낮춤.
-	if def.SemaphoreCapacity != 2 {
-		t.Errorf("DefaultFetcherChromedpPoolConfig.SemaphoreCapacity: got %d, want 2 (per-worker 의미 default)", def.SemaphoreCapacity)
+	// 이슈 #229 — per-worker 의미 + KafkaConsumerPool 순차 처리 모델 정정 (gemini 피드백):
+	// capacity > 1 은 추가 동시성 이득 없으므로 default 1.
+	if def.SemaphoreCapacity != 1 {
+		t.Errorf("DefaultFetcherChromedpPoolConfig.SemaphoreCapacity: got %d, want 1 (per-worker, 1 이상 의미 없음)", def.SemaphoreCapacity)
 	}
 	if cfg.SemaphoreCapacity != def.SemaphoreCapacity {
 		t.Errorf("SemaphoreCapacity: got %d, want %d", cfg.SemaphoreCapacity, def.SemaphoreCapacity)


### PR DESCRIPTION
## 연관 이슈
- Closes #229
- Parent: #228 (chromedp worker:Chrome 1:1 매핑)

<br>

## 구현 내용

이슈 #228 (chromedp worker:Chrome 1:1 매핑) 의 **구조 준비** 단계 (sub-issue 1/2). 본 PR 머지 후 운영 동작 변경 0 — sub-issue #230 에서 RemoteURL 매핑 + docker-compose Chrome N개로 1:1 활성화.

### Worker ID context 주입 ([FEAT])
- `internal/processor/fetcher/worker/worker_id.go` 신설 — `WithWorkerID` / `WorkerIDFromContext` 헬퍼
- `KafkaConsumerPool.Start` 가 worker goroutine 에 `0..N-1` 인덱스 부여 + ctx 첨부
- 미설정 / 타입 불일치 시 sentinel `-1` 반환 (호출자 fallback 책임)

### ChromedpJobHandler per-worker Semaphore ([REFAC])
- 단일 `sem Semaphore` → `sems []Semaphore` (worker_id 인덱스)
- `Handle` 진입 시 ctx 의 worker_id 로 자기 슬롯 lookup → Acquire/Release
- worker_id 미설정 / 범위 밖이면 0번 슬롯 fallback + WARN (방어 + 가시성)
- `NewChromedpJobHandler` 가 nil/empty/nil-원소 sems 거부 (이슈 #208 정책)

### Config / Wiring ([REFAC])
- `FetcherChromedpPoolConfig.SemaphoreCapacity` 의미 글로벌 → per-worker 로 변경
- default `4 → 2` 조정 (전체 동시성 = `WorkerCount × 2 = 4` 와 동일 수준)
- `cmd/issuetracker/main.go` 가 `WorkerCount` 만큼 Semaphore 생성해 `[]Semaphore` 로 전달
- 로그 필드명 `semaphore_capacity` → `per_worker_semaphore_capacity`

### 테스트 추가
- `worker_id_test.go` — round-trip / nil ctx / override
- `chromedp_handler_test.go` — nil registry / empty sems / nil 원소 / nil job / unregistered crawler / non-ChainHandler / per-worker 격리 (worker 0 점유 시 worker 1 통과) / out-of-range fallback / no-worker-id fallback
- `config_test.go` — default 값 (특히 `SemaphoreCapacity == 2` 검증) / env override / invalid 값 거부

<br>

## CI / 머지 게이트 점검

> [CI 운영 규약](docs/ci/conventions.md) 및 [Required Status Checks 단일 소스](docs/ci/status-checks.md)에 따라 작성합니다.

### 변경 영향 범위
- 영향 패키지/모듈: `internal/processor/fetcher/worker`, `pkg/config`, `cmd/issuetracker`
- 위험도(택1): `Low`
  - chromedp pool wiring 만 변경. 기존 운영자가 `FETCHER_CHROMEDP_SEMAPHORE_CAPACITY` 를 명시했다면 의미만 글로벌 → per-worker 로 변경 (전체 동시성 N배 ↑) — 운영자 명시적 의사결정으로 처리.

### Required Status Checks
- 통과 확인 대상 (PR Checks 탭에서 확인):
  - [ ] \`Commit Lint\`
  - [ ] \`PR Title Lint\`
  - [ ] \`Linked Issue Check\`
  - [ ] \`Format Check\`
  - [ ] \`Build\`
  - [ ] \`Test\`
  - [ ] \`Lint\`

### 롤백 계획
- revert merge — 코드 의존성 단순. ChromedpJobHandler 시그니처 (sems → sem) 만 원복.
- \`FETCHER_CHROMEDP_SEMAPHORE_CAPACITY\` env 운영자가 명시한 값이 있다면 변경 후 재기동 필요 (의미가 글로벌 → per-worker 로 변경되었으므로).

<br>

## TODO
- sub-issue #230 (FEATURE) 에서 RemoteURL 매핑 + docker-compose Chrome N개 + 라이브 검증 진행

<br>

## 논의 사항
- 본 PR 단계에서는 RemoteURL 은 단일 \`ws://localhost:9222\` 그대로 — 운영 동작 동일. 분할 의도는 #230 의 인프라 변경 + 라이브 검증을 atomic 하게 묶기 위함.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Enhanced concurrency control for web scraping operations with per-worker resource management, enabling more efficient parallel processing.

* **Configuration**
  * Updated default semaphore capacity from 4 to 2 per worker; overall concurrency is now calculated as `WorkerCount × SemaphoreCapacity`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->