### PR TITLE
[DOCS#243] 이슈/PR 라벨·Type 부여 시 scripts/gh-meta.sh 사용 명시

### DIFF
--- a/.claude/rules/07-workflow.md
+++ b/.claude/rules/07-workflow.md
@@ -248,7 +248,9 @@ GitHub Issue Type 은 라벨과 별개의 native 분류 — `gh api graphql` 의
 
 #### 부여 명령 예시
 
-> **`scripts/gh-meta.sh` 를 사용한다** — 이슈/PR 생성 직후 Label + Type 을 한 번에 부여하는 전용 스크립트. 수동 `gh api graphql` 호출 대신 항상 이 스크립트를 사용한다.
+> **`scripts/gh-meta.sh` 를 사용한다** — title prefix 기반으로 Label · Issue Type 을 자동 부여하는 전용 스크립트. 수동 `gh api graphql` 호출 대신 항상 이 스크립트를 사용한다.
+> - **이슈**: Label + Issue Type 동시 부여 (`scripts/gh-meta.sh issue <N>`)
+> - **PR**: Label 만 부여 (`scripts/gh-meta.sh pr <N>`) — PR 에는 Issue Type 없음
 
 **이슈 생성 시 Label + Type 부여 (생성 직후)**:
 ```bash

--- a/.claude/rules/07-workflow.md
+++ b/.claude/rules/07-workflow.md
@@ -248,33 +248,27 @@ GitHub Issue Type 은 라벨과 별개의 native 분류 — `gh api graphql` 의
 
 #### 부여 명령 예시
 
-**이슈 생성 시 Label** (title 은 issue prefix 사용 — full-word, 콜론 없음):
+> **`scripts/gh-meta.sh` 를 사용한다** — 이슈/PR 생성 직후 Label + Type 을 한 번에 부여하는 전용 스크립트. 수동 `gh api graphql` 호출 대신 항상 이 스크립트를 사용한다.
+
+**이슈 생성 시 Label + Type 부여 (생성 직후)**:
 ```bash
+# 이슈 생성 (--label 은 생략 가능 — gh-meta.sh 가 title prefix 로 자동 판단)
 gh issue create --repo EinSofINTEREST/IssueTracker \
   --title "[DOCS] 제목" \
-  --label documentation \
   --body "..."
+
+# Label + Issue Type 일괄 부여 (이슈 번호 지정)
+scripts/gh-meta.sh issue <ISSUE_NUMBER>
 ```
 
 다른 issue prefix 예: `[FEATURE] 새 크롤러`, `[REFACTOR] 모듈 분리`, `[HOTFIX] 배포 직후 데드락`.
 
-**이슈 Type 부여 (생성 직후)**:
+**PR 생성 후 Label 부여**:
 ```bash
-ISSUE_ID=$(gh issue view <ISSUE_NUMBER> --json id --jq .id)
+gh pr create --title "[DOCS#N] 제목" --body "..."
 
-gh api graphql -f query='
-mutation($issueId: ID!, $issueTypeId: ID!) {
-  updateIssueIssueType(input: {issueId: $issueId, issueTypeId: $issueTypeId}) {
-    issue { number issueType { name } }
-  }
-}' -f issueId="$ISSUE_ID" -f issueTypeId="IT_kwDODsDQh84By0jZ"
-```
-
-**PR 생성 시 Label**:
-```bash
-gh pr create --label documentation --title "[DOCS#N] 제목" --body "..."
-# 또는 생성 후
-gh pr edit <PR_NUMBER> --add-label documentation
+# PR Label 부여 (닫는 이슈의 Label 과 자동 동기화)
+scripts/gh-meta.sh pr <PR_NUMBER>
 ```
 
 #### Why
@@ -285,9 +279,10 @@ gh pr edit <PR_NUMBER> --add-label documentation
 
 #### How to apply
 
-- 이슈 생성 후 즉시 Label + Type 둘 다 부여 (생성 직후 같은 회차에서 처리, 까먹지 않도록)
-- PR 생성 시 `--label` 플래그로 같이 지정 (생성 후 add-label 도 OK)
+- **이슈 생성 직후** `scripts/gh-meta.sh issue <N>` 호출 — Label + Type 동시 부여, 까먹지 않도록 생성 직후 같은 회차에서 처리
+- **PR 생성 직후** `scripts/gh-meta.sh pr <N>` 호출 — 닫는 이슈의 Label 과 자동 동기화
 - 매핑이 모호하면 (예: refactor 인데 bug 도 같이 잡는 PR) 가장 큰 변경 의도 prefix 기준으로 분류 + 보조 label 추가 가능
+- `gh api graphql` 직접 호출은 사용하지 않는다 — `gh-meta.sh` 로 표준화
 
 <br>
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,7 +70,7 @@ docs/ci/        → CI 운영 규약, status check 단일 소스
 3. **Commit-per-TODO** — 별 언급 없으면 논리적 변경 단위마다 commit (메시지 컨벤션 준수).
 4. **PR 자동 생성** — 작업 완료 직후 컨벤션 + 템플릿 준수해서 `Closes #<sub-issue>` 포함 PR 자동 생성. 마지막 sub-issue PR 에서 메인 이슈도 close.
 5. **권한 사용 최소화** — 새 permission / 외부 도구 / 의존성은 작업 완수에 불가피한 경우에만.
-6. **Label · Issue Type 부여 필수** (이슈 #210, #212) — 이슈는 **issue prefix** 기준 Label + Type (`[FEATURE]→enhancement/Feature`, `[REFACTOR]→refactor/Task`, `[CHORE]→chore/Task`, `[DOCS]→documentation/Task`, `[FIX]→bug/Bug`, `[HOTFIX]→bug+hotfix/Bug`). PR Label 은 그 PR 이 닫는 이슈의 Label 과 동일. 표기 체계 3분리 (commit `[FEAT]:` / PR `[FEAT#N]` / issue `[FEATURE]`) 는 [규약 6](.claude/rules/07-workflow.md) 참조.
+6. **Label · Issue Type 부여 필수** (이슈 #210, #212) — 이슈는 **issue prefix** 기준 Label + Type (`[FEATURE]→enhancement/Feature`, `[REFACTOR]→refactor/Task`, `[CHORE]→chore/Task`, `[DOCS]→documentation/Task`, `[FIX]→bug/Bug`, `[HOTFIX]→bug+hotfix/Bug`). PR Label 은 그 PR 이 닫는 이슈의 Label 과 동일. **부여 수단: `scripts/gh-meta.sh issue <N>` / `scripts/gh-meta.sh pr <N>` — 수동 `gh api graphql` 대신 항상 이 스크립트 사용** (이슈 #243). 표기 체계 3분리 (commit `[FEAT]:` / PR `[FEAT#N]` / issue `[FEATURE]`) 는 [규약 6](.claude/rules/07-workflow.md) 참조.
 
 ## PR 생성 후 자동 동작 (이슈 #129)
 

--- a/scripts/gh-meta.sh
+++ b/scripts/gh-meta.sh
@@ -32,8 +32,9 @@ usage() {
 resolve_label_and_type() {
   local title="$1"
   local prefix
-  # [FEATURE], [FEAT#123] 등에서 대괄호 안의 알파벳 부분만 추출 (POSIX 호환 sed — grep -P 제거)
-  prefix=$(echo "$title" | sed -En 's/^\[([A-Z]+)[#\]].*/\1/p' || true)
+  # [FEATURE], [FEAT#123], [DOCS] 등에서 대괄호 안의 알파벳 부분만 추출
+  # `[#\]]` 패턴은 POSIX sed 에서 ] 매칭 버그 있음 → 단순화: `[A-Z]+` 뒤 전체 소비 (#243)
+  prefix=$(echo "$title" | sed -En 's/^\[([A-Z]+).*/\1/p' || true)
 
   case "$prefix" in
     FEATURE|FEAT)    echo "enhancement $FEATURE_TYPE_ID" ;;

--- a/scripts/gh-meta.sh
+++ b/scripts/gh-meta.sh
@@ -33,8 +33,8 @@ resolve_label_and_type() {
   local title="$1"
   local prefix
   # [FEATURE], [FEAT#123], [DOCS] 등에서 대괄호 안의 알파벳 부분만 추출
-  # `[#\]]` 패턴은 POSIX sed 에서 ] 매칭 버그 있음 → 단순화: `[A-Z]+` 뒤 전체 소비 (#243)
-  prefix=$(echo "$title" | sed -En 's/^\[([A-Z]+).*/\1/p' || true)
+  # POSIX 호환: []#] 는 ] 를 문자 클래스 첫 자리에 놓아 리터럴로 인식 — ] 또는 # 필수 (PR #244 Copilot)
+  prefix=$(echo "$title" | sed -En 's/^\[([A-Z]+)[]#].*/\1/p' || true)
 
   case "$prefix" in
     FEATURE|FEAT)    echo "enhancement $FEATURE_TYPE_ID" ;;


### PR DESCRIPTION
## 연관 이슈

Closes #243

## 구현 내용

### 1. `scripts/gh-meta.sh` — sed 패턴 버그 수정

`[DOCS] 제목` 형식(대괄호 뒤 공백)에서 prefix 추출이 실패하던 버그 수정.
`[#\]]` 문자 클래스의 POSIX sed 호환 문제 → `^\[([A-Z]+).*` 단순 패턴으로 교체.

### 2. `.claude/rules/07-workflow.md` — 규약 6 부여 명령 교체

기존: 수동 `gh api graphql` 호출 예시
변경:
- `scripts/gh-meta.sh issue <N>` — 이슈 Label + Type 일괄 부여
- `scripts/gh-meta.sh pr <N>` — PR Label (닫는 이슈와 자동 동기화)
- How to apply 항목에 "gh api graphql 직접 호출 금지" 명시

### 3. `CLAUDE.md` — 규약 6 요약 라인 업데이트

**부여 수단: `scripts/gh-meta.sh issue <N>` / `scripts/gh-meta.sh pr <N>`** 명시 추가.

## CI / 머지 게이트

- 빌드/테스트 영향 없음 (스크립트 버그 수정 + 문서 변경)

## 변경 영향 범위

- `gh-meta.sh`: 동작 동일, 버그만 수정 (기존 정상 케이스 불변)
- `07-workflow.md`, `CLAUDE.md`: AI 지침 문서 업데이트

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated workflow procedures with standardized command examples and clearer guidelines.

* **Refactor**
  * Improved internal script pattern extraction for enhanced flexibility and compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->