### PR TITLE
[FEAT#230] chromedp pool — per-worker RemoteURL 1:1 매핑 + docker-compose Chrome N개

### DIFF
--- a/cmd/issuetracker/main.go
+++ b/cmd/issuetracker/main.go
@@ -160,11 +160,23 @@ func main() {
 		log.WithError(err).Fatal("failed to init force_fetcher token")
 	}
 
+	// 이슈 #230: chromedp pool config 를 사이트 등록 전에 로드 — 사이트별 chromedp chain 이
+	// worker_id 별 RemoteURL 로 N 개 build 되어야 ChainHandler 가 worker:Chrome 1:1 매핑 활성화.
+	chromedpPoolCfg, err := config.LoadFetcherChromedpPool()
+	if err != nil {
+		log.WithError(err).Fatal("failed to load fetcher chromedp pool config")
+	}
+	chromedpRemoteURLs := chromedpPoolCfg.RemoteURLs
+	if !chromedpPoolCfg.Enabled {
+		// pool 비활성 시 사이트 chromedp chain 도 미wiring — fail-fast 로직은 별도 분기 (아래).
+		chromedpRemoteURLs = nil
+	}
+
 	// fetcher 측 등록 (이슈 #134 분리 후): chain handler 가 raw_contents 저장 + RawContentRef 발행만 수행.
-	if err := kr.Register(registry, core.DefaultConfig(), rawSvc, crawlerProducer, fetcherResolver, log); err != nil {
+	if err := kr.Register(registry, core.DefaultConfig(), rawSvc, crawlerProducer, fetcherResolver, chromedpRemoteURLs, log); err != nil {
 		log.WithError(err).Fatal("failed to register kr crawlers")
 	}
-	if err := us.Register(registry, core.DefaultConfig(), rawSvc, crawlerProducer, fetcherResolver, log); err != nil {
+	if err := us.Register(registry, core.DefaultConfig(), rawSvc, crawlerProducer, fetcherResolver, chromedpRemoteURLs, log); err != nil {
 		log.WithError(err).Fatal("failed to register us crawlers")
 	}
 
@@ -235,10 +247,8 @@ func main() {
 	}
 
 	// 이슈 #218: chromedp 전용 worker pool — semaphore 로 Chrome 동시 호출 제한.
-	chromedpPoolCfg, err := config.LoadFetcherChromedpPool()
-	if err != nil {
-		log.WithError(err).Fatal("failed to load fetcher chromedp pool config")
-	}
+	// chromedpPoolCfg 는 사이트 등록 단계에서 미리 로드됨 (이슈 #230 — RemoteURLs 가 사이트
+	// chromedp chain build 에 필요).
 	if chromedpPoolCfg.Enabled {
 		chromedpKafkaCfg := queue.DefaultConfig()
 		chromedpKafkaCfg.GroupID = queue.GroupChromedpFetchers

--- a/deployments/docker/.env.example
+++ b/deployments/docker/.env.example
@@ -12,14 +12,29 @@ KAFKA_PARTITIONS_NORMAL=8
 KAFKA_PARTITIONS_LOW=4
 
 # chromedp pool — worker:Chrome 1:1 매핑 (이슈 #230)
-# WORKER_COUNT 와 REMOTE_URLS 길이가 일치해야 함 (LoadFetcherChromedpPool 가 fail-fast 검증).
-# docker-compose 의 chrome-N 컨테이너 수도 함께 조정 필요.
+#
+# 운영 워크플로 (단일 chrome 서비스 + scale 패턴):
+#   1. WORKER_COUNT 조정
+#   2. docker compose up -d --scale chrome=$WORKER_COUNT
+#   3. REMOTE_URL_PATTERN 의 {n} placeholder 가 1..WorkerCount 로 자동 치환되어 RemoteURLs 생성
+#
+# PATTERN 모드는 WorkerCount 만 바꾸면 RemoteURLs 도 자동 동기화 — 두 env 따로 동기화 불필요.
+# 명시적 매핑이 필요할 땐 REMOTE_URLS (콤마 구분 list) 로 override 가능 (PATTERN 보다 우선).
 FETCHER_CHROMEDP_POOL_ENABLED=true
 FETCHER_CHROMEDP_WORKER_COUNT=2
 FETCHER_CHROMEDP_SEMAPHORE_CAPACITY=1
+
 # docker-compose 내부 컨테이너에서 실행 시 (앱도 같은 compose 네트워크 안 — 본 .env.example 위치가
-# deployments/docker 이므로 이를 default 로 둠. 컨테이너 안에서 localhost 는 앱 자신을 가리키므로
-# 호스트 모드 URL 을 그대로 사용하면 worker:Chrome 매핑이 깨짐):
-FETCHER_CHROMEDP_REMOTE_URLS=ws://issuetracker-chrome-1:9222,ws://issuetracker-chrome-2:9222
-# 호스트에서 실행 시 (docker-compose 외부 — 호스트 포트 9222/9223 사용):
+# deployments/docker 이므로 이를 default 로 둠).
+# {n} 은 1..WorkerCount 로 치환 — chrome-1, chrome-2, ... 컨테이너 호스트명과 1:1 매칭.
+# compose v2 가 scale 시 자동으로 <project>-chrome-{n} 호스트명을 DNS 에 등록.
+FETCHER_CHROMEDP_REMOTE_URL_PATTERN=ws://chrome-{n}:9222
+
+# 호스트에서 실행 시 (docker-compose 외부 — 호스트 포트 9222-9229 자동 매핑):
+# FETCHER_CHROMEDP_REMOTE_URL_PATTERN=ws://localhost:922{n}  # WorkerCount=8 까지 (922{1..8})
+# 또는 명시 list:
 # FETCHER_CHROMEDP_REMOTE_URLS=ws://localhost:9222,ws://localhost:9223
+
+# Chrome 컨테이너의 호스트 포트 range — replica 수만큼 자동 할당.
+# default 9222-9229 = 8 replica 까지. 더 큰 운영은 range 확장 (예: 9222-9239).
+# FETCHER_CHROMEDP_HOST_PORT_RANGE=9222-9229

--- a/deployments/docker/.env.example
+++ b/deployments/docker/.env.example
@@ -10,3 +10,14 @@
 KAFKA_PARTITIONS_HIGH=6
 KAFKA_PARTITIONS_NORMAL=8
 KAFKA_PARTITIONS_LOW=4
+
+# chromedp pool — worker:Chrome 1:1 매핑 (이슈 #230)
+# WORKER_COUNT 와 REMOTE_URLS 길이가 일치해야 함 (LoadFetcherChromedpPool 가 fail-fast 검증).
+# docker-compose 의 chrome-N 컨테이너 수도 함께 조정 필요.
+FETCHER_CHROMEDP_POOL_ENABLED=true
+FETCHER_CHROMEDP_WORKER_COUNT=2
+FETCHER_CHROMEDP_SEMAPHORE_CAPACITY=1
+# 호스트에서 실행 시 (docker-compose 외부 — 호스트 포트 9222/9223 사용):
+FETCHER_CHROMEDP_REMOTE_URLS=ws://localhost:9222,ws://localhost:9223
+# docker-compose 내부 컨테이너에서 실행 시 (앱도 같은 compose 네트워크 안):
+# FETCHER_CHROMEDP_REMOTE_URLS=ws://issuetracker-chrome-1:9222,ws://issuetracker-chrome-2:9222

--- a/deployments/docker/.env.example
+++ b/deployments/docker/.env.example
@@ -17,7 +17,9 @@ KAFKA_PARTITIONS_LOW=4
 FETCHER_CHROMEDP_POOL_ENABLED=true
 FETCHER_CHROMEDP_WORKER_COUNT=2
 FETCHER_CHROMEDP_SEMAPHORE_CAPACITY=1
+# docker-compose 내부 컨테이너에서 실행 시 (앱도 같은 compose 네트워크 안 — 본 .env.example 위치가
+# deployments/docker 이므로 이를 default 로 둠. 컨테이너 안에서 localhost 는 앱 자신을 가리키므로
+# 호스트 모드 URL 을 그대로 사용하면 worker:Chrome 매핑이 깨짐):
+FETCHER_CHROMEDP_REMOTE_URLS=ws://issuetracker-chrome-1:9222,ws://issuetracker-chrome-2:9222
 # 호스트에서 실행 시 (docker-compose 외부 — 호스트 포트 9222/9223 사용):
-FETCHER_CHROMEDP_REMOTE_URLS=ws://localhost:9222,ws://localhost:9223
-# docker-compose 내부 컨테이너에서 실행 시 (앱도 같은 compose 네트워크 안):
-# FETCHER_CHROMEDP_REMOTE_URLS=ws://issuetracker-chrome-1:9222,ws://issuetracker-chrome-2:9222
+# FETCHER_CHROMEDP_REMOTE_URLS=ws://localhost:9222,ws://localhost:9223

--- a/deployments/docker/docker-compose.yml
+++ b/deployments/docker/docker-compose.yml
@@ -164,3 +164,41 @@ services:
         condition: service_healthy
     restart: unless-stopped
 
+  # ─────────────────────────────────────────────────────────────
+  # Chrome (chromedp) – worker:Chrome 1:1 매핑 (이슈 #230)
+  # 기본 FETCHER_CHROMEDP_WORKER_COUNT=2 와 일치하도록 컨테이너 2개 정의.
+  # 운영 worker 수 조정 시:
+  #   1. .env 의 FETCHER_CHROMEDP_WORKER_COUNT / FETCHER_CHROMEDP_REMOTE_URLS 수정
+  #   2. 본 파일에 chrome-N 서비스 추가/제거
+  # 각 컨테이너는 host 에 다른 포트 (9222, 9223, ...) 로 노출 — 디버깅용.
+  # 컨테이너 내부 통신은 ws://issuetracker-chrome-{N}:9222 (모두 9222 동일).
+  # ─────────────────────────────────────────────────────────────
+  chrome-1:
+    image: chromedp/headless-shell:latest
+    container_name: issuetracker-chrome-1
+    ports:
+      - "9222:9222"
+    # headless-shell 은 default 가 0.0.0.0:9222 listen + no-sandbox 비활성. 컨테이너 한정 안전.
+    shm_size: 1gb
+    healthcheck:
+      test: ["CMD-SHELL", "wget -q -O- http://localhost:9222/json/version > /dev/null || exit 1"]
+      interval: 15s
+      timeout: 5s
+      retries: 5
+      start_period: 10s
+    restart: unless-stopped
+
+  chrome-2:
+    image: chromedp/headless-shell:latest
+    container_name: issuetracker-chrome-2
+    ports:
+      - "9223:9222"
+    shm_size: 1gb
+    healthcheck:
+      test: ["CMD-SHELL", "wget -q -O- http://localhost:9222/json/version > /dev/null || exit 1"]
+      interval: 15s
+      timeout: 5s
+      retries: 5
+      start_period: 10s
+    restart: unless-stopped
+

--- a/deployments/docker/docker-compose.yml
+++ b/deployments/docker/docker-compose.yml
@@ -166,33 +166,26 @@ services:
 
   # ─────────────────────────────────────────────────────────────
   # Chrome (chromedp) – worker:Chrome 1:1 매핑 (이슈 #230)
-  # 기본 FETCHER_CHROMEDP_WORKER_COUNT=2 와 일치하도록 컨테이너 2개 정의.
-  # 운영 worker 수 조정 시:
-  #   1. .env 의 FETCHER_CHROMEDP_WORKER_COUNT / FETCHER_CHROMEDP_REMOTE_URLS 수정
-  #   2. 본 파일에 chrome-N 서비스 추가/제거
-  # 각 컨테이너는 host 에 다른 포트 (9222, 9223, ...) 로 노출 — 디버깅용.
-  # 컨테이너 내부 통신은 ws://issuetracker-chrome-{N}:9222 (모두 9222 동일).
+  #
+  # 단일 서비스 + scale 패턴: 운영자가 `docker compose up --scale chrome=N` 으로 N개 replica 기동.
+  # compose 가 자동으로 chrome-1, chrome-2, ..., chrome-N 호스트명 부여 (compose v2 + DNS 등록).
+  #
+  # 호스트 포트는 range 로 매핑 — N replica 까지 자동 할당 (default 9222-9229 = 8개까지).
+  # range 가 부족하면 .env 의 FETCHER_CHROMEDP_HOST_PORT_RANGE 로 확장 (예: 9222-9239).
+  #
+  # 앱 측 RemoteURLs 도 동기화: .env 의 FETCHER_CHROMEDP_REMOTE_URL_PATTERN 이 {n} placeholder 를
+  # 1..WorkerCount 로 치환하여 자동 생성 — WorkerCount 와 scale 만 일치시키면 됨.
+  #
+  # 운영 워크플로:
+  #   1. .env 의 FETCHER_CHROMEDP_WORKER_COUNT 조정
+  #   2. docker compose up -d --scale chrome=$WORKER_COUNT
+  #   (PATTERN 이 ws://chrome-{n}:9222 default 라 자동 매핑)
   # ─────────────────────────────────────────────────────────────
-  chrome-1:
+  chrome:
     image: chromedp/headless-shell:latest
-    container_name: issuetracker-chrome-1
+    # container_name 은 scale 시 충돌 → 미설정. compose 가 <project>-chrome-{n} 형태로 자동 부여.
     ports:
-      - "9222:9222"
-    # headless-shell 은 default 가 0.0.0.0:9222 listen + no-sandbox 비활성. 컨테이너 한정 안전.
-    shm_size: 1gb
-    healthcheck:
-      test: ["CMD-SHELL", "wget -q -O- http://localhost:9222/json/version > /dev/null || exit 1"]
-      interval: 15s
-      timeout: 5s
-      retries: 5
-      start_period: 10s
-    restart: unless-stopped
-
-  chrome-2:
-    image: chromedp/headless-shell:latest
-    container_name: issuetracker-chrome-2
-    ports:
-      - "9223:9222"
+      - "${FETCHER_CHROMEDP_HOST_PORT_RANGE:-9222-9229}:9222"
     shm_size: 1gb
     healthcheck:
       test: ["CMD-SHELL", "wget -q -O- http://localhost:9222/json/version > /dev/null || exit 1"]

--- a/internal/processor/fetcher/core/worker_id.go
+++ b/internal/processor/fetcher/core/worker_id.go
@@ -1,20 +1,21 @@
-package worker
+package core
 
 import "context"
 
-// 이슈 #229 — KafkaConsumerPool 의 worker goroutine 별 인덱스를 ctx 로 전달하기 위한
-// helper. ChromedpJobHandler 가 per-worker Semaphore 슬롯을 lookup 하는 데 사용 (이슈 #228 의
-// 1:1 매핑 모델 — sub-issue #230 에서 RemoteURL 매핑까지 확장).
+// 이슈 #229 — KafkaConsumerPool 의 worker goroutine 별 인덱스를 ctx 로 전달하기 위한 helper.
+// ChromedpJobHandler 가 per-worker Semaphore 슬롯을 lookup 하는 데 사용. 이슈 #230 에서
+// general.ChainHandler 의 chromedpChains slice lookup 에도 동일 키 재사용 — 이를 위해
+// worker 패키지 외부 (사이클 없는 core) 에 위치.
 //
 // 컨텍스트 키 노출 정책: unexported type + sentinel — context.WithValue 충돌 회피 표준 패턴.
 // 외부 패키지는 WithWorkerID / WorkerIDFromContext 만 사용.
 
 type workerIDKey struct{}
 
-// noWorkerID 는 WorkerIDFromContext 가 worker_id 미설정을 나타낼 때 반환하는 값입니다.
+// NoWorkerID 는 WorkerIDFromContext 가 worker_id 미설정을 나타낼 때 반환하는 값입니다.
 // pool 외 호출 경로 (테스트, 다른 worker 종류) 에서 안전하게 fallback 분기할 수 있도록
 // 음수 sentinel 을 사용합니다.
-const noWorkerID = -1
+const NoWorkerID = -1
 
 // WithWorkerID 는 ctx 에 worker_id (0..N-1) 를 첨부하여 반환합니다.
 // KafkaConsumerPool 의 worker goroutine 이 처리 진입 시 1회 호출.
@@ -23,15 +24,15 @@ func WithWorkerID(ctx context.Context, workerID int) context.Context {
 }
 
 // WorkerIDFromContext 는 ctx 에서 worker_id 를 추출합니다.
-// 미설정 / 타입 불일치 시 noWorkerID (-1) 반환 — 호출자는 fallback 분기 책임.
+// 미설정 / 타입 불일치 시 NoWorkerID (-1) 반환 — 호출자는 fallback 분기 책임.
 func WorkerIDFromContext(ctx context.Context) int {
 	if ctx == nil {
-		return noWorkerID
+		return NoWorkerID
 	}
 	v := ctx.Value(workerIDKey{})
 	id, ok := v.(int)
 	if !ok {
-		return noWorkerID
+		return NoWorkerID
 	}
 	return id
 }

--- a/internal/processor/fetcher/domain/general/chain_handler.go
+++ b/internal/processor/fetcher/domain/general/chain_handler.go
@@ -87,7 +87,14 @@ func (h *ChainHandler) hasChromedpChain() bool {
 
 // resolveChromedpChain 은 ctx 의 worker_id 로 자기 전용 chromedp chain 을 반환합니다.
 // worker_id 미설정 / 범위 밖이면 0번 chain fallback (방어 + 가시성 WARN).
+//
+// defense-in-depth (gemini 피드백): ChromedpChains 가 empty 면 nil 반환 — 호출자
+// (HandleChromedpOnly) 가 사전에 hasChromedpChain 검사하지만, 헬퍼 자체에서도
+// 슬라이스 길이 확인으로 인덱스 panic 방지. 미래 다른 호출자가 사전 검사 누락해도 안전.
 func (h *ChainHandler) resolveChromedpChain(ctx context.Context) Handler {
+	if len(h.ChromedpChains) == 0 {
+		return nil
+	}
 	id := core.WorkerIDFromContext(ctx)
 	if id < 0 || id >= len(h.ChromedpChains) {
 		if h.Log != nil {
@@ -290,6 +297,11 @@ func (h *ChainHandler) HandleChromedpOnly(ctx context.Context, job *core.CrawlJo
 	}
 
 	chain := h.resolveChromedpChain(ctx)
+	if chain == nil {
+		// defense-in-depth (gemini 피드백): hasChromedpChain 통과 후에도 헬퍼가 nil 반환하면
+		// race condition 또는 ChromedpChains 가 nil 원소 포함 같은 invariant 위반 — graceful error.
+		return nil, fmt.Errorf("crawler %s resolved nil chromedp chain (invariant violation)", job.CrawlerName)
+	}
 	raw, err := chain.Handle(ctx, job)
 	if err != nil {
 		return nil, err

--- a/internal/processor/fetcher/domain/general/chain_handler.go
+++ b/internal/processor/fetcher/domain/general/chain_handler.go
@@ -28,9 +28,14 @@ import (
 //
 // host 단위 fetcher 정책 (이슈 #175 단계 1):
 //   - Resolver 가 nil 이거나 룰 미등록 host: DefaultChain 사용 (gq → browser fallback)
-//   - 룰 = 'chromedp': ChromedpChain 사용 (browser only) — goquery 시도 skip
+//   - 룰 = 'chromedp': ChromedpChains 사용 (browser only) — goquery 시도 skip
 //   - 룰 = 'goquery':  DefaultChain 사용 (gq → browser fallback) — 현재로선 default 와 동일.
 //     단계 3 의 자동 downgrade 정책이 도입되면 GoQueryOnly chain 으로 분기 가능.
+//
+// 이슈 #230 — ChromedpChains 를 worker_id 별 slice 로 분리하여 worker:Chrome 1:1 매핑 활성화:
+//   - 각 chain 인스턴스는 자기 전용 RemoteURL 의 ChromedpCrawler 를 보유
+//   - HandleChromedpOnly 가 ctx 의 worker_id 로 자기 chain 선택 → worker:Chrome 격리
+//   - chain 길이는 chromedp pool 의 WorkerCount 와 일치 (main.go wiring 시 보장)
 //
 // 본 분리의 핵심 가치:
 //   - parser 가 무거워져도 (chromedp 가 큰 HTML 처리, LLM 호출 등) fetcher worker 슬롯 점유 X
@@ -38,51 +43,83 @@ import (
 //   - raw HTML 이 DB 에 보존되어 worker crash 시에도 복구 가능
 //   - 파싱 실패한 raw 가 잔존 → LLM 으로 새 rule 생성 (이슈 #149) 후 재처리 가능
 type ChainHandler struct {
-	Crawler       SourceCrawler
-	DefaultChain  Handler       // gq → browser (현재 동작 — 룰 미등록 host 의 기본)
-	ChromedpChain Handler       // browser only (룰 = chromedp 인 host 전용)
-	Resolver      rule.Resolver // optional. nil 이면 항상 DefaultChain 사용
-	RawSvc        service.RawContentService
-	Producer      queue.Producer
-	Log           *logger.Logger
+	Crawler        SourceCrawler
+	DefaultChain   Handler       // gq → browser (현재 동작 — 룰 미등록 host 의 기본)
+	ChromedpChains []Handler     // worker_id 별 browser only chain (이슈 #230)
+	Resolver       rule.Resolver // optional. nil 이면 항상 DefaultChain 사용
+	RawSvc         service.RawContentService
+	Producer       queue.Producer
+	Log            *logger.Logger
 }
 
 // NewChainHandler 는 새 ChainHandler 를 생성합니다.
 // DefaultChain / RawSvc / Producer / Log 모두 비-nil 필수.
-// ChromedpChain 이 nil 이면 룰 = 'chromedp' 매칭이어도 DefaultChain fallback (warn 로그).
+// ChromedpChains 가 nil/empty 이면 룰 = 'chromedp' 매칭이어도 DefaultChain fallback (warn 로그).
 // Resolver 가 nil 이면 룰 조회 없이 항상 DefaultChain — 기존 동작 100% 보존.
+//
+// 이슈 #230 — chromedpChains 길이는 chromedp pool 의 WorkerCount 와 일치해야 함 (호출자 책임).
+// 단일 Chrome 운영 호환 모드 (sub-issue #229 머지 직후 시점) 에서는 길이 1 의 slice 로 호출.
 func NewChainHandler(
 	crawler SourceCrawler,
 	defaultChain Handler,
-	chromedpChain Handler,
+	chromedpChains []Handler,
 	resolver rule.Resolver,
 	rawSvc service.RawContentService,
 	producer queue.Producer,
 	log *logger.Logger,
 ) *ChainHandler {
 	return &ChainHandler{
-		Crawler:       crawler,
-		DefaultChain:  defaultChain,
-		ChromedpChain: chromedpChain,
-		Resolver:      resolver,
-		RawSvc:        rawSvc,
-		Producer:      producer,
-		Log:           log,
+		Crawler:        crawler,
+		DefaultChain:   defaultChain,
+		ChromedpChains: chromedpChains,
+		Resolver:       resolver,
+		RawSvc:         rawSvc,
+		Producer:       producer,
+		Log:            log,
 	}
 }
 
-// selectChain 은 host 단위 fetcher 룰을 조회하여 사용할 chain 을 결정합니다.
+// hasChromedpChain 은 ChromedpChains 가 wiring 되어 있는지 확인합니다.
+// nil 또는 empty slice 모두 미wiring 으로 판단.
+func (h *ChainHandler) hasChromedpChain() bool {
+	return len(h.ChromedpChains) > 0
+}
+
+// resolveChromedpChain 은 ctx 의 worker_id 로 자기 전용 chromedp chain 을 반환합니다.
+// worker_id 미설정 / 범위 밖이면 0번 chain fallback (방어 + 가시성 WARN).
+func (h *ChainHandler) resolveChromedpChain(ctx context.Context) Handler {
+	id := core.WorkerIDFromContext(ctx)
+	if id < 0 || id >= len(h.ChromedpChains) {
+		if h.Log != nil {
+			h.Log.WithFields(map[string]interface{}{
+				"worker_id":   id,
+				"chain_count": len(h.ChromedpChains),
+				"fallback_id": 0,
+			}).Warn("chain handler received out-of-range worker_id, using chromedp chain 0 fallback")
+		}
+		return h.ChromedpChains[0]
+	}
+	return h.ChromedpChains[id]
+}
+
+// selectChain 은 host 단위 fetcher 룰을 조회하여 사용할 chain 과 chromedp 매칭 여부를 결정합니다.
 //
 // 우선순위 (위에서부터):
-//  1. Target.Metadata["force_fetcher"] == "chromedp" → ChromedpChain (단계 3 republish 경로)
+//  1. Target.Metadata["force_fetcher"] == "chromedp" → chromedp 매칭 (단계 3 republish 경로)
 //  2. Resolver 의 host 룰 조회 결과
 //  3. fallback → DefaultChain
 //
+// 반환 (chain, isChromedp):
+//   - isChromedp=true: 호출자 (Handle) 가 republish 분기로 진입 (chain 자체는 사용 안 함)
+//   - isChromedp=false: chain 직접 호출
+//
+// 이슈 #230 — ChromedpChains 가 worker_id 별 slice 가 되면서 selectChain 단계에서는 어느 슬롯을
+// 쓸지 결정하지 않음 (republish 후 ChromedpJobHandler 가 slot 선택). Handle 의 분기 식별을
+// chain 포인터 비교 대신 isChromedp 플래그로 안전하게 처리.
+//
 // Resolver 가 nil 이거나 host 추출 실패 또는 룰 조회 실패 시 DefaultChain 으로 fallback —
 // fetcher 정책이 부분적으로 망가져도 fetch 자체는 계속 진행 (graceful degrade).
-//
-// chain 선택 외에 룰 결과를 로그에 남겨 운영 가시성 확보.
-func (h *ChainHandler) selectChain(ctx context.Context, job *core.CrawlJob) Handler {
+func (h *ChainHandler) selectChain(ctx context.Context, job *core.CrawlJob) (Handler, bool) {
 	// 단계 3 republish 경로 — Resolver 보다 우선. 자동 chromedp 전환 trigger 가 발행한
 	// 새 CrawlJob 이 즉시 chromedp 처리되도록 보장.
 	//
@@ -96,26 +133,26 @@ func (h *ChainHandler) selectChain(ctx context.Context, job *core.CrawlJob) Hand
 				h.Log.WithFields(map[string]interface{}{
 					"url": job.Target.URL,
 				}).Warn("force_fetcher metadata present but token invalid/absent — falling back to default chain")
-			} else if h.ChromedpChain != nil {
+			} else if h.hasChromedpChain() {
 				h.Log.WithFields(map[string]interface{}{
 					"url":     job.Target.URL,
 					"fetcher": s,
 				}).Debug("force_fetcher metadata applied (republish path)")
-				return h.ChromedpChain
+				return nil, true
 			} else {
 				h.Log.WithFields(map[string]interface{}{
 					"url": job.Target.URL,
-				}).Warn("force_fetcher=chromedp but no ChromedpChain wired, using default chain")
+				}).Warn("force_fetcher=chromedp but no ChromedpChains wired, using default chain")
 			}
 		}
 	}
 
 	if h.Resolver == nil {
-		return h.DefaultChain
+		return h.DefaultChain, false
 	}
 	host := extractHost(job.Target.URL)
 	if host == "" {
-		return h.DefaultChain
+		return h.DefaultChain, false
 	}
 	res, err := h.Resolver.Resolve(ctx, host)
 	if err != nil {
@@ -123,28 +160,28 @@ func (h *ChainHandler) selectChain(ctx context.Context, job *core.CrawlJob) Hand
 			"url":  job.Target.URL,
 			"host": host,
 		}).WithError(err).Warn("fetcher rule resolve failed, falling back to default chain")
-		return h.DefaultChain
+		return h.DefaultChain, false
 	}
 	if !res.Found {
-		return h.DefaultChain
+		return h.DefaultChain, false
 	}
 	if res.Fetcher == storage.FetcherChromedp {
-		if h.ChromedpChain == nil {
+		if !h.hasChromedpChain() {
 			h.Log.WithFields(map[string]interface{}{
 				"url":  job.Target.URL,
 				"host": host,
-			}).Warn("rule selected chromedp but no ChromedpChain wired, using default chain")
-			return h.DefaultChain
+			}).Warn("rule selected chromedp but no ChromedpChains wired, using default chain")
+			return h.DefaultChain, false
 		}
 		h.Log.WithFields(map[string]interface{}{
 			"url":     job.Target.URL,
 			"host":    host,
 			"fetcher": string(res.Fetcher),
 		}).Debug("fetcher rule applied")
-		return h.ChromedpChain
+		return nil, true
 	}
 	// FetcherGoQuery — 현재는 DefaultChain 과 동작이 같음. 단계 3 자동 downgrade 도입 시 분기.
-	return h.DefaultChain
+	return h.DefaultChain, false
 }
 
 // extractHost 는 URL 에서 host 만 뽑습니다 (port 제거 포함).
@@ -161,19 +198,21 @@ func extractHost(rawURL string) string {
 //
 // 항상 nil Content slice 를 반환 — 파싱은 parser worker 가 TopicFetched 를 consume 하여 처리.
 //
-// 이슈 #218: chromedp 처리는 별도 worker pool 로 격리. selectChain 결과가 ChromedpChain 이거나
+// 이슈 #218: chromedp 처리는 별도 worker pool 로 격리. selectChain 결과가 chromedp 매칭이거나
 // DefaultChain 의 GoQuery 가 lazy detect 시 sentinel 반환하면 직접 호출 대신 TopicCrawlChromedp
 // 로 republish — Chrome 자원 동시 호출량을 chromedp pool 의 semaphore 로 제어.
+//
+// 이슈 #230 — selectChain 이 (chain, isChromedp) tuple 반환. ChromedpChains slice 모델로
+// 변경되어 chain 포인터 비교가 부적합 → isChromedp 플래그로 분기.
 func (h *ChainHandler) Handle(ctx context.Context, job *core.CrawlJob) ([]*core.Content, error) {
 	if h.DefaultChain == nil || h.Log == nil || h.RawSvc == nil || h.Producer == nil {
 		return nil, fmt.Errorf("chain handler is not properly initialized")
 	}
 
-	chain := h.selectChain(ctx, job)
+	chain, isChromedp := h.selectChain(ctx, job)
 
-	// 이슈 #218: ChromedpChain 매칭 (force_fetcher 또는 Resolver 룰) → 직접 호출 안 하고 republish.
-	// 같은 인스턴스 비교 (포인터 ID) 로 selectChain 의 ChromedpChain 분기 식별.
-	if h.ChromedpChain != nil && chain == h.ChromedpChain {
+	// 이슈 #218: chromedp 매칭 (force_fetcher 또는 Resolver 룰) → 직접 호출 안 하고 republish.
+	if isChromedp {
 		if err := h.republishToChromedpQueue(ctx, job); err != nil {
 			return nil, fmt.Errorf("republish to chromedp queue for %s: %w", job.Target.URL, err)
 		}
@@ -233,23 +272,25 @@ func (h *ChainHandler) processFetchedRaw(ctx context.Context, job *core.CrawlJob
 	return nil
 }
 
-// HandleChromedpOnly 는 ChromedpChain 만 호출하여 chromedp 단독 fetch 를 수행합니다 (이슈 #218).
+// HandleChromedpOnly 는 ChromedpChains 중 worker_id 슬롯을 호출하여 chromedp 단독 fetch 를 수행합니다 (이슈 #218, #230).
 //
 // chromedp pool 의 ChromedpJobHandler 가 같은 ChainHandler 인스턴스를 Registry 에서 lookup 하여
-// 본 메소드 호출 — Resolver / force_fetcher / republish 분기 skip 하고 ChromedpChain 직접 호출.
-// 그 외 처리 흐름 (raw_contents 저장 + RawContentRef publish) 은 일반 Handle 과 동일.
+// 본 메소드 호출 — Resolver / force_fetcher / republish 분기 skip 하고 ctx 의 worker_id 로
+// ChromedpChains[id] 직접 호출. 그 외 처리 흐름 (raw_contents 저장 + RawContentRef publish) 은
+// 일반 Handle 과 동일.
 //
-// ChromedpChain 미wiring 사이트 (예: yonhap) 에 대해서는 정의상 chromedp pool 이 큐 메시지를
-// 받지 않아야 하지만, 안전장치로 nil 일 때 graceful error.
+// ChromedpChains 미wiring 사이트 (예: yonhap) 에 대해서는 정의상 chromedp pool 이 큐 메시지를
+// 받지 않아야 하지만, 안전장치로 empty 일 때 graceful error.
 func (h *ChainHandler) HandleChromedpOnly(ctx context.Context, job *core.CrawlJob) ([]*core.Content, error) {
 	if h.Log == nil || h.RawSvc == nil || h.Producer == nil {
 		return nil, fmt.Errorf("chain handler is not properly initialized")
 	}
-	if h.ChromedpChain == nil {
+	if !h.hasChromedpChain() {
 		return nil, fmt.Errorf("crawler %s has no chromedp chain wired", job.CrawlerName)
 	}
 
-	raw, err := h.ChromedpChain.Handle(ctx, job)
+	chain := h.resolveChromedpChain(ctx)
+	raw, err := chain.Handle(ctx, job)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/processor/fetcher/domain/general/sources/kr/registry.go
+++ b/internal/processor/fetcher/domain/general/sources/kr/registry.go
@@ -26,6 +26,8 @@ import (
 //
 // rawSvc + producer 는 ChainHandler (fetcher 측) 가 raw_contents 저장 + RawContentRef 발행에 사용.
 // resolver 는 호스트 단위 fetcher 룰 (이슈 #175) 적용. nil 이면 항상 default chain.
+// chromedpRemoteURLs 는 worker_id 별 Chrome RemoteURL slice (이슈 #230). 길이 = chromedp pool 의
+// WorkerCount. empty 면 chromedp 사용 사이트도 chromedp chain 미wiring (운영자 명시적 비활성화).
 // parser worker 는 본 함수 외부에서 별도 wiring (cmd/issuetracker/main.go).
 //
 // 등록 중 wiring 실패 (BuildChain misconfig 등) 시 error 반환 — 호출자가 fail-fast 결정.
@@ -35,15 +37,16 @@ func Register(
 	rawSvc service.RawContentService,
 	producer queue.Producer,
 	resolver rule.Resolver,
+	chromedpRemoteURLs []string,
 	log *logger.Logger,
 ) error {
-	if err := registerNaver(registry, config, rawSvc, producer, resolver, log); err != nil {
+	if err := registerNaver(registry, config, rawSvc, producer, resolver, chromedpRemoteURLs, log); err != nil {
 		return err
 	}
 	if err := registerYonhap(registry, config, rawSvc, producer, resolver, log); err != nil {
 		return err
 	}
-	if err := registerDaum(registry, config, rawSvc, producer, resolver, log); err != nil {
+	if err := registerDaum(registry, config, rawSvc, producer, resolver, chromedpRemoteURLs, log); err != nil {
 		return err
 	}
 	return nil
@@ -54,14 +57,42 @@ func Register(
 //   - 호출자가 넘긴 config 는 사용하지 않음 (사이트별 디테일 덮어쓰기 회피)
 //   - ChainHandler 는 fetch + raw store + RawContentRef publish 만 수행 — 파싱은 parser worker 책임
 
-func registerNaver(registry *handler.Registry, _ core.Config, rawSvc service.RawContentService, producer queue.Producer, resolver rule.Resolver, log *logger.Logger) error {
+// buildChromedpChainsForSite 는 site 의 chromedp chain 을 worker_id 별 N 개 build 합니다 (이슈 #230).
+//
+// remoteURLs 길이만큼 ChromedpCrawler / BrowserFetcher / Chain 생성 — 각 인스턴스가 자기 RemoteURL
+// 에 연결. nameBase 는 로깅·식별용 prefix (예: "naver-browser" → "naver-browser-0", "naver-browser-1").
+//
+// remoteURLs 가 empty 면 nil slice 반환 — 호출자는 chromedpChains nil 로 ChainHandler 생성 (chromedp 미사용 사이트와 동일 fallback 흐름).
+func buildChromedpChainsForSite(
+	nameBase string,
+	sourceInfo core.SourceInfo,
+	cfg core.Config,
+	remoteURLs []string,
+	log *logger.Logger,
+) ([]general.Handler, error) {
+	if len(remoteURLs) == 0 {
+		return nil, nil
+	}
+	chains := make([]general.Handler, len(remoteURLs))
+	for i, url := range remoteURLs {
+		opts := cdp.DefaultRemoteOptions()
+		opts.RemoteURL = url
+		cdpCrawler := cdp.NewChromedpCrawlerWithOptions(fmt.Sprintf("%s-%d", nameBase, i), sourceInfo, cfg, opts)
+		brFetcher := fetcher.NewBrowserFetcher(cdpCrawler, cfg)
+		chain, err := general.BuildChain(nil, brFetcher, log)
+		if err != nil {
+			return nil, fmt.Errorf("%s chromedp chain wiring (worker_id=%d, remote_url=%s): %w", nameBase, i, url, err)
+		}
+		chains[i] = chain
+	}
+	return chains, nil
+}
+
+func registerNaver(registry *handler.Registry, _ core.Config, rawSvc service.RawContentService, producer queue.Producer, resolver rule.Resolver, chromedpRemoteURLs []string, log *logger.Logger) error {
 	cfg := naver.Default()
 
 	gqCrawler := goquery.NewGoqueryCrawler("naver-goquery", cfg.CrawlerConfig.SourceInfo, cfg.CrawlerConfig)
 	gqFetcher := fetcher.NewGoqueryFetcher(gqCrawler)
-
-	cdpCrawler := cdp.NewChromedpCrawlerWithOptions("naver-browser", cfg.CrawlerConfig.SourceInfo, cfg.CrawlerConfig, cdp.DefaultRemoteOptions())
-	brFetcher := fetcher.NewBrowserFetcher(cdpCrawler, cfg.CrawlerConfig)
 
 	crawler := general.NewGenericCrawler("naver", cfg.CrawlerConfig.SourceInfo, gqFetcher, cfg.BaseURL, cfg.CrawlerConfig)
 	// 이슈 #218: DefaultChain 은 goquery only — lazy detect 시 sentinel 반환 → ChainHandler 가 chromedp pool 로 republish.
@@ -71,13 +102,16 @@ func registerNaver(registry *handler.Registry, _ core.Config, rawSvc service.Raw
 	if err != nil {
 		return fmt.Errorf("naver default chain wiring: %w", err)
 	}
-	chromedpChain, err := general.BuildChain(nil, brFetcher, log)
+	chromedpChains, err := buildChromedpChainsForSite("naver-browser", cfg.CrawlerConfig.SourceInfo, cfg.CrawlerConfig, chromedpRemoteURLs, log)
 	if err != nil {
-		return fmt.Errorf("naver chromedp chain wiring: %w", err)
+		return err
 	}
 
-	registry.Register("naver", general.NewChainHandler(crawler, defaultChain, chromedpChain, resolver, rawSvc, producer, log))
-	log.WithField("crawler", "naver").Info("naver crawler registered")
+	registry.Register("naver", general.NewChainHandler(crawler, defaultChain, chromedpChains, resolver, rawSvc, producer, log))
+	log.WithFields(map[string]interface{}{
+		"crawler":          "naver",
+		"chromedp_workers": len(chromedpChains),
+	}).Info("naver crawler registered")
 	return nil
 }
 
@@ -93,21 +127,18 @@ func registerYonhap(registry *handler.Registry, _ core.Config, rawSvc service.Ra
 		return fmt.Errorf("yonhap chain wiring: %w", err)
 	}
 
-	// yonhap 은 browser fetcher 미설정 — chromedpChain=nil. 룰=chromedp 매칭 시 ChainHandler 가
+	// yonhap 은 browser fetcher 미설정 — chromedpChains=nil. 룰=chromedp 매칭 시 ChainHandler 가
 	// warn 로그 + DefaultChain 으로 fallback.
 	registry.Register("yonhap", general.NewChainHandler(crawler, defaultChain, nil, resolver, rawSvc, producer, log))
 	log.WithField("crawler", "yonhap").Info("yonhap crawler registered")
 	return nil
 }
 
-func registerDaum(registry *handler.Registry, _ core.Config, rawSvc service.RawContentService, producer queue.Producer, resolver rule.Resolver, log *logger.Logger) error {
+func registerDaum(registry *handler.Registry, _ core.Config, rawSvc service.RawContentService, producer queue.Producer, resolver rule.Resolver, chromedpRemoteURLs []string, log *logger.Logger) error {
 	cfg := daum.Default()
 
 	gqCrawler := goquery.NewGoqueryCrawler("daum-goquery", cfg.CrawlerConfig.SourceInfo, cfg.CrawlerConfig)
 	gqFetcher := fetcher.NewGoqueryFetcher(gqCrawler)
-
-	cdpCrawler := cdp.NewChromedpCrawlerWithOptions("daum-browser", cfg.CrawlerConfig.SourceInfo, cfg.CrawlerConfig, cdp.DefaultRemoteOptions())
-	brFetcher := fetcher.NewBrowserFetcher(cdpCrawler, cfg.CrawlerConfig)
 
 	crawler := general.NewGenericCrawler("daum", cfg.CrawlerConfig.SourceInfo, gqFetcher, cfg.BaseURL, cfg.CrawlerConfig)
 	// 이슈 #218: DefaultChain = goquery only.
@@ -117,12 +148,15 @@ func registerDaum(registry *handler.Registry, _ core.Config, rawSvc service.RawC
 	if err != nil {
 		return fmt.Errorf("daum default chain wiring: %w", err)
 	}
-	chromedpChain, err := general.BuildChain(nil, brFetcher, log)
+	chromedpChains, err := buildChromedpChainsForSite("daum-browser", cfg.CrawlerConfig.SourceInfo, cfg.CrawlerConfig, chromedpRemoteURLs, log)
 	if err != nil {
-		return fmt.Errorf("daum chromedp chain wiring: %w", err)
+		return err
 	}
 
-	registry.Register("daum", general.NewChainHandler(crawler, defaultChain, chromedpChain, resolver, rawSvc, producer, log))
-	log.WithField("crawler", "daum").Info("daum crawler registered")
+	registry.Register("daum", general.NewChainHandler(crawler, defaultChain, chromedpChains, resolver, rawSvc, producer, log))
+	log.WithFields(map[string]interface{}{
+		"crawler":          "daum",
+		"chromedp_workers": len(chromedpChains),
+	}).Info("daum crawler registered")
 	return nil
 }

--- a/internal/processor/fetcher/domain/general/sources/kr/registry.go
+++ b/internal/processor/fetcher/domain/general/sources/kr/registry.go
@@ -81,7 +81,9 @@ func buildChromedpChainsForSite(
 		brFetcher := fetcher.NewBrowserFetcher(cdpCrawler, cfg)
 		chain, err := general.BuildChain(nil, brFetcher, log)
 		if err != nil {
-			return nil, fmt.Errorf("%s chromedp chain wiring (worker_id=%d, remote_url=%s): %w", nameBase, i, url, err)
+			// CodeRabbit 피드백: error message 에 RemoteURL 포함 시 ws://user:pass@... 같은
+			// 인증 토큰이 로그에 누출. worker_id 만으로 triage 충분.
+			return nil, fmt.Errorf("%s chromedp chain wiring (worker_id=%d): %w", nameBase, i, err)
 		}
 		chains[i] = chain
 	}

--- a/internal/processor/fetcher/domain/general/sources/us/registry.go
+++ b/internal/processor/fetcher/domain/general/sources/us/registry.go
@@ -55,7 +55,9 @@ func buildChromedpChainsForCNN(
 		brFetcher := fetcher.NewBrowserFetcher(cdpCrawler, cfg)
 		chain, err := general.BuildChain(nil, brFetcher, log)
 		if err != nil {
-			return nil, fmt.Errorf("cnn chromedp chain wiring (worker_id=%d, remote_url=%s): %w", i, url, err)
+			// CodeRabbit 피드백: error message 에 RemoteURL 포함 시 ws://user:pass@... 같은
+			// 인증 토큰이 로그에 누출. worker_id 만으로 triage 충분.
+			return nil, fmt.Errorf("cnn chromedp chain wiring (worker_id=%d): %w", i, err)
 		}
 		chains[i] = chain
 	}

--- a/internal/processor/fetcher/domain/general/sources/us/registry.go
+++ b/internal/processor/fetcher/domain/general/sources/us/registry.go
@@ -21,6 +21,8 @@ import (
 
 // Register 는 모든 미국 사이트 크롤러를 registry 에 등록합니다 (이슈 #134 — fetcher/parser 분리 후).
 // resolver 는 호스트 단위 fetcher 룰 (이슈 #175) 적용. nil 이면 항상 default chain.
+// chromedpRemoteURLs 는 worker_id 별 Chrome RemoteURL slice (이슈 #230). 길이 = chromedp pool 의
+// WorkerCount. empty 면 chromedp chain 미wiring.
 // 등록 중 wiring 실패 시 error 반환 — 호출자가 fail-fast 결정.
 func Register(
 	registry *handler.Registry,
@@ -28,20 +30,44 @@ func Register(
 	rawSvc service.RawContentService,
 	producer queue.Producer,
 	resolver rule.Resolver,
+	chromedpRemoteURLs []string,
 	log *logger.Logger,
 ) error {
-	return registerCNN(registry, config, rawSvc, producer, resolver, log)
+	return registerCNN(registry, config, rawSvc, producer, resolver, chromedpRemoteURLs, log)
+}
+
+// buildChromedpChainsForCNN 는 CNN 의 chromedp chain 을 worker_id 별 N 개 build 합니다 (이슈 #230).
+// kr/registry.go 의 buildChromedpChainsForSite 와 동일 로직 — site 패키지 경계로 인해 각자 보유.
+func buildChromedpChainsForCNN(
+	sourceInfo core.SourceInfo,
+	cfg core.Config,
+	remoteURLs []string,
+	log *logger.Logger,
+) ([]general.Handler, error) {
+	if len(remoteURLs) == 0 {
+		return nil, nil
+	}
+	chains := make([]general.Handler, len(remoteURLs))
+	for i, url := range remoteURLs {
+		opts := cdp.DefaultRemoteOptions()
+		opts.RemoteURL = url
+		cdpCrawler := cdp.NewChromedpCrawlerWithOptions(fmt.Sprintf("cnn-browser-%d", i), sourceInfo, cfg, opts)
+		brFetcher := fetcher.NewBrowserFetcher(cdpCrawler, cfg)
+		chain, err := general.BuildChain(nil, brFetcher, log)
+		if err != nil {
+			return nil, fmt.Errorf("cnn chromedp chain wiring (worker_id=%d, remote_url=%s): %w", i, url, err)
+		}
+		chains[i] = chain
+	}
+	return chains, nil
 }
 
 // 사이트별 등록 패턴은 kr/registry.go 와 동일.
-func registerCNN(registry *handler.Registry, _ core.Config, rawSvc service.RawContentService, producer queue.Producer, resolver rule.Resolver, log *logger.Logger) error {
+func registerCNN(registry *handler.Registry, _ core.Config, rawSvc service.RawContentService, producer queue.Producer, resolver rule.Resolver, chromedpRemoteURLs []string, log *logger.Logger) error {
 	cfg := cnn.Default()
 
 	gqCrawler := goquery.NewGoqueryCrawler("cnn-goquery", cfg.CrawlerConfig.SourceInfo, cfg.CrawlerConfig)
 	gqFetcher := fetcher.NewGoqueryFetcher(gqCrawler)
-
-	cdpCrawler := cdp.NewChromedpCrawlerWithOptions("cnn-browser", cfg.CrawlerConfig.SourceInfo, cfg.CrawlerConfig, cdp.DefaultRemoteOptions())
-	brFetcher := fetcher.NewBrowserFetcher(cdpCrawler, cfg.CrawlerConfig)
 
 	crawler := general.NewGenericCrawler("cnn", cfg.CrawlerConfig.SourceInfo, gqFetcher, cfg.BaseURL, cfg.CrawlerConfig)
 	// 이슈 #218: DefaultChain = goquery only.
@@ -51,12 +77,15 @@ func registerCNN(registry *handler.Registry, _ core.Config, rawSvc service.RawCo
 	if err != nil {
 		return fmt.Errorf("cnn default chain wiring: %w", err)
 	}
-	chromedpChain, err := general.BuildChain(nil, brFetcher, log)
+	chromedpChains, err := buildChromedpChainsForCNN(cfg.CrawlerConfig.SourceInfo, cfg.CrawlerConfig, chromedpRemoteURLs, log)
 	if err != nil {
-		return fmt.Errorf("cnn chromedp chain wiring: %w", err)
+		return err
 	}
 
-	registry.Register("cnn", general.NewChainHandler(crawler, defaultChain, chromedpChain, resolver, rawSvc, producer, log))
-	log.WithField("crawler", "cnn").Info("cnn crawler registered")
+	registry.Register("cnn", general.NewChainHandler(crawler, defaultChain, chromedpChains, resolver, rawSvc, producer, log))
+	log.WithFields(map[string]interface{}{
+		"crawler":          "cnn",
+		"chromedp_workers": len(chromedpChains),
+	}).Info("cnn crawler registered")
 	return nil
 }

--- a/internal/processor/fetcher/worker/chromedp_handler.go
+++ b/internal/processor/fetcher/worker/chromedp_handler.go
@@ -68,7 +68,7 @@ func NewChromedpJobHandler(registry *handler.Registry, sems []Semaphore, log *lo
 // resolveSemaphore 는 ctx 의 worker_id 로 자기 전용 Semaphore 를 반환합니다.
 // worker_id 미설정 또는 범위 밖이면 0번 슬롯 fallback + WARN 로그 (방어 + 가시성).
 func (h *ChromedpJobHandler) resolveSemaphore(ctx context.Context) (Semaphore, int) {
-	id := WorkerIDFromContext(ctx)
+	id := core.WorkerIDFromContext(ctx)
 	if id < 0 || id >= len(h.sems) {
 		if h.log != nil {
 			h.log.WithFields(map[string]interface{}{

--- a/internal/processor/fetcher/worker/pool.go
+++ b/internal/processor/fetcher/worker/pool.go
@@ -375,7 +375,8 @@ func (p *KafkaConsumerPool) worker(ctx context.Context, workerID int) {
 
 	// 이슈 #229 — worker_id 를 ctx 에 첨부. ChromedpJobHandler 가 per-worker Semaphore
 	// 슬롯을 선택하는 데 사용. priority pool 에서는 handler 가 ID 를 무시.
-	ctx = WithWorkerID(ctx, workerID)
+	// 이슈 #230 — general.ChainHandler 의 chromedpChains slice lookup 에도 동일 키 재사용.
+	ctx = core.WithWorkerID(ctx, workerID)
 
 	log := logger.FromContext(ctx)
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -317,8 +317,11 @@ type FetcherChromedpPoolConfig struct {
 	// RemoteURLs: worker_id 별 Chrome 인스턴스의 CDP WebSocket URL 매핑 (이슈 #230).
 	// 길이는 WorkerCount 와 일치해야 하며 (LoadFetcherChromedpPool 가 검증), 사이트별 ChromedpCrawler
 	// 가 worker_id 인덱스로 자기 전용 RemoteURL 을 사용 → worker:Chrome 1:1 매핑.
-	// 환경변수 FETCHER_CHROMEDP_REMOTE_URLS (콤마 구분 list, default 는 ws://localhost:9222 을
-	// WorkerCount 만큼 복제 — 기존 단일 Chrome 호환).
+	//
+	// 우선순위 (LoadFetcherChromedpPool 가 채움):
+	//  1. FETCHER_CHROMEDP_REMOTE_URLS (콤마 구분 list, 명시적 매핑)
+	//  2. FETCHER_CHROMEDP_REMOTE_URL_PATTERN ({n} placeholder, 1..WorkerCount 치환)
+	//  3. default (ws://localhost:9222 × WorkerCount — 단일 Chrome 호환)
 	RemoteURLs []string
 }
 
@@ -349,8 +352,12 @@ func DefaultFetcherChromedpPoolConfig() FetcherChromedpPoolConfig {
 //   - FETCHER_CHROMEDP_POOL_ENABLED: true | false (default true)
 //   - FETCHER_CHROMEDP_WORKER_COUNT: 양의 정수 (default 2) — 실질 전체 동시 navigate 수
 //   - FETCHER_CHROMEDP_SEMAPHORE_CAPACITY: 양의 정수, per-worker (default 1, 1 이상 의미 없음)
-//   - FETCHER_CHROMEDP_REMOTE_URLS: 콤마 구분 CDP WS URL 리스트 (default ws://localhost:9222
-//     × WorkerCount, 이슈 #230). 길이가 WorkerCount 와 일치해야 함 — 미일치 시 fail-fast.
+//   - FETCHER_CHROMEDP_REMOTE_URLS: 콤마 구분 CDP WS URL 리스트 (이슈 #230). 명시 시 가장 우선.
+//     길이가 WorkerCount 와 일치해야 함 — 미일치 시 fail-fast.
+//   - FETCHER_CHROMEDP_REMOTE_URL_PATTERN: {n} placeholder 를 1..WorkerCount 로 치환하여 RemoteURLs
+//     자동 생성 (예: "ws://chrome-{n}:9222"). REMOTE_URLS 미지정 시 적용. {n} 누락 시 fail-fast
+//     (모든 worker 가 같은 url 로 향해 1:1 매핑이 무력화되는 사고 방지).
+//   - 둘 다 미지정 시 default ws://localhost:9222 × WorkerCount — 단일 Chrome 호환.
 func LoadFetcherChromedpPool(envFiles ...string) (FetcherChromedpPoolConfig, error) {
 	if len(envFiles) == 0 {
 		envFiles = []string{".env"}
@@ -389,8 +396,13 @@ func LoadFetcherChromedpPool(envFiles ...string) (FetcherChromedpPoolConfig, err
 		cfg.SemaphoreCapacity = n
 	}
 
-	// 이슈 #230: RemoteURLs 처리 — 미지정 시 default ws://localhost:9222 × WorkerCount 로 채움.
-	// 명시된 경우 콤마 구분으로 파싱 후 길이가 WorkerCount 와 일치하는지 검증 (fail-fast).
+	// 이슈 #230: RemoteURLs 처리 — 우선순위:
+	//   1. FETCHER_CHROMEDP_REMOTE_URLS (콤마 구분 list, 명시적 매핑)
+	//   2. FETCHER_CHROMEDP_REMOTE_URL_PATTERN ({n} placeholder, 1..WorkerCount 치환)
+	//   3. default (ws://localhost:9222 × WorkerCount — 단일 Chrome 호환)
+	//
+	// PATTERN 모드는 docker compose --scale chrome=N 운영과 결합 — WorkerCount 만 조정하면
+	// RemoteURLs 도 자동으로 N 개 생성. 운영자가 두 env 를 따로 동기화할 필요 없음.
 	if v := os.Getenv("FETCHER_CHROMEDP_REMOTE_URLS"); v != "" {
 		parts := strings.Split(v, ",")
 		urls := make([]string, 0, len(parts))
@@ -405,10 +417,22 @@ func LoadFetcherChromedpPool(envFiles ...string) (FetcherChromedpPoolConfig, err
 			return FetcherChromedpPoolConfig{}, fmt.Errorf("invalid FETCHER_CHROMEDP_REMOTE_URLS: got %d url(s), want %d (= FETCHER_CHROMEDP_WORKER_COUNT)", len(urls), cfg.WorkerCount)
 		}
 		cfg.RemoteURLs = urls
+	} else if pattern := strings.TrimSpace(os.Getenv("FETCHER_CHROMEDP_REMOTE_URL_PATTERN")); pattern != "" {
+		// {n} placeholder 누락 시 모든 worker 가 같은 url 로 향함 — 1:1 매핑이 사실상 무력화.
+		// fail-fast 로 운영자가 명시적 의사결정 (REMOTE_URLS 사용 또는 PATTERN 에 {n} 추가) 강제.
+		if !strings.Contains(pattern, "{n}") {
+			return FetcherChromedpPoolConfig{}, fmt.Errorf("invalid FETCHER_CHROMEDP_REMOTE_URL_PATTERN %q: missing {n} placeholder (use REMOTE_URLS for static mapping or add {n} for per-worker substitution)", pattern)
+		}
+		urls := make([]string, cfg.WorkerCount)
+		for i := 0; i < cfg.WorkerCount; i++ {
+			// 1-indexed: docker compose 의 chrome-1, chrome-2, ... 명명 규칙과 일치
+			urls[i] = strings.ReplaceAll(pattern, "{n}", strconv.Itoa(i+1))
+		}
+		cfg.RemoteURLs = urls
 	} else {
 		// Default: 단일 Chrome 호환 (이전 동작 100% 보존). worker 가 N>1 이어도 같은 Chrome 공유.
 		// → worker:Chrome 1:1 격리 효과는 사라지지만 graceful default — 운영자가 명시적 RemoteURLs
-		// 지정으로 1:1 활성화. docker-compose 도 default 는 단일 chrome 컨테이너.
+		// 또는 REMOTE_URL_PATTERN 지정으로 1:1 활성화.
 		cfg.RemoteURLs = make([]string, cfg.WorkerCount)
 		for i := range cfg.RemoteURLs {
 			cfg.RemoteURLs[i] = "ws://localhost:9222"

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"os"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/joho/godotenv"
@@ -312,6 +313,13 @@ type FetcherChromedpPoolConfig struct {
 	// 운영 처리량 조정은 SemaphoreCapacity 가 아닌 WorkerCount 로 수행.
 	// 환경변수 FETCHER_CHROMEDP_SEMAPHORE_CAPACITY (default 1).
 	SemaphoreCapacity int
+
+	// RemoteURLs: worker_id 별 Chrome 인스턴스의 CDP WebSocket URL 매핑 (이슈 #230).
+	// 길이는 WorkerCount 와 일치해야 하며 (LoadFetcherChromedpPool 가 검증), 사이트별 ChromedpCrawler
+	// 가 worker_id 인덱스로 자기 전용 RemoteURL 을 사용 → worker:Chrome 1:1 매핑.
+	// 환경변수 FETCHER_CHROMEDP_REMOTE_URLS (콤마 구분 list, default 는 ws://localhost:9222 을
+	// WorkerCount 만큼 복제 — 기존 단일 Chrome 호환).
+	RemoteURLs []string
 }
 
 // DefaultFetcherChromedpPoolConfig 는 기본 FetcherChromedpPoolConfig 를 반환합니다.
@@ -321,11 +329,17 @@ type FetcherChromedpPoolConfig struct {
 // 기존 운영자가 환경변수로 4 를 명시했다면 — 그 값은 무시되지 않고 그대로 적용되지만 (slot 수
 // 4 의 sem 이 worker 별로 만들어짐) 실효 동시성은 변하지 않음 (worker 1 + slot 4 = 동시 1건).
 // 처리량 변경은 WorkerCount 환경변수로만 조정 가능.
+//
+// 이슈 #230 — RemoteURLs default:
+// FETCHER_CHROMEDP_REMOTE_URLS 미지정 시 LoadFetcherChromedpPool 가 ws://localhost:9222 을
+// WorkerCount 만큼 복제하여 채움 — 기존 단일 Chrome 운영 호환 (이전 동작 100% 보존).
+// Default 함수 자체는 빈 slice 반환 — Load 가 WorkerCount 결정 후 채움.
 func DefaultFetcherChromedpPoolConfig() FetcherChromedpPoolConfig {
 	return FetcherChromedpPoolConfig{
 		Enabled:           true,
 		WorkerCount:       2,
 		SemaphoreCapacity: 1,
+		RemoteURLs:        nil,
 	}
 }
 
@@ -335,6 +349,8 @@ func DefaultFetcherChromedpPoolConfig() FetcherChromedpPoolConfig {
 //   - FETCHER_CHROMEDP_POOL_ENABLED: true | false (default true)
 //   - FETCHER_CHROMEDP_WORKER_COUNT: 양의 정수 (default 2) — 실질 전체 동시 navigate 수
 //   - FETCHER_CHROMEDP_SEMAPHORE_CAPACITY: 양의 정수, per-worker (default 1, 1 이상 의미 없음)
+//   - FETCHER_CHROMEDP_REMOTE_URLS: 콤마 구분 CDP WS URL 리스트 (default ws://localhost:9222
+//     × WorkerCount, 이슈 #230). 길이가 WorkerCount 와 일치해야 함 — 미일치 시 fail-fast.
 func LoadFetcherChromedpPool(envFiles ...string) (FetcherChromedpPoolConfig, error) {
 	if len(envFiles) == 0 {
 		envFiles = []string{".env"}
@@ -371,6 +387,32 @@ func LoadFetcherChromedpPool(envFiles ...string) (FetcherChromedpPoolConfig, err
 			return FetcherChromedpPoolConfig{}, fmt.Errorf("invalid FETCHER_CHROMEDP_SEMAPHORE_CAPACITY %d: must be 1 or greater", n)
 		}
 		cfg.SemaphoreCapacity = n
+	}
+
+	// 이슈 #230: RemoteURLs 처리 — 미지정 시 default ws://localhost:9222 × WorkerCount 로 채움.
+	// 명시된 경우 콤마 구분으로 파싱 후 길이가 WorkerCount 와 일치하는지 검증 (fail-fast).
+	if v := os.Getenv("FETCHER_CHROMEDP_REMOTE_URLS"); v != "" {
+		parts := strings.Split(v, ",")
+		urls := make([]string, 0, len(parts))
+		for _, p := range parts {
+			trimmed := strings.TrimSpace(p)
+			if trimmed == "" {
+				return FetcherChromedpPoolConfig{}, fmt.Errorf("invalid FETCHER_CHROMEDP_REMOTE_URLS %q: empty entry detected", v)
+			}
+			urls = append(urls, trimmed)
+		}
+		if len(urls) != cfg.WorkerCount {
+			return FetcherChromedpPoolConfig{}, fmt.Errorf("invalid FETCHER_CHROMEDP_REMOTE_URLS: got %d url(s), want %d (= FETCHER_CHROMEDP_WORKER_COUNT)", len(urls), cfg.WorkerCount)
+		}
+		cfg.RemoteURLs = urls
+	} else {
+		// Default: 단일 Chrome 호환 (이전 동작 100% 보존). worker 가 N>1 이어도 같은 Chrome 공유.
+		// → worker:Chrome 1:1 격리 효과는 사라지지만 graceful default — 운영자가 명시적 RemoteURLs
+		// 지정으로 1:1 활성화. docker-compose 도 default 는 단일 chrome 컨테이너.
+		cfg.RemoteURLs = make([]string, cfg.WorkerCount)
+		for i := range cfg.RemoteURLs {
+			cfg.RemoteURLs[i] = "ws://localhost:9222"
+		}
 	}
 
 	return cfg, nil

--- a/test/internal/processor/fetcher/core/worker_id_test.go
+++ b/test/internal/processor/fetcher/core/worker_id_test.go
@@ -1,4 +1,4 @@
-package worker_test
+package core_test
 
 import (
 	"context"
@@ -6,20 +6,21 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"issuetracker/internal/processor/fetcher/worker"
+	"issuetracker/internal/processor/fetcher/core"
 )
 
 // TestWorkerIDFromContext_Unset_ReturnsNegative 는 worker_id 미설정 ctx 가
-// sentinel (-1) 을 반환하는지 검증합니다 (이슈 #229).
+// sentinel (-1) 을 반환하는지 검증합니다 (이슈 #229, #230 에서 core 로 이동).
 func TestWorkerIDFromContext_Unset_ReturnsNegative(t *testing.T) {
-	id := worker.WorkerIDFromContext(context.Background())
+	id := core.WorkerIDFromContext(context.Background())
+	assert.Equal(t, core.NoWorkerID, id)
 	assert.Equal(t, -1, id)
 }
 
 // TestWorkerIDFromContext_NilContext_ReturnsNegative 는 nil ctx 도 panic 없이
 // sentinel (-1) 을 반환하는지 검증합니다.
 func TestWorkerIDFromContext_NilContext_ReturnsNegative(t *testing.T) {
-	id := worker.WorkerIDFromContext(nil) //nolint:staticcheck // 의도적 nil 검증
+	id := core.WorkerIDFromContext(nil) //nolint:staticcheck // 의도적 nil 검증
 	assert.Equal(t, -1, id)
 }
 
@@ -27,8 +28,8 @@ func TestWorkerIDFromContext_NilContext_ReturnsNegative(t *testing.T) {
 func TestWithWorkerID_RoundTrip(t *testing.T) {
 	cases := []int{0, 1, 5, 99}
 	for _, want := range cases {
-		ctx := worker.WithWorkerID(context.Background(), want)
-		got := worker.WorkerIDFromContext(ctx)
+		ctx := core.WithWorkerID(context.Background(), want)
+		got := core.WorkerIDFromContext(ctx)
 		assert.Equal(t, want, got)
 	}
 }
@@ -36,7 +37,7 @@ func TestWithWorkerID_RoundTrip(t *testing.T) {
 // TestWithWorkerID_Override 는 마지막 WithWorkerID 호출이 우선하는지 검증합니다
 // (context.WithValue chain 동작).
 func TestWithWorkerID_Override(t *testing.T) {
-	ctx := worker.WithWorkerID(context.Background(), 0)
-	ctx = worker.WithWorkerID(ctx, 7)
-	assert.Equal(t, 7, worker.WorkerIDFromContext(ctx))
+	ctx := core.WithWorkerID(context.Background(), 0)
+	ctx = core.WithWorkerID(ctx, 7)
+	assert.Equal(t, 7, core.WorkerIDFromContext(ctx))
 }

--- a/test/internal/processor/fetcher/domain/general/chain_handler_chromedp_routing_test.go
+++ b/test/internal/processor/fetcher/domain/general/chain_handler_chromedp_routing_test.go
@@ -1,0 +1,149 @@
+package general_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"issuetracker/internal/processor/fetcher/core"
+	"issuetracker/internal/processor/fetcher/domain/general"
+	"issuetracker/internal/storage"
+	"issuetracker/pkg/logger"
+	"issuetracker/pkg/queue"
+)
+
+// 이슈 #230 — ChainHandler.HandleChromedpOnly 의 worker_id 별 chromedpChains slice 라우팅 검증.
+//
+// 라우팅 검증 전략 (black-box):
+//   - fake chain 각 인스턴스가 식별 가능한 sentinel error 반환 — Handle 호출 후 error 메시지로
+//     어느 chain (worker_id) 이 실행됐는지 추적
+//   - chain.Handle 이 error 반환 시 ChainHandler 는 raw store / publish 호출 안 함 → stub
+//     RawSvc / Producer 메소드는 panic 으로 invariant 강제
+
+// fakeChain 은 식별 가능한 sentinel error 를 반환하는 general.Handler 스텁.
+type fakeChain struct {
+	id string
+}
+
+func (f *fakeChain) Handle(_ context.Context, _ *core.CrawlJob) (*core.RawContent, error) {
+	return nil, errors.New("fake-" + f.id)
+}
+
+// SetNext 는 chain 의 다음 노드 설정 — 본 테스트에서는 사용 안 함 (단일 노드 chain 시뮬레이션).
+func (*fakeChain) SetNext(_ general.Handler) {}
+
+// stubRawSvc 는 invariant 검증용 — 호출되면 안 됨 (chain.Handle error → 즉시 return).
+type stubRawSvc struct{}
+
+func (stubRawSvc) Store(_ context.Context, _ *core.RawContent) (string, bool, error) {
+	panic("stubRawSvc.Store should not be called")
+}
+func (stubRawSvc) GetByID(_ context.Context, _ string) (*core.RawContent, error) {
+	panic("stubRawSvc.GetByID should not be called")
+}
+func (stubRawSvc) Delete(_ context.Context, _ string) error {
+	panic("stubRawSvc.Delete should not be called")
+}
+func (stubRawSvc) List(_ context.Context, _ storage.RawContentFilter) ([]*core.RawContent, error) {
+	panic("stubRawSvc.List should not be called")
+}
+func (stubRawSvc) PurgeOlderThan(_ context.Context, _ time.Time) (int64, error) {
+	panic("stubRawSvc.PurgeOlderThan should not be called")
+}
+
+type stubProducer struct{}
+
+func (stubProducer) Publish(_ context.Context, _ queue.Message) error {
+	panic("stubProducer.Publish should not be called")
+}
+func (stubProducer) PublishBatch(_ context.Context, _ []queue.Message) error {
+	panic("stubProducer.PublishBatch should not be called")
+}
+func (stubProducer) Close() error { return nil }
+
+func newRoutingHandler(t *testing.T, chains []general.Handler) *general.ChainHandler {
+	t.Helper()
+	log := logger.New(logger.DefaultConfig())
+	defaultChain := &fakeChain{id: "default"} // 본 테스트에서는 호출되지 않음
+	return general.NewChainHandler(
+		nil, // SourceCrawler — HandleChromedpOnly 경로에서 사용 X
+		defaultChain,
+		chains,
+		nil,
+		stubRawSvc{},
+		stubProducer{},
+		log,
+	)
+}
+
+func newJob() *core.CrawlJob {
+	return &core.CrawlJob{
+		ID:          "j1",
+		CrawlerName: "test-crawler",
+		Target:      core.Target{URL: "https://example.com/article"},
+	}
+}
+
+// TestHandleChromedpOnly_NoChains_ReturnsError 는 ChromedpChains 가 nil 이면 graceful error 검증.
+func TestHandleChromedpOnly_NoChains_ReturnsError(t *testing.T) {
+	h := newRoutingHandler(t, nil)
+	_, err := h.HandleChromedpOnly(context.Background(), newJob())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no chromedp chain wired")
+}
+
+// TestHandleChromedpOnly_RoutesByWorkerID 는 각 worker_id 가 자기 슬롯의 chain 을 호출하는지 검증.
+func TestHandleChromedpOnly_RoutesByWorkerID(t *testing.T) {
+	chains := []general.Handler{
+		&fakeChain{id: "0"},
+		&fakeChain{id: "1"},
+		&fakeChain{id: "2"},
+	}
+	h := newRoutingHandler(t, chains)
+
+	for id := 0; id < len(chains); id++ {
+		t.Run(fmt.Sprintf("worker_id=%d", id), func(t *testing.T) {
+			ctx := core.WithWorkerID(context.Background(), id)
+			_, err := h.HandleChromedpOnly(ctx, newJob())
+			require.Error(t, err)
+			want := fmt.Sprintf("fake-%d", id)
+			assert.True(t, strings.Contains(err.Error(), want),
+				"worker_id=%d 의 error %q 에 %q 포함되어야 함", id, err.Error(), want)
+		})
+	}
+}
+
+// TestHandleChromedpOnly_OutOfRangeWorkerID_FallbackToSlot0 는 worker_id 가 chains 범위를 벗어날 때
+// 0번 chain 으로 fallback 되는지 검증합니다 (방어).
+func TestHandleChromedpOnly_OutOfRangeWorkerID_FallbackToSlot0(t *testing.T) {
+	chains := []general.Handler{
+		&fakeChain{id: "0"},
+	}
+	h := newRoutingHandler(t, chains)
+
+	ctx := core.WithWorkerID(context.Background(), 99)
+	_, err := h.HandleChromedpOnly(ctx, newJob())
+	require.Error(t, err)
+	assert.True(t, strings.Contains(err.Error(), "fake-0"),
+		"out-of-range worker_id 는 slot 0 으로 fallback 되어야 함, got %q", err.Error())
+}
+
+// TestHandleChromedpOnly_NoWorkerID_FallbackToSlot0 는 ctx 에 worker_id 미설정 시 0번 chain fallback.
+func TestHandleChromedpOnly_NoWorkerID_FallbackToSlot0(t *testing.T) {
+	chains := []general.Handler{
+		&fakeChain{id: "0"},
+		&fakeChain{id: "1"},
+	}
+	h := newRoutingHandler(t, chains)
+
+	_, err := h.HandleChromedpOnly(context.Background(), newJob())
+	require.Error(t, err)
+	assert.True(t, strings.Contains(err.Error(), "fake-0"),
+		"worker_id 미설정 시 slot 0 fallback 되어야 함, got %q", err.Error())
+}

--- a/test/internal/processor/fetcher/worker/chromedp_handler_test.go
+++ b/test/internal/processor/fetcher/worker/chromedp_handler_test.go
@@ -125,7 +125,7 @@ func TestChromedpJobHandler_PerWorkerSemaphores_AcquireOnlyAssignedSlot(t *testi
 
 	// worker 1 ctx 로 Handle 호출 — Registry 미등록이라 lookup 단계에서 실패하지만,
 	// 그 전에 sem1 은 정상 Acquire 후 Release 되어야 함.
-	ctx := worker.WithWorkerID(context.Background(), 1)
+	ctx := core.WithWorkerID(context.Background(), 1)
 	job := &core.CrawlJob{ID: "j1", CrawlerName: "missing", Target: core.Target{URL: "https://example.com"}}
 	_, err = h.Handle(ctx, job)
 	assert.Error(t, err) // unregistered → error
@@ -152,7 +152,7 @@ func TestChromedpJobHandler_OutOfRangeWorkerID_FallbackToSlot0(t *testing.T) {
 	require.NoError(t, err)
 
 	// worker_id=99 → sems 길이 1 → fallback to slot 0
-	ctx := worker.WithWorkerID(context.Background(), 99)
+	ctx := core.WithWorkerID(context.Background(), 99)
 	job := &core.CrawlJob{ID: "j1", CrawlerName: "missing", Target: core.Target{URL: "https://example.com"}}
 	_, err = h.Handle(ctx, job)
 	assert.Error(t, err) // unregistered → error

--- a/test/pkg/config/config_test.go
+++ b/test/pkg/config/config_test.go
@@ -518,6 +518,7 @@ func unsetFetcherChromedpPoolEnvVars(t *testing.T) {
 		"FETCHER_CHROMEDP_POOL_ENABLED",
 		"FETCHER_CHROMEDP_WORKER_COUNT",
 		"FETCHER_CHROMEDP_SEMAPHORE_CAPACITY",
+		"FETCHER_CHROMEDP_REMOTE_URLS",
 	}
 	for _, v := range vars {
 		t.Setenv(v, "")
@@ -546,6 +547,71 @@ func TestLoadFetcherChromedpPool_DefaultValues(t *testing.T) {
 	}
 	if cfg.SemaphoreCapacity != def.SemaphoreCapacity {
 		t.Errorf("SemaphoreCapacity: got %d, want %d", cfg.SemaphoreCapacity, def.SemaphoreCapacity)
+	}
+
+	// 이슈 #230 — RemoteURLs default: ws://localhost:9222 × WorkerCount (단일 Chrome 호환).
+	if len(cfg.RemoteURLs) != cfg.WorkerCount {
+		t.Errorf("RemoteURLs length: got %d, want %d (= WorkerCount)", len(cfg.RemoteURLs), cfg.WorkerCount)
+	}
+	for i, url := range cfg.RemoteURLs {
+		if url != "ws://localhost:9222" {
+			t.Errorf("RemoteURLs[%d]: got %q, want ws://localhost:9222 (default)", i, url)
+		}
+	}
+}
+
+func TestLoadFetcherChromedpPool_RemoteURLsEnvOverride(t *testing.T) {
+	unsetFetcherChromedpPoolEnvVars(t)
+	t.Setenv("FETCHER_CHROMEDP_WORKER_COUNT", "3")
+	t.Setenv("FETCHER_CHROMEDP_REMOTE_URLS", "ws://chrome-1:9222, ws://chrome-2:9222 ,ws://chrome-3:9222")
+
+	cfg, err := config.LoadFetcherChromedpPool("/tmp/nonexistent-env-file.env")
+	if err != nil {
+		t.Fatalf("RemoteURLs override 실패: %v", err)
+	}
+
+	want := []string{"ws://chrome-1:9222", "ws://chrome-2:9222", "ws://chrome-3:9222"}
+	if len(cfg.RemoteURLs) != len(want) {
+		t.Fatalf("RemoteURLs length: got %d, want %d", len(cfg.RemoteURLs), len(want))
+	}
+	for i, w := range want {
+		if cfg.RemoteURLs[i] != w {
+			t.Errorf("RemoteURLs[%d]: got %q, want %q (TrimSpace 적용 검증)", i, cfg.RemoteURLs[i], w)
+		}
+	}
+}
+
+func TestLoadFetcherChromedpPool_RemoteURLsLengthMismatch_Fails(t *testing.T) {
+	// 이슈 #230 — RemoteURLs 길이가 WorkerCount 와 일치하지 않으면 fail-fast.
+	cases := []struct {
+		name        string
+		workerCount string
+		urls        string
+	}{
+		{"too few", "3", "ws://chrome-1:9222,ws://chrome-2:9222"},
+		{"too many", "1", "ws://chrome-1:9222,ws://chrome-2:9222"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			unsetFetcherChromedpPoolEnvVars(t)
+			t.Setenv("FETCHER_CHROMEDP_WORKER_COUNT", c.workerCount)
+			t.Setenv("FETCHER_CHROMEDP_REMOTE_URLS", c.urls)
+			_, err := config.LoadFetcherChromedpPool("/tmp/nonexistent-env-file.env")
+			if err == nil {
+				t.Fatalf("WorkerCount=%s, urls=%q 는 거부되어야 함", c.workerCount, c.urls)
+			}
+		})
+	}
+}
+
+func TestLoadFetcherChromedpPool_RemoteURLsEmptyEntry_Fails(t *testing.T) {
+	// 이슈 #230 — 콤마 구분 list 안 빈 항목 (예: "url1,,url2") 거부.
+	unsetFetcherChromedpPoolEnvVars(t)
+	t.Setenv("FETCHER_CHROMEDP_WORKER_COUNT", "2")
+	t.Setenv("FETCHER_CHROMEDP_REMOTE_URLS", "ws://chrome-1:9222, ,ws://chrome-2:9222")
+	_, err := config.LoadFetcherChromedpPool("/tmp/nonexistent-env-file.env")
+	if err == nil {
+		t.Fatal("빈 항목 포함 list 는 거부되어야 함")
 	}
 }
 

--- a/test/pkg/config/config_test.go
+++ b/test/pkg/config/config_test.go
@@ -519,6 +519,7 @@ func unsetFetcherChromedpPoolEnvVars(t *testing.T) {
 		"FETCHER_CHROMEDP_WORKER_COUNT",
 		"FETCHER_CHROMEDP_SEMAPHORE_CAPACITY",
 		"FETCHER_CHROMEDP_REMOTE_URLS",
+		"FETCHER_CHROMEDP_REMOTE_URL_PATTERN",
 	}
 	for _, v := range vars {
 		t.Setenv(v, "")
@@ -612,6 +613,58 @@ func TestLoadFetcherChromedpPool_RemoteURLsEmptyEntry_Fails(t *testing.T) {
 	_, err := config.LoadFetcherChromedpPool("/tmp/nonexistent-env-file.env")
 	if err == nil {
 		t.Fatal("빈 항목 포함 list 는 거부되어야 함")
+	}
+}
+
+func TestLoadFetcherChromedpPool_RemoteURLPattern_Expands(t *testing.T) {
+	// 이슈 #230 — PATTERN 의 {n} placeholder 가 1..WorkerCount 로 치환되는지 검증.
+	unsetFetcherChromedpPoolEnvVars(t)
+	t.Setenv("FETCHER_CHROMEDP_WORKER_COUNT", "3")
+	t.Setenv("FETCHER_CHROMEDP_REMOTE_URL_PATTERN", "ws://chrome-{n}:9222")
+
+	cfg, err := config.LoadFetcherChromedpPool("/tmp/nonexistent-env-file.env")
+	if err != nil {
+		t.Fatalf("PATTERN expand 실패: %v", err)
+	}
+
+	want := []string{"ws://chrome-1:9222", "ws://chrome-2:9222", "ws://chrome-3:9222"}
+	if len(cfg.RemoteURLs) != len(want) {
+		t.Fatalf("RemoteURLs length: got %d, want %d", len(cfg.RemoteURLs), len(want))
+	}
+	for i, w := range want {
+		if cfg.RemoteURLs[i] != w {
+			t.Errorf("RemoteURLs[%d]: got %q, want %q ({n} 치환 1-indexed 검증)", i, cfg.RemoteURLs[i], w)
+		}
+	}
+}
+
+func TestLoadFetcherChromedpPool_RemoteURLsOverridesPattern(t *testing.T) {
+	// 이슈 #230 — REMOTE_URLS 가 PATTERN 보다 우선 적용되는지 검증.
+	unsetFetcherChromedpPoolEnvVars(t)
+	t.Setenv("FETCHER_CHROMEDP_WORKER_COUNT", "2")
+	t.Setenv("FETCHER_CHROMEDP_REMOTE_URLS", "ws://explicit-1:9222,ws://explicit-2:9222")
+	t.Setenv("FETCHER_CHROMEDP_REMOTE_URL_PATTERN", "ws://chrome-{n}:9222")
+
+	cfg, err := config.LoadFetcherChromedpPool("/tmp/nonexistent-env-file.env")
+	if err != nil {
+		t.Fatalf("override 실패: %v", err)
+	}
+
+	if cfg.RemoteURLs[0] != "ws://explicit-1:9222" || cfg.RemoteURLs[1] != "ws://explicit-2:9222" {
+		t.Errorf("RemoteURLs: got %v, want explicit URLs (PATTERN 보다 우선)", cfg.RemoteURLs)
+	}
+}
+
+func TestLoadFetcherChromedpPool_RemoteURLPattern_MissingPlaceholder_Fails(t *testing.T) {
+	// 이슈 #230 — PATTERN 에 {n} 누락 시 모든 worker 가 같은 url 로 향함 → 1:1 매핑 무력화.
+	// fail-fast 로 운영자가 명시적 의사결정 강제.
+	unsetFetcherChromedpPoolEnvVars(t)
+	t.Setenv("FETCHER_CHROMEDP_WORKER_COUNT", "2")
+	t.Setenv("FETCHER_CHROMEDP_REMOTE_URL_PATTERN", "ws://chrome-static:9222")
+
+	_, err := config.LoadFetcherChromedpPool("/tmp/nonexistent-env-file.env")
+	if err == nil {
+		t.Fatal("{n} placeholder 누락 PATTERN 은 거부되어야 함")
 	}
 }
 


### PR DESCRIPTION
## 연관 이슈
- Closes #230
- Parent: #228 (chromedp worker:Chrome 1:1 매핑)
- Depends on: #229 (REFACTOR — per-worker Semaphore + worker_id context, 머지됨)

<br>

## 구현 내용

이슈 #228 (chromedp worker:Chrome 1:1 매핑) 의 **활성화** 단계 (sub-issue 2/2). #229 의 worker_id ctx + per-worker Semaphore 위에 RemoteURL 매핑 + 사이트 chromedp chain N개 + docker-compose Chrome N개를 한 PR 에 묶어 1:1 모델 활성화.

### worker_id 헬퍼를 core 로 이동 ([REFAC])
- `internal/processor/fetcher/core/worker_id.go` 신설 (`WithWorkerID` / `WorkerIDFromContext` / `NoWorkerID`)
- 사유: `general` 패키지의 ChainHandler 가 worker_id 로 chromedpChains 라우팅 활성화하려면 헬퍼 필요. `worker → general` import 가 이미 존재하므로 사이클 회피를 위해 core 로 이전.

### Config 확장 ([FEAT])
- `FetcherChromedpPoolConfig.RemoteURLs []string` 추가
- env `FETCHER_CHROMEDP_REMOTE_URLS` (콤마 구분, TrimSpace 적용)
- 길이가 `WorkerCount` 와 일치하지 않으면 fail-fast
- 미지정 시 default `ws://localhost:9222` × WorkerCount (단일 Chrome 호환)

### ChainHandler chromedp slice 라우팅 ([REFAC])
- `ChromedpChain Handler` 단일 → `ChromedpChains []Handler` (worker_id 인덱스)
- `selectChain` 반환을 `(Handler, bool isChromedp)` tuple 로 변경 — 포인터 비교 대신 명시적 분기
- `HandleChromedpOnly` 가 ctx 의 worker_id 로 `ChromedpChains[id]` 선택 (out-of-range 면 0번 fallback + WARN)

### 사이트별 chromedp chain N개 build ([FEAT])
- `kr.Register` / `us.Register` 시그니처에 `chromedpRemoteURLs []string` 추가
- 사이트별 `buildChromedpChainsForSite/CNN` 헬퍼 — RemoteURLs 길이만큼 ChromedpCrawler / Fetcher / Chain 생성, 각 인스턴스명에 worker_id 인덱스 (`naver-browser-0`, `-1`, ...)
- main.go: chromedp pool config 를 사이트 등록 전으로 이동, RemoteURLs 를 사이트 Register 에 전달
- yonhap 은 chromedp 미사용 → chains=nil 그대로

### 인프라 ([CHORE])
- `deployments/docker/docker-compose.yml`: chrome-1 / chrome-2 (`chromedp/headless-shell` 이미지) 추가
  - 호스트 포트 9222 / 9223 분리 (디버깅), 컨테이너 내부는 모두 9222 (호스트명 분리)
  - shm_size 1gb, healthcheck 포함
- `.env.example`: `FETCHER_CHROMEDP_*` 4종 + RemoteURLs 호스트/컨테이너 모드 예시

### 테스트 추가
- `pkg/config`: RemoteURLs default (ws://localhost:9222 × 2) / env override (TrimSpace) / 길이 불일치 (too few/too many) / 빈 항목 거부
- `internal/processor/fetcher/domain/general`: HandleChromedpOnly 의 worker_id 라우팅 (worker 0/1/2 가 자기 chain 호출) / out-of-range fallback / no-worker-id fallback / no-chains graceful error — fake chain 의 sentinel error 로 호출 chain 식별 (black-box)

<br>

## CI / 머지 게이트 점검

> [CI 운영 규약](docs/ci/conventions.md) 및 [Required Status Checks 단일 소스](docs/ci/status-checks.md)에 따라 작성합니다.

### 변경 영향 범위
- 영향 패키지/모듈: `pkg/config`, `internal/processor/fetcher/{core,worker,domain/general,domain/general/sources/{kr,us}}`, `cmd/issuetracker`, `deployments/docker`
- 위험도(택1): `Medium`
  - 코드 변경 자체는 단일 Chrome (`ws://localhost:9222` × WorkerCount) default 로 100% 하위 호환
  - 운영자가 인프라 (docker-compose chrome-N + RemoteURLs env) 명시적으로 활성화하면 1:1 모델 동작
  - sub-issue #229 의 per-worker Semaphore 와 결합되어 worker_id 기반 격리 활성화
  - **라이브 검증 필요**: worker_id ↔ remote_url 1:1 매핑 + ERR_INSUFFICIENT_RESOURCES 0건 / 30분 (이슈 #230 완료 조건)

### Required Status Checks
- 통과 확인 대상 (PR Checks 탭에서 확인):
  - [ ] `Commit Lint`
  - [ ] `PR Title Lint`
  - [ ] `Linked Issue Check`
  - [ ] `Format Check`
  - [ ] `Build`
  - [ ] `Test`
  - [ ] `Lint`

### 롤백 계획
- revert merge — 코드 변경은 ChainHandler / Register 시그니처 + Config 필드 추가가 핵심
- `ChromedpChain Handler` (단일) → `ChromedpChains []Handler` (slice) 시그니처 원복
- 사이트 Register 시그니처에서 `chromedpRemoteURLs` 인자 제거
- docker-compose 의 chrome-N 서비스 제거 (외부 Chrome 의존성으로 회귀)

<br>

## TODO (라이브 검증)
- [ ] staging 에서 Chrome 컨테이너 2개 기동 + RemoteURLs 명시 적용
- [ ] 라이브 로그에서 `crawler=naver-browser-0` ↔ `remote_url=ws://...:9222`, `naver-browser-1` ↔ `:9223` 1:1 확인
- [ ] chromedp consumer lag 분산 + `ERR_INSUFFICIENT_RESOURCES` 0건 / 30분 측정

<br>

## 논의 사항
- docker-compose 의 default chrome-N 수를 2 로 고정 — env 만 바꾸면 worker 수와 어긋날 수 있음. 운영 자동화 필요시 별도 sub-issue 로 docker-compose template 화 검토
- chromedp pool 비활성 시 사이트도 chromedp chain 미wiring → fail-fast 분기 (main.go 의 기존 분기) 와 일관 동작

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for multiple Chrome worker pools to improve content fetching capacity and resilience.

* **Chores**
  * Added Docker services for Chrome workers with configurable remote URLs.
  * Introduced new environment variables for Chrome pool configuration: `FETCHER_CHROMEDP_POOL_ENABLED`, `FETCHER_CHROMEDP_WORKER_COUNT`, `FETCHER_CHROMEDP_SEMAPHORE_CAPACITY`, and `FETCHER_CHROMEDP_REMOTE_URLS`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->