### PR TITLE
[FEAT#262] llmgen pendingQueue — Redis LIST 기반 대기 URL 보존 + 재투입

### DIFF
--- a/cmd/issuetracker/main.go
+++ b/cmd/issuetracker/main.go
@@ -425,6 +425,18 @@ func main() {
 		llmGen.SetValidateFailureHandler(pw.RequeueForLLMRetry)
 	}
 
+	// ── Pending URL 큐 (이슈 #262) ────────────────────────────────────────────
+	// in-flight 중 동일 도메인으로 유입된 URL 을 Redis LIST 에 보존.
+	// 룰 생성 완료 시 대기 URL 을 issuetracker.fetched 에 재발행 — 새 룰로 재파싱.
+	// Redis 미설정 시 graceful degrade (pending URL 보존 없이 기존 skip 동작 유지).
+	if llmGen != nil && redisClientShared != nil {
+		llmGen.SetPendingQueue(
+			llmgen.NewRedisPendingQueue(redisClientShared.Raw()),
+			pw.RequeueParsing,
+		)
+		log.Info("llmgen: Redis 기반 pending URL 큐 활성화")
+	}
+
 	// ── Refiner (이슈 #173 단계 4-2) ──────────────────────────────────────────
 	// catch-all + llm-auto rule 의 누적 sample URL 로부터 path_pattern 정밀화.
 	// REFINEMENT_ENABLED=false 또는 config 실패 시 nil — 기존 catch-all rule 그대로 동작.

--- a/internal/processor/parser/rule/llmgen/generator.go
+++ b/internal/processor/parser/rule/llmgen/generator.go
@@ -280,7 +280,8 @@ func (g *Generator) Enqueue(ctx context.Context, host string, targetType storage
 		}
 
 		// 룰 생성 성공 — pending 대기 URL 을 파서 워커에 재투입 (이슈 #262).
-		// lock release 후 flush: release 이후 새로 들어온 URL 은 새 runOnce 가 처리.
+		// flush 는 defer(Release) 실행 전에 수행됨 — flush 중 새로 들어온 URL 은 pending 에 적재되고
+		// 락 해제 후 새 runOnce 가 다음 flush 에서 처리.
 		if g.pendingQueue != nil && g.requeueFn != nil {
 			items, ferr := g.pendingQueue.Flush(bgCtx, host, targetType)
 			if ferr != nil {

--- a/internal/processor/parser/rule/llmgen/generator.go
+++ b/internal/processor/parser/rule/llmgen/generator.go
@@ -8,13 +8,12 @@
 //  2. Generator goroutine: in-flight dedup 후 LLM 프롬프트 생성 → Provider.Generate 호출
 //  3. 응답 JSON 파싱 → storage.SelectorMap 으로 변환
 //  4. validation: 생성된 selector 로 실제 HTML 매칭 확인 (0건이면 폐기)
-//  5. ParsingRuleRepository.Insert (enabled=false — 운영자 review 후 enabled=true flip)
+//  5. ParsingRuleRepository.Insert (enabled=true — CSS selector 검증 통과가 품질 게이트)
 //  6. Resolver.Invalidate 로 negative cache flush — 다음 fetch 부터 새 rule 사용 가능
 //
 // 본 PR scope (이슈 #149 1차):
 //   - 단일 LLM 호출 + 기본 validation + DB INSERT + cache invalidate
 //   - Best-effort in-process dedup (단일 instance 보호)
-//   - enabled=false 로 INSERT (운영자 spot-check 게이트)
 //
 // 후속 PR scope (이슈 TBD 2차):
 //   - 비용 cap (일일 / 시간당 호출 수 제한)
@@ -173,12 +172,13 @@ func New(provider llm.Provider, repo storage.ParsingRuleRepository, resolver *ru
 //
 // llmRetryCount 는 호출자 (parser_worker) 가 RawContentRef 에서 전달하는 재큐 횟수입니다.
 // crawlerName 은 Kafka 메시지 헤더 복원용 — validateSelectors 실패 시 재큐 메시지에 포함됩니다.
+// jobTimeout 은 원본 crawl job 의 timeout — pending 재투입 시 카테고리 chained job timeout 보존 (이슈 #262 리뷰).
 // validateSelectors 실패 시 validateFailureHandler 가 등록되어 있으면
 // (ctx, ref, llmRetryCount, targetType, crawlerName) 으로 호출됩니다 (이슈 #237).
 //
 // 동일 (host, type) 에 대한 in-flight 호출이 이미 있으면 즉시 skip.
 // Stop 호출 후의 Enqueue 는 즉시 noop.
-func (g *Generator) Enqueue(ctx context.Context, host string, targetType storage.TargetType, raw *core.RawContent, llmRetryCount int, crawlerName string) {
+func (g *Generator) Enqueue(ctx context.Context, host string, targetType storage.TargetType, raw *core.RawContent, llmRetryCount int, crawlerName string, jobTimeout time.Duration) {
 	if g.stopped.Load() {
 		return
 	}
@@ -225,6 +225,7 @@ func (g *Generator) Enqueue(ctx context.Context, host string, targetType storage
 				CrawlerName:   crawlerName,
 				LLMRetryCount: llmRetryCount,
 				TargetType:    targetType,
+				TimeoutMs:     jobTimeout.Milliseconds(),
 			}
 			if perr := g.pendingQueue.Push(context.WithoutCancel(ctx), host, targetType, item); perr != nil {
 				g.log.WithFields(map[string]interface{}{
@@ -282,6 +283,7 @@ func (g *Generator) Enqueue(ctx context.Context, host string, targetType storage
 		// 룰 생성 성공 — pending 대기 URL 을 파서 워커에 재투입 (이슈 #262).
 		// flush 는 defer(Release) 실행 전에 수행됨 — flush 중 새로 들어온 URL 은 pending 에 적재되고
 		// 락 해제 후 새 runOnce 가 다음 flush 에서 처리.
+		// Kafka publish 실패 항목은 requeueFn 이 반환 → pending 에 재적재 (이슈 #262 리뷰).
 		if g.pendingQueue != nil && g.requeueFn != nil {
 			items, ferr := g.pendingQueue.Flush(bgCtx, host, targetType)
 			if ferr != nil {
@@ -290,11 +292,21 @@ func (g *Generator) Enqueue(ctx context.Context, host string, targetType storage
 					"target_type": string(targetType),
 				}).WithError(ferr).Warn("llmgen pending queue flush failed")
 			} else if len(items) > 0 {
-				g.requeueFn(bgCtx, items)
+				failed := g.requeueFn(bgCtx, items)
+				for _, item := range failed {
+					if perr := g.pendingQueue.Push(bgCtx, host, targetType, item); perr != nil {
+						logger.FromContext(bgCtx).WithFields(map[string]interface{}{
+							"host":        host,
+							"target_type": string(targetType),
+							"url":         item.RawRef.URL,
+						}).WithError(perr).Warn("llmgen failed to re-push Kafka-failed pending item")
+					}
+				}
 				logger.FromContext(bgCtx).WithFields(map[string]interface{}{
 					"host":        host,
 					"target_type": string(targetType),
 					"count":       len(items),
+					"failed":      len(failed),
 				}).Info("llmgen pending URLs requeued for parsing")
 			}
 		}
@@ -384,7 +396,7 @@ func (g *Generator) runOnce(ctx context.Context, host string, targetType storage
 		HostPattern: host,
 		TargetType:  targetType,
 		Version:     1,
-		Enabled:     false, // 운영자 review 게이트 — spot-check 후 수동 enable
+		Enabled:     true, // CSS selector 검증 통과 = 품질 게이트 — 즉시 활성화하여 pending 재투입이 유효하도록
 		Selectors:   selectors,
 		Description: fmt.Sprintf("%s (sample url: %s, model: %s)", llmAutoDescription, sampleURL, modelName),
 	}
@@ -392,8 +404,7 @@ func (g *Generator) runOnce(ctx context.Context, host string, targetType storage
 		return fmt.Errorf("insert parsing rule: %w", err)
 	}
 
-	// negative cache 만 즉시 무효화 — enabled=false 상태이므로 다음 lookup 도 ErrNoRule 이지만,
-	// 운영자가 enabled=true 로 flip 한 직후 새 rule 이 즉시 반영되도록 cache 비움.
+	// negative cache 무효화 — 다음 lookup 부터 새 rule 이 즉시 반영되도록.
 	g.resolver.Invalidate(host, targetType)
 
 	g.log.WithFields(map[string]interface{}{
@@ -401,8 +412,8 @@ func (g *Generator) runOnce(ctx context.Context, host string, targetType storage
 		"target_type": string(targetType),
 		"rule_id":     record.ID,
 		"model":       modelName,
-		"enabled":     false,
-	}).Info("llm-generated parsing rule inserted (review required before enabling)")
+		"enabled":     true,
+	}).Info("llm-generated parsing rule inserted and enabled")
 
 	return nil
 }

--- a/internal/processor/parser/rule/llmgen/generator.go
+++ b/internal/processor/parser/rule/llmgen/generator.go
@@ -101,15 +101,25 @@ type Generator struct {
 	// nil 이면 호출 안 함.
 	validateFailureHandler func(context.Context, core.RawContentRef, int, storage.TargetType, string)
 
-	locker  InflightLocker // 기본: memInflightLocker, Redis 활성 시: RedisInflightLocker (이슈 #261)
-	wg      sync.WaitGroup
-	stopped atomic.Bool
+	locker       InflightLocker // 기본: memInflightLocker, Redis 활성 시: RedisInflightLocker (이슈 #261)
+	pendingQueue PendingQueue   // nil 이면 pending URL 보존 비활성 (이슈 #262)
+	requeueFn    RequeueFunc    // nil 이면 재투입 비활성 (이슈 #262)
+	wg           sync.WaitGroup
+	stopped      atomic.Bool
 }
 
 // SetValidateFailureHandler 는 selector 검증 실패 시 호출할 콜백을 등록합니다 (이슈 #237).
 // Stop 전에 설정해야 하며, goroutine-safe 하지 않으므로 초기화 시 1회만 호출합니다.
 func (g *Generator) SetValidateFailureHandler(fn func(context.Context, core.RawContentRef, int, storage.TargetType, string)) {
 	g.validateFailureHandler = fn
+}
+
+// SetPendingQueue 는 대기 URL 큐와 재투입 콜백을 등록합니다 (이슈 #262).
+// 둘 다 비-nil 이어야 활성화됩니다. Stop 전에 설정해야 하며, goroutine-safe 하지 않으므로
+// 초기화 시 1회만 호출합니다.
+func (g *Generator) SetPendingQueue(pq PendingQueue, fn RequeueFunc) {
+	g.pendingQueue = pq
+	g.requeueFn = fn
 }
 
 // SetLocker 는 분산 Lock 구현체를 교체합니다 (이슈 #261).
@@ -208,10 +218,32 @@ func (g *Generator) Enqueue(ctx context.Context, host string, targetType storage
 		return
 	}
 	if !acquired {
-		g.log.WithFields(map[string]interface{}{
-			"host":        host,
-			"target_type": string(targetType),
-		}).Debug("llmgen enqueue skipped — in-flight request already exists")
+		// in-flight 중 — pending 큐에 적재하여 룰 생성 완료 후 재파싱 (이슈 #262).
+		if g.pendingQueue != nil {
+			item := PendingItem{
+				RawRef:        rawRef,
+				CrawlerName:   crawlerName,
+				LLMRetryCount: llmRetryCount,
+				TargetType:    targetType,
+			}
+			if perr := g.pendingQueue.Push(context.WithoutCancel(ctx), host, targetType, item); perr != nil {
+				g.log.WithFields(map[string]interface{}{
+					"host":        host,
+					"target_type": string(targetType),
+				}).WithError(perr).Warn("llmgen pending queue push failed")
+			} else {
+				g.log.WithFields(map[string]interface{}{
+					"host":        host,
+					"target_type": string(targetType),
+					"url":         rawRef.URL,
+				}).Debug("llmgen enqueue deferred — added to pending queue")
+			}
+		} else {
+			g.log.WithFields(map[string]interface{}{
+				"host":        host,
+				"target_type": string(targetType),
+			}).Debug("llmgen enqueue skipped — in-flight request already exists")
+		}
 		return
 	}
 
@@ -243,6 +275,26 @@ func (g *Generator) Enqueue(ctx context.Context, host string, targetType storage
 			var sve *selectorValidationError
 			if errors.As(err, &sve) && g.validateFailureHandler != nil {
 				g.validateFailureHandler(bgCtx, rawRef, llmRetryCount, targetType, crawlerName)
+			}
+			return
+		}
+
+		// 룰 생성 성공 — pending 대기 URL 을 파서 워커에 재투입 (이슈 #262).
+		// lock release 후 flush: release 이후 새로 들어온 URL 은 새 runOnce 가 처리.
+		if g.pendingQueue != nil && g.requeueFn != nil {
+			items, ferr := g.pendingQueue.Flush(bgCtx, host, targetType)
+			if ferr != nil {
+				logger.FromContext(bgCtx).WithFields(map[string]interface{}{
+					"host":        host,
+					"target_type": string(targetType),
+				}).WithError(ferr).Warn("llmgen pending queue flush failed")
+			} else if len(items) > 0 {
+				g.requeueFn(bgCtx, items)
+				logger.FromContext(bgCtx).WithFields(map[string]interface{}{
+					"host":        host,
+					"target_type": string(targetType),
+					"count":       len(items),
+				}).Info("llmgen pending URLs requeued for parsing")
 			}
 		}
 	}()

--- a/internal/processor/parser/rule/llmgen/pending.go
+++ b/internal/processor/parser/rule/llmgen/pending.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"time"
 
 	goredis "github.com/redis/go-redis/v9"
 	"issuetracker/internal/processor/fetcher/core"
@@ -12,16 +13,27 @@ import (
 
 const pendingKeyPrefix = "llmgen:pending:"
 
+// defaultPendingTTL 은 pending LIST 키의 기본 TTL 입니다.
+// rule 생성이 계속 실패해도 Redis 메모리가 무기한 증가하지 않도록 제한합니다 (이슈 #262 리뷰).
+const defaultPendingTTL = 24 * time.Hour
+
+// defaultPendingMaxLen 은 (host, targetType) 당 pending LIST 의 최대 항목 수입니다.
+// noisy host 하나가 Redis 메모리를 독점하지 않도록 상한을 둡니다 (이슈 #262 리뷰).
+const defaultPendingMaxLen = 1000
+
 // PendingItem 은 in-flight 중 대기 중인 URL 의 재투입에 필요한 정보입니다 (이슈 #262).
 type PendingItem struct {
 	RawRef        core.RawContentRef `json:"raw_ref"`
 	CrawlerName   string             `json:"crawler_name"`
 	LLMRetryCount int                `json:"llm_retry_count"`
 	TargetType    storage.TargetType `json:"target_type"`
+	// TimeoutMs 는 원본 crawl job 의 timeout — 카테고리 재투입 시 chained job timeout 보존 (이슈 #262 리뷰).
+	TimeoutMs int64 `json:"timeout_ms"`
 }
 
 // RequeueFunc 는 pending 대기 URL 목록을 파서 워커에 재투입하는 콜백 타입입니다 (이슈 #262).
-type RequeueFunc func(ctx context.Context, items []PendingItem)
+// Kafka 발행에 실패한 항목을 반환하면 Generator 가 pending queue 에 재적재합니다.
+type RequeueFunc func(ctx context.Context, items []PendingItem) (failed []PendingItem)
 
 // PendingQueue 는 (host, targetType) 단위 대기 URL 목록을 저장/조회하는 인터페이스입니다 (이슈 #262).
 type PendingQueue interface {
@@ -44,21 +56,42 @@ return items`
 
 // RedisPendingQueue 는 Redis LIST 기반 PendingQueue 구현입니다.
 type RedisPendingQueue struct {
-	rdb *goredis.Client
+	rdb    *goredis.Client
+	ttl    time.Duration
+	maxLen int64
 }
 
-// NewRedisPendingQueue 는 RedisPendingQueue 를 생성합니다.
+// NewRedisPendingQueue 는 기본 TTL(24h) + 최대 길이(1000) 로 RedisPendingQueue 를 생성합니다.
 func NewRedisPendingQueue(rdb *goredis.Client) *RedisPendingQueue {
-	return &RedisPendingQueue{rdb: rdb}
+	return &RedisPendingQueue{
+		rdb:    rdb,
+		ttl:    defaultPendingTTL,
+		maxLen: defaultPendingMaxLen,
+	}
 }
 
 func (r *RedisPendingQueue) Push(ctx context.Context, host string, targetType storage.TargetType, item PendingItem) error {
+	key := r.key(host, targetType)
+
+	// 길이 상한 초과 시 skip — noisy host 가 Redis 메모리를 독점하지 않도록 (이슈 #262 리뷰).
+	llen, err := r.rdb.LLen(ctx, key).Result()
+	if err != nil && err != goredis.Nil {
+		return fmt.Errorf("redis pending llen %s: %w", key, err)
+	}
+	if llen >= r.maxLen {
+		return fmt.Errorf("redis pending queue full (%s, len=%d): item dropped", key, llen)
+	}
+
 	data, err := json.Marshal(item)
 	if err != nil {
 		return fmt.Errorf("marshal pending item: %w", err)
 	}
-	key := r.key(host, targetType)
-	if err := r.rdb.RPush(ctx, key, data).Err(); err != nil {
+
+	// RPUSH + EXPIRE 를 pipeline 으로 묶어 TTL 갱신 보장 (이슈 #262 리뷰).
+	pipe := r.rdb.Pipeline()
+	pipe.RPush(ctx, key, data)
+	pipe.Expire(ctx, key, r.ttl)
+	if _, err := pipe.Exec(ctx); err != nil {
 		return fmt.Errorf("redis pending push %s: %w", key, err)
 	}
 	return nil

--- a/internal/processor/parser/rule/llmgen/pending.go
+++ b/internal/processor/parser/rule/llmgen/pending.go
@@ -1,0 +1,87 @@
+package llmgen
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	goredis "github.com/redis/go-redis/v9"
+	"issuetracker/internal/processor/fetcher/core"
+	"issuetracker/internal/storage"
+)
+
+const pendingKeyPrefix = "llmgen:pending:"
+
+// PendingItem 은 in-flight 중 대기 중인 URL 의 재투입에 필요한 정보입니다 (이슈 #262).
+type PendingItem struct {
+	RawRef        core.RawContentRef `json:"raw_ref"`
+	CrawlerName   string             `json:"crawler_name"`
+	LLMRetryCount int                `json:"llm_retry_count"`
+	TargetType    storage.TargetType `json:"target_type"`
+}
+
+// RequeueFunc 는 pending 대기 URL 목록을 파서 워커에 재투입하는 콜백 타입입니다 (이슈 #262).
+type RequeueFunc func(ctx context.Context, items []PendingItem)
+
+// PendingQueue 는 (host, targetType) 단위 대기 URL 목록을 저장/조회하는 인터페이스입니다 (이슈 #262).
+type PendingQueue interface {
+	// Push 는 대기 항목을 큐에 적재합니다.
+	Push(ctx context.Context, host string, targetType storage.TargetType, item PendingItem) error
+	// Flush 는 큐의 모든 항목을 원자적으로 꺼내 반환합니다. 반환 후 큐는 비어 있습니다.
+	Flush(ctx context.Context, host string, targetType storage.TargetType) ([]PendingItem, error)
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// RedisPendingQueue — Redis LIST 기반 구현 (이슈 #262)
+// ─────────────────────────────────────────────────────────────────────────────
+
+// luaFlush 는 LRANGE + DEL 을 원자적으로 수행하는 Lua 스크립트입니다.
+// 두 명령 사이에 다른 RPUSH 가 끼어들어도 안전하게 스냅샷을 꺼냅니다.
+const luaFlush = `
+local items = redis.call("LRANGE", KEYS[1], 0, -1)
+redis.call("DEL", KEYS[1])
+return items`
+
+// RedisPendingQueue 는 Redis LIST 기반 PendingQueue 구현입니다.
+type RedisPendingQueue struct {
+	rdb *goredis.Client
+}
+
+// NewRedisPendingQueue 는 RedisPendingQueue 를 생성합니다.
+func NewRedisPendingQueue(rdb *goredis.Client) *RedisPendingQueue {
+	return &RedisPendingQueue{rdb: rdb}
+}
+
+func (r *RedisPendingQueue) Push(ctx context.Context, host string, targetType storage.TargetType, item PendingItem) error {
+	data, err := json.Marshal(item)
+	if err != nil {
+		return fmt.Errorf("marshal pending item: %w", err)
+	}
+	key := r.key(host, targetType)
+	if err := r.rdb.RPush(ctx, key, data).Err(); err != nil {
+		return fmt.Errorf("redis pending push %s: %w", key, err)
+	}
+	return nil
+}
+
+func (r *RedisPendingQueue) Flush(ctx context.Context, host string, targetType storage.TargetType) ([]PendingItem, error) {
+	key := r.key(host, targetType)
+	result, err := r.rdb.Eval(ctx, luaFlush, []string{key}).StringSlice()
+	if err != nil && err != goredis.Nil {
+		return nil, fmt.Errorf("redis pending flush %s: %w", key, err)
+	}
+
+	items := make([]PendingItem, 0, len(result))
+	for _, raw := range result {
+		var item PendingItem
+		if err := json.Unmarshal([]byte(raw), &item); err != nil {
+			continue // 손상된 항목은 skip — best-effort
+		}
+		items = append(items, item)
+	}
+	return items, nil
+}
+
+func (r *RedisPendingQueue) key(host string, targetType storage.TargetType) string {
+	return pendingKeyPrefix + host + ":" + string(targetType)
+}

--- a/internal/processor/parser/worker/parser_worker.go
+++ b/internal/processor/parser/worker/parser_worker.go
@@ -293,7 +293,7 @@ func (w *ParserWorker) processCategoryPage(ctx context.Context, raw *core.RawCon
 
 	items, err := w.parser.ParseLinks(ctx, raw)
 	if err != nil {
-		return w.handleRuleError(ctx, raw, rawID, "parse_links", storage.TargetTypeList, err, llmRetryCount, crawlerName, mlog)
+		return w.handleRuleError(ctx, raw, rawID, "parse_links", storage.TargetTypeList, err, llmRetryCount, crawlerName, jobTimeout, mlog)
 	}
 	if len(items) == 0 {
 		mlog.Debug("no article links found in category page")
@@ -325,7 +325,7 @@ func (w *ParserWorker) processArticlePage(ctx context.Context, raw *core.RawCont
 
 	page, err := w.parser.ParsePage(ctx, raw)
 	if err != nil {
-		return w.handleRuleError(ctx, raw, rawID, "parse_page", storage.TargetTypePage, err, llmRetryCount, crawlerName, mlog)
+		return w.handleRuleError(ctx, raw, rawID, "parse_page", storage.TargetTypePage, err, llmRetryCount, crawlerName, 0, mlog)
 	}
 
 	// 이슈 #220: parse 자체는 성공했지만 Title / MainContent 텍스트 길이가 임계값 미달이면
@@ -355,7 +355,7 @@ func (w *ParserWorker) processArticlePage(ctx context.Context, raw *core.RawCont
 // 이슈 #220 (page 단계 한정): rule.ErrParseFailure / rule.ErrEmptySelector 는 host 단위 카운터로
 // 누적 — 임계값 도달 시 단계 3 (#221) 의 chromedp 자동 전환 트리거 입력. ErrNoRule 은 LLM 자동
 // rule 생성 (이슈 #149) 의 책임 영역이라 카운팅 제외 (다른 정책으로 처리됨).
-func (w *ParserWorker) handleRuleError(ctx context.Context, raw *core.RawContent, rawID, stage string, targetType storage.TargetType, err error, llmRetryCount int, crawlerName string, mlog *logger.Logger) error {
+func (w *ParserWorker) handleRuleError(ctx context.Context, raw *core.RawContent, rawID, stage string, targetType storage.TargetType, err error, llmRetryCount int, crawlerName string, jobTimeout time.Duration, mlog *logger.Logger) error {
 	var rerr *rule.Error
 	if errors.As(err, &rerr) {
 		mlog.WithFields(map[string]interface{}{
@@ -366,8 +366,9 @@ func (w *ParserWorker) handleRuleError(ctx context.Context, raw *core.RawContent
 
 		// ErrNoRule + llmGen 활성화 → LLM 자동 rule 생성 비동기 트리거 (이슈 #149)
 		// crawlerName 은 validate 실패 시 재큐 메시지 헤더 복원용 (이슈 #237 피드백).
+		// jobTimeout 은 pending 재투입 시 카테고리 chained job timeout 보존 (이슈 #262 리뷰).
 		if rerr.Code == rule.ErrNoRule && w.llmGen != nil {
-			w.llmGen.Enqueue(ctx, rerr.Host, targetType, raw, llmRetryCount, crawlerName)
+			w.llmGen.Enqueue(ctx, rerr.Host, targetType, raw, llmRetryCount, crawlerName, jobTimeout)
 		}
 
 		// 이슈 #220: page 단계의 ParseFailure / EmptySelector 만 host 카운터에 누적.
@@ -585,7 +586,9 @@ func (w *ParserWorker) RequeueForLLMRetry(ctx context.Context, ref core.RawConte
 		Topic: queue.TopicFetched,
 		Value: payload,
 		Headers: map[string]string{
-			"target_type": string(targetType),
+			// storageToFetcherTargetType: storage "list"/"page" → fetcher "category"/"article"
+			// 파서 워커가 target_type 을 core.TargetType 으로 읽으므로 변환 필수 (이슈 #262 리뷰).
+			"target_type": storageToFetcherTargetType(targetType),
 			"crawler":     crawlerName,
 		},
 	}
@@ -602,7 +605,7 @@ func (w *ParserWorker) RequeueForLLMRetry(ctx context.Context, ref core.RawConte
 		"raw_id":          ref.ID,
 		"url":             ref.URL,
 		"llm_retry_count": nextCount,
-		"target_type":     string(targetType),
+		"target_type":     storageToFetcherTargetType(targetType),
 		"crawler":         crawlerName,
 	}).Info("raw content requeued for llm retry after selector validation failure")
 }
@@ -611,16 +614,21 @@ func (w *ParserWorker) RequeueForLLMRetry(ctx context.Context, ref core.RawConte
 // llmgen.Generator 의 RequeueFunc 로 등록됩니다.
 //
 // 룰 생성 완료 후 호출 — 대기 중이던 URL 이 새 룰로 재파싱될 수 있도록 TopicFetched 에 투입.
-// 실패는 non-fatal — raw 는 TTL cleanup 으로 최종 정리됩니다.
-func (w *ParserWorker) RequeueParsing(ctx context.Context, items []llmgen.PendingItem) {
+// Kafka 발행에 실패한 항목을 반환 — Generator 가 pending queue 에 재적재 (이슈 #262 리뷰).
+func (w *ParserWorker) RequeueParsing(ctx context.Context, items []llmgen.PendingItem) (failed []llmgen.PendingItem) {
 	// WithoutCancel 은 루프 외부에서 1회 — 루프마다 새 컨텍스트 파생 불필요 (Gemini 피드백).
 	baseCtx := context.WithoutCancel(ctx)
 	for _, item := range items {
-		payload, err := json.Marshal(item.RawRef)
+		// LLMRetryCount 를 ref 에 반영하여 직렬화 — item.RawRef 는 원본(0)이므로 별도 세팅 필요
+		// (이슈 #262 리뷰: PendingItem.LLMRetryCount 가 payload 에서 유실되는 버그).
+		ref := item.RawRef
+		ref.LLMRetryCount = item.LLMRetryCount
+		payload, err := json.Marshal(ref)
 		if err != nil {
 			w.log.WithFields(map[string]interface{}{
 				"raw_id": item.RawRef.ID,
 			}).WithError(err).Error("failed to marshal RawContentRef for pending requeue")
+			failed = append(failed, item)
 			continue
 		}
 
@@ -629,18 +637,23 @@ func (w *ParserWorker) RequeueParsing(ctx context.Context, items []llmgen.Pendin
 			Topic: queue.TopicFetched,
 			Value: payload,
 			Headers: map[string]string{
-				"target_type": string(item.TargetType),
+				// storage "list"/"page" → fetcher "category"/"article" 변환 (이슈 #262 리뷰).
+				"target_type": storageToFetcherTargetType(item.TargetType),
 				"crawler":     item.CrawlerName,
+				// timeout_ms 보존 — 카테고리 재투입 시 chained job timeout 유지 (이슈 #262 리뷰).
+				"timeout_ms": strconv.FormatInt(item.TimeoutMs, 10),
 			},
 		}
 		if err := w.producer.Publish(pubCtx, msg); err != nil {
 			w.log.WithFields(map[string]interface{}{
 				"raw_id": item.RawRef.ID,
 				"url":    item.RawRef.URL,
-			}).WithError(err).Warn("failed to requeue pending URL for parsing (non-fatal)")
+			}).WithError(err).Warn("failed to requeue pending URL for parsing, will re-push to pending queue")
+			failed = append(failed, item)
 		}
 		cancel()
 	}
+	return failed
 }
 
 // deleteRaw 는 처리 완료된 raw_contents row 를 즉시 정리합니다.
@@ -710,6 +723,18 @@ func uniqueURLs(items []parser.LinkItem, limit int) []string {
 		}
 	}
 	return urls
+}
+
+// storageToFetcherTargetType 은 storage.TargetType ("list"/"page") 을
+// TopicFetched 헤더에서 사용하는 core.TargetType 문자열 ("category"/"article") 로 변환합니다.
+//
+// 초기 fetcher 는 core.TargetType 값을 target_type 헤더로 발행하므로,
+// RequeueParsing / RequeueForLLMRetry 에서 재발행 시 동일 변환이 필요합니다 (이슈 #262 리뷰).
+func storageToFetcherTargetType(t storage.TargetType) string {
+	if t == storage.TargetTypeList {
+		return string(core.TargetTypeCategory)
+	}
+	return string(core.TargetTypeArticle)
 }
 
 // parseTimeoutHeader 는 timeout_ms 헤더를 time.Duration 으로 파싱합니다.

--- a/internal/processor/parser/worker/parser_worker.go
+++ b/internal/processor/parser/worker/parser_worker.go
@@ -607,6 +607,40 @@ func (w *ParserWorker) RequeueForLLMRetry(ctx context.Context, ref core.RawConte
 	}).Info("raw content requeued for llm retry after selector validation failure")
 }
 
+// RequeueParsing 은 pending 대기 URL 목록을 issuetracker.fetched 에 재발행합니다 (이슈 #262).
+// llmgen.Generator 의 RequeueFunc 로 등록됩니다.
+//
+// 룰 생성 완료 후 호출 — 대기 중이던 URL 이 새 룰로 재파싱될 수 있도록 TopicFetched 에 투입.
+// 실패는 non-fatal — raw 는 TTL cleanup 으로 최종 정리됩니다.
+func (w *ParserWorker) RequeueParsing(ctx context.Context, items []llmgen.PendingItem) {
+	for _, item := range items {
+		payload, err := json.Marshal(item.RawRef)
+		if err != nil {
+			w.log.WithFields(map[string]interface{}{
+				"raw_id": item.RawRef.ID,
+			}).WithError(err).Error("failed to marshal RawContentRef for pending requeue")
+			continue
+		}
+
+		pubCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 10*time.Second)
+		msg := queue.Message{
+			Topic: queue.TopicFetched,
+			Value: payload,
+			Headers: map[string]string{
+				"target_type": string(item.TargetType),
+				"crawler":     item.CrawlerName,
+			},
+		}
+		if err := w.producer.Publish(pubCtx, msg); err != nil {
+			w.log.WithFields(map[string]interface{}{
+				"raw_id": item.RawRef.ID,
+				"url":    item.RawRef.URL,
+			}).WithError(err).Warn("failed to requeue pending URL for parsing (non-fatal)")
+		}
+		cancel()
+	}
+}
+
 // deleteRaw 는 처리 완료된 raw_contents row 를 즉시 정리합니다.
 // 실패는 non-fatal — cleanup cron 이 안전망으로 동작.
 func (w *ParserWorker) deleteRaw(ctx context.Context, rawID string, mlog *logger.Logger) {

--- a/internal/processor/parser/worker/parser_worker.go
+++ b/internal/processor/parser/worker/parser_worker.go
@@ -613,6 +613,8 @@ func (w *ParserWorker) RequeueForLLMRetry(ctx context.Context, ref core.RawConte
 // 룰 생성 완료 후 호출 — 대기 중이던 URL 이 새 룰로 재파싱될 수 있도록 TopicFetched 에 투입.
 // 실패는 non-fatal — raw 는 TTL cleanup 으로 최종 정리됩니다.
 func (w *ParserWorker) RequeueParsing(ctx context.Context, items []llmgen.PendingItem) {
+	// WithoutCancel 은 루프 외부에서 1회 — 루프마다 새 컨텍스트 파생 불필요 (Gemini 피드백).
+	baseCtx := context.WithoutCancel(ctx)
 	for _, item := range items {
 		payload, err := json.Marshal(item.RawRef)
 		if err != nil {
@@ -622,7 +624,7 @@ func (w *ParserWorker) RequeueParsing(ctx context.Context, items []llmgen.Pendin
 			continue
 		}
 
-		pubCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 10*time.Second)
+		pubCtx, cancel := context.WithTimeout(baseCtx, 10*time.Second)
 		msg := queue.Message{
 			Topic: queue.TopicFetched,
 			Value: payload,

--- a/test/internal/processor/parser/rule/llmgen/generator_test.go
+++ b/test/internal/processor/parser/rule/llmgen/generator_test.go
@@ -157,7 +157,7 @@ func waitForInserts(t *testing.T, repo *recordingRepo, want int, timeout time.Du
 // Tests
 // ─────────────────────────────────────────────────────────────────────────────
 
-func TestGenerator_Enqueue_PageSuccess_InsertsDisabledRule(t *testing.T) {
+func TestGenerator_Enqueue_PageSuccess_InsertsEnabledRule(t *testing.T) {
 	provider := &fakeProvider{
 		name: "fake",
 		response: `{
@@ -171,7 +171,7 @@ func TestGenerator_Enqueue_PageSuccess_InsertsDisabledRule(t *testing.T) {
 
 	g.Enqueue(context.Background(), "example.com", storage.TargetTypePage, &core.RawContent{
 		URL: "https://example.com/article/1", HTML: samplePageHTML,
-	}, 0, "")
+	}, 0, "", 0)
 
 	waitForInserts(t, repo, 1, 2*time.Second)
 
@@ -180,7 +180,7 @@ func TestGenerator_Enqueue_PageSuccess_InsertsDisabledRule(t *testing.T) {
 	rec := got[0]
 	assert.Equal(t, "example.com", rec.HostPattern)
 	assert.Equal(t, storage.TargetTypePage, rec.TargetType)
-	assert.False(t, rec.Enabled, "운영자 review 게이트 — 자동 생성은 enabled=false")
+	assert.True(t, rec.Enabled, "CSS selector 검증 통과 = 품질 게이트 — LLM 자동 생성 룰은 즉시 enabled=true")
 	assert.Equal(t, "llm-auto", rec.SourceName)
 	require.NotNil(t, rec.Selectors.Title)
 	assert.Equal(t, "h1.article-title", rec.Selectors.Title.CSS)
@@ -201,7 +201,7 @@ func TestGenerator_Enqueue_ListSuccess(t *testing.T) {
 
 	g.Enqueue(context.Background(), "example.com", storage.TargetTypeList, &core.RawContent{
 		URL: "https://example.com/news", HTML: sampleListHTML,
-	}, 0, "")
+	}, 0, "", 0)
 
 	waitForInserts(t, repo, 1, 2*time.Second)
 	rec := repo.inserts()[0]
@@ -224,7 +224,7 @@ func TestGenerator_Enqueue_ValidationFailure_NoInsert(t *testing.T) {
 
 	g.Enqueue(context.Background(), "example.com", storage.TargetTypePage, &core.RawContent{
 		URL: "https://example.com/article/1", HTML: samplePageHTML,
-	}, 0, "")
+	}, 0, "", 0)
 
 	// validation reject 시 INSERT 가 발생하지 않는지 확인 — 충분한 wait 후에도 0건이어야 함
 	time.Sleep(300 * time.Millisecond)
@@ -238,7 +238,7 @@ func TestGenerator_Enqueue_LLMError_NoInsert(t *testing.T) {
 
 	g.Enqueue(context.Background(), "example.com", storage.TargetTypePage, &core.RawContent{
 		URL: "https://example.com/x", HTML: samplePageHTML,
-	}, 0, "")
+	}, 0, "", 0)
 
 	// async goroutine 이 LLM 호출 후 실패 — INSERT 없어야 함
 	deadline := time.Now().Add(500 * time.Millisecond)
@@ -274,7 +274,7 @@ func TestGenerator_Enqueue_InflightDedup_SingleLLMCall(t *testing.T) {
 			defer wg.Done()
 			g.Enqueue(context.Background(), "example.com", storage.TargetTypePage, &core.RawContent{
 				URL: "https://example.com/x", HTML: samplePageHTML,
-			}, 0, "")
+			}, 0, "", 0)
 		}()
 	}
 	wg.Wait()
@@ -298,10 +298,10 @@ func TestGenerator_Enqueue_DifferentHosts_BothCalled(t *testing.T) {
 
 	g.Enqueue(context.Background(), "a.example.com", storage.TargetTypePage, &core.RawContent{
 		URL: "https://a.example.com/x", HTML: samplePageHTML,
-	}, 0, "")
+	}, 0, "", 0)
 	g.Enqueue(context.Background(), "b.example.com", storage.TargetTypePage, &core.RawContent{
 		URL: "https://b.example.com/x", HTML: samplePageHTML,
-	}, 0, "")
+	}, 0, "", 0)
 
 	waitForInserts(t, repo, 2, 2*time.Second)
 	assert.Equal(t, 2, provider.callCount())
