### PR TITLE
[REFAC#246] DB 기반 RegisterAll 구현 + main.go kr/us.Register 교체

### DIFF
--- a/cmd/issuetracker/main.go
+++ b/cmd/issuetracker/main.go
@@ -171,6 +171,15 @@ func main() {
 		chromedpRemoteURLs = nil
 	}
 
+	// chromedp pool 이 활성화된 경우 remoteURLs 수 == WorkerCount 를 사전 검증합니다 (CodeRabbit Major 반영).
+	// RegisterAll 이 URL 당 1 개 chain 을 생성하므로, 불일치 시 worker:chain 매핑이 어긋납니다 (이슈 #230).
+	if chromedpPoolCfg.Enabled && len(chromedpRemoteURLs) != chromedpPoolCfg.WorkerCount {
+		log.WithFields(map[string]interface{}{
+			"worker_count":     chromedpPoolCfg.WorkerCount,
+			"remote_url_count": len(chromedpRemoteURLs),
+		}).Fatal("chromedp pool config mismatch: remote_urls count must equal worker_count")
+	}
+
 	// fetcher 측 등록 (이슈 #246): fetcher_rules DB 에서 모든 source 를 읽어 일괄 등록.
 	if err := sources.RegisterAll(ctx, registry, fetcherRuleRepo, core.DefaultConfig(), rawSvc, crawlerProducer, fetcherResolver, chromedpRemoteURLs, log); err != nil {
 		log.WithError(err).Fatal("failed to register crawlers from db")

--- a/cmd/issuetracker/main.go
+++ b/cmd/issuetracker/main.go
@@ -15,8 +15,7 @@ import (
 	"issuetracker/internal/processor"
 	"issuetracker/internal/processor/fetcher"
 	"issuetracker/internal/processor/fetcher/core"
-	"issuetracker/internal/processor/fetcher/domain/general/sources/kr"
-	"issuetracker/internal/processor/fetcher/domain/general/sources/us"
+	"issuetracker/internal/processor/fetcher/domain/general/sources"
 	"issuetracker/internal/processor/fetcher/handler"
 	fetcherRule "issuetracker/internal/processor/fetcher/rule"
 	crawlerWorker "issuetracker/internal/processor/fetcher/worker"
@@ -172,12 +171,9 @@ func main() {
 		chromedpRemoteURLs = nil
 	}
 
-	// fetcher 측 등록 (이슈 #134 분리 후): chain handler 가 raw_contents 저장 + RawContentRef 발행만 수행.
-	if err := kr.Register(registry, core.DefaultConfig(), rawSvc, crawlerProducer, fetcherResolver, chromedpRemoteURLs, log); err != nil {
-		log.WithError(err).Fatal("failed to register kr crawlers")
-	}
-	if err := us.Register(registry, core.DefaultConfig(), rawSvc, crawlerProducer, fetcherResolver, chromedpRemoteURLs, log); err != nil {
-		log.WithError(err).Fatal("failed to register us crawlers")
+	// fetcher 측 등록 (이슈 #246): fetcher_rules DB 에서 모든 source 를 읽어 일괄 등록.
+	if err := sources.RegisterAll(ctx, registry, fetcherRuleRepo, core.DefaultConfig(), rawSvc, crawlerProducer, fetcherResolver, chromedpRemoteURLs, log); err != nil {
+		log.WithError(err).Fatal("failed to register crawlers from db")
 	}
 
 	// Redis 기반 ProcessingLock: 동일 URL 이 여러 worker/인스턴스에서 단계별 (fetcher/parser/validator)

--- a/internal/processor/fetcher/domain/general/sources/registry.go
+++ b/internal/processor/fetcher/domain/general/sources/registry.go
@@ -1,0 +1,153 @@
+// Package sources 는 fetcher_rules DB 에서 모든 사이트 크롤러를 읽어 Registry 에 등록합니다 (이슈 #246).
+//
+// 기존 사이트별 kr.Register / us.Register 를 RegisterAll 하나로 통합.
+// SourceInfo·RequestsPerHour 는 fetcher_rules 테이블 (migration 014) 에서 조회.
+package sources
+
+import (
+	"context"
+	"fmt"
+
+	"issuetracker/internal/processor/fetcher/core"
+	"issuetracker/internal/processor/fetcher/domain/general"
+	"issuetracker/internal/processor/fetcher/domain/general/fetcher"
+	"issuetracker/internal/processor/fetcher/handler"
+	cdp "issuetracker/internal/processor/fetcher/implementation/chromedp"
+	"issuetracker/internal/processor/fetcher/implementation/goquery"
+	"issuetracker/internal/processor/fetcher/rule"
+	"issuetracker/internal/storage"
+	"issuetracker/internal/storage/service"
+	"issuetracker/pkg/logger"
+	"issuetracker/pkg/queue"
+)
+
+// defaultLazyKeywords 는 대부분 뉴스 사이트가 사용하는 lazy-load 감지 attr 목록입니다.
+// BuildChain 에 전달되어 goquery-only chain 이 lazy page 를 감지하면 sentinel 을 반환,
+// ChainHandler 가 chromedp pool 로 republish 하도록 합니다 (이슈 #218).
+var defaultLazyKeywords = []string{"data-lazy-src", "lazyload", "data-lazy"}
+
+// RegisterAll 은 fetcher_rules 테이블에서 SourceInfo 가 채워진 모든 source 를 읽어
+// Registry 에 등록합니다 (이슈 #246).
+//
+// 각 source_name 별로 goquery + (optional) chromedp ChainHandler 를 생성.
+// chromedpRemoteURLs 가 empty 이면 chromedp chain 없이 goquery-only 로 등록.
+// source_name 이 비어있는 row (SourceInfo 미입력) 는 건너뜁니다.
+func RegisterAll(
+	ctx context.Context,
+	registry *handler.Registry,
+	fetcherRuleRepo storage.FetcherRuleRepository,
+	baseConfig core.Config,
+	rawSvc service.RawContentService,
+	producer queue.Producer,
+	resolver rule.Resolver,
+	chromedpRemoteURLs []string,
+	log *logger.Logger,
+) error {
+	rules, err := fetcherRuleRepo.List(ctx)
+	if err != nil {
+		return fmt.Errorf("RegisterAll: list fetcher rules: %w", err)
+	}
+
+	// source_name 기준으로 대표 row 수집 (첫 번째 row 의 SourceInfo/RequestsPerHour 사용).
+	type sourceEntry struct {
+		rec *storage.FetcherRuleRecord
+	}
+	bySource := make(map[string]sourceEntry)
+	for _, r := range rules {
+		if r.SourceName == "" {
+			continue
+		}
+		if _, seen := bySource[r.SourceName]; !seen {
+			bySource[r.SourceName] = sourceEntry{rec: r}
+		}
+	}
+
+	for sourceName, entry := range bySource {
+		if err := registerSource(
+			ctx, registry, sourceName, entry.rec,
+			baseConfig, rawSvc, producer, resolver, chromedpRemoteURLs, log,
+		); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func registerSource(
+	_ context.Context,
+	registry *handler.Registry,
+	sourceName string,
+	rec *storage.FetcherRuleRecord,
+	baseConfig core.Config,
+	rawSvc service.RawContentService,
+	producer queue.Producer,
+	resolver rule.Resolver,
+	chromedpRemoteURLs []string,
+	log *logger.Logger,
+) error {
+	sourceInfo := core.SourceInfo{
+		Country:  rec.Country,
+		Type:     core.SourceType(rec.SourceType),
+		Name:     rec.SourceName,
+		BaseURL:  rec.BaseURL,
+		Language: rec.Language,
+	}
+
+	cfg := baseConfig
+	cfg.SourceInfo = sourceInfo
+	if rec.RequestsPerHour > 0 {
+		cfg.RequestsPerHour = rec.RequestsPerHour
+	}
+
+	gqCrawler := goquery.NewGoqueryCrawler(sourceName+"-goquery", sourceInfo, cfg)
+	gqFetcher := fetcher.NewGoqueryFetcher(gqCrawler)
+
+	crawler := general.NewGenericCrawler(sourceName, sourceInfo, gqFetcher, rec.BaseURL, cfg)
+
+	defaultChain, err := general.BuildChain(gqFetcher, nil, log, defaultLazyKeywords...)
+	if err != nil {
+		return fmt.Errorf("RegisterAll: %s default chain wiring: %w", sourceName, err)
+	}
+
+	chromedpChains, err := buildChromedpChains(sourceName, sourceInfo, cfg, chromedpRemoteURLs, log)
+	if err != nil {
+		return err
+	}
+
+	registry.Register(sourceName, general.NewChainHandler(crawler, defaultChain, chromedpChains, resolver, rawSvc, producer, log))
+	log.WithFields(map[string]interface{}{
+		"crawler":           sourceName,
+		"chromedp_workers":  len(chromedpChains),
+		"requests_per_hour": cfg.RequestsPerHour,
+	}).Info("crawler registered from db")
+	return nil
+}
+
+// buildChromedpChains 는 source 의 chromedp chain 을 worker_id 별 N 개 build 합니다.
+// remoteURLs 가 empty 이면 nil 반환 (chromedp 미사용).
+func buildChromedpChains(
+	sourceName string,
+	sourceInfo core.SourceInfo,
+	cfg core.Config,
+	remoteURLs []string,
+	log *logger.Logger,
+) ([]general.Handler, error) {
+	if len(remoteURLs) == 0 {
+		return nil, nil
+	}
+	chains := make([]general.Handler, len(remoteURLs))
+	for i, url := range remoteURLs {
+		opts := cdp.DefaultRemoteOptions()
+		opts.RemoteURL = url
+		cdpCrawler := cdp.NewChromedpCrawlerWithOptions(
+			fmt.Sprintf("%s-browser-%d", sourceName, i), sourceInfo, cfg, opts,
+		)
+		brFetcher := fetcher.NewBrowserFetcher(cdpCrawler, cfg)
+		chain, err := general.BuildChain(nil, brFetcher, log)
+		if err != nil {
+			return nil, fmt.Errorf("%s chromedp chain wiring (worker_id=%d): %w", sourceName, i, err)
+		}
+		chains[i] = chain
+	}
+	return chains, nil
+}

--- a/internal/processor/fetcher/domain/general/sources/registry.go
+++ b/internal/processor/fetcher/domain/general/sources/registry.go
@@ -7,6 +7,7 @@ package sources
 import (
 	"context"
 	"fmt"
+	"net/url"
 
 	"issuetracker/internal/processor/fetcher/core"
 	"issuetracker/internal/processor/fetcher/domain/general"
@@ -48,17 +49,22 @@ func RegisterAll(
 		return fmt.Errorf("RegisterAll: list fetcher rules: %w", err)
 	}
 
-	// source_name 기준으로 대표 row 수집 (첫 번째 row 의 SourceInfo/RequestsPerHour 사용).
+	// source_name 기준으로 대표 row 수집.
+	// base_url 의 hostname 과 host_pattern 이 일치하는 row 를 canonical 로 우선 선택.
+	// 일치하는 row 가 없으면 첫 번째 row 를 fallback 으로 사용.
 	type sourceEntry struct {
-		rec *storage.FetcherRuleRecord
+		rec      *storage.FetcherRuleRecord
+		hasExact bool // base_url hostname == host_pattern
 	}
 	bySource := make(map[string]sourceEntry)
 	for _, r := range rules {
 		if r.SourceName == "" {
 			continue
 		}
-		if _, seen := bySource[r.SourceName]; !seen {
-			bySource[r.SourceName] = sourceEntry{rec: r}
+		exact := isCanonicalHost(r)
+		existing, seen := bySource[r.SourceName]
+		if !seen || (!existing.hasExact && exact) {
+			bySource[r.SourceName] = sourceEntry{rec: r, hasExact: exact}
 		}
 	}
 
@@ -121,6 +127,19 @@ func registerSource(
 		"requests_per_hour": cfg.RequestsPerHour,
 	}).Info("crawler registered from db")
 	return nil
+}
+
+// isCanonicalHost 는 r.BaseURL 의 hostname 이 r.HostPattern 과 일치하면 true 를 반환합니다.
+// 동일 source_name 의 여러 row 중 canonical(대표) host 를 결정적으로 선택하는 데 사용합니다.
+func isCanonicalHost(r *storage.FetcherRuleRecord) bool {
+	if r.BaseURL == "" {
+		return false
+	}
+	u, err := url.Parse(r.BaseURL)
+	if err != nil {
+		return false
+	}
+	return u.Hostname() == r.HostPattern
 }
 
 // buildChromedpChains 는 source 의 chromedp chain 을 worker_id 별 N 개 build 합니다.

--- a/internal/processor/fetcher/domain/general/sources/registry.go
+++ b/internal/processor/fetcher/domain/general/sources/registry.go
@@ -23,16 +23,19 @@ import (
 )
 
 // defaultLazyKeywords 는 대부분 뉴스 사이트가 사용하는 lazy-load 감지 attr 목록입니다.
-// BuildChain 에 전달되어 goquery-only chain 이 lazy page 를 감지하면 sentinel 을 반환,
-// ChainHandler 가 chromedp pool 로 republish 하도록 합니다 (이슈 #218).
+// chromedp 가 활성화된 경우에만 BuildChain 에 전달합니다 — pool 이 꺼진 환경에서
+// lazy sentinel 이 발생하면 TopicCrawlChromedp 로 republish 되지만 consumer 가 없어
+// 메시지가 유실됩니다 (이슈 #218, Copilot 피드백 반영).
 var defaultLazyKeywords = []string{"data-lazy-src", "lazyload", "data-lazy"}
 
-// RegisterAll 은 fetcher_rules 테이블에서 SourceInfo 가 채워진 모든 source 를 읽어
+// RegisterAll 은 fetcher_rules 테이블에서 source_name 이 채워진 모든 source 를 읽어
 // Registry 에 등록합니다 (이슈 #246).
 //
 // 각 source_name 별로 goquery + (optional) chromedp ChainHandler 를 생성.
 // chromedpRemoteURLs 가 empty 이면 chromedp chain 없이 goquery-only 로 등록.
-// source_name 이 비어있는 row (SourceInfo 미입력) 는 건너뜁니다.
+// source_name 이 비어있는 row 는 건너뜁니다.
+// 동일 source_name 의 row 간 Country/Language/BaseURL/SourceType/RequestsPerHour 불일치 시 에러.
+// 등록 가능한 source 가 하나도 없으면 에러 (migration 014 seed 누락 감지).
 func RegisterAll(
 	ctx context.Context,
 	registry *handler.Registry,
@@ -46,33 +49,46 @@ func RegisterAll(
 ) error {
 	rules, err := fetcherRuleRepo.List(ctx)
 	if err != nil {
-		return fmt.Errorf("RegisterAll: list fetcher rules: %w", err)
+		return fmt.Errorf("list fetcher rules: %w", err)
 	}
 
-	// source_name 기준으로 대표 row 수집.
-	// base_url 의 hostname 과 host_pattern 이 일치하는 row 를 canonical 로 우선 선택.
-	// 일치하는 row 가 없으면 첫 번째 row 를 fallback 으로 사용.
+	// source_name 기준으로 canonical row 수집.
+	// 1. base_url hostname == host_pattern 인 row 를 우선 canonical 로 선택.
+	// 2. 동일 source_name 내 SourceInfo 필드가 불일치하면 즉시 에러 (CodeRabbit Major 반영).
 	type sourceEntry struct {
 		rec      *storage.FetcherRuleRecord
-		hasExact bool // base_url hostname == host_pattern
+		hasExact bool
 	}
 	bySource := make(map[string]sourceEntry)
 	for _, r := range rules {
 		if r.SourceName == "" {
 			continue
 		}
-		exact := isCanonicalHost(r)
-		existing, seen := bySource[r.SourceName]
-		if !seen || (!existing.hasExact && exact) {
-			bySource[r.SourceName] = sourceEntry{rec: r, hasExact: exact}
+		if prev, seen := bySource[r.SourceName]; seen {
+			if prev.rec.Country != r.Country ||
+				prev.rec.Language != r.Language ||
+				prev.rec.BaseURL != r.BaseURL ||
+				prev.rec.SourceType != r.SourceType ||
+				prev.rec.RequestsPerHour != r.RequestsPerHour {
+				return fmt.Errorf("inconsistent source metadata for source_name=%q (host=%q vs host=%q)",
+					r.SourceName, prev.rec.HostPattern, r.HostPattern)
+			}
+			// canonical 우선: base_url hostname == host_pattern 인 row 로 교체.
+			if !prev.hasExact && isCanonicalHost(r) {
+				bySource[r.SourceName] = sourceEntry{rec: r, hasExact: true}
+			}
+			continue
 		}
+		bySource[r.SourceName] = sourceEntry{rec: r, hasExact: isCanonicalHost(r)}
+	}
+
+	if len(bySource) == 0 {
+		return fmt.Errorf("no sources found in fetcher_rules; apply migration 014 seed data")
 	}
 
 	for sourceName, entry := range bySource {
-		if err := registerSource(
-			ctx, registry, sourceName, entry.rec,
-			baseConfig, rawSvc, producer, resolver, chromedpRemoteURLs, log,
-		); err != nil {
+		if err := registerSource(registry, sourceName, entry.rec,
+			baseConfig, rawSvc, producer, resolver, chromedpRemoteURLs, log); err != nil {
 			return err
 		}
 	}
@@ -80,7 +96,6 @@ func RegisterAll(
 }
 
 func registerSource(
-	_ context.Context,
 	registry *handler.Registry,
 	sourceName string,
 	rec *storage.FetcherRuleRecord,
@@ -101,18 +116,23 @@ func registerSource(
 
 	cfg := baseConfig
 	cfg.SourceInfo = sourceInfo
-	if rec.RequestsPerHour > 0 {
-		cfg.RequestsPerHour = rec.RequestsPerHour
-	}
+	// DB 값을 그대로 반영 — 0 은 스키마 상 "제한 없음" 이므로 > 0 조건 없이 항상 적용 (CodeRabbit Major 반영).
+	cfg.RequestsPerHour = rec.RequestsPerHour
 
 	gqCrawler := goquery.NewGoqueryCrawler(sourceName+"-goquery", sourceInfo, cfg)
 	gqFetcher := fetcher.NewGoqueryFetcher(gqCrawler)
 
 	crawler := general.NewGenericCrawler(sourceName, sourceInfo, gqFetcher, rec.BaseURL, cfg)
 
-	defaultChain, err := general.BuildChain(gqFetcher, nil, log, defaultLazyKeywords...)
+	// lazy keyword 는 chromedp 가 활성화된 경우에만 전달.
+	// pool 이 꺼진 환경에서 lazy sentinel 발생 시 republish 대상 consumer 가 없어 메시지 유실 (Copilot 반영).
+	var lazyKeywords []string
+	if len(chromedpRemoteURLs) > 0 {
+		lazyKeywords = defaultLazyKeywords
+	}
+	defaultChain, err := general.BuildChain(gqFetcher, nil, log, lazyKeywords...)
 	if err != nil {
-		return fmt.Errorf("RegisterAll: %s default chain wiring: %w", sourceName, err)
+		return fmt.Errorf("%s default chain wiring: %w", sourceName, err)
 	}
 
 	chromedpChains, err := buildChromedpChains(sourceName, sourceInfo, cfg, chromedpRemoteURLs, log)
@@ -155,9 +175,9 @@ func buildChromedpChains(
 		return nil, nil
 	}
 	chains := make([]general.Handler, len(remoteURLs))
-	for i, url := range remoteURLs {
+	for i, remoteURL := range remoteURLs {
 		opts := cdp.DefaultRemoteOptions()
-		opts.RemoteURL = url
+		opts.RemoteURL = remoteURL
 		cdpCrawler := cdp.NewChromedpCrawlerWithOptions(
 			fmt.Sprintf("%s-browser-%d", sourceName, i), sourceInfo, cfg, opts,
 		)


### PR DESCRIPTION
## 연관 이슈

Closes #246
Parent: #233

## 구현 내용

- **`sources/registry.go` 신규 작성** — `fetcher_rules` 테이블 조회 → `source_name` 기준 그룹화 → goquery + chromedp ChainHandler 빌드 → Registry 일괄 등록
- **`main.go` 교체** — `kr.Register()` + `us.Register()` 2회 호출 → `sources.RegisterAll()` 단일 호출
- **`defaultLazyKeywords` 공통 상수** — 기존 사이트별로 흩어진 `"data-lazy-src", "lazyload", "data-lazy"` 통합
- SourceInfo·RequestsPerHour는 migration 014 seed 데이터로 공급, `source_name` 비어있는 row 는 건너뜀
- `kr/`, `us/` 패키지는 아직 삭제하지 않음 — #247에서 처리

## CI / 머지 게이트 점검

- [x] `go build ./...` 통과
- [x] `go test ./...` 전체 통과
- [x] `make fmt` 통과

## 변경 영향 범위 + 위험도

- **Medium** — main.go 의 등록 경로가 변경되어 DB에 데이터가 없으면 크롤러가 등록되지 않음. migration 014 seed 가 적용된 환경에서만 정상 동작. 전제 조건: PR #249 (migration 014) 머지+배포 완료.
- 기존 `kr/`, `us/` 패키지 코드는 변경 없음 — #247에서 삭제 예정.

## 롤백 계획

- `main.go` 에서 `sources.RegisterAll` 을 다시 `kr.Register` + `us.Register` 로 되돌리면 즉시 복구

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Transitioned source registration from static hardcoded configurations to dynamic database-driven registration, enabling flexible source management and configuration updates without requiring code modifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->