### PR TITLE
[FIX#253] goquery fetch charset 자동 감지 + UTF-8 변환

### DIFF
--- a/internal/processor/fetcher/implementation/goquery/fetch.go
+++ b/internal/processor/fetcher/implementation/goquery/fetch.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 
 	"github.com/PuerkitoBio/goquery"
+	"golang.org/x/net/html/charset"
 
 	"issuetracker/internal/processor/fetcher/core"
 	"issuetracker/pkg/logger"
@@ -49,8 +50,17 @@ func (c *GoqueryCrawler) Fetch(ctx context.Context, target core.Target) (*core.R
 		return nil, err
 	}
 
+	// charset.NewReader: Content-Type 헤더와 HTML meta 태그를 기반으로 charset 감지 후
+	// 응답 body 를 UTF-8 스트림으로 변환한다 (이슈 #253 — EUC-KR 등 비UTF-8 인코딩 대응).
+	// 변환 실패 시 원본 body 를 그대로 사용 (graceful degrade).
+	contentType := resp.Header.Get("Content-Type")
+	utf8Reader, err := charset.NewReader(resp.Body, contentType)
+	if err != nil {
+		utf8Reader = resp.Body
+	}
+
 	// goquery Document 생성
-	doc, err := goquery.NewDocumentFromReader(resp.Body)
+	doc, err := goquery.NewDocumentFromReader(utf8Reader)
 	if err != nil {
 		return nil, &core.CrawlerError{
 			Category: core.ErrCategoryParse,

--- a/internal/processor/fetcher/implementation/goquery/fetch.go
+++ b/internal/processor/fetcher/implementation/goquery/fetch.go
@@ -1,7 +1,9 @@
 package goquery
 
 import (
+	"bytes"
 	"context"
+	"io"
 	"net/http"
 
 	"github.com/PuerkitoBio/goquery"
@@ -50,17 +52,31 @@ func (c *GoqueryCrawler) Fetch(ctx context.Context, target core.Target) (*core.R
 		return nil, err
 	}
 
-	// charset.NewReader: Content-Type 헤더와 HTML meta 태그를 기반으로 charset 감지 후
-	// 응답 body 를 UTF-8 스트림으로 변환한다 (이슈 #253 — EUC-KR 등 비UTF-8 인코딩 대응).
-	// 변환 실패 시 WARN 로깅 후 원본 body 로 fallback — 하위 호환 유지.
+	// body 를 메모리에 완전히 읽은 뒤 charset 감지를 수행합니다 (이슈 #253, CodeRabbit Major 반영).
+	// charset.NewReader 는 내부에서 최대 1024 바이트를 미리 읽으므로, resp.Body 를 직접 fallback 으로
+	// 재사용하면 해당 바이트가 소실된 truncated 스트림이 됩니다. io.ReadAll 로 전체를 읽어두고
+	// bytes.NewReader 로 재생성하면 charset 감지 실패 시에도 원본 body 를 온전히 유지합니다.
+	bodyBytes, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, &core.CrawlerError{
+			Category:  core.ErrCategoryNetwork,
+			Code:      "NET_002",
+			Message:   "failed to read response body",
+			Source:    c.name,
+			URL:       target.URL,
+			Retryable: true,
+			Err:       err,
+		}
+	}
+
 	contentType := resp.Header.Get("Content-Type")
-	utf8Reader, err := charset.NewReader(resp.Body, contentType)
+	utf8Reader, err := charset.NewReader(bytes.NewReader(bodyBytes), contentType)
 	if err != nil {
 		log.WithFields(map[string]interface{}{
 			"url":          target.URL,
 			"content_type": contentType,
 		}).WithError(err).Warn("charset detection failed, falling back to raw body")
-		utf8Reader = resp.Body
+		utf8Reader = bytes.NewReader(bodyBytes)
 	}
 
 	// goquery Document 생성

--- a/internal/processor/fetcher/implementation/goquery/fetch.go
+++ b/internal/processor/fetcher/implementation/goquery/fetch.go
@@ -52,10 +52,14 @@ func (c *GoqueryCrawler) Fetch(ctx context.Context, target core.Target) (*core.R
 
 	// charset.NewReader: Content-Type 헤더와 HTML meta 태그를 기반으로 charset 감지 후
 	// 응답 body 를 UTF-8 스트림으로 변환한다 (이슈 #253 — EUC-KR 등 비UTF-8 인코딩 대응).
-	// 변환 실패 시 원본 body 를 그대로 사용 (graceful degrade).
+	// 변환 실패 시 WARN 로깅 후 원본 body 로 fallback — 하위 호환 유지.
 	contentType := resp.Header.Get("Content-Type")
 	utf8Reader, err := charset.NewReader(resp.Body, contentType)
 	if err != nil {
+		log.WithFields(map[string]interface{}{
+			"url":          target.URL,
+			"content_type": contentType,
+		}).WithError(err).Warn("charset detection failed, falling back to raw body")
 		utf8Reader = resp.Body
 	}
 

--- a/internal/processor/fetcher/implementation/goquery/parse.go
+++ b/internal/processor/fetcher/implementation/goquery/parse.go
@@ -1,13 +1,16 @@
 package goquery
 
 import (
+	"bytes"
 	"context"
 	"fmt"
+	"io"
 	"net/http"
 	"strings"
 	"time"
 
 	"github.com/PuerkitoBio/goquery"
+	"golang.org/x/net/html/charset"
 
 	"issuetracker/internal/processor/fetcher/core"
 	"issuetracker/pkg/logger"
@@ -32,8 +35,23 @@ func (c *GoqueryCrawler) FetchAndParse(ctx context.Context, target core.Target, 
 	}
 	defer resp.Body.Close()
 
+	// fetch.go 와 동일하게 body 전체를 메모리에 읽은 뒤 charset 감지 (이슈 #253).
+	bodyBytes, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+	contentType := resp.Header.Get("Content-Type")
+	utf8Reader, err := charset.NewReader(bytes.NewReader(bodyBytes), contentType)
+	if err != nil {
+		log.WithFields(map[string]interface{}{
+			"url":          target.URL,
+			"content_type": contentType,
+		}).WithError(err).Warn("charset detection failed, falling back to raw body")
+		utf8Reader = bytes.NewReader(bodyBytes)
+	}
+
 	// goquery Document 생성
-	doc, err := goquery.NewDocumentFromReader(resp.Body)
+	doc, err := goquery.NewDocumentFromReader(utf8Reader)
 	if err != nil {
 		return nil, err
 	}

--- a/test/internal/processor/fetcher/implementation/goquery/fetch_charset_test.go
+++ b/test/internal/processor/fetcher/implementation/goquery/fetch_charset_test.go
@@ -1,0 +1,134 @@
+package goquery_test
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"issuetracker/internal/processor/fetcher/core"
+	gqimpl "issuetracker/internal/processor/fetcher/implementation/goquery"
+)
+
+// euckrBytes 는 "네이버뉴스" 를 EUC-KR 로 인코딩한 바이트입니다.
+// Python: "네이버뉴스".encode("euc-kr") → b'\xb3×\xc0̹ö\xb4º\xbd º'
+var euckrTitle = []byte{0xb3, 0xd7, 0xc0, 0xcc, 0xb9, 0xf6, 0xb4, 0xba, 0xbd, 0xba} // 네이버뉴스 in EUC-KR
+
+func newTestCrawler(name string) *gqimpl.GoqueryCrawler {
+	cfg := core.DefaultConfig()
+	cfg.UserAgent = "test-agent"
+	info := core.SourceInfo{Name: name, Country: "KR", Language: "ko"}
+	return gqimpl.NewGoqueryCrawler(name, info, cfg)
+}
+
+// TestFetch_EUCKR_ConvertedToUTF8 는 EUC-KR Content-Type 헤더를 가진 응답이
+// UTF-8 로 변환되어 RawContent.HTML 에 저장되는지 검증합니다 (이슈 #253).
+func TestFetch_EUCKR_ConvertedToUTF8(t *testing.T) {
+	// EUC-KR 인코딩된 HTML — Content-Type 에 charset 명시
+	body := append(
+		[]byte(`<html><head><meta http-equiv="Content-Type" content="text/html; charset=euc-kr"></head><body><h1>`),
+		euckrTitle...,
+	)
+	body = append(body, []byte(`</h1></body></html>`)...)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/html; charset=euc-kr")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(body)
+	}))
+	defer srv.Close()
+
+	crawler := newTestCrawler("test-euckr")
+	raw, err := crawler.Fetch(t.Context(), core.Target{URL: srv.URL, Type: core.TargetTypeArticle})
+
+	require.NoError(t, err)
+	require.NotNil(t, raw)
+	// UTF-8 변환 후 HTML은 유효한 UTF-8 문자열이어야 합니다.
+	assert.True(t, isValidUTF8(raw.HTML), "RawContent.HTML must be valid UTF-8 after charset conversion")
+	// 제목 텍스트 "네이버뉴스"가 올바르게 변환되어야 합니다.
+	assert.True(t, strings.Contains(raw.HTML, "네이버뉴스"),
+		"EUC-KR title should be converted to UTF-8 '네이버뉴스', got: %q", raw.HTML[:min(200, len(raw.HTML))])
+}
+
+// TestFetch_UTF8_NoConversion 은 이미 UTF-8 인 응답이 손상 없이 저장되는지 검증합니다.
+func TestFetch_UTF8_NoConversion(t *testing.T) {
+	body := `<html><head></head><body><h1>네이버뉴스</h1></body></html>`
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprint(w, body)
+	}))
+	defer srv.Close()
+
+	crawler := newTestCrawler("test-utf8")
+	raw, err := crawler.Fetch(t.Context(), core.Target{URL: srv.URL, Type: core.TargetTypeArticle})
+
+	require.NoError(t, err)
+	require.NotNil(t, raw)
+	assert.True(t, isValidUTF8(raw.HTML), "UTF-8 response must remain valid UTF-8")
+	assert.True(t, strings.Contains(raw.HTML, "네이버뉴스"))
+}
+
+// TestFetch_NoCharsetHeader_FallbackToUTF8 은 Content-Type 에 charset 이 없는 경우
+// graceful degrade (원본 body 사용) 해도 빌드/실행이 깨지지 않음을 검증합니다.
+func TestFetch_NoCharsetHeader_FallbackToUTF8(t *testing.T) {
+	body := `<html><head></head><body><p>hello world</p></body></html>`
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/html")
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprint(w, body)
+	}))
+	defer srv.Close()
+
+	crawler := newTestCrawler("test-no-charset")
+	raw, err := crawler.Fetch(t.Context(), core.Target{URL: srv.URL, Type: core.TargetTypeArticle})
+
+	require.NoError(t, err)
+	require.NotNil(t, raw)
+	assert.True(t, strings.Contains(raw.HTML, "hello world"))
+}
+
+func isValidUTF8(s string) bool {
+	for i := 0; i < len(s); {
+		r := rune(s[i])
+		if r < 0x80 {
+			i++
+			continue
+		}
+		// multi-byte UTF-8 시작 바이트 확인
+		var size int
+		switch {
+		case r>>5 == 0b110:
+			size = 2
+		case r>>4 == 0b1110:
+			size = 3
+		case r>>3 == 0b11110:
+			size = 4
+		default:
+			return false
+		}
+		if i+size > len(s) {
+			return false
+		}
+		for j := 1; j < size; j++ {
+			if s[i+j]>>6 != 0b10 {
+				return false
+			}
+		}
+		i += size
+	}
+	return true
+}
+
+func min(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}

