### PR TITLE
[FEAT#256] claudegen.Executor — Claude Code Docker 셀렉터 추출

### DIFF
--- a/internal/processor/parser/rule/claudegen/executor.go
+++ b/internal/processor/parser/rule/claudegen/executor.go
@@ -15,11 +15,11 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
-	"strings"
 	"time"
 
 	"issuetracker/internal/storage"
@@ -33,18 +33,22 @@ const (
 )
 
 // DockerRunner 는 docker 명령 실행을 추상화합니다 (테스트에서 mock 교체 용).
+// env 는 컨테이너 프로세스에 추가할 환경변수 목록 — API 키 등 비밀값은 args 가 아닌
+// 이 슬라이스로 전달해 ps/proc 노출을 방지합니다 (Gemini Security + Copilot 반영).
 type DockerRunner interface {
-	Run(ctx context.Context, args []string) (stdout string, stderr string, err error)
+	Run(ctx context.Context, args []string, env []string) (stdout string, stderr string, err error)
 }
 
 // execDockerRunner 는 실제 docker CLI 를 실행하는 기본 구현입니다.
 type execDockerRunner struct{}
 
-func (r *execDockerRunner) Run(ctx context.Context, args []string) (string, string, error) {
+func (r *execDockerRunner) Run(ctx context.Context, args []string, env []string) (string, string, error) {
 	var stdout, stderr bytes.Buffer
 	cmd := exec.CommandContext(ctx, "docker", args...)
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr
+	// 비밀값(API 키 등)은 cmd.Env 를 통해 주입 — args 에 포함 시 ps/procfs 로 노출됨.
+	cmd.Env = append(os.Environ(), env...)
 	return stdout.String(), stderr.String(), cmd.Run()
 }
 
@@ -58,6 +62,10 @@ type Executor struct {
 	log     *logger.Logger
 }
 
+// ModelName 은 이 Executor 가 사용하는 모델 ID 를 반환합니다.
+// llmgen.Generator 가 DB description 에 기록할 때 사용합니다 (이슈 #256).
+func (e *Executor) ModelName() string { return e.model }
+
 // NewFromEnv 는 환경변수 기반 Executor 를 생성합니다.
 //
 //	CLAUDE_CODE_IMAGE   — Docker 이미지 (기본: ghcr.io/anthropics/claude-code:latest)
@@ -65,13 +73,21 @@ type Executor struct {
 //	ANTHROPIC_API_KEY   — 인증 키     (필수)
 //	CLAUDE_CODE_TIMEOUT — 타임아웃    (기본: 120s, Go duration 형식)
 func NewFromEnv(log *logger.Logger) (*Executor, error) {
+	if log == nil {
+		return nil, errors.New("claudegen: NewFromEnv requires non-nil logger")
+	}
 	apiKey := os.Getenv("ANTHROPIC_API_KEY")
 	if apiKey == "" {
 		return nil, fmt.Errorf("claudegen: ANTHROPIC_API_KEY is required")
 	}
 	timeout := defaultTimeout
 	if s := os.Getenv("CLAUDE_CODE_TIMEOUT"); s != "" {
-		if d, err := time.ParseDuration(s); err == nil {
+		d, err := time.ParseDuration(s)
+		if err != nil {
+			log.WithFields(map[string]interface{}{
+				"value": s,
+			}).WithError(err).Warn("CLAUDE_CODE_TIMEOUT parse failed, using default")
+		} else {
 			timeout = d
 		}
 	}
@@ -85,14 +101,20 @@ func NewFromEnv(log *logger.Logger) (*Executor, error) {
 	}, nil
 }
 
-// New 는 명시적 파라미터로 Executor 를 생성합니다 (테스트/DI 용).
-func New(image, model, apiKey string, timeout time.Duration, log *logger.Logger) *Executor {
-	return &Executor{image: image, model: model, apiKey: apiKey, timeout: timeout, runner: &execDockerRunner{}, log: log}
+// New 는 명시적 파라미터로 Executor 를 생성합니다 (DI 용).
+func New(image, model, apiKey string, timeout time.Duration, log *logger.Logger) (*Executor, error) {
+	if log == nil {
+		return nil, errors.New("claudegen: New requires non-nil logger")
+	}
+	return &Executor{image: image, model: model, apiKey: apiKey, timeout: timeout, runner: &execDockerRunner{}, log: log}, nil
 }
 
 // NewWithRunner 는 DockerRunner 를 주입하는 생성자입니다 (테스트/DI 용).
-func NewWithRunner(image, model, apiKey string, timeout time.Duration, runner DockerRunner, log *logger.Logger) *Executor {
-	return &Executor{image: image, model: model, apiKey: apiKey, timeout: timeout, runner: runner, log: log}
+func NewWithRunner(image, model, apiKey string, timeout time.Duration, runner DockerRunner, log *logger.Logger) (*Executor, error) {
+	if log == nil {
+		return nil, errors.New("claudegen: NewWithRunner requires non-nil logger")
+	}
+	return &Executor{image: image, model: model, apiKey: apiKey, timeout: timeout, runner: runner, log: log}, nil
 }
 
 // Extract 는 HTML 을 Docker 컨테이너에 마운트하고 Claude Code 로 셀렉터를 추출합니다.
@@ -116,15 +138,18 @@ func (e *Executor) Extract(ctx context.Context, host string, targetType storage.
 	runCtx, cancel := context.WithTimeout(ctx, e.timeout)
 	defer cancel()
 
+	// ANTHROPIC_API_KEY 는 args 가 아닌 env 슬라이스로 전달 — ps/proc 노출 방지 (보안).
+	// docker args 에는 `-e ANTHROPIC_API_KEY` (값 없이) 만 포함하여 컨테이너가 부모 환경에서 상속.
 	args := []string{
 		"run", "--rm",
-		"-e", "ANTHROPIC_API_KEY=" + e.apiKey,
+		"-e", "ANTHROPIC_API_KEY",
 		"-v", tmpDir + ":/workspace:ro",
 		e.image,
 		"--model", e.model,
 		"--dangerously-skip-permissions",
 		"-p", buildPrompt(host, targetType),
 	}
+	env := []string{"ANTHROPIC_API_KEY=" + e.apiKey}
 
 	e.log.WithFields(map[string]interface{}{
 		"host":        host,
@@ -133,7 +158,7 @@ func (e *Executor) Extract(ctx context.Context, host string, targetType storage.
 		"model":       e.model,
 	}).Debug("running claude code extractor")
 
-	stdout, stderr, err := e.runner.Run(runCtx, args)
+	stdout, stderr, err := e.runner.Run(runCtx, args, env)
 	if err != nil {
 		return storage.SelectorMap{}, fmt.Errorf("claude code docker run: %w (stderr: %s)",
 			err, truncate(stderr, 512))
@@ -141,8 +166,13 @@ func (e *Executor) Extract(ctx context.Context, host string, targetType storage.
 
 	sm, err := parseSelectorOutput(stdout)
 	if err != nil {
-		return storage.SelectorMap{}, fmt.Errorf("parse claude output: %w (raw: %s)",
-			err, truncate(stdout, 256))
+		// raw stdout 은 debug 로그에만 기록 — 에러 메시지 포함 시 민감정보 노출 가능 (Copilot 반영).
+		e.log.WithFields(map[string]interface{}{
+			"host":        host,
+			"target_type": string(targetType),
+			"raw_output":  truncate(stdout, 256),
+		}).Debug("claude code output parse failed")
+		return storage.SelectorMap{}, fmt.Errorf("parse claude output: %w", err)
 	}
 
 	e.log.WithFields(map[string]interface{}{
@@ -180,20 +210,40 @@ func parseSelectorOutput(output string) (storage.SelectorMap, error) {
 	return sm, nil
 }
 
-// extractJSON 은 출력 텍스트에서 첫 번째 {...} JSON 블록을 추출합니다.
+// extractJSON 은 출력 텍스트에서 첫 번째 유효한 {...} JSON 블록을 추출합니다.
+// JSON 문자열 내부의 중괄호(CSS selector 내 :contains('{') 등)는 depth 계산에서 제외합니다.
 func extractJSON(s string) string {
-	start := strings.Index(s, "{")
-	if start == -1 {
-		return ""
-	}
+	start := -1
 	depth := 0
-	for i := start; i < len(s); i++ {
-		switch s[i] {
+	inString := false
+	escaped := false
+
+	for i := 0; i < len(s); i++ {
+		ch := s[i]
+		if escaped {
+			escaped = false
+			continue
+		}
+		if ch == '\\' && inString {
+			escaped = true
+			continue
+		}
+		if ch == '"' {
+			inString = !inString
+			continue
+		}
+		if inString {
+			continue
+		}
+		switch ch {
 		case '{':
+			if depth == 0 {
+				start = i
+			}
 			depth++
 		case '}':
 			depth--
-			if depth == 0 {
+			if depth == 0 && start != -1 {
 				return s[start : i+1]
 			}
 		}

--- a/internal/processor/parser/rule/claudegen/executor.go
+++ b/internal/processor/parser/rule/claudegen/executor.go
@@ -1,0 +1,202 @@
+// Package claudegen 은 Claude Code Docker 컨테이너를 실행하여 HTML 에서 CSS 셀렉터를
+// 생성하는 컴포넌트입니다 (이슈 #256).
+//
+// 역할: 기존 llmgen.Generator 가 Gemini Flash 로 수행하던 셀렉터 추출 단계를 대체.
+// 검증은 validator.ValidatorPool (이슈 #257) 이 담당.
+//
+// 환경변수:
+//   - ANTHROPIC_API_KEY  : Claude Code 인증 (필수)
+//   - CLAUDE_CODE_MODEL  : 모델 ID (기본: claude-sonnet-4-6)
+//   - CLAUDE_CODE_IMAGE  : Docker 이미지 (기본: ghcr.io/anthropics/claude-code:latest)
+//   - CLAUDE_CODE_TIMEOUT: 단일 실행 타임아웃 (기본: 120s)
+package claudegen
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"issuetracker/internal/storage"
+	"issuetracker/pkg/logger"
+)
+
+const (
+	defaultImage   = "ghcr.io/anthropics/claude-code:latest"
+	defaultModel   = "claude-sonnet-4-6"
+	defaultTimeout = 120 * time.Second
+)
+
+// DockerRunner 는 docker 명령 실행을 추상화합니다 (테스트에서 mock 교체 용).
+type DockerRunner interface {
+	Run(ctx context.Context, args []string) (stdout string, stderr string, err error)
+}
+
+// execDockerRunner 는 실제 docker CLI 를 실행하는 기본 구현입니다.
+type execDockerRunner struct{}
+
+func (r *execDockerRunner) Run(ctx context.Context, args []string) (string, string, error) {
+	var stdout, stderr bytes.Buffer
+	cmd := exec.CommandContext(ctx, "docker", args...)
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	return stdout.String(), stderr.String(), cmd.Run()
+}
+
+// Executor 는 Claude Code Docker 를 실행하여 CSS 셀렉터를 추출합니다.
+type Executor struct {
+	image   string
+	model   string
+	apiKey  string
+	timeout time.Duration
+	runner  DockerRunner
+	log     *logger.Logger
+}
+
+// NewFromEnv 는 환경변수 기반 Executor 를 생성합니다.
+//
+//	CLAUDE_CODE_IMAGE   — Docker 이미지 (기본: ghcr.io/anthropics/claude-code:latest)
+//	CLAUDE_CODE_MODEL   — 모델 ID     (기본: claude-sonnet-4-6)
+//	ANTHROPIC_API_KEY   — 인증 키     (필수)
+//	CLAUDE_CODE_TIMEOUT — 타임아웃    (기본: 120s, Go duration 형식)
+func NewFromEnv(log *logger.Logger) (*Executor, error) {
+	apiKey := os.Getenv("ANTHROPIC_API_KEY")
+	if apiKey == "" {
+		return nil, fmt.Errorf("claudegen: ANTHROPIC_API_KEY is required")
+	}
+	timeout := defaultTimeout
+	if s := os.Getenv("CLAUDE_CODE_TIMEOUT"); s != "" {
+		if d, err := time.ParseDuration(s); err == nil {
+			timeout = d
+		}
+	}
+	return &Executor{
+		image:   envOr("CLAUDE_CODE_IMAGE", defaultImage),
+		model:   envOr("CLAUDE_CODE_MODEL", defaultModel),
+		apiKey:  apiKey,
+		timeout: timeout,
+		runner:  &execDockerRunner{},
+		log:     log,
+	}, nil
+}
+
+// New 는 명시적 파라미터로 Executor 를 생성합니다 (테스트/DI 용).
+func New(image, model, apiKey string, timeout time.Duration, log *logger.Logger) *Executor {
+	return &Executor{image: image, model: model, apiKey: apiKey, timeout: timeout, runner: &execDockerRunner{}, log: log}
+}
+
+// NewWithRunner 는 DockerRunner 를 주입하는 생성자입니다 (테스트/DI 용).
+func NewWithRunner(image, model, apiKey string, timeout time.Duration, runner DockerRunner, log *logger.Logger) *Executor {
+	return &Executor{image: image, model: model, apiKey: apiKey, timeout: timeout, runner: runner, log: log}
+}
+
+// Extract 는 HTML 을 Docker 컨테이너에 마운트하고 Claude Code 로 셀렉터를 추출합니다.
+//
+// 실행 흐름:
+//  1. HTML 을 임시 디렉토리에 page.html 로 기록
+//  2. docker run --rm 으로 컨테이너 실행 (/workspace 마운트)
+//  3. Claude Code -p <prompt> 로 셀렉터 JSON 생성
+//  4. stdout 에서 JSON 파싱 후 SelectorMap 반환
+func (e *Executor) Extract(ctx context.Context, host string, targetType storage.TargetType, html string) (storage.SelectorMap, error) {
+	tmpDir, err := os.MkdirTemp("", "claudegen-*")
+	if err != nil {
+		return storage.SelectorMap{}, fmt.Errorf("create tmpdir: %w", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	if err := os.WriteFile(filepath.Join(tmpDir, "page.html"), []byte(html), 0o644); err != nil {
+		return storage.SelectorMap{}, fmt.Errorf("write html: %w", err)
+	}
+
+	runCtx, cancel := context.WithTimeout(ctx, e.timeout)
+	defer cancel()
+
+	args := []string{
+		"run", "--rm",
+		"-e", "ANTHROPIC_API_KEY=" + e.apiKey,
+		"-v", tmpDir + ":/workspace:ro",
+		e.image,
+		"--model", e.model,
+		"--dangerously-skip-permissions",
+		"-p", buildPrompt(host, targetType),
+	}
+
+	e.log.WithFields(map[string]interface{}{
+		"host":        host,
+		"target_type": string(targetType),
+		"image":       e.image,
+		"model":       e.model,
+	}).Debug("running claude code extractor")
+
+	stdout, stderr, err := e.runner.Run(runCtx, args)
+	if err != nil {
+		return storage.SelectorMap{}, fmt.Errorf("claude code docker run: %w (stderr: %s)",
+			err, truncate(stderr, 512))
+	}
+
+	sm, err := parseSelectorOutput(stdout)
+	if err != nil {
+		return storage.SelectorMap{}, fmt.Errorf("parse claude output: %w (raw: %s)",
+			err, truncate(stdout, 256))
+	}
+
+	e.log.WithFields(map[string]interface{}{
+		"host":        host,
+		"target_type": string(targetType),
+	}).Info("claude code extractor succeeded")
+
+	return sm, nil
+}
+
+func envOr(key, fallback string) string {
+	if v := os.Getenv(key); v != "" {
+		return v
+	}
+	return fallback
+}
+
+func truncate(s string, n int) string {
+	if len(s) <= n {
+		return s
+	}
+	return s[:n] + "..."
+}
+
+// parseSelectorOutput 은 Claude Code 출력에서 JSON 블록을 추출하고 SelectorMap 으로 파싱합니다.
+func parseSelectorOutput(output string) (storage.SelectorMap, error) {
+	jsonStr := extractJSON(output)
+	if jsonStr == "" {
+		return storage.SelectorMap{}, fmt.Errorf("no JSON object found in output")
+	}
+	var sm storage.SelectorMap
+	if err := json.Unmarshal([]byte(jsonStr), &sm); err != nil {
+		return storage.SelectorMap{}, fmt.Errorf("unmarshal selector map: %w", err)
+	}
+	return sm, nil
+}
+
+// extractJSON 은 출력 텍스트에서 첫 번째 {...} JSON 블록을 추출합니다.
+func extractJSON(s string) string {
+	start := strings.Index(s, "{")
+	if start == -1 {
+		return ""
+	}
+	depth := 0
+	for i := start; i < len(s); i++ {
+		switch s[i] {
+		case '{':
+			depth++
+		case '}':
+			depth--
+			if depth == 0 {
+				return s[start : i+1]
+			}
+		}
+	}
+	return ""
+}

--- a/internal/processor/parser/rule/claudegen/prompt.go
+++ b/internal/processor/parser/rule/claudegen/prompt.go
@@ -12,7 +12,7 @@ func buildPrompt(host string, targetType storage.TargetType) string {
 	fieldsGuide := fieldsGuideFor(targetType)
 	return fmt.Sprintf(`Read the HTML file at /workspace/page.html from the %s website.
 
-Your task: extract CSS selectors for the fields below and return them as a **single JSON object only** — no explanation, no markdown, no code blocks.
+Your task: extract CSS selectors for the fields below and return them as a single JSON object only — no explanation, no markdown, no code blocks.
 
 Target page type: %s
 

--- a/internal/processor/parser/rule/claudegen/prompt.go
+++ b/internal/processor/parser/rule/claudegen/prompt.go
@@ -1,0 +1,53 @@
+package claudegen
+
+import (
+	"fmt"
+
+	"issuetracker/internal/storage"
+)
+
+// buildPrompt 는 Claude Code 에 전달할 프롬프트를 생성합니다.
+// Claude Code 는 /workspace/page.html 을 파일 읽기 툴로 직접 접근합니다.
+func buildPrompt(host string, targetType storage.TargetType) string {
+	fieldsGuide := fieldsGuideFor(targetType)
+	return fmt.Sprintf(`Read the HTML file at /workspace/page.html from the %s website.
+
+Your task: extract CSS selectors for the fields below and return them as a **single JSON object only** — no explanation, no markdown, no code blocks.
+
+Target page type: %s
+
+Required fields:
+%s
+
+Rules:
+1. Use only selectors that actually appear in the HTML — do not invent.
+2. Prefer stable selectors (semantic tags, ARIA roles, id/class with meaningful names) over brittle ones (auto-generated hashes, nth-child indices).
+3. "css" must be a valid goquery/CSS selector. "attribute" must be empty for text content, or the HTML attribute name (e.g. "href", "datetime", "content").
+4. "multi": true when the selector matches multiple elements (lists, paragraphs).
+5. Omit fields you cannot find a reliable selector for.
+
+Return ONLY the JSON object.`, host, string(targetType), fieldsGuide)
+}
+
+func fieldsGuideFor(targetType storage.TargetType) string {
+	switch targetType {
+	case storage.TargetTypeList:
+		return `{
+  "item_container": {"css": "<selector for each list item root>"},
+  "item_link":      {"css": "<selector inside item for the article link>", "attribute": "href"},
+  "item_title":     {"css": "<selector inside item for the title text>"},
+  "item_snippet":   {"css": "<selector inside item for the short summary>"}
+}`
+	default: // TargetTypePage / TargetTypeArticle
+		return `{
+  "title":        {"css": "<selector for page title>"},
+  "main_content": {"css": "<selector for primary article body>", "multi": true},
+  "summary":      {"css": "<selector for description/summary, often meta>", "attribute": "content"},
+  "author":       {"css": "<selector for author name>"},
+  "published_at": {"css": "<selector for publish datetime>", "attribute": "datetime"},
+  "category":     {"css": "<selector for section/category>"},
+  "tags":         {"css": "<selector for tag links>", "multi": true},
+  "images":       {"css": "<selector for content images>", "attribute": "src", "multi": true}
+}`
+	}
+}

--- a/internal/processor/parser/rule/llmgen/generator.go
+++ b/internal/processor/parser/rule/llmgen/generator.go
@@ -60,6 +60,15 @@ func (e *selectorValidationError) Error() string {
 }
 func (e *selectorValidationError) Unwrap() error { return e.cause }
 
+// SelectorExtractor 는 HTML 에서 CSS 셀렉터를 추출하는 인터페이스입니다 (이슈 #256).
+//
+// 기본 구현: pkg/llm.Provider 기반 LLM 호출 (Gemini Flash 등).
+// 대체 구현: claudegen.Executor (Claude Code Docker).
+// SetExtractor 로 교체하면 추출 단계만 대체되고 나머지 흐름 (validation, INSERT) 은 동일.
+type SelectorExtractor interface {
+	Extract(ctx context.Context, host string, targetType storage.TargetType, html string) (storage.SelectorMap, error)
+}
+
 // Generator 는 host 별 parsing rule 을 LLM 으로 자동 생성합니다.
 //
 // goroutine-safe — provider / repo / resolver 가 자체 thread-safety 를 가짐.
@@ -70,10 +79,11 @@ func (e *selectorValidationError) Unwrap() error { return e.cause }
 //   - Stop(ctx) 호출 시 새 Enqueue 차단 + 진행 중 goroutine 의 완료 대기 (graceful shutdown)
 //   - Stop 후 Enqueue 는 noop (race 안전)
 type Generator struct {
-	provider llm.Provider
-	repo     storage.ParsingRuleRepository
-	resolver *rule.Resolver
-	log      *logger.Logger
+	provider  llm.Provider
+	extractor SelectorExtractor // nil 이면 provider 로 fallback (이슈 #256)
+	repo      storage.ParsingRuleRepository
+	resolver  *rule.Resolver
+	log       *logger.Logger
 
 	// validateFailureHandler 는 selector 검증 실패 시 호출되는 콜백입니다 (이슈 #237).
 	// 인자: (ctx, ref, llmRetryCount, targetType, crawlerName).
@@ -92,6 +102,13 @@ type Generator struct {
 // Stop 전에 설정해야 하며, goroutine-safe 하지 않으므로 초기화 시 1회만 호출합니다.
 func (g *Generator) SetValidateFailureHandler(fn func(context.Context, core.RawContentRef, int, storage.TargetType, string)) {
 	g.validateFailureHandler = fn
+}
+
+// SetExtractor 는 셀렉터 추출 단계를 교체합니다 (이슈 #256).
+// nil 이면 기존 provider (Gemini Flash 등) 로 fallback.
+// Stop 전에 설정해야 하며, goroutine-safe 하지 않으므로 초기화 시 1회만 호출합니다.
+func (g *Generator) SetExtractor(e SelectorExtractor) {
+	g.extractor = e
 }
 
 // New 는 Generator 를 생성합니다.
@@ -222,28 +239,44 @@ func (g *Generator) Stop(ctx context.Context) {
 	}
 }
 
-// runOnce 는 단일 LLM 호출 + validation + INSERT + cache invalidate 의 동기 실행입니다.
+// runOnce 는 단일 추출 + validation + INSERT + cache invalidate 의 동기 실행입니다.
 // 호출자 (Enqueue 의 goroutine) 가 in-flight 슬롯 release 책임.
 func (g *Generator) runOnce(ctx context.Context, host string, targetType storage.TargetType, sampleURL, html string) error {
-	system, user := BuildPrompt(host, targetType, html)
+	var (
+		selectors storage.SelectorMap
+		modelName string
+	)
 
-	resp, err := g.provider.Generate(ctx, llm.Request{
-		Messages: []llm.Message{
-			{Role: llm.RoleSystem, Content: system},
-			{Role: llm.RoleUser, Content: user},
-		},
-		TaskHint: llm.TaskHintJSON,
-	})
-	if err != nil {
-		return fmt.Errorf("llm provider call: %w", err)
-	}
-	if resp == nil || resp.Content == "" {
-		return errors.New("llm returned empty response")
-	}
-
-	selectors, err := parseSelectorMap(resp.Content)
-	if err != nil {
-		return fmt.Errorf("parse llm response: %w", err)
+	if g.extractor != nil {
+		// Claude Code Docker 추출 경로 (이슈 #256)
+		sm, err := g.extractor.Extract(ctx, host, targetType, html)
+		if err != nil {
+			return fmt.Errorf("claude code extractor: %w", err)
+		}
+		selectors = sm
+		modelName = "claude-code"
+	} else {
+		// 기존 LLM provider 경로 (Gemini Flash 등)
+		system, user := BuildPrompt(host, targetType, html)
+		resp, err := g.provider.Generate(ctx, llm.Request{
+			Messages: []llm.Message{
+				{Role: llm.RoleSystem, Content: system},
+				{Role: llm.RoleUser, Content: user},
+			},
+			TaskHint: llm.TaskHintJSON,
+		})
+		if err != nil {
+			return fmt.Errorf("llm provider call: %w", err)
+		}
+		if resp == nil || resp.Content == "" {
+			return errors.New("llm returned empty response")
+		}
+		sm, err := parseSelectorMap(resp.Content)
+		if err != nil {
+			return fmt.Errorf("parse llm response: %w", err)
+		}
+		selectors = sm
+		modelName = resp.Model
 	}
 
 	if err := validateSelectors(selectors, targetType, html); err != nil {
@@ -257,7 +290,7 @@ func (g *Generator) runOnce(ctx context.Context, host string, targetType storage
 		Version:     1,
 		Enabled:     false, // 운영자 review 게이트 — spot-check 후 수동 enable
 		Selectors:   selectors,
-		Description: fmt.Sprintf("%s (sample url: %s, model: %s)", llmAutoDescription, sampleURL, resp.Model),
+		Description: fmt.Sprintf("%s (sample url: %s, model: %s)", llmAutoDescription, sampleURL, modelName),
 	}
 	if err := g.repo.Insert(ctx, record); err != nil {
 		return fmt.Errorf("insert parsing rule: %w", err)
@@ -271,7 +304,7 @@ func (g *Generator) runOnce(ctx context.Context, host string, targetType storage
 		"host":        host,
 		"target_type": string(targetType),
 		"rule_id":     record.ID,
-		"model":       resp.Model,
+		"model":       modelName,
 		"enabled":     false,
 	}).Info("llm-generated parsing rule inserted (review required before enabling)")
 

--- a/internal/processor/parser/rule/llmgen/generator.go
+++ b/internal/processor/parser/rule/llmgen/generator.go
@@ -69,6 +69,13 @@ type SelectorExtractor interface {
 	Extract(ctx context.Context, host string, targetType storage.TargetType, html string) (storage.SelectorMap, error)
 }
 
+// modelNamer 는 추출기가 사용하는 모델 ID 를 반환하는 선택적 인터페이스입니다 (이슈 #256).
+// SelectorExtractor 구현체가 이 인터페이스도 구현하면 실제 모델 ID 를 DB description 에 기록합니다.
+// 구현하지 않으면 fallback 으로 "claude-code" 를 사용합니다.
+type modelNamer interface {
+	ModelName() string
+}
+
 // Generator 는 host 별 parsing rule 을 LLM 으로 자동 생성합니다.
 //
 // goroutine-safe — provider / repo / resolver 가 자체 thread-safety 를 가짐.
@@ -254,7 +261,12 @@ func (g *Generator) runOnce(ctx context.Context, host string, targetType storage
 			return fmt.Errorf("claude code extractor: %w", err)
 		}
 		selectors = sm
-		modelName = "claude-code"
+		// 추출기가 ModelName() 을 구현하면 실제 모델 ID 를 사용, 없으면 fallback.
+		if mn, ok := g.extractor.(modelNamer); ok {
+			modelName = mn.ModelName()
+		} else {
+			modelName = "claude-code"
+		}
 	} else {
 		// 기존 LLM provider 경로 (Gemini Flash 등)
 		system, user := BuildPrompt(host, targetType, html)

--- a/test/internal/processor/parser/rule/claudegen/executor_test.go
+++ b/test/internal/processor/parser/rule/claudegen/executor_test.go
@@ -20,16 +20,19 @@ type mockRunner struct {
 	stderr       string
 	err          error
 	capturedArgs []string
+	capturedEnv  []string
 }
 
-func (m *mockRunner) Run(_ context.Context, args []string) (string, string, error) {
+func (m *mockRunner) Run(_ context.Context, args []string, env []string) (string, string, error) {
 	m.capturedArgs = args
+	m.capturedEnv = env
 	return m.stdout, m.stderr, m.err
 }
 
-func newTestExecutor(runner *mockRunner) *claudegen.Executor {
+func newTestExecutor(t *testing.T, runner *mockRunner) *claudegen.Executor {
+	t.Helper()
 	log := logger.New(logger.DefaultConfig())
-	return claudegen.NewWithRunner(
+	ex, err := claudegen.NewWithRunner(
 		"ghcr.io/anthropics/claude-code:latest",
 		"claude-sonnet-4-6",
 		"test-api-key",
@@ -37,6 +40,8 @@ func newTestExecutor(runner *mockRunner) *claudegen.Executor {
 		runner,
 		log,
 	)
+	require.NoError(t, err)
+	return ex
 }
 
 func TestExtract_Success_ArticlePage(t *testing.T) {
@@ -44,7 +49,7 @@ func TestExtract_Success_ArticlePage(t *testing.T) {
 		stdout: `Here are the selectors:
 {"title":{"css":"h1.article-title"},"main_content":{"css":"div.article-body","multi":true},"published_at":{"css":"time","attribute":"datetime"}}`,
 	}
-	sm, err := newTestExecutor(runner).Extract(t.Context(), "news.naver.com", storage.TargetTypePage, "<html>...</html>")
+	sm, err := newTestExecutor(t, runner).Extract(t.Context(), "news.naver.com", storage.TargetTypePage, "<html>...</html>")
 
 	require.NoError(t, err)
 	require.NotNil(t, sm.Title)
@@ -59,7 +64,7 @@ func TestExtract_Success_ListPage(t *testing.T) {
 	runner := &mockRunner{
 		stdout: `{"item_container":{"css":"ul.news-list li"},"item_link":{"css":"a.news-link","attribute":"href"},"item_title":{"css":"span.title"}}`,
 	}
-	sm, err := newTestExecutor(runner).Extract(t.Context(), "news.daum.net", storage.TargetTypeList, "<html>...</html>")
+	sm, err := newTestExecutor(t, runner).Extract(t.Context(), "news.daum.net", storage.TargetTypeList, "<html>...</html>")
 
 	require.NoError(t, err)
 	require.NotNil(t, sm.ItemContainer)
@@ -73,7 +78,7 @@ func TestExtract_DockerRunError(t *testing.T) {
 		stderr: "docker: Cannot connect to the Docker daemon",
 		err:    errors.New("exit status 1"),
 	}
-	_, err := newTestExecutor(runner).Extract(t.Context(), "example.com", storage.TargetTypePage, "<html></html>")
+	_, err := newTestExecutor(t, runner).Extract(t.Context(), "example.com", storage.TargetTypePage, "<html></html>")
 
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "docker run")
@@ -83,30 +88,39 @@ func TestExtract_NoJSONInOutput(t *testing.T) {
 	runner := &mockRunner{
 		stdout: "I could not find any relevant selectors in the provided HTML.",
 	}
-	_, err := newTestExecutor(runner).Extract(t.Context(), "example.com", storage.TargetTypePage, "<html></html>")
+	_, err := newTestExecutor(t, runner).Extract(t.Context(), "example.com", storage.TargetTypePage, "<html></html>")
 
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "parse claude output")
 }
 
-func TestExtract_DockerArgsContainAPIKey(t *testing.T) {
+// TestExtract_APIKeyNotInDockerArgs 는 ANTHROPIC_API_KEY 가 docker args 가 아닌
+// env 슬라이스로 전달되는지 검증합니다 (ps/proc 노출 방지 — PR #258 보안 요건).
+func TestExtract_APIKeyNotInDockerArgs(t *testing.T) {
 	runner := &mockRunner{stdout: `{"title":{"css":"h1"}}`}
-	_, err := newTestExecutor(runner).Extract(t.Context(), "example.com", storage.TargetTypePage, "<html><h1>test</h1></html>")
+	_, err := newTestExecutor(t, runner).Extract(t.Context(), "example.com", storage.TargetTypePage, "<html><h1>test</h1></html>")
 	require.NoError(t, err)
 
-	found := false
+	// API 키 값이 docker args 에 포함되어서는 안 됨 (ps 로 노출 방지)
 	for _, arg := range runner.capturedArgs {
-		if arg == "ANTHROPIC_API_KEY=test-api-key" {
+		assert.NotContains(t, arg, "test-api-key",
+			"ANTHROPIC_API_KEY value must not appear in docker args (ps/proc exposure)")
+	}
+
+	// API 키는 env 슬라이스로 전달되어야 함
+	found := false
+	for _, e := range runner.capturedEnv {
+		if e == "ANTHROPIC_API_KEY=test-api-key" {
 			found = true
 			break
 		}
 	}
-	assert.True(t, found, "ANTHROPIC_API_KEY must be passed to docker run args")
+	assert.True(t, found, "ANTHROPIC_API_KEY must be passed via env slice, not docker args")
 }
 
 func TestExtract_ModelInArgs(t *testing.T) {
 	runner := &mockRunner{stdout: `{"title":{"css":"h1"}}`}
-	_, _ = newTestExecutor(runner).Extract(t.Context(), "example.com", storage.TargetTypePage, "<html></html>")
+	_, _ = newTestExecutor(t, runner).Extract(t.Context(), "example.com", storage.TargetTypePage, "<html></html>")
 
 	modelFound := false
 	for i, arg := range runner.capturedArgs {

--- a/test/internal/processor/parser/rule/claudegen/executor_test.go
+++ b/test/internal/processor/parser/rule/claudegen/executor_test.go
@@ -1,0 +1,127 @@
+package claudegen_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"issuetracker/internal/processor/parser/rule/claudegen"
+	"issuetracker/internal/storage"
+	"issuetracker/pkg/logger"
+)
+
+// mockRunner 는 docker 명령을 실행하지 않는 테스트용 구현입니다.
+type mockRunner struct {
+	stdout       string
+	stderr       string
+	err          error
+	capturedArgs []string
+}
+
+func (m *mockRunner) Run(_ context.Context, args []string) (string, string, error) {
+	m.capturedArgs = args
+	return m.stdout, m.stderr, m.err
+}
+
+func newTestExecutor(runner *mockRunner) *claudegen.Executor {
+	log := logger.New(logger.DefaultConfig())
+	return claudegen.NewWithRunner(
+		"ghcr.io/anthropics/claude-code:latest",
+		"claude-sonnet-4-6",
+		"test-api-key",
+		10*time.Second,
+		runner,
+		log,
+	)
+}
+
+func TestExtract_Success_ArticlePage(t *testing.T) {
+	runner := &mockRunner{
+		stdout: `Here are the selectors:
+{"title":{"css":"h1.article-title"},"main_content":{"css":"div.article-body","multi":true},"published_at":{"css":"time","attribute":"datetime"}}`,
+	}
+	sm, err := newTestExecutor(runner).Extract(t.Context(), "news.naver.com", storage.TargetTypePage, "<html>...</html>")
+
+	require.NoError(t, err)
+	require.NotNil(t, sm.Title)
+	assert.Equal(t, "h1.article-title", sm.Title.CSS)
+	require.NotNil(t, sm.MainContent)
+	assert.True(t, sm.MainContent.Multi)
+	require.NotNil(t, sm.PublishedAt)
+	assert.Equal(t, "datetime", sm.PublishedAt.Attribute)
+}
+
+func TestExtract_Success_ListPage(t *testing.T) {
+	runner := &mockRunner{
+		stdout: `{"item_container":{"css":"ul.news-list li"},"item_link":{"css":"a.news-link","attribute":"href"},"item_title":{"css":"span.title"}}`,
+	}
+	sm, err := newTestExecutor(runner).Extract(t.Context(), "news.daum.net", storage.TargetTypeList, "<html>...</html>")
+
+	require.NoError(t, err)
+	require.NotNil(t, sm.ItemContainer)
+	assert.Equal(t, "ul.news-list li", sm.ItemContainer.CSS)
+	require.NotNil(t, sm.ItemLink)
+	assert.Equal(t, "href", sm.ItemLink.Attribute)
+}
+
+func TestExtract_DockerRunError(t *testing.T) {
+	runner := &mockRunner{
+		stderr: "docker: Cannot connect to the Docker daemon",
+		err:    errors.New("exit status 1"),
+	}
+	_, err := newTestExecutor(runner).Extract(t.Context(), "example.com", storage.TargetTypePage, "<html></html>")
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "docker run")
+}
+
+func TestExtract_NoJSONInOutput(t *testing.T) {
+	runner := &mockRunner{
+		stdout: "I could not find any relevant selectors in the provided HTML.",
+	}
+	_, err := newTestExecutor(runner).Extract(t.Context(), "example.com", storage.TargetTypePage, "<html></html>")
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "parse claude output")
+}
+
+func TestExtract_DockerArgsContainAPIKey(t *testing.T) {
+	runner := &mockRunner{stdout: `{"title":{"css":"h1"}}`}
+	_, err := newTestExecutor(runner).Extract(t.Context(), "example.com", storage.TargetTypePage, "<html><h1>test</h1></html>")
+	require.NoError(t, err)
+
+	found := false
+	for _, arg := range runner.capturedArgs {
+		if arg == "ANTHROPIC_API_KEY=test-api-key" {
+			found = true
+			break
+		}
+	}
+	assert.True(t, found, "ANTHROPIC_API_KEY must be passed to docker run args")
+}
+
+func TestExtract_ModelInArgs(t *testing.T) {
+	runner := &mockRunner{stdout: `{"title":{"css":"h1"}}`}
+	_, _ = newTestExecutor(runner).Extract(t.Context(), "example.com", storage.TargetTypePage, "<html></html>")
+
+	modelFound := false
+	for i, arg := range runner.capturedArgs {
+		if arg == "--model" && i+1 < len(runner.capturedArgs) && runner.capturedArgs[i+1] == "claude-sonnet-4-6" {
+			modelFound = true
+			break
+		}
+	}
+	assert.True(t, modelFound, "--model claude-sonnet-4-6 must be in docker args")
+}
+
+func TestNewFromEnv_MissingAPIKey(t *testing.T) {
+	t.Setenv("ANTHROPIC_API_KEY", "")
+	log := logger.New(logger.DefaultConfig())
+	_, err := claudegen.NewFromEnv(log)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "ANTHROPIC_API_KEY")
+}

--- a/test/internal/processor/parser/rule/llmgen/generator_test.go
+++ b/test/internal/processor/parser/rule/llmgen/generator_test.go
@@ -426,3 +426,121 @@ func (s *slowProvider) Generate(ctx context.Context, req llm.Request) (*llm.Resp
 	}
 	return s.fakeProvider.Generate(ctx, req)
 }
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Extractor path tests (이슈 #256)
+// ─────────────────────────────────────────────────────────────────────────────
+
+// fakeExtractor 는 SelectorExtractor 의 테스트용 구현입니다.
+type fakeExtractor struct {
+	sm  storage.SelectorMap
+	err error
+	mu  sync.Mutex
+	n   int
+}
+
+func (e *fakeExtractor) Extract(_ context.Context, _ string, _ storage.TargetType, _ string) (storage.SelectorMap, error) {
+	e.mu.Lock()
+	e.n++
+	e.mu.Unlock()
+	return e.sm, e.err
+}
+
+func (e *fakeExtractor) callCount() int {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	return e.n
+}
+
+// fakeExtractorWithModel 은 ModelName() 도 구현하는 SelectorExtractor 입니다.
+type fakeExtractorWithModel struct {
+	fakeExtractor
+	modelName string
+}
+
+func (e *fakeExtractorWithModel) ModelName() string { return e.modelName }
+
+// TestGenerator_SetExtractor_UsesExtractorNotProvider 는 SetExtractor 설정 시
+// provider (Gemini 등) 대신 extractor 가 사용되는지 검증합니다 (이슈 #256).
+func TestGenerator_SetExtractor_UsesExtractorNotProvider(t *testing.T) {
+	provider := &fakeProvider{name: "gemini-flash", response: "{}"}
+	repo := &recordingRepo{}
+	g, _ := newGenerator(t, provider, repo)
+
+	extractor := &fakeExtractor{
+		sm: storage.SelectorMap{
+			Title:       &storage.FieldSelector{CSS: "h1.article-title"},
+			MainContent: &storage.FieldSelector{CSS: "article p", Multi: true},
+		},
+	}
+	g.SetExtractor(extractor)
+
+	g.Enqueue(context.Background(), "example.com", storage.TargetTypePage, &core.RawContent{
+		URL: "https://example.com/article/1", HTML: samplePageHTML,
+	}, 0, "")
+
+	waitForInserts(t, repo, 1, 2*time.Second)
+
+	assert.Equal(t, 0, provider.callCount(), "extractor 설정 시 provider 는 호출 안 됨")
+	assert.Equal(t, 1, extractor.callCount(), "extractor 가 1회 호출됨")
+	recs := repo.inserts()
+	require.Len(t, recs, 1)
+	assert.Equal(t, "h1.article-title", recs[0].Selectors.Title.CSS)
+}
+
+// TestGenerator_SetExtractor_ModelNameFromInterface 는 extractor 가 ModelName() 을 구현하면
+// 실제 모델 ID 가 DB description 에 기록되는지 검증합니다 (이슈 #256).
+func TestGenerator_SetExtractor_ModelNameFromInterface(t *testing.T) {
+	provider := &fakeProvider{name: "gemini-flash", response: "{}"}
+	repo := &recordingRepo{}
+	g, _ := newGenerator(t, provider, repo)
+
+	extractor := &fakeExtractorWithModel{
+		fakeExtractor: fakeExtractor{
+			sm: storage.SelectorMap{
+				Title:       &storage.FieldSelector{CSS: "h1.article-title"},
+				MainContent: &storage.FieldSelector{CSS: "article p"},
+			},
+		},
+		modelName: "claude-sonnet-4-6",
+	}
+	g.SetExtractor(extractor)
+
+	g.Enqueue(context.Background(), "example.com", storage.TargetTypePage, &core.RawContent{
+		URL: "https://example.com/article/1", HTML: samplePageHTML,
+	}, 0, "")
+
+	waitForInserts(t, repo, 1, 2*time.Second)
+
+	recs := repo.inserts()
+	require.Len(t, recs, 1)
+	assert.Contains(t, recs[0].Description, "claude-sonnet-4-6",
+		"ModelName() 구현체의 모델 ID 가 description 에 포함되어야 함")
+}
+
+// TestGenerator_SetExtractor_FallbackModelName 는 extractor 가 ModelName() 을 구현하지 않으면
+// fallback "claude-code" 가 description 에 기록되는지 검증합니다 (이슈 #256).
+func TestGenerator_SetExtractor_FallbackModelName(t *testing.T) {
+	provider := &fakeProvider{name: "gemini-flash", response: "{}"}
+	repo := &recordingRepo{}
+	g, _ := newGenerator(t, provider, repo)
+
+	extractor := &fakeExtractor{
+		sm: storage.SelectorMap{
+			Title:       &storage.FieldSelector{CSS: "h1.article-title"},
+			MainContent: &storage.FieldSelector{CSS: "article p"},
+		},
+	}
+	g.SetExtractor(extractor)
+
+	g.Enqueue(context.Background(), "example.com", storage.TargetTypePage, &core.RawContent{
+		URL: "https://example.com/article/1", HTML: samplePageHTML,
+	}, 0, "")
+
+	waitForInserts(t, repo, 1, 2*time.Second)
+
+	recs := repo.inserts()
+	require.Len(t, recs, 1)
+	assert.Contains(t, recs[0].Description, "claude-code",
+		"ModelName() 미구현 시 fallback 'claude-code' 가 description 에 포함되어야 함")
+}


### PR DESCRIPTION
## 연관 이슈

Closes #256
Parent: #254

## 구현 내용

### `claudegen` 패키지 (신규)

- **`executor.go`**: `DockerRunner` 인터페이스 + `Executor`
  - `NewFromEnv()` — 환경변수 기반 생성
  - `NewWithRunner()` — DI 생성자 (테스트용)
  - `Extract()` — HTML tmpdir 마운트 → `docker run` → stdout JSON 파싱
  - `--dangerously-skip-permissions`: 비대화형 환경에서 파일 읽기 권한 자동 처리
- **`prompt.go`**: page/list 타입별 파일 기반 프롬프트 (Claude Code가 `/workspace/page.html` 직접 읽기)

### 환경변수

| 변수 | 기본값 | 설명 |
|---|---|---|
| `ANTHROPIC_API_KEY` | — (필수) | Claude Code 인증 |
| `CLAUDE_CODE_MODEL` | `claude-sonnet-4-6` | 모델 ID |
| `CLAUDE_CODE_IMAGE` | `ghcr.io/anthropics/claude-code:latest` | Docker 이미지 |
| `CLAUDE_CODE_TIMEOUT` | `120s` | 단일 실행 타임아웃 |

### `llmgen` 패키지 수정

- `SelectorExtractor` 인터페이스 추가
- `Generator.SetExtractor()` — 추출 엔진 교체 메서드
- `runOnce()` — extractor 설정 시 Claude Code 경로, nil 이면 기존 LLM provider fallback

## 테스트

| 케이스 | 결과 |
|---|---|
| page 타입 정상 추출 | PASS |
| list 타입 정상 추출 | PASS |
| docker run 에러 | PASS |
| JSON 없는 출력 | PASS |
| API key docker args 전달 확인 | PASS |
| --model args 전달 확인 | PASS |
| ANTHROPIC_API_KEY 없음 | PASS |

## 변경 영향 범위 + 위험도

- **Low** — `llmgen.Generator` 의 기존 동작 무변경. `SetExtractor` 를 호출하지 않으면 기존 Gemini Flash 경로로 동작. 신규 패키지는 독립적.

## 롤백 계획

- `SetExtractor` 호출 제거 시 즉시 기존 경로로 복귀

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Integrated Claude Code Docker image with configurable environment variables (`ANTHROPIC_API_KEY`, optional `CLAUDE_CODE_MODEL`, `CLAUDE_CODE_IMAGE`, `CLAUDE_CODE_TIMEOUT`)
* Introduced pluggable selector extraction interface for flexible integration patterns
* Added error handling for Docker execution failures and output parsing

## Tests
* Comprehensive test suite covering successful and error scenarios in selector extraction workflows

<!-- end of auto-generated comment: release notes by coderabbit.ai -->