### PR TITLE
[FEAT#261] llmgen inflightSet — Redis 분산 Lock 전환

### DIFF
--- a/cmd/issuetracker/main.go
+++ b/cmd/issuetracker/main.go
@@ -310,7 +310,7 @@ func main() {
 	//
 	// 이슈 #173 단계 4-2: 동일 provider 를 refiner 와 공유 — 환경변수 1세트로 동시 제어.
 	llmProvider := buildLLMProvider(log)
-	llmGen := buildLLMGenerator(llmProvider, parsingRuleRepo, ruleResolver, log)
+	llmGen := buildLLMGenerator(llmProvider, parsingRuleRepo, ruleResolver, redisClientShared, log)
 
 	// ── Fetcher 실패 카운터 (이슈 #220) ────────────────────────────────────────
 	// host 단위 fetcher 실패를 sliding window 로 누적 — 단계 3 (#221) 의 chromedp 자동 전환
@@ -628,13 +628,18 @@ func buildLLMProvider(log *logger.Logger) llm.Provider {
 //
 // provider 가 nil (LLM 비활성) 이면 nil 반환 — parser worker 는 ErrNoRule 시 raw 만 잔존.
 // llmgen.New 자체 실패는 wiring 버그라 fatal — 도달하면 dependency injection 모순 (이슈 #208).
-func buildLLMGenerator(provider llm.Provider, repo storage.ParsingRuleRepository, resolver *rule.Resolver, log *logger.Logger) *llmgen.Generator {
+// redisClient 가 nil 이면 in-process memInflightLocker 로 graceful degrade (이슈 #261).
+func buildLLMGenerator(provider llm.Provider, repo storage.ParsingRuleRepository, resolver *rule.Resolver, redisClient *redis.Client, log *logger.Logger) *llmgen.Generator {
 	if provider == nil {
 		return nil
 	}
 	gen, err := llmgen.New(provider, repo, resolver, log)
 	if err != nil {
 		log.WithError(err).Fatal("failed to construct llmgen generator")
+	}
+	if redisClient != nil {
+		gen.SetLocker(llmgen.NewRedisInflightLocker(redisClient.Raw(), llmgen.DefaultInflightLockTTL))
+		log.Info("llmgen: Redis 분산 inflight lock 활성화")
 	}
 	return gen
 }

--- a/internal/processor/parser/rule/llmgen/dedup.go
+++ b/internal/processor/parser/rule/llmgen/dedup.go
@@ -2,6 +2,9 @@ package llmgen
 
 import (
 	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"errors"
 	"fmt"
 	"sync"
 	"time"
@@ -72,32 +75,76 @@ func (m *memInflightLocker) Release(_ context.Context, host string, targetType s
 // RedisInflightLocker — 분산 Lock 구현 (이슈 #261)
 // ─────────────────────────────────────────────────────────────────────────────
 
-// RedisInflightLocker 는 Redis SETNX+TTL 기반 분산 Lock 구현입니다.
+// luaRelease 는 소유권 확인 후 삭제하는 Lua 스크립트입니다.
+// GET 과 DEL 의 원자성 보장 — 다른 인스턴스가 재획득한 락을 삭제하지 않습니다.
+const luaRelease = `
+if redis.call("GET", KEYS[1]) == ARGV[1] then
+    return redis.call("DEL", KEYS[1])
+else
+    return 0
+end`
+
+// RedisInflightLocker 는 Redis SET NX+TTL 기반 분산 Lock 구현입니다.
 //
 // 다중 인스턴스 환경에서 동일 (host, targetType) 에 대한 LLM 호출을 1회로 제한합니다.
 // TTL 은 프로세스 크래시 후 stuck 슬롯 자동 해제를 보장합니다.
+//
+// 소유권 보장: TryAcquire 시 고유 token 을 값으로 저장하고, Release 시 Lua 스크립트로
+// token 일치를 확인한 후 삭제 — TTL 만료 후 다른 인스턴스가 재획득한 락을 삭제하지 않습니다.
 type RedisInflightLocker struct {
-	rdb *goredis.Client
-	ttl time.Duration
+	rdb    *goredis.Client
+	ttl    time.Duration
+	mu     sync.Mutex
+	tokens map[string]string // lockKey → token (소유권 추적)
 }
 
 // NewRedisInflightLocker 는 RedisInflightLocker 를 생성합니다.
+// ttl ≤ 0 이면 DefaultInflightLockTTL 로 보정합니다.
 func NewRedisInflightLocker(rdb *goredis.Client, ttl time.Duration) *RedisInflightLocker {
-	return &RedisInflightLocker{rdb: rdb, ttl: ttl}
+	if ttl <= 0 {
+		ttl = DefaultInflightLockTTL
+	}
+	return &RedisInflightLocker{rdb: rdb, ttl: ttl, tokens: make(map[string]string)}
 }
 
 func (r *RedisInflightLocker) TryAcquire(ctx context.Context, host string, targetType storage.TargetType) (bool, error) {
 	key := r.key(host, targetType)
-	ok, err := r.rdb.SetNX(ctx, key, 1, r.ttl).Result()
+	token := newLockToken()
+
+	// SET key token NX PX ttl — SetNX 는 deprecated, SetArgs 의 NX mode 사용.
+	err := r.rdb.SetArgs(ctx, key, token, goredis.SetArgs{
+		Mode: "NX",
+		TTL:  r.ttl,
+	}).Err()
+	if errors.Is(err, goredis.Nil) {
+		return false, nil // 이미 다른 소유자가 획득 중
+	}
 	if err != nil {
 		return false, fmt.Errorf("redis inflight acquire %s: %w", key, err)
 	}
-	return ok, nil
+
+	r.mu.Lock()
+	r.tokens[key] = token
+	r.mu.Unlock()
+	return true, nil
 }
 
 func (r *RedisInflightLocker) Release(ctx context.Context, host string, targetType storage.TargetType) error {
 	key := r.key(host, targetType)
-	if err := r.rdb.Del(ctx, key).Err(); err != nil {
+
+	r.mu.Lock()
+	token, ok := r.tokens[key]
+	if ok {
+		delete(r.tokens, key)
+	}
+	r.mu.Unlock()
+
+	if !ok {
+		return nil // 이 인스턴스가 소유하지 않음
+	}
+
+	// Lua 스크립트로 소유권 확인 후 원자적 삭제 — TTL 만료 후 재획득된 락을 삭제하지 않음.
+	if err := r.rdb.Eval(ctx, luaRelease, []string{key}, token).Err(); err != nil && !errors.Is(err, goredis.Nil) {
 		return fmt.Errorf("redis inflight release %s: %w", key, err)
 	}
 	return nil
@@ -105,4 +152,10 @@ func (r *RedisInflightLocker) Release(ctx context.Context, host string, targetTy
 
 func (r *RedisInflightLocker) key(host string, targetType storage.TargetType) string {
 	return inflightKeyPrefix + host + ":" + string(targetType)
+}
+
+func newLockToken() string {
+	b := make([]byte, 16)
+	_, _ = rand.Read(b)
+	return hex.EncodeToString(b)
 }

--- a/internal/processor/parser/rule/llmgen/dedup.go
+++ b/internal/processor/parser/rule/llmgen/dedup.go
@@ -1,56 +1,108 @@
 package llmgen
 
 import (
+	"context"
+	"fmt"
 	"sync"
+	"time"
 
+	goredis "github.com/redis/go-redis/v9"
 	"issuetracker/internal/storage"
 )
 
-// inflightKey 는 in-flight LLM 요청을 식별하는 (host, target_type) 튜플입니다.
+// DefaultInflightLockTTL 은 Redis 분산 Lock 의 기본 TTL 입니다.
+// CLAUDE_CODE_TIMEOUT 기본값(120s) 의 2.5배 — 프로세스 크래시 후 stuck 슬롯 자동 해제 보장.
+const DefaultInflightLockTTL = 5 * time.Minute
+
+const inflightKeyPrefix = "llmgen:inflight:"
+
+// inflightKey 는 (host, target_type) 튜플입니다 — DB FindActiveCandidates 인자와 1:1 매칭.
 type inflightKey struct {
 	host       string
 	targetType storage.TargetType
 }
 
-// inflightSet 은 동일 (host, type) 에 대해 동시에 진행 중인 LLM 호출을 1회로 제한합니다.
+// InflightLocker 는 (host, targetType) 단위 중복 실행 방지 인터페이스입니다 (이슈 #261).
 //
-// inflightSet provides best-effort in-process dedup. 새 host 에 대해 100개 article URL 이
-// 동시에 들어와도 LLM 호출은 1회만 발생하도록 보장 (이슈 #149 의 안전망).
-//
-// **Best-effort 한계**: 본 set 은 단일 process 내 상태 — 여러 instance 가 같은 host 를
-// 동시에 처리하면 instance 수만큼 호출 발생 가능. 분산 dedup 은 후속 PR (Redis lock).
-//
-// 모든 메소드는 goroutine-safe.
-type inflightSet struct {
+// 구현체:
+//   - memInflightLocker: in-process map 기반 (기본값, 단일 인스턴스 환경)
+//   - RedisInflightLocker: Redis SETNX+TTL 기반 (다중 인스턴스 환경)
+type InflightLocker interface {
+	// TryAcquire 는 슬롯 획득을 시도합니다.
+	// acquired=true: 호출자가 작업 진행 + 완료 후 Release 책임.
+	// acquired=false: 다른 goroutine/인스턴스가 이미 처리 중 — skip.
+	TryAcquire(ctx context.Context, host string, targetType storage.TargetType) (acquired bool, err error)
+	// Release 는 획득한 슬롯을 해제합니다.
+	Release(ctx context.Context, host string, targetType storage.TargetType) error
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// memInflightLocker — in-process 기본 구현
+// ─────────────────────────────────────────────────────────────────────────────
+
+type memInflightLocker struct {
 	mu      sync.Mutex
 	pending map[inflightKey]struct{}
 }
 
-// newInflightSet 은 빈 inflightSet 을 반환합니다.
-func newInflightSet() *inflightSet {
-	return &inflightSet{pending: make(map[inflightKey]struct{})}
+func newMemInflightLocker() *memInflightLocker {
+	return &memInflightLocker{pending: make(map[inflightKey]struct{})}
 }
 
-// tryAcquire 는 (host, type) 의 LLM 호출 슬롯을 획득합니다.
-//
-// 반환값 acquired=true: 호출자가 LLM 호출을 진행 + 종료 후 release 호출 책임.
-// 반환값 acquired=false: 다른 goroutine 이 이미 동일 key 를 처리 중 — 호출자는 skip.
-func (s *inflightSet) tryAcquire(host string, t storage.TargetType) bool {
-	key := inflightKey{host: host, targetType: t}
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	if _, exists := s.pending[key]; exists {
-		return false
+func (m *memInflightLocker) TryAcquire(_ context.Context, host string, targetType storage.TargetType) (bool, error) {
+	key := inflightKey{host: host, targetType: targetType}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if _, exists := m.pending[key]; exists {
+		return false, nil
 	}
-	s.pending[key] = struct{}{}
-	return true
+	m.pending[key] = struct{}{}
+	return true, nil
 }
 
-// release 는 acquire 한 (host, type) 슬롯을 해제합니다.
-// tryAcquire 가 false 를 반환한 호출자는 release 를 호출하면 안 됩니다 (다른 owner 의 슬롯 침범).
-func (s *inflightSet) release(host string, t storage.TargetType) {
-	key := inflightKey{host: host, targetType: t}
-	s.mu.Lock()
-	delete(s.pending, key)
-	s.mu.Unlock()
+func (m *memInflightLocker) Release(_ context.Context, host string, targetType storage.TargetType) error {
+	key := inflightKey{host: host, targetType: targetType}
+	m.mu.Lock()
+	delete(m.pending, key)
+	m.mu.Unlock()
+	return nil
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// RedisInflightLocker — 분산 Lock 구현 (이슈 #261)
+// ─────────────────────────────────────────────────────────────────────────────
+
+// RedisInflightLocker 는 Redis SETNX+TTL 기반 분산 Lock 구현입니다.
+//
+// 다중 인스턴스 환경에서 동일 (host, targetType) 에 대한 LLM 호출을 1회로 제한합니다.
+// TTL 은 프로세스 크래시 후 stuck 슬롯 자동 해제를 보장합니다.
+type RedisInflightLocker struct {
+	rdb *goredis.Client
+	ttl time.Duration
+}
+
+// NewRedisInflightLocker 는 RedisInflightLocker 를 생성합니다.
+func NewRedisInflightLocker(rdb *goredis.Client, ttl time.Duration) *RedisInflightLocker {
+	return &RedisInflightLocker{rdb: rdb, ttl: ttl}
+}
+
+func (r *RedisInflightLocker) TryAcquire(ctx context.Context, host string, targetType storage.TargetType) (bool, error) {
+	key := r.key(host, targetType)
+	ok, err := r.rdb.SetNX(ctx, key, 1, r.ttl).Result()
+	if err != nil {
+		return false, fmt.Errorf("redis inflight acquire %s: %w", key, err)
+	}
+	return ok, nil
+}
+
+func (r *RedisInflightLocker) Release(ctx context.Context, host string, targetType storage.TargetType) error {
+	key := r.key(host, targetType)
+	if err := r.rdb.Del(ctx, key).Err(); err != nil {
+		return fmt.Errorf("redis inflight release %s: %w", key, err)
+	}
+	return nil
+}
+
+func (r *RedisInflightLocker) key(host string, targetType storage.TargetType) string {
+	return inflightKeyPrefix + host + ":" + string(targetType)
 }

--- a/internal/processor/parser/rule/llmgen/generator.go
+++ b/internal/processor/parser/rule/llmgen/generator.go
@@ -195,8 +195,9 @@ func (g *Generator) Enqueue(ctx context.Context, host string, targetType storage
 		SourceInfo: raw.SourceInfo,
 	}
 
-	// TryAcquire: short-timeout context 사용 — Redis 장애 시 Enqueue 전체가 무기한 블록되지 않도록.
-	acquireCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	// TryAcquire: WithoutCancel 후 timeout — 호출자 ctx cancel 이 즉시 전파되지 않도록 하되
+	// Redis 장애 시 무기한 블록도 방지. 기존 inflightSet 동작(cancel 무시)과 일관성 유지.
+	acquireCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 5*time.Second)
 	acquired, err := g.locker.TryAcquire(acquireCtx, host, targetType)
 	cancel()
 	if err != nil {

--- a/internal/processor/parser/rule/llmgen/generator.go
+++ b/internal/processor/parser/rule/llmgen/generator.go
@@ -30,6 +30,7 @@ import (
 	"strings"
 	"sync"
 	"sync/atomic"
+	"time"
 
 	"github.com/PuerkitoBio/goquery"
 
@@ -79,7 +80,7 @@ func (e *selectorValidationError) Unwrap() error { return e.cause }
 // Generator 는 host 별 parsing rule 을 LLM 으로 자동 생성합니다.
 //
 // goroutine-safe — provider / repo / resolver 가 자체 thread-safety 를 가짐.
-// inflightSet 은 자체 mutex 로 보호.
+// locker 는 InflightLocker 구현체에 따라 자체 thread-safety 를 가짐.
 //
 // Lifecycle:
 //   - Enqueue 가 background goroutine 으로 LLM 호출 수행 — sync.WaitGroup 으로 추적
@@ -100,15 +101,26 @@ type Generator struct {
 	// nil 이면 호출 안 함.
 	validateFailureHandler func(context.Context, core.RawContentRef, int, storage.TargetType, string)
 
-	inflight *inflightSet
-	wg       sync.WaitGroup
-	stopped  atomic.Bool
+	locker  InflightLocker // 기본: memInflightLocker, Redis 활성 시: RedisInflightLocker (이슈 #261)
+	wg      sync.WaitGroup
+	stopped atomic.Bool
 }
 
 // SetValidateFailureHandler 는 selector 검증 실패 시 호출할 콜백을 등록합니다 (이슈 #237).
 // Stop 전에 설정해야 하며, goroutine-safe 하지 않으므로 초기화 시 1회만 호출합니다.
 func (g *Generator) SetValidateFailureHandler(fn func(context.Context, core.RawContentRef, int, storage.TargetType, string)) {
 	g.validateFailureHandler = fn
+}
+
+// SetLocker 는 분산 Lock 구현체를 교체합니다 (이슈 #261).
+// nil 이면 기본 in-process memInflightLocker 로 fallback.
+// Stop 전에 설정해야 하며, goroutine-safe 하지 않으므로 초기화 시 1회만 호출합니다.
+func (g *Generator) SetLocker(l InflightLocker) {
+	if l == nil {
+		g.locker = newMemInflightLocker()
+		return
+	}
+	g.locker = l
 }
 
 // SetExtractor 는 셀렉터 추출 단계를 교체합니다 (이슈 #256).
@@ -140,7 +152,7 @@ func New(provider llm.Provider, repo storage.ParsingRuleRepository, resolver *ru
 		repo:     repo,
 		resolver: resolver,
 		log:      log,
-		inflight: newInflightSet(),
+		locker:   newMemInflightLocker(),
 	}, nil
 }
 
@@ -183,7 +195,18 @@ func (g *Generator) Enqueue(ctx context.Context, host string, targetType storage
 		SourceInfo: raw.SourceInfo,
 	}
 
-	if !g.inflight.tryAcquire(host, targetType) {
+	// TryAcquire: short-timeout context 사용 — Redis 장애 시 Enqueue 전체가 무기한 블록되지 않도록.
+	acquireCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	acquired, err := g.locker.TryAcquire(acquireCtx, host, targetType)
+	cancel()
+	if err != nil {
+		g.log.WithFields(map[string]interface{}{
+			"host":        host,
+			"target_type": string(targetType),
+		}).WithError(err).Warn("llmgen inflight lock acquire failed, skipping")
+		return
+	}
+	if !acquired {
 		g.log.WithFields(map[string]interface{}{
 			"host":        host,
 			"target_type": string(targetType),
@@ -197,7 +220,14 @@ func (g *Generator) Enqueue(ctx context.Context, host string, targetType storage
 	g.wg.Add(1)
 	go func() {
 		defer g.wg.Done()
-		defer g.inflight.release(host, targetType)
+		defer func() {
+			if rerr := g.locker.Release(bgCtx, host, targetType); rerr != nil {
+				logger.FromContext(bgCtx).WithFields(map[string]interface{}{
+					"host":        host,
+					"target_type": string(targetType),
+				}).WithError(rerr).Warn("llmgen inflight lock release failed")
+			}
+		}()
 
 		err := g.runOnce(bgCtx, host, targetType, urlSnapshot, htmlSnapshot)
 		if err != nil {

--- a/test/internal/processor/parser/rule/llmgen/inflight_test.go
+++ b/test/internal/processor/parser/rule/llmgen/inflight_test.go
@@ -1,0 +1,143 @@
+package llmgen_test
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"issuetracker/internal/processor/fetcher/core"
+	"issuetracker/internal/processor/parser/rule/llmgen"
+	"issuetracker/internal/storage"
+)
+
+// ─────────────────────────────────────────────────────────────────────────────
+// InflightLocker 인터페이스 계약 검증
+// ─────────────────────────────────────────────────────────────────────────────
+
+// TestGenerator_SetLocker_Nil_FallsBackToMem 는 SetLocker(nil) 시 in-process 로 fallback 하는지 검증합니다.
+func TestGenerator_SetLocker_Nil_FallsBackToMem(t *testing.T) {
+	provider := &fakeProvider{
+		name: "fake",
+		response: `{
+			"title": {"css": "h1.article-title"},
+			"main_content": {"css": "article p"}
+		}`,
+	}
+	repo := &recordingRepo{}
+	g, _ := newGenerator(t, provider, repo)
+
+	g.SetLocker(nil)
+
+	g.Enqueue(context.Background(), "example.com", storage.TargetTypePage, &core.RawContent{
+		URL: "https://example.com/article/1", HTML: samplePageHTML,
+	}, 0, "")
+
+	waitForInserts(t, repo, 1, 2*time.Second)
+	assert.Equal(t, 1, provider.callCount(), "nil SetLocker 시 기존 동작 유지")
+}
+
+// TestGenerator_SetLocker_AlwaysLocked_NoLLMCall 는 locker 가 항상 false 를 반환하면
+// LLM 이 호출되지 않는지 검증합니다 (다른 인스턴스가 처리 중인 분산 환경 시뮬레이션).
+func TestGenerator_SetLocker_AlwaysLocked_NoLLMCall(t *testing.T) {
+	provider := &fakeProvider{name: "fake", response: "{}"}
+	repo := &recordingRepo{}
+	g, _ := newGenerator(t, provider, repo)
+
+	g.SetLocker(&alwaysLockedLocker{})
+
+	g.Enqueue(context.Background(), "example.com", storage.TargetTypePage, &core.RawContent{
+		URL: "https://example.com/x", HTML: samplePageHTML,
+	}, 0, "")
+
+	time.Sleep(200 * time.Millisecond)
+	assert.Equal(t, 0, provider.callCount(), "locker 가 false 반환 시 LLM 호출 없어야 함")
+}
+
+// TestGenerator_SetLocker_CustomLocker_IsInvoked 는 SetLocker 로 주입한 locker 의
+// TryAcquire 가 실제로 호출되는지 검증합니다.
+func TestGenerator_SetLocker_CustomLocker_IsInvoked(t *testing.T) {
+	provider := &fakeProvider{
+		name: "fake",
+		response: `{
+			"title": {"css": "h1.article-title"},
+			"main_content": {"css": "article p"}
+		}`,
+	}
+	repo := &recordingRepo{}
+	g, _ := newGenerator(t, provider, repo)
+
+	locker := &countingLocker{}
+	g.SetLocker(locker)
+
+	g.Enqueue(context.Background(), "example.com", storage.TargetTypePage, &core.RawContent{
+		URL: "https://example.com/x", HTML: samplePageHTML,
+	}, 0, "")
+
+	waitForInserts(t, repo, 1, 2*time.Second)
+	assert.Equal(t, 1, locker.acquireCalls(), "TryAcquire 가 1회 호출되어야 함")
+	assert.Equal(t, 1, locker.releaseCalls(), "Release 가 1회 호출되어야 함")
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// test fakes
+// ─────────────────────────────────────────────────────────────────────────────
+
+// alwaysLockedLocker 는 항상 acquired=false 를 반환합니다.
+type alwaysLockedLocker struct{}
+
+func (a *alwaysLockedLocker) TryAcquire(_ context.Context, _ string, _ storage.TargetType) (bool, error) {
+	return false, nil
+}
+func (a *alwaysLockedLocker) Release(_ context.Context, _ string, _ storage.TargetType) error {
+	return nil
+}
+
+// countingLocker 는 TryAcquire/Release 호출 횟수를 기록하며 실제 dedup 도 수행합니다.
+type countingLocker struct {
+	mu      sync.Mutex
+	acquire int
+	release int
+	held    map[string]struct{}
+}
+
+func (c *countingLocker) TryAcquire(_ context.Context, host string, targetType storage.TargetType) (bool, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.acquire++
+	if c.held == nil {
+		c.held = make(map[string]struct{})
+	}
+	key := host + ":" + string(targetType)
+	if _, ok := c.held[key]; ok {
+		return false, nil
+	}
+	c.held[key] = struct{}{}
+	return true, nil
+}
+
+func (c *countingLocker) Release(_ context.Context, host string, targetType storage.TargetType) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.release++
+	delete(c.held, host+":"+string(targetType))
+	return nil
+}
+
+func (c *countingLocker) acquireCalls() int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.acquire
+}
+
+func (c *countingLocker) releaseCalls() int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.release
+}
+
+// Ensure test fakes implement llmgen.InflightLocker
+var _ llmgen.InflightLocker = (*alwaysLockedLocker)(nil)
+var _ llmgen.InflightLocker = (*countingLocker)(nil)


### PR DESCRIPTION
## 연관 이슈
Closes #261

## 구현 내용

### 변경 구조

```
기존: inflight *inflightSet  (in-process map)
변경: locker  InflightLocker (인터페이스)
       ├── memInflightLocker  — 기본값, 단일 인스턴스 환경
       └── RedisInflightLocker — Redis SETNX+TTL, 다중 인스턴스 환경
```

### 파일별 변경

**`llmgen/dedup.go`**
- `InflightLocker` 인터페이스: `TryAcquire` / `Release`
- `memInflightLocker`: 기존 in-process map 래핑
- `RedisInflightLocker`: `SETNX + TTL(5분)` — 프로세스 크래시 후 stuck 슬롯 자동 해제

**`llmgen/generator.go`**
- `inflight *inflightSet` → `locker InflightLocker`
- `SetLocker(l InflightLocker)` 추가 — nil 전달 시 mem fallback
- `TryAcquire` 에 5초 timeout context — Redis 장애 시 Enqueue 무기한 블록 방지
- `Release` 실패 시 WARN 로그 (goroutine 종료에는 영향 없음)

**`cmd/issuetracker/main.go`**
- `buildLLMGenerator` 에 `redisClient *redis.Client` 파라미터 추가
- Redis 활성 시 `RedisInflightLocker` 주입, nil 시 `memInflightLocker` graceful degrade

## CI / 머지 게이트
- [x] `go build ./...` 통과
- [x] `go test -race ./...` 통과
- [x] `make fmt` 완료

## 변경 영향 범위
- Redis 미설정 환경: 기존과 동일하게 in-process 동작
- Redis 설정 환경: 다중 인스턴스 간 분산 dedup 활성화

## 위험도
낮음 — Redis 장애 시 WARN 로그 + skip (LLM 미호출), 서비스 중단 없음

## 롤백
`buildLLMGenerator` 에서 `gen.SetLocker(...)` 호출 제거 시 즉시 in-process 동작으로 복귀

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Redis-backed distributed locking to prevent duplicate LLM generation across multiple instances, with fallback to in-memory deduplication for single-instance deployments.

* **Tests**
  * Added comprehensive test coverage for the pluggable locking mechanism.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->