--- a/test/internal/processor/fetcher/implementation/goquery/fetch_charset_test.go
+++ b/test/internal/processor/fetcher/implementation/goquery/fetch_charset_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"unicode/utf8"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -48,10 +49,10 @@ func TestFetch_EUCKR_ConvertedToUTF8(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, raw)
 	// UTF-8 변환 후 HTML은 유효한 UTF-8 문자열이어야 합니다.
-	assert.True(t, isValidUTF8(raw.HTML), "RawContent.HTML must be valid UTF-8 after charset conversion")
+	assert.True(t, utf8.ValidString(raw.HTML), "RawContent.HTML must be valid UTF-8 after charset conversion")
 	// 제목 텍스트 "네이버뉴스"가 올바르게 변환되어야 합니다.
 	assert.True(t, strings.Contains(raw.HTML, "네이버뉴스"),
-		"EUC-KR title should be converted to UTF-8 '네이버뉴스', got: %q", raw.HTML[:min(200, len(raw.HTML))])
+		"EUC-KR title should be converted to UTF-8 '네이버뉴스'")
 }
 
 // TestFetch_UTF8_NoConversion 은 이미 UTF-8 인 응답이 손상 없이 저장되는지 검증합니다.
@@ -70,7 +71,7 @@ func TestFetch_UTF8_NoConversion(t *testing.T) {
 
 	require.NoError(t, err)
 	require.NotNil(t, raw)
-	assert.True(t, isValidUTF8(raw.HTML), "UTF-8 response must remain valid UTF-8")
+	assert.True(t, utf8.ValidString(raw.HTML), "UTF-8 response must remain valid UTF-8")
 	assert.True(t, strings.Contains(raw.HTML, "네이버뉴스"))
 }
 
