### PR TITLE
[REFAC#248] CrawlJob.CrawlerName host 기반으로 통일

### DIFF
--- a/internal/processor/fetcher/domain/general/sources/registry.go
+++ b/internal/processor/fetcher/domain/general/sources/registry.go
@@ -86,17 +86,42 @@ func RegisterAll(
 		return fmt.Errorf("no sources found in fetcher_rules; apply migration 014 seed data")
 	}
 
+	// source_name 별로 handler 를 빌드한 뒤, 해당 source 의 모든 host_pattern 에도 동일 handler 등록.
+	// CrawlerName 이 host 기반으로 통일 (#248) 되면서 Registry 가 host key 로 dispatch 해야 함.
+	// source_name key 도 유지 — 기존 CrawlJob 하위 호환.
+	hostsBySource := make(map[string][]string)
+	for _, r := range rules {
+		if r.SourceName == "" {
+			continue
+		}
+		hostsBySource[r.SourceName] = append(hostsBySource[r.SourceName], r.HostPattern)
+	}
+
 	for sourceName, entry := range bySource {
-		if err := registerSource(registry, sourceName, entry.rec,
-			baseConfig, rawSvc, producer, resolver, chromedpRemoteURLs, log); err != nil {
+		h, err := buildHandler(registry, sourceName, entry.rec,
+			baseConfig, rawSvc, producer, resolver, chromedpRemoteURLs, log)
+		if err != nil {
 			return err
 		}
+		// source_name 으로 등록 (기존 경로 호환).
+		registry.Register(sourceName, h)
+		// 각 host_pattern 으로도 등록 — host 기반 CrawlerName dispatch 지원 (이슈 #248).
+		for _, host := range hostsBySource[sourceName] {
+			registry.Register(host, h)
+		}
+		log.WithFields(map[string]interface{}{
+			"source":            sourceName,
+			"hosts":             hostsBySource[sourceName],
+			"requests_per_hour": entry.rec.RequestsPerHour,
+		}).Info("crawler registered from db")
 	}
 	return nil
 }
 
-func registerSource(
-	registry *handler.Registry,
+// buildHandler 는 source 의 ChainHandler 를 빌드하여 반환합니다.
+// 등록(registry.Register)은 호출자가 직접 수행 — source_name 과 host_pattern 양쪽 등록 지원.
+func buildHandler(
+	_ *handler.Registry,
 	sourceName string,
 	rec *storage.FetcherRuleRecord,
 	baseConfig core.Config,
@@ -105,7 +130,7 @@ func registerSource(
 	resolver rule.Resolver,
 	chromedpRemoteURLs []string,
 	log *logger.Logger,
-) error {
+) (handler.Handler, error) {
 	sourceInfo := core.SourceInfo{
 		Country:  rec.Country,
 		Type:     core.SourceType(rec.SourceType),
@@ -132,21 +157,15 @@ func registerSource(
 	}
 	defaultChain, err := general.BuildChain(gqFetcher, nil, log, lazyKeywords...)
 	if err != nil {
-		return fmt.Errorf("%s default chain wiring: %w", sourceName, err)
+		return nil, fmt.Errorf("%s default chain wiring: %w", sourceName, err)
 	}
 
 	chromedpChains, err := buildChromedpChains(sourceName, sourceInfo, cfg, chromedpRemoteURLs, log)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
-	registry.Register(sourceName, general.NewChainHandler(crawler, defaultChain, chromedpChains, resolver, rawSvc, producer, log))
-	log.WithFields(map[string]interface{}{
-		"crawler":           sourceName,
-		"chromedp_workers":  len(chromedpChains),
-		"requests_per_hour": cfg.RequestsPerHour,
-	}).Info("crawler registered from db")
-	return nil
+	return general.NewChainHandler(crawler, defaultChain, chromedpChains, resolver, rawSvc, producer, log), nil
 }
 
 // isCanonicalHost 는 r.BaseURL 의 hostname 이 r.HostPattern 과 일치하면 true 를 반환합니다.

--- a/internal/processor/fetcher/domain/general/sources/registry.go
+++ b/internal/processor/fetcher/domain/general/sources/registry.go
@@ -52,18 +52,20 @@ func RegisterAll(
 		return fmt.Errorf("list fetcher rules: %w", err)
 	}
 
-	// source_name 기준으로 canonical row 수집.
-	// 1. base_url hostname == host_pattern 인 row 를 우선 canonical 로 선택.
-	// 2. 동일 source_name 내 SourceInfo 필드가 불일치하면 즉시 에러 (CodeRabbit Major 반영).
+	// 단일 루프에서 canonical row(bySource)와 host 목록(hostsBySource) 동시 수집 (Gemini Medium 반영).
+	// - base_url hostname == host_pattern 인 row 를 canonical 로 우선 선택
+	// - 동일 source_name 내 SourceInfo 불일치 시 즉시 에러
 	type sourceEntry struct {
 		rec      *storage.FetcherRuleRecord
 		hasExact bool
 	}
 	bySource := make(map[string]sourceEntry)
+	hostsBySource := make(map[string][]string)
 	for _, r := range rules {
 		if r.SourceName == "" {
 			continue
 		}
+		hostsBySource[r.SourceName] = append(hostsBySource[r.SourceName], r.HostPattern)
 		if prev, seen := bySource[r.SourceName]; seen {
 			if prev.rec.Country != r.Country ||
 				prev.rec.Language != r.Language ||
@@ -86,26 +88,15 @@ func RegisterAll(
 		return fmt.Errorf("no sources found in fetcher_rules; apply migration 014 seed data")
 	}
 
-	// source_name 별로 handler 를 빌드한 뒤, 해당 source 의 모든 host_pattern 에도 동일 handler 등록.
-	// CrawlerName 이 host 기반으로 통일 (#248) 되면서 Registry 가 host key 로 dispatch 해야 함.
-	// source_name key 도 유지 — 기존 CrawlJob 하위 호환.
-	hostsBySource := make(map[string][]string)
-	for _, r := range rules {
-		if r.SourceName == "" {
-			continue
-		}
-		hostsBySource[r.SourceName] = append(hostsBySource[r.SourceName], r.HostPattern)
-	}
-
+	// source_name 별로 handler 를 빌드한 뒤, source_name 과 각 host_pattern 양쪽으로 등록.
+	// CrawlerName 이 host 기반으로 통일 (#248) — source_name 키는 하위 호환 유지.
 	for sourceName, entry := range bySource {
-		h, err := buildHandler(registry, sourceName, entry.rec,
+		h, err := buildHandler(sourceName, entry.rec,
 			baseConfig, rawSvc, producer, resolver, chromedpRemoteURLs, log)
 		if err != nil {
 			return err
 		}
-		// source_name 으로 등록 (기존 경로 호환).
 		registry.Register(sourceName, h)
-		// 각 host_pattern 으로도 등록 — host 기반 CrawlerName dispatch 지원 (이슈 #248).
 		for _, host := range hostsBySource[sourceName] {
 			registry.Register(host, h)
 		}
@@ -121,7 +112,6 @@ func RegisterAll(
 // buildHandler 는 source 의 ChainHandler 를 빌드하여 반환합니다.
 // 등록(registry.Register)은 호출자가 직접 수행 — source_name 과 host_pattern 양쪽 등록 지원.
 func buildHandler(
-	_ *handler.Registry,
 	sourceName string,
 	rec *storage.FetcherRuleRecord,
 	baseConfig core.Config,

--- a/internal/processor/fetcher/rule/upgrader.go
+++ b/internal/processor/fetcher/rule/upgrader.go
@@ -299,6 +299,7 @@ func hostnameOf(rawURL, fallback string) string {
 	return u.Hostname()
 }
 
+// newRepublishJobID 는 republish job 의 고유 ID 를 생성합니다.
 func newRepublishJobID() string {
 	b := make([]byte, 16)
 	if _, err := rand.Read(b); err != nil {

--- a/internal/processor/fetcher/rule/upgrader.go
+++ b/internal/processor/fetcher/rule/upgrader.go
@@ -6,6 +6,7 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"net/url"
 	"time"
 
 	goredis "github.com/redis/go-redis/v9"
@@ -200,7 +201,7 @@ func (u *Upgrader) republishRaws(ctx context.Context, host string, rawIDs []stri
 
 		job := &core.CrawlJob{
 			ID:          newRepublishJobID(),
-			CrawlerName: raw.SourceInfo.Name,
+			CrawlerName: hostnameOf(raw.URL, raw.SourceInfo.Name),
 			Target: core.Target{
 				URL:  raw.URL,
 				Type: core.TargetTypeArticle,
@@ -288,6 +289,16 @@ func (u *Upgrader) logFields(msg string, fields map[string]interface{}) {
 }
 
 // newRepublishJobID 는 republish CrawlJob 의 고유 ID 를 생성합니다 (publisher.newJobID 와 동일 패턴 — 32자 hex).
+// hostnameOf 는 rawURL 에서 hostname 을 추출합니다.
+// 파싱 실패 또는 hostname 이 비어있으면 fallback 을 반환합니다 (이슈 #248).
+func hostnameOf(rawURL, fallback string) string {
+	u, err := url.Parse(rawURL)
+	if err != nil || u.Hostname() == "" {
+		return fallback
+	}
+	return u.Hostname()
+}
+
 func newRepublishJobID() string {
 	b := make([]byte, 16)
 	if _, err := rand.Read(b); err != nil {

--- a/internal/scheduler/entries.go
+++ b/internal/scheduler/entries.go
@@ -1,6 +1,8 @@
 package scheduler
 
 import (
+	"net/url"
+
 	"issuetracker/internal/processor/fetcher/core"
 	"issuetracker/pkg/config"
 )
@@ -50,17 +52,27 @@ var sourceCategoryURLs = map[string][]string{
 	},
 }
 
+// hostOf 는 rawURL 에서 hostname 을 추출합니다. 파싱 실패 시 rawURL 을 그대로 반환합니다.
+func hostOf(rawURL string) string {
+	u, err := url.Parse(rawURL)
+	if err != nil || u.Hostname() == "" {
+		return rawURL
+	}
+	return u.Hostname()
+}
+
 // DefaultEntries는 현재 등록된 모든 소스의 기본 ScheduleEntry 목록을 반환합니다.
 //
 // DefaultEntries builds the full list of ScheduleEntry values from sourceCategoryURLs.
 // Intervals are controlled by SchedulerConfig.
 func DefaultEntries(cfg config.SchedulerConfig) []ScheduleEntry {
 	var entries []ScheduleEntry
-	for crawlerName, urls := range sourceCategoryURLs {
-		for _, url := range urls {
+	for _, urls := range sourceCategoryURLs {
+		for _, rawURL := range urls {
+			host := hostOf(rawURL)
 			entries = append(entries, ScheduleEntry{
-				CrawlerName: crawlerName,
-				URL:         url,
+				CrawlerName: host,
+				URL:         rawURL,
 				TargetType:  core.TargetTypeCategory,
 				Interval:    cfg.CategoryInterval,
 				Priority:    core.PriorityNormal,

--- a/internal/scheduler/source.go
+++ b/internal/scheduler/source.go
@@ -16,7 +16,7 @@ import (
 //
 // ScheduleEntry describes a single URL to be crawled on a fixed interval.
 type ScheduleEntry struct {
-	// CrawlerName은 이 Job을 처리할 크롤러 이름입니다 (registry 키).
+	// CrawlerName은 이 Job을 처리할 크롤러 이름입니다 (registry 키 — host 기반, 이슈 #248).
 	CrawlerName string
 
 	// URL은 크롤링 대상 URL입니다.


### PR DESCRIPTION
## 연관 이슈

Closes #248
Parent: #233

## 구현 내용

- **`sources/registry.go`**: handler 를 `source_name` 과 각 `host_pattern` 양쪽으로 이중 등록
  - source_name 키 유지 → 기존 CrawlJob 하위 호환
  - host_pattern 키 추가 → host 기반 CrawlerName dispatch 지원
  - `buildHandler` 로 분리하여 단일 handler 인스턴스를 두 키가 공유
- **`scheduler/entries.go`**: `CrawlerName = URL hostname` (예: `news.naver.com`, `edition.cnn.com`)
- **`rule/upgrader.go`**: `CrawlerName = raw.URL hostname` (파싱 실패 시 `SourceInfo.Name` fallback)
- **`scheduler/source.go`**: 주석에 host 기반 명시

## CI / 머지 게이트 점검

- [x] `go build ./...` 통과
- [x] `go test ./...` 전체 통과
- [x] `make fmt` 통과

## 변경 영향 범위 + 위험도

- **Low-Medium** — 신규 CrawlJob의 CrawlerName이 host로 바뀌지만, registry에 source_name 키도 유지되어 하위 호환 보장. upgrader의 기존 republish job도 올바른 host key로 dispatch됨.

## 롤백 계획

- git revert 로 즉시 복구 가능. registry source_name 키 유지로 안전.