### PR TITLE
[FEAT#234] 신규 PR 자동 감지 및 피드백 루프

### DIFF
--- a/.claude/pr-feedback.md
+++ b/.claude/pr-feedback.md
@@ -1,0 +1,74 @@
+# 신규 PR 감지 및 자동 피드백
+
+모델: claude-sonnet-4-6
+
+## 목적
+3분마다 최신 열린 PR 3개를 폴링하여 신규 PR이 등장하면 자동으로 코드 리뷰 피드백을 남긴다.
+
+## 절차
+
+### 1. 신규 PR 감지
+
+```bash
+scripts/pr-feedback.sh
+```
+
+- 출력이 없으면 → **idle** 처리 후 종료
+- 숫자(PR 번호)가 출력되면 → 각 번호에 대해 2단계 진행
+
+### 2. 신규 PR 리뷰 (PR 번호별 반복)
+
+각 신규 PR에 대해 순서대로 수행한다.
+
+#### 2-1. PR 정보 수집
+
+```bash
+gh pr view <PR번호> --json number,title,body,additions,deletions,changedFiles,baseRefName,headRefName
+gh pr diff <PR번호>
+```
+
+#### 2-2. 리뷰 기준 (선별적으로 적용, 토큰 최소화)
+
+다음 항목만 검토하고 해당 없으면 언급하지 않는다:
+
+1. **버그 / 로직 오류** — 명백한 결함, nil 역참조, 경쟁 조건
+2. **보안** — 자격증명 노출, SQL/Command 인젝션 가능성
+3. **아키텍처 일관성** — 기존 레이어 규약(`internal/`, `pkg/`) 위반
+4. **성능** — 루프 내 불필요한 할당, N+1 쿼리
+
+단순 스타일 · 포맷 · 오타는 제외한다.
+
+#### 2-3. 리뷰 코멘트 작성
+
+- 지적 사항이 있으면 `gh pr review <PR번호> --comment --body "..."` 로 코멘트
+- 지적 사항이 없으면 `gh pr review <PR번호> --approve --body "코드 리뷰 완료. 특이 사항 없음."` 으로 승인
+- 코멘트는 항목당 2~3문장 이내로 간결하게 작성
+
+### 3. idle 카운터 관리 및 자동 종료
+
+상태 파일: `/tmp/issuetracker-pr-feedback-loop.json`
+
+스키마:
+```json
+{
+  "idle_streak": 0,
+  "last_run_at": "2026-05-03T00:00:00Z"
+}
+```
+
+**회차 분류:**
+- **active**: 신규 PR 감지 및 리뷰 수행 → `idle_streak = 0`
+- **idle**: 신규 PR 없음 → `idle_streak += 1`
+
+**자동 종료 임계값: `idle_streak >= 20` (약 1시간)**
+
+조건 충족 시:
+1. `CronList` 로 활성 cron 조회
+2. prompt 에 `pr-feedback.md` 가 포함된 cron 식별
+3. 매칭된 cron ID 로 `CronDelete` 호출
+4. 상태 파일 삭제: `rm -f /tmp/issuetracker-pr-feedback-loop.json /tmp/issuetracker-pr-watch-state.json`
+5. 사용자에게 알림: `"신규 PR 없음 20회 연속 (약 1시간) — pr-feedback loop 자동 종료 (cron <id>)"`
+
+### 4. 상태 파일 갱신
+
+매 회차 마지막에 `/tmp/issuetracker-pr-feedback-loop.json` 을 현재 `idle_streak` 와 `last_run_at` 으로 갱신한다.

--- a/.claude/pr-feedback.md
+++ b/.claude/pr-feedback.md
@@ -41,7 +41,7 @@ gh pr diff <PR번호>
 #### 2-3. 리뷰 코멘트 작성
 
 - 지적 사항이 있으면 `gh pr review <PR번호> --comment --body "..."` 로 코멘트
-- 지적 사항이 없으면 `gh pr review <PR번호> --approve --body "코드 리뷰 완료. 특이 사항 없음."` 으로 승인
+- 지적 사항이 없으면 `gh pr review <PR번호> --comment --body "코드 리뷰 완료. 자동 검토 결과 특이 사항 없음. 최종 승인은 담당자가 확인 후 진행."` 으로 코멘트 (자동 approve 금지 — 브랜치 보호 정책 우회 및 prompt injection 위험)
 - 코멘트는 항목당 2~3문장 이내로 간결하게 작성
 
 ### 3. idle 카운터 관리 및 자동 종료

--- a/.claude/pr-feedback.md
+++ b/.claude/pr-feedback.md
@@ -3,7 +3,7 @@
 모델: claude-sonnet-4-6
 
 ## 목적
-3분마다 최신 열린 PR 3개를 폴링하여 신규 PR이 등장하면 자동으로 코드 리뷰 피드백을 남긴다.
+3분마다 최신 열린 PR 20개를 폴링하여 신규 PR이 등장하면 자동으로 코드 리뷰 피드백을 남긴다.
 
 ## 절차
 
@@ -66,7 +66,7 @@ gh pr diff <PR번호>
 1. `CronList` 로 활성 cron 조회
 2. prompt 에 `pr-feedback.md` 가 포함된 cron 식별
 3. 매칭된 cron ID 로 `CronDelete` 호출
-4. 상태 파일 삭제: `rm -f /tmp/issuetracker-pr-feedback-loop.json /tmp/issuetracker-pr-watch-state.json`
+4. 루프 상태 파일만 삭제: `rm -f /tmp/issuetracker-pr-feedback-loop.json` (pr-watch-state.json 은 유지 — 재시작 시 기존 리뷰 PR 재감지 방지)
 5. 사용자에게 알림: `"신규 PR 없음 20회 연속 (약 1시간) — pr-feedback loop 자동 종료 (cron <id>)"`
 
 ### 4. 상태 파일 갱신

--- a/scripts/pr-feedback.sh
+++ b/scripts/pr-feedback.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+#
+# pr-watch.sh
+#
+# 최신 열린 PR 3개를 조회하고, 상태 파일과 비교해 신규 PR 번호를 stdout 에 출력.
+# .claude/pr-watch.md 의 cron loop 에서 사용.
+#
+# Usage:
+#   scripts/pr-watch.sh
+#
+# 출력:
+#   신규 PR 번호를 한 줄에 하나씩 출력 (없으면 출력 없음)
+#
+# 상태 파일:
+#   /tmp/issuetracker-pr-watch-state.json
+#   {"known_prs": [232, 231, 230], "last_run_at": "2026-05-03T..."}
+
+set -euo pipefail
+
+STATE_FILE="/tmp/issuetracker-pr-watch-state.json"
+
+# 최신 열린 PR 3개 조회
+latest=$(gh pr list --state open --limit 3 --json number --jq '[.[].number]')
+
+if [[ -z "$latest" || "$latest" == "[]" ]]; then
+  exit 0
+fi
+
+# 상태 파일에서 기존 known_prs 로드
+if [[ -f "$STATE_FILE" ]]; then
+  known=$(jq '.known_prs // []' "$STATE_FILE")
+else
+  known="[]"
+fi
+
+# 신규 PR = latest 에 있고 known 에 없는 것
+new_prs=$(jq -n --argjson latest "$latest" --argjson known "$known" \
+  '$latest - $known | .[]')
+
+# 상태 파일 갱신 (known_prs = latest 3개로 교체)
+now=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+tmp=$(mktemp)
+jq -n --argjson known_prs "$latest" --arg last_run_at "$now" \
+  '{known_prs: $known_prs, last_run_at: $last_run_at}' > "$tmp"
+mv "$tmp" "$STATE_FILE"
+
+# 신규 PR 번호 출력
+echo "$new_prs"

--- a/scripts/pr-feedback.sh
+++ b/scripts/pr-feedback.sh
@@ -1,12 +1,12 @@
 #!/usr/bin/env bash
 #
-# pr-watch.sh
+# pr-feedback.sh
 #
-# 최신 열린 PR 3개를 조회하고, 상태 파일과 비교해 신규 PR 번호를 stdout 에 출력.
-# .claude/pr-watch.md 의 cron loop 에서 사용.
+# 최신 열린 PR 20개를 조회하고, 상태 파일과 비교해 신규 PR 번호를 stdout 에 출력.
+# .claude/pr-feedback.md 의 cron loop 에서 사용.
 #
 # Usage:
-#   scripts/pr-watch.sh
+#   scripts/pr-feedback.sh
 #
 # 출력:
 #   신규 PR 번호를 한 줄에 하나씩 출력 (없으면 출력 없음)
@@ -19,8 +19,8 @@ set -euo pipefail
 
 STATE_FILE="/tmp/issuetracker-pr-watch-state.json"
 
-# 최신 열린 PR 3개 조회
-latest=$(gh pr list --state open --limit 3 --json number --jq '[.[].number]')
+# 최신 열린 PR 20개 조회 (짧은 시간 다수 PR 누락 방지)
+latest=$(gh pr list --state open --limit 20 --json number --jq '[.[].number]')
 
 if [[ -z "$latest" || "$latest" == "[]" ]]; then
   exit 0
@@ -37,12 +37,12 @@ fi
 new_prs=$(jq -n --argjson latest "$latest" --argjson known "$known" \
   '$latest - $known | .[]')
 
-# 상태 파일 갱신 (known_prs = latest 3개로 교체)
+# 상태 파일 갱신 (known_prs = latest 20개로 교체)
 now=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
 tmp=$(mktemp)
 jq -n --argjson known_prs "$latest" --arg last_run_at "$now" \
   '{known_prs: $known_prs, last_run_at: $last_run_at}' > "$tmp"
 mv "$tmp" "$STATE_FILE"
 
-# 신규 PR 번호 출력
-echo "$new_prs"
+# 신규 PR 번호 출력 (없으면 출력 생략)
+[[ -n "$new_prs" ]] && echo "$new_prs"


### PR DESCRIPTION
## 연관 이슈

Closes #234

## 구현 내용

- `scripts/pr-feedback.sh`: 최신 열린 PR 3개를 `gh pr list`로 조회 → `/tmp/issuetracker-pr-watch-state.json` 상태 파일과 비교 → 신규 PR 번호만 stdout 출력
- `.claude/pr-feedback.md`: 3분 주기 cron 루프 절차
  - 신규 PR 감지 → `gh pr diff` + `gh pr view`로 정보 수집 → 버그·보안·아키텍처·성능 4가지 기준으로 선별 리뷰
  - 지적 사항 있으면 comment, 없으면 approve
  - idle 20회 연속(약 1시간) 시 `CronDelete`로 자동 종료

## CI / 머지 게이트 점검

- [ ] `make build` 통과 (Go 소스 변경 없음, 스크립트·md만 추가)
- [ ] `make lint` 통과
- [ ] `make test` 통과

## 변경 영향 범위 및 위험도

- **범위**: `.claude/`, `scripts/` 디렉토리만 추가 — 기존 Go 코드 무영향
- **위험도**: 낮음. 스크립트는 읽기 전용(`gh pr list`, `gh pr diff`) + 상태 파일 쓰기만 수행

## 롤백 계획

파일 2개 삭제(`scripts/pr-feedback.sh`, `.claude/pr-feedback.md`)로 즉시 롤백 가능.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Automated pull request evaluation system that continuously assesses new submissions for critical issues including security vulnerabilities, architecture inconsistencies, performance concerns, and functional bugs.
  * Provides selective feedback focused on high-impact areas.
  * Features intelligent idle detection with automatic system shutdown after extended inactivity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->