@@ -92,43 +93,4 @@ func TestFetch_NoCharsetHeader_FallbackToUTF8(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, raw)
 	assert.True(t, strings.Contains(raw.HTML, "hello world"))
-}
-
-func isValidUTF8(s string) bool {
-	for i := 0; i < len(s); {
-		r := rune(s[i])
-		if r < 0x80 {
-			i++
-			continue
-		}
-		// multi-byte UTF-8 시작 바이트 확인
-		var size int
-		switch {
-		case r>>5 == 0b110:
-			size = 2
-		case r>>4 == 0b1110:
-			size = 3
-		case r>>3 == 0b11110:
-			size = 4
-		default:
-			return false
-		}
-		if i+size > len(s) {
-			return false
-		}
-		for j := 1; j < size; j++ {
-			if s[i+j]>>6 != 0b10 {
-				return false
-			}
-		}
-		i += size
-	}
-	return true
-}
-
-func min(a, b int) int {
-	if a < b {
-		return a
-	}
-	return b
 }


### PR DESCRIPTION
## 연관 이슈

Closes #253

## 원인

`GoqueryCrawler.Fetch`가 HTTP 응답 body를 charset 변환 없이 그대로 `goquery.NewDocumentFromReader`에 전달. 서버가 `Content-Type: text/html; charset=euc-kr`로 응답하면 EUC-KR 바이트가 그대로 HTML 문자열에 포함되어 PostgreSQL UTF-8 제약 위반(`SQLSTATE 22021`)으로 저장 실패.