@@ -314,7 +314,7 @@ func TestGenerator_Enqueue_EmptyHTML_NoCall(t *testing.T) {
 
 	g.Enqueue(context.Background(), "example.com", storage.TargetTypePage, &core.RawContent{
 		URL: "https://example.com/x", HTML: "",
-	}, 0, "")
+	}, 0, "", 0)
 
 	time.Sleep(200 * time.Millisecond)
 	assert.Equal(t, 0, provider.callCount(), "빈 HTML 은 LLM 호출 skip")
@@ -338,7 +338,7 @@ func TestGenerator_Stop_WaitsForInflightGoroutines(t *testing.T) {
 
 	g.Enqueue(context.Background(), "example.com", storage.TargetTypePage, &core.RawContent{
 		URL: "https://example.com/x", HTML: samplePageHTML,
-	}, 0, "")
+	}, 0, "", 0)
 
 	// 충분한 timeout 으로 Stop — provider delay (200ms) 가 끝날 때까지 대기.
 	stopCtx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
@@ -359,7 +359,7 @@ func TestGenerator_EnqueueAfterStop_NoOp(t *testing.T) {
 
 	g.Enqueue(context.Background(), "example.com", storage.TargetTypePage, &core.RawContent{
 		URL: "https://example.com/x", HTML: samplePageHTML,
-	}, 0, "")
+	}, 0, "", 0)
 
 	time.Sleep(100 * time.Millisecond)
 	assert.Equal(t, 0, provider.callCount(), "Stop 이후 Enqueue 는 LLM 호출하지 않아야 함")
@@ -396,7 +396,7 @@ func TestGenerator_Enqueue_OutlivesCallerCtxCancel(t *testing.T) {
 	callerCtx, cancel := context.WithCancel(context.Background())
 	g.Enqueue(callerCtx, "example.com", storage.TargetTypePage, &core.RawContent{
 		URL: "https://example.com/x", HTML: samplePageHTML,
-	}, 0, "")
+	}, 0, "", 0)
 
 	// 호출자 ctx 즉시 cancel — LLM 호출 중에 cancel 됨. WithoutCancel 이라 호출은 계속 진행되어야 함.
 	cancel()
@@ -455,7 +455,7 @@ func TestGenerator_SetExtractor_UsesExtractorNotProvider(t *testing.T) {
 
 	g.Enqueue(context.Background(), "example.com", storage.TargetTypePage, &core.RawContent{
 		URL: "https://example.com/article/1", HTML: samplePageHTML,
-	}, 0, "")
+	}, 0, "", 0)
 
 	waitForInserts(t, repo, 1, 2*time.Second)
 
@@ -486,7 +486,7 @@ func TestGenerator_SetExtractor_ModelNameFromInterface(t *testing.T) {
 
 	g.Enqueue(context.Background(), "example.com", storage.TargetTypePage, &core.RawContent{
 		URL: "https://example.com/article/1", HTML: samplePageHTML,
-	}, 0, "")
+	}, 0, "", 0)
 
 	waitForInserts(t, repo, 1, 2*time.Second)
 
@@ -513,7 +513,7 @@ func TestGenerator_SetExtractor_FallbackModelName(t *testing.T) {
 
 	g.Enqueue(context.Background(), "example.com", storage.TargetTypePage, &core.RawContent{
 		URL: "https://example.com/article/1", HTML: samplePageHTML,
-	}, 0, "")
+	}, 0, "", 0)
 
 	waitForInserts(t, repo, 1, 2*time.Second)
 
@@ -534,7 +534,7 @@ func TestGenerator_SetExtractor_Error_NoInsert(t *testing.T) {
 
 	g.Enqueue(context.Background(), "example.com", storage.TargetTypePage, &core.RawContent{
 		URL: "https://example.com/article/1", HTML: samplePageHTML,
-	}, 0, "")
+	}, 0, "", 0)
 
 	time.Sleep(300 * time.Millisecond)
 	assert.Empty(t, repo.inserts(), "extractor 오류 시 INSERT 없어야 함")
@@ -557,7 +557,7 @@ func TestGenerator_SetExtractor_Nil_FallsBackToProvider(t *testing.T) {
 
 	g.Enqueue(context.Background(), "example.com", storage.TargetTypePage, &core.RawContent{
 		URL: "https://example.com/article/1", HTML: samplePageHTML,
-	}, 0, "")
+	}, 0, "", 0)
 
 	waitForInserts(t, repo, 1, 2*time.Second)
 	assert.Equal(t, 1, provider.callCount(), "nil extractor 시 provider 가 호출되어야 함")

--- a/test/internal/processor/parser/rule/llmgen/inflight_test.go
+++ b/test/internal/processor/parser/rule/llmgen/inflight_test.go
@@ -33,7 +33,7 @@ func TestGenerator_SetLocker_Nil_FallsBackToMem(t *testing.T) {
 
 	g.Enqueue(context.Background(), "example.com", storage.TargetTypePage, &core.RawContent{
 		URL: "https://example.com/article/1", HTML: samplePageHTML,
-	}, 0, "")
+	}, 0, "", 0)
 
 	waitForInserts(t, repo, 1, 2*time.Second)
 	assert.Equal(t, 1, provider.callCount(), "nil SetLocker 시 기존 동작 유지")
@@ -50,7 +50,7 @@ func TestGenerator_SetLocker_AlwaysLocked_NoLLMCall(t *testing.T) {
 
 	g.Enqueue(context.Background(), "example.com", storage.TargetTypePage, &core.RawContent{
 		URL: "https://example.com/x", HTML: samplePageHTML,
-	}, 0, "")
+	}, 0, "", 0)
 
 	time.Sleep(200 * time.Millisecond)
 	assert.Equal(t, 0, provider.callCount(), "locker 가 false 반환 시 LLM 호출 없어야 함")
@@ -74,7 +74,7 @@ func TestGenerator_SetLocker_CustomLocker_IsInvoked(t *testing.T) {
 
 	g.Enqueue(context.Background(), "example.com", storage.TargetTypePage, &core.RawContent{
 		URL: "https://example.com/x", HTML: samplePageHTML,
-	}, 0, "")
+	}, 0, "", 0)
 
 	waitForInserts(t, repo, 1, 2*time.Second)
 	assert.Equal(t, 1, locker.acquireCalls(), "TryAcquire 가 1회 호출되어야 함")

--- a/test/internal/processor/parser/rule/llmgen/pending_test.go
+++ b/test/internal/processor/parser/rule/llmgen/pending_test.go
@@ -1,0 +1,249 @@
+package llmgen_test
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"issuetracker/internal/processor/fetcher/core"
+	"issuetracker/internal/processor/parser/rule/llmgen"
+	"issuetracker/internal/storage"
+)
+
+// ─────────────────────────────────────────────────────────────────────────────
+// pendingQueue 통합 테스트 — memPendingQueue (in-process fake)
+// ─────────────────────────────────────────────────────────────────────────────
+
+// memPendingQueue 는 테스트용 in-process PendingQueue 구현입니다.
+type memPendingQueue struct {
+	mu    sync.Mutex
+	items map[string][]llmgen.PendingItem
+}
+
+func newMemPendingQueue() *memPendingQueue {
+	return &memPendingQueue{items: make(map[string][]llmgen.PendingItem)}
+}
+
+func (m *memPendingQueue) Push(_ context.Context, host string, targetType storage.TargetType, item llmgen.PendingItem) error {
+	key := host + ":" + string(targetType)
+	m.mu.Lock()
+	m.items[key] = append(m.items[key], item)
+	m.mu.Unlock()
+	return nil
+}
+
+func (m *memPendingQueue) Flush(_ context.Context, host string, targetType storage.TargetType) ([]llmgen.PendingItem, error) {
+	key := host + ":" + string(targetType)
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	out := m.items[key]
+	delete(m.items, key)
+	return out, nil
+}
+
+func (m *memPendingQueue) count(host string, targetType storage.TargetType) int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return len(m.items[host+":"+string(targetType)])
+}
+
+// Ensure memPendingQueue implements llmgen.PendingQueue
+var _ llmgen.PendingQueue = (*memPendingQueue)(nil)
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Tests
+// ─────────────────────────────────────────────────────────────────────────────
+
+// TestGenerator_PendingQueue_InFlight_Queued 는 in-flight 중 동일 도메인 URL 이
+// pendingQueue 에 적재되는지 검증합니다 (이슈 #262).
+func TestGenerator_PendingQueue_InFlight_Queued(t *testing.T) {
+	provider := &slowProvider{
+		fakeProvider: fakeProvider{
+			name: "fake",
+			response: `{
+				"title": {"css": "h1.article-title"},
+				"main_content": {"css": "article p"}
+			}`,
+		},
+		delay: 150 * time.Millisecond,
+	}
+	repo := &recordingRepo{}
+	g, _ := newGenerator(t, provider, repo)
+
+	pq := newMemPendingQueue()
+	var requeued []llmgen.PendingItem
+	var requeueMu sync.Mutex
+	g.SetPendingQueue(pq, func(_ context.Context, items []llmgen.PendingItem) {
+		requeueMu.Lock()
+		requeued = append(requeued, items...)
+		requeueMu.Unlock()
+	})
+
+	// URL 1: 슬롯 획득 → LLM 시작
+	g.Enqueue(context.Background(), "example.com", storage.TargetTypePage, &core.RawContent{
+		URL: "https://example.com/article/1", HTML: samplePageHTML,
+	}, 0, "")
+
+	// URL 2: in-flight 중 → pendingQueue 적재
+	time.Sleep(20 * time.Millisecond) // URL 1 goroutine 확실히 시작 후
+	g.Enqueue(context.Background(), "example.com", storage.TargetTypePage, &core.RawContent{
+		URL: "https://example.com/article/2", HTML: samplePageHTML,
+	}, 0, "")
+
+	assert.Equal(t, 1, pq.count("example.com", storage.TargetTypePage), "URL 2는 pendingQueue에 적재되어야 함")
+
+	// LLM 완료 대기 → pending flush 후 requeueFn 호출
+	waitForInserts(t, repo, 1, 2*time.Second)
+	time.Sleep(50 * time.Millisecond) // flush + requeue 비동기 완료 대기
+
+	requeueMu.Lock()
+	requeuedCount := len(requeued)
+	requeueMu.Unlock()
+
+	assert.Equal(t, 1, requeuedCount, "룰 생성 완료 후 pending URL 1개가 requeueFn으로 전달되어야 함")
+	assert.Equal(t, 0, pq.count("example.com", storage.TargetTypePage), "flush 후 pendingQueue는 비어야 함")
+}
+
+// TestGenerator_PendingQueue_LLMFail_NotFlushed 는 LLM 실패 시 pendingQueue 가
+// flush 되지 않는지 검증합니다 (이슈 #262 — 룰 없이 재파싱 의미 없음).
+func TestGenerator_PendingQueue_LLMFail_NotFlushed(t *testing.T) {
+	provider := &slowProvider{
+		fakeProvider: fakeProvider{name: "fake", err: assert.AnError},
+		delay:        50 * time.Millisecond,
+	}
+	repo := &recordingRepo{}
+	g, _ := newGenerator(t, provider, repo)
+
+	pq := newMemPendingQueue()
+	var requeueCalled bool
+	g.SetPendingQueue(pq, func(_ context.Context, _ []llmgen.PendingItem) {
+		requeueCalled = true
+	})
+
+	g.Enqueue(context.Background(), "example.com", storage.TargetTypePage, &core.RawContent{
+		URL: "https://example.com/article/1", HTML: samplePageHTML,
+	}, 0, "")
+
+	time.Sleep(20 * time.Millisecond)
+	g.Enqueue(context.Background(), "example.com", storage.TargetTypePage, &core.RawContent{
+		URL: "https://example.com/article/2", HTML: samplePageHTML,
+	}, 0, "")
+
+	stopCtx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	g.Stop(stopCtx)
+
+	assert.False(t, requeueCalled, "LLM 실패 시 requeueFn 호출 없어야 함")
+	assert.Equal(t, 1, pq.count("example.com", storage.TargetTypePage), "LLM 실패 시 pending URL 보존되어야 함")
+}
+
+// TestGenerator_NoPendingQueue_SkipsBehaviorUnchanged 는 pendingQueue 미설정 시
+// 기존 skip 동작을 유지하는지 검증합니다.
+func TestGenerator_NoPendingQueue_SkipsBehaviorUnchanged(t *testing.T) {
+	provider := &slowProvider{
+		fakeProvider: fakeProvider{
+			name: "fake",
+			response: `{
+				"title": {"css": "h1.article-title"},
+				"main_content": {"css": "article p"}
+			}`,
+		},
+		delay: 100 * time.Millisecond,
+	}
+	repo := &recordingRepo{}
+	g, _ := newGenerator(t, provider, repo) // pendingQueue 미설정
+
+	g.Enqueue(context.Background(), "example.com", storage.TargetTypePage, &core.RawContent{
+		URL: "https://example.com/article/1", HTML: samplePageHTML,
+	}, 0, "")
+
+	time.Sleep(20 * time.Millisecond)
+	g.Enqueue(context.Background(), "example.com", storage.TargetTypePage, &core.RawContent{
+		URL: "https://example.com/article/2", HTML: samplePageHTML,
+	}, 0, "")
+
+	waitForInserts(t, repo, 1, 2*time.Second)
+	assert.Equal(t, 1, provider.callCount(), "pendingQueue 없으면 LLM은 1회만 호출")
+}
+
+// TestGenerator_PendingQueue_DifferentHosts_Independent 는 서로 다른 도메인의
+// pendingQueue 가 독립적으로 동작하는지 검증합니다.
+func TestGenerator_PendingQueue_DifferentHosts_Independent(t *testing.T) {
+	provider := &fakeProvider{
+		name: "fake",
+		response: `{
+			"title": {"css": "h1.article-title"},
+			"main_content": {"css": "article p"}
+		}`,
+	}
+	repo := &recordingRepo{}
+	g, _ := newGenerator(t, provider, repo)
+
+	pq := newMemPendingQueue()
+	g.SetPendingQueue(pq, func(_ context.Context, _ []llmgen.PendingItem) {})
+
+	g.Enqueue(context.Background(), "a.com", storage.TargetTypePage, &core.RawContent{
+		URL: "https://a.com/x", HTML: samplePageHTML,
+	}, 0, "")
+	g.Enqueue(context.Background(), "b.com", storage.TargetTypePage, &core.RawContent{
+		URL: "https://b.com/x", HTML: samplePageHTML,
+	}, 0, "")
+
+	waitForInserts(t, repo, 2, 2*time.Second)
+	assert.Equal(t, 2, provider.callCount(), "다른 도메인은 각자 LLM 호출")
+	assert.Equal(t, 0, pq.count("a.com", storage.TargetTypePage), "a.com pending 없어야 함")
+	assert.Equal(t, 0, pq.count("b.com", storage.TargetTypePage), "b.com pending 없어야 함")
+}
+
+// TestPendingItem_RequeueFunc_ReceivesCorrectData 는 requeueFn 이 올바른 PendingItem 을
+// 전달받는지 검증합니다.
+func TestPendingItem_RequeueFunc_ReceivesCorrectData(t *testing.T) {
+	provider := &slowProvider{
+		fakeProvider: fakeProvider{
+			name: "fake",
+			response: `{
+				"title": {"css": "h1.article-title"},
+				"main_content": {"css": "article p"}
+			}`,
+		},
+		delay: 100 * time.Millisecond,
+	}
+	repo := &recordingRepo{}
+	g, _ := newGenerator(t, provider, repo)
+
+	pq := newMemPendingQueue()
+	var received []llmgen.PendingItem
+	var mu sync.Mutex
+	g.SetPendingQueue(pq, func(_ context.Context, items []llmgen.PendingItem) {
+		mu.Lock()
+		received = append(received, items...)
+		mu.Unlock()
+	})
+
+	g.Enqueue(context.Background(), "example.com", storage.TargetTypePage, &core.RawContent{
+		URL: "https://example.com/article/1", HTML: samplePageHTML,
+	}, 0, "test-crawler")
+
+	time.Sleep(20 * time.Millisecond)
+	g.Enqueue(context.Background(), "example.com", storage.TargetTypePage, &core.RawContent{
+		URL: "https://example.com/article/2", HTML: samplePageHTML,
+	}, 1, "test-crawler")
+
+	waitForInserts(t, repo, 1, 2*time.Second)
+	time.Sleep(50 * time.Millisecond)
+
+	mu.Lock()
+	items := make([]llmgen.PendingItem, len(received))
+	copy(items, received)
+	mu.Unlock()
+
+	require.Len(t, items, 1)
+	assert.Equal(t, "https://example.com/article/2", items[0].RawRef.URL)
+	assert.Equal(t, "test-crawler", items[0].CrawlerName)
+	assert.Equal(t, 1, items[0].LLMRetryCount)
+	assert.Equal(t, storage.TargetTypePage, items[0].TargetType)
+}

--- a/test/internal/processor/parser/rule/llmgen/pending_test.go
+++ b/test/internal/processor/parser/rule/llmgen/pending_test.go
@@ -77,22 +77,23 @@ func TestGenerator_PendingQueue_InFlight_Queued(t *testing.T) {
 	pq := newMemPendingQueue()
 	var requeued []llmgen.PendingItem
 	var requeueMu sync.Mutex
-	g.SetPendingQueue(pq, func(_ context.Context, items []llmgen.PendingItem) {
+	g.SetPendingQueue(pq, func(_ context.Context, items []llmgen.PendingItem) []llmgen.PendingItem {
 		requeueMu.Lock()
 		requeued = append(requeued, items...)
 		requeueMu.Unlock()
+		return nil
 	})
 
 	// URL 1: 슬롯 획득 → LLM 시작
 	g.Enqueue(context.Background(), "example.com", storage.TargetTypePage, &core.RawContent{
 		URL: "https://example.com/article/1", HTML: samplePageHTML,
-	}, 0, "")
+	}, 0, "", 0)
 
 	// URL 2: in-flight 중 → pendingQueue 적재
 	time.Sleep(20 * time.Millisecond) // URL 1 goroutine 확실히 시작 후
 	g.Enqueue(context.Background(), "example.com", storage.TargetTypePage, &core.RawContent{
 		URL: "https://example.com/article/2", HTML: samplePageHTML,
-	}, 0, "")
+	}, 0, "", 0)
 
 	assert.Equal(t, 1, pq.count("example.com", storage.TargetTypePage), "URL 2는 pendingQueue에 적재되어야 함")
 
@@ -120,18 +121,19 @@ func TestGenerator_PendingQueue_LLMFail_NotFlushed(t *testing.T) {
 
 	pq := newMemPendingQueue()
 	var requeueCalled bool
-	g.SetPendingQueue(pq, func(_ context.Context, _ []llmgen.PendingItem) {
+	g.SetPendingQueue(pq, func(_ context.Context, _ []llmgen.PendingItem) []llmgen.PendingItem {
 		requeueCalled = true
+		return nil
 	})
 
 	g.Enqueue(context.Background(), "example.com", storage.TargetTypePage, &core.RawContent{
 		URL: "https://example.com/article/1", HTML: samplePageHTML,
-	}, 0, "")
+	}, 0, "", 0)
 
 	time.Sleep(20 * time.Millisecond)
 	g.Enqueue(context.Background(), "example.com", storage.TargetTypePage, &core.RawContent{
 		URL: "https://example.com/article/2", HTML: samplePageHTML,
-	}, 0, "")
+	}, 0, "", 0)
 
 	stopCtx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancel()
@@ -159,12 +161,12 @@ func TestGenerator_NoPendingQueue_SkipsBehaviorUnchanged(t *testing.T) {
 
 	g.Enqueue(context.Background(), "example.com", storage.TargetTypePage, &core.RawContent{
 		URL: "https://example.com/article/1", HTML: samplePageHTML,
-	}, 0, "")
+	}, 0, "", 0)
 
 	time.Sleep(20 * time.Millisecond)
 	g.Enqueue(context.Background(), "example.com", storage.TargetTypePage, &core.RawContent{
 		URL: "https://example.com/article/2", HTML: samplePageHTML,
-	}, 0, "")
+	}, 0, "", 0)
 
 	waitForInserts(t, repo, 1, 2*time.Second)
 	assert.Equal(t, 1, provider.callCount(), "pendingQueue 없으면 LLM은 1회만 호출")
@@ -184,14 +186,14 @@ func TestGenerator_PendingQueue_DifferentHosts_Independent(t *testing.T) {
 	g, _ := newGenerator(t, provider, repo)
 
 	pq := newMemPendingQueue()
-	g.SetPendingQueue(pq, func(_ context.Context, _ []llmgen.PendingItem) {})
+	g.SetPendingQueue(pq, func(_ context.Context, _ []llmgen.PendingItem) []llmgen.PendingItem { return nil })
 
 	g.Enqueue(context.Background(), "a.com", storage.TargetTypePage, &core.RawContent{
 		URL: "https://a.com/x", HTML: samplePageHTML,
-	}, 0, "")
+	}, 0, "", 0)
 	g.Enqueue(context.Background(), "b.com", storage.TargetTypePage, &core.RawContent{
 		URL: "https://b.com/x", HTML: samplePageHTML,
-	}, 0, "")
+	}, 0, "", 0)
 
 	waitForInserts(t, repo, 2, 2*time.Second)
 	assert.Equal(t, 2, provider.callCount(), "다른 도메인은 각자 LLM 호출")
@@ -218,20 +220,21 @@ func TestPendingItem_RequeueFunc_ReceivesCorrectData(t *testing.T) {
 	pq := newMemPendingQueue()
 	var received []llmgen.PendingItem
 	var mu sync.Mutex
-	g.SetPendingQueue(pq, func(_ context.Context, items []llmgen.PendingItem) {
+	g.SetPendingQueue(pq, func(_ context.Context, items []llmgen.PendingItem) []llmgen.PendingItem {
 		mu.Lock()
 		received = append(received, items...)
 		mu.Unlock()
+		return nil
 	})
 
 	g.Enqueue(context.Background(), "example.com", storage.TargetTypePage, &core.RawContent{
 		URL: "https://example.com/article/1", HTML: samplePageHTML,
-	}, 0, "test-crawler")
+	}, 0, "test-crawler", 0)
 
 	time.Sleep(20 * time.Millisecond)
 	g.Enqueue(context.Background(), "example.com", storage.TargetTypePage, &core.RawContent{
 		URL: "https://example.com/article/2", HTML: samplePageHTML,
-	}, 1, "test-crawler")
+	}, 1, "test-crawler", 0)
 
 	waitForInserts(t, repo, 1, 2*time.Second)
 	time.Sleep(50 * time.Millisecond)
@@ -246,4 +249,61 @@ func TestPendingItem_RequeueFunc_ReceivesCorrectData(t *testing.T) {
 	assert.Equal(t, "test-crawler", items[0].CrawlerName)
 	assert.Equal(t, 1, items[0].LLMRetryCount)
 	assert.Equal(t, storage.TargetTypePage, items[0].TargetType)
+}
+
+// TestGenerator_PendingQueue_TargetTypeList_Queued 는 TargetTypeList (카테고리 페이지) 에 대한
+// pendingQueue 가 TargetTypePage 와 독립적으로 동작하는지 검증합니다 (이슈 #262 리뷰).
+func TestGenerator_PendingQueue_TargetTypeList_Queued(t *testing.T) {
+	provider := &slowProvider{
+		fakeProvider: fakeProvider{
+			name: "fake",
+			response: `{
+				"item_container": {"css": "li.news-item"},
+				"item_link": {"css": "a", "attribute": "href"}
+			}`,
+		},
+		delay: 150 * time.Millisecond,
+	}
+	repo := &recordingRepo{}
+	g, _ := newGenerator(t, provider, repo)
+
+	pq := newMemPendingQueue()
+	var requeued []llmgen.PendingItem
+	var mu sync.Mutex
+	g.SetPendingQueue(pq, func(_ context.Context, items []llmgen.PendingItem) []llmgen.PendingItem {
+		mu.Lock()
+		requeued = append(requeued, items...)
+		mu.Unlock()
+		return nil
+	})
+
+	// URL 1: TargetTypeList 슬롯 획득 → LLM 시작
+	g.Enqueue(context.Background(), "example.com", storage.TargetTypeList, &core.RawContent{
+		URL: "https://example.com/news", HTML: sampleListHTML,
+	}, 0, "", 0)
+
+	// URL 2: 동일 host + TargetTypeList, in-flight 중 → pending 적재
+	time.Sleep(20 * time.Millisecond)
+	g.Enqueue(context.Background(), "example.com", storage.TargetTypeList, &core.RawContent{
+		URL: "https://example.com/news/2", HTML: sampleListHTML,
+	}, 0, "", 0)
+
+	assert.Equal(t, 1, pq.count("example.com", storage.TargetTypeList), "URL 2는 TargetTypeList pending 에 적재되어야 함")
+	// TargetTypePage pending 은 영향 없어야 함
+	assert.Equal(t, 0, pq.count("example.com", storage.TargetTypePage), "TargetTypePage pending 은 독립")
+
+	waitForInserts(t, repo, 1, 2*time.Second)
+	time.Sleep(50 * time.Millisecond)
+
+	mu.Lock()
+	requeuedCount := len(requeued)
+	mu.Unlock()
+
+	assert.Equal(t, 1, requeuedCount, "룰 생성 완료 후 TargetTypeList pending URL이 requeueFn 으로 전달되어야 함")
+	assert.Equal(t, 0, pq.count("example.com", storage.TargetTypeList), "flush 후 pending 비어야 함")
+	if requeuedCount > 0 {
+		mu.Lock()
+		assert.Equal(t, storage.TargetTypeList, requeued[0].TargetType, "재투입 항목의 TargetType 은 TargetTypeList")
+		mu.Unlock()
+	}
 }

--- a/test/internal/processor/parser/worker/requeue_test.go
+++ b/test/internal/processor/parser/worker/requeue_test.go
@@ -84,7 +84,8 @@ func TestRequeueForLLMRetry_PreservesHeaders(t *testing.T) {
 
 	require.Len(t, prod.published, 1)
 	msg := prod.published[0]
-	assert.Equal(t, "list", msg.Headers["target_type"], "target_type 헤더 보존")
+	// storage.TargetTypeList ("list") → core.TargetTypeCategory ("category") 변환 검증 (이슈 #262 리뷰).
+	assert.Equal(t, "category", msg.Headers["target_type"], "target_type 헤더는 fetcher 형식(category)으로 변환되어야 함")
 	assert.Equal(t, "naver", msg.Headers["crawler"], "crawler 헤더 보존")
 }
 


### PR DESCRIPTION
## 연관 이슈
Closes #262
Depends on #261 (merged)

## 구현 내용

### 변경 흐름

```
기존:
  lock 획득 실패 → skip → URL 유실

변경:
  lock 획득 실패 → Redis LIST RPUSH → URL 보존
  runOnce 성공   → Lua LRANGE+DEL → requeueFn → TopicFetched 재발행 → 새 룰로 재파싱
  runOnce 실패   → flush 없음 (룰 없으면 재파싱 의미 없음, 다음 runOnce 시 flush)
```

### 신규 파일

**`llmgen/pending.go`**
- `PendingItem`: rawRef + crawlerName + llmRetryCount + targetType
- `PendingQueue` 인터페이스: `Push` / `Flush`
- `RedisPendingQueue`: `RPUSH` + Lua `LRANGE+DEL` 원자적 flush
- `RequeueFunc`: 재투입 콜백 타입

### 변경 파일

**`llmgen/generator.go`**
- `SetPendingQueue(pq, fn)` — 초기화 시 1회 호출
- `Enqueue()`: lock 실패 시 `pendingQueue.Push`
- goroutine: `runOnce()` 성공 후 `pendingQueue.Flush` + `requeueFn`

**`parser_worker.go`**
- `RequeueParsing(ctx, []PendingItem)`: TopicFetched 재발행 (non-fatal)

**`main.go`**
- Redis 활성 시 `SetPendingQueue(RedisPendingQueue, pw.RequeueParsing)` 와이어링

## CI / 머지 게이트
- [x] `go build ./...` 통과
- [x] `go test -race ./...` 통과 (pending 5케이스 포함)
- [x] `make fmt` 완료

## 변경 영향 범위
- Redis 미설정 환경: 기존과 동일 (lock 실패 → skip)
- Redis 설정 환경: lock 실패 → pending 보존 → 룰 생성 완료 후 재파싱

## 위험도
낮음 — Redis 미설정/장애 시 기존 동작 유지

## 롤백
`SetPendingQueue` 호출 제거 시 즉시 기존 동작으로 복귀