## 수정 내용

`golang.org/x/net/html/charset.NewReader`로 응답 body를 감싸 Content-Type 헤더 + HTML meta 태그 기반으로 charset 자동 감지 후 UTF-8 스트림으로 변환.

```go
// 변경 전
doc, err := goquery.NewDocumentFromReader(resp.Body)

// 변경 후
utf8Reader, err := charset.NewReader(resp.Body, resp.Header.Get("Content-Type"))
if err != nil {
    utf8Reader = resp.Body  // graceful degrade
}
doc, err := goquery.NewDocumentFromReader(utf8Reader)
```

변환 실패 시 원본 body로 fallback (기존 동작 보존).

## 테스트

| 케이스 | 결과 |
|---|---|
| EUC-KR 응답 → UTF-8 변환 확인 | PASS |
| 이미 UTF-8 응답 → 무손상 통과 | PASS |
| charset 헤더 없음 → graceful degrade | PASS |

## 변경 영향 범위 + 위험도

- **Low** — goquery fetch 경로에만 적용. charset 감지 실패 시 원본 body 사용으로 기존 동작과 동일. `golang.org/x/net`은 기존 indirect 의존성이므로 신규 외부 모듈 추가 없음.

## 롤백 계획

- `charset.NewReader` 래핑 제거 시 즉시 원복

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced character encoding support to automatically detect and convert non-UTF-8 web content to UTF-8 based on HTTP headers, improving content display reliability across different character sets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->