### PR TITLE
[FEAT#269] claudegen 자체 Dockerfile — Anthropic 공식 미공개 대응 + 라이브 sonnet 검증

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -68,20 +68,24 @@ LLM_API_KEY=
 # LLM prompt 디렉토리 override (default: scripts/prompts)
 # ISSUETRACKER_PROMPTS_DIR=scripts/prompts
 
-# Claude Code 웜 컨테이너 셀렉터 추출기 설정 (이슈 #256, #266)
+# Claude Code 웜 컨테이너 셀렉터 추출기 설정 (이슈 #256, #266, #269)
 # LLM_PROVIDER=gemini 대신 Claude Code Docker 를 추출기로 사용할 때 설정.
 #
 # 인증 방식 (이슈 #266 — auth_token 구독 방식):
-#   1. 호스트에서 `claude` CLI 1회 로그인 → ~/.claude/ 에 OAuth token 저장
-#   2. 본 디렉토리를 컨테이너에 read-only 마운트 → 구독 quota 안에서 sonnet 사용 가능
+#   1. 호스트에서 `claude` CLI 1회 로그인 → ~/.claude/ + ~/.claude.json 에 OAuth token 저장
+#   2. 본 path 들을 컨테이너에 read-write 마운트 → 구독 quota 안에서 sonnet 사용 가능
+#      (Claude CLI 가 세션 history 등을 .claude/ 에 기록하므로 :ro 마운트 불가)
 #   3. ANTHROPIC_API_KEY 종량제 과금 방식은 더 이상 claudegen 에 사용하지 않음
 #      (validator.Pool 의 anthropic provider 용도로는 여전히 유효)
-CLAUDE_CODE_IMAGE=ghcr.io/anthropics/claude-code:latest
+#
+# 이미지 (이슈 #269 — Anthropic 공식 ghcr.io/anthropics/claude-code 비공개 대응):
+#   사전 빌드 필요: make claudegen-build
+CLAUDE_CODE_IMAGE=issuetracker-claudegen:local
 CLAUDE_CODE_MODEL=claude-sonnet-4-6
 CLAUDE_CODE_TIMEOUT=120s
 # 호스트의 Claude 인증 디렉토리 (기본: $HOME/.claude)
-# CLAUDE_CODE_AUTH_DIR=/home/user/.claude
-# 컨테이너 내 인증 디렉토리 마운트 경로 (기본: /root/.claude — 이미지 user 에 따라 변경 필요할 수 있음)
+# CLAUDE_CODE_AUTH_DIR=/root/.claude
+# 컨테이너 내 인증 디렉토리 마운트 경로 (기본: /root/.claude — root user 컨테이너 기준)
 # CLAUDE_CODE_CONTAINER_AUTH_PATH=/root/.claude
 
 # PathInfer 휴리스틱 설정 (이슈 #173)

--- a/.env.example
+++ b/.env.example
@@ -68,12 +68,21 @@ LLM_API_KEY=
 # LLM prompt 디렉토리 override (default: scripts/prompts)
 # ISSUETRACKER_PROMPTS_DIR=scripts/prompts
 
-# Claude Code 웜 컨테이너 셀렉터 추출기 설정 (이슈 #256)
-# LLM_PROVIDER=gemini 대신 Claude Code Docker 를 추출기로 사용할 때 설정
-# ANTHROPIC_API_KEY 가 설정되어 있어야 컨테이너가 API 호출 가능
+# Claude Code 웜 컨테이너 셀렉터 추출기 설정 (이슈 #256, #266)
+# LLM_PROVIDER=gemini 대신 Claude Code Docker 를 추출기로 사용할 때 설정.
+#
+# 인증 방식 (이슈 #266 — auth_token 구독 방식):
+#   1. 호스트에서 `claude` CLI 1회 로그인 → ~/.claude/ 에 OAuth token 저장
+#   2. 본 디렉토리를 컨테이너에 read-only 마운트 → 구독 quota 안에서 sonnet 사용 가능
+#   3. ANTHROPIC_API_KEY 종량제 과금 방식은 더 이상 claudegen 에 사용하지 않음
+#      (validator.Pool 의 anthropic provider 용도로는 여전히 유효)
 CLAUDE_CODE_IMAGE=ghcr.io/anthropics/claude-code:latest
 CLAUDE_CODE_MODEL=claude-sonnet-4-6
 CLAUDE_CODE_TIMEOUT=120s
+# 호스트의 Claude 인증 디렉토리 (기본: $HOME/.claude)
+# CLAUDE_CODE_AUTH_DIR=/home/user/.claude
+# 컨테이너 내 인증 디렉토리 마운트 경로 (기본: /root/.claude — 이미지 user 에 따라 변경 필요할 수 있음)
+# CLAUDE_CODE_CONTAINER_AUTH_PATH=/root/.claude
 
 # PathInfer 휴리스틱 설정 (이슈 #173)
 # URL 패턴 추론에 필요한 최소 샘플 URL 수 (1 이상)

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@
         run-kafka-pipeline \
         kafka-start kafka-stop kafka-clean kafka-status kafka-logs kafka-topics kafka-init \
         pg-start pg-stop pg-clean pg-migrate pg-status pg-psql \
-        proto
+        proto claudegen-build
 
 # 기본 변수
 BINARY_DIR=bin

--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,7 @@ ISSUETRACKER_BINARY=$(BINARY_DIR)/issuetracker
 MIGRATE_BINARY=$(BINARY_DIR)/migrate
 MIGRATE_DOWN_BINARY=$(BINARY_DIR)/migrate-down
 RULE_VALIDATOR_BINARY=$(BINARY_DIR)/rule-validator
+CLAUDEGEN_IMAGE_TAG ?= issuetracker-claudegen:local
 EXAMPLE_BINARY=$(BINARY_DIR)/basic_usage
 COMPARISON_BINARY=$(BINARY_DIR)/crawler_comparison
 KAFKA_PIPELINE_BINARY=$(BINARY_DIR)/kafka_pipeline
@@ -51,6 +52,11 @@ build: ## 모든 바이너리 빌드
 	@echo "Build complete: $(PROCESSOR_BINARY), $(ISSUETRACKER_BINARY), $(MIGRATE_BINARY), $(MIGRATE_DOWN_BINARY), $(RULE_VALIDATOR_BINARY)"
 
 build-all: build ## 모든 실행 파일 빌드 (build와 동일)
+
+claudegen-build: ## claudegen 자체 Claude Code 이미지 빌드 (이슈 #269 — Anthropic 공식 미공개 대응)
+	@echo "Building claudegen image: $(CLAUDEGEN_IMAGE_TAG)"
+	docker build -t $(CLAUDEGEN_IMAGE_TAG) deployments/docker/claudegen/
+	@echo "Build complete: $(CLAUDEGEN_IMAGE_TAG)"
 
 start: ## Crawler + Processor 통합 실행 (의존: chrome, kafka 자동 기동, 직렬 실행)
 	@$(MAKE) chrome-ensure

--- a/deployments/docker/claudegen/Dockerfile
+++ b/deployments/docker/claudegen/Dockerfile
@@ -22,11 +22,17 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     curl \
     && rm -rf /var/lib/apt/lists/*
 
-# Claude Code CLI 전역 설치
-# postinstall 스크립트가 native binary 를 다운로드하지 못하는 경우가 있어 명시적으로 install.cjs 실행 (이슈 #269)
-RUN npm install -g @anthropic-ai/claude-code \
-    && (node /usr/lib/node_modules/@anthropic-ai/claude-code/install.cjs || \
-        echo "install.cjs not found, native binary may already be present")
+# Claude Code CLI 전역 설치 (이슈 #269)
+# - 버전 고정 (재현성 확보 — PR #270 리뷰 피드백)
+# - npm root -g 로 실제 global 경로 동적 결정 (node:20-slim 은 /usr/local/lib/node_modules)
+# - postinstall 스크립트가 native binary 를 다운로드하지 못하는 경우가 있어 install.cjs 명시 실행
+# - 마지막에 claude --version 으로 smoke check — 실패 시 빌드 실패 (silent breakage 회피)
+ARG CLAUDE_CODE_VERSION=2.1.128
+RUN npm install -g @anthropic-ai/claude-code@${CLAUDE_CODE_VERSION} \
+    && INSTALL_CJS="$(npm root -g)/@anthropic-ai/claude-code/install.cjs" \
+    && if [ -f "$INSTALL_CJS" ]; then node "$INSTALL_CJS"; \
+       else echo "install.cjs not found at $INSTALL_CJS — native binary may already be present"; fi \
+    && claude --version
 
 # 인증 디렉토리 마운트 지점 (이슈 #266) — 호스트 ~/.claude 가 read-write 로 마운트됨
 RUN mkdir -p /root/.claude

--- a/deployments/docker/claudegen/Dockerfile
+++ b/deployments/docker/claudegen/Dockerfile
@@ -1,0 +1,39 @@
+# claudegen 자체 Claude Code 이미지 (이슈 #269)
+#
+# Anthropic 공식 ghcr.io/anthropics/claude-code 이미지가 비공개 상태이므로 자체 빌드합니다.
+# 호스트의 ~/.claude/ 디렉토리 + ~/.claude.json 파일을 마운트하여 구독 quota 안에서
+# sonnet 호출 (이슈 #266).
+#
+# 기본 user 는 root — Claude CLI 의 OAuth 인증은 HOME 기반 ($HOME/.claude{.json,/}) 로 동작.
+# 호스트 인증 디렉토리가 root 소유인 경우가 일반적이라 root user 가 권한 일관성 면에서 단순.
+#
+# 빌드:    make claudegen-build
+# 사용:    docker run -d --rm \
+#            -v $HOME/.claude:/root/.claude \
+#            -v $HOME/.claude.json:/root/.claude.json \
+#            -v /tmp/workspace:/workspace \
+#            issuetracker-claudegen:local tail -f /dev/null
+
+FROM node:20-slim
+
+# 시스템 의존성: ca-certificates (HTTPS), curl (디버그 용)
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    ca-certificates \
+    curl \
+    && rm -rf /var/lib/apt/lists/*
+
+# Claude Code CLI 전역 설치
+# postinstall 스크립트가 native binary 를 다운로드하지 못하는 경우가 있어 명시적으로 install.cjs 실행 (이슈 #269)
+RUN npm install -g @anthropic-ai/claude-code \
+    && (node /usr/lib/node_modules/@anthropic-ai/claude-code/install.cjs || \
+        echo "install.cjs not found, native binary may already be present")
+
+# 인증 디렉토리 마운트 지점 (이슈 #266) — 호스트 ~/.claude 가 read-write 로 마운트됨
+RUN mkdir -p /root/.claude
+
+# 작업 디렉토리 — 호스트의 임시 workspace 가 마운트됨
+WORKDIR /workspace
+
+# 컨테이너는 docker exec 세션이 올 때까지 대기
+ENTRYPOINT []
+CMD ["tail", "-f", "/dev/null"]

--- a/internal/processor/parser/rule/claudegen/container.go
+++ b/internal/processor/parser/rule/claudegen/container.go
@@ -25,18 +25,24 @@ type execContainerRunner struct{}
 //     호스트에 파일이 존재할 때만 마운트 — 신규 사용자(claude CLI 미실행)는 .claude.json 부재 가능.
 //
 // 컨테이너는 `tail -f /dev/null` 로 대기 — docker exec 세션이 올 때까지 유지.
-// env 슬라이스의 값은 cmd.Env 로 주입 — args 에 포함하지 않아 ps 에 노출되지 않습니다.
-func (r *execContainerRunner) StartContainer(ctx context.Context, image, workDir, authDir, containerAuthPath string, env []string) (string, error) {
+func (r *execContainerRunner) StartContainer(ctx context.Context, image, workDir, authDir, containerAuthPath string) (string, error) {
+	// trailing slash 등 정규화 — sibling .claude.json 도출이 정확하도록 (PR #268 리뷰).
+	cleanAuthDir := filepath.Clean(authDir)
+	cleanContainerAuthPath := filepath.Clean(containerAuthPath)
+
 	args := []string{
 		"run", "-d", "--rm",
-		"-v", authDir + ":" + containerAuthPath,
+		"-v", cleanAuthDir + ":" + cleanContainerAuthPath,
 	}
 
 	// .claude.json 파일도 함께 마운트 (이슈 #266) — Claude CLI 가 main config 를 sibling 위치에서 찾음.
-	hostJSON := filepath.Join(filepath.Dir(authDir), ".claude.json")
+	hostJSON := filepath.Join(filepath.Dir(cleanAuthDir), ".claude.json")
 	if _, err := os.Stat(hostJSON); err == nil {
-		containerJSON := filepath.Join(filepath.Dir(containerAuthPath), ".claude.json")
+		containerJSON := filepath.Join(filepath.Dir(cleanContainerAuthPath), ".claude.json")
 		args = append(args, "-v", hostJSON+":"+containerJSON)
+	} else if !os.IsNotExist(err) {
+		// 권한 거부 등 다른 에러는 명시적으로 보고 — silent skip 회피.
+		return "", fmt.Errorf("stat host claude config %q: %w", hostJSON, err)
 	}
 
 	args = append(args,
@@ -49,7 +55,6 @@ func (r *execContainerRunner) StartContainer(ctx context.Context, image, workDir
 	cmd := exec.CommandContext(ctx, "docker", args...)
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr
-	cmd.Env = append(os.Environ(), env...)
 	if err := cmd.Run(); err != nil {
 		return "", fmt.Errorf("docker run: %w (stderr: %s)", err, truncate(stderr.String(), truncateStdoutLen))
 	}

--- a/internal/processor/parser/rule/claudegen/container.go
+++ b/internal/processor/parser/rule/claudegen/container.go
@@ -17,9 +17,11 @@ type execContainerRunner struct{}
 //
 // 마운트 정책 (이슈 #266):
 //   - workDir → /workspace (read-write): 세션별 페이지 + 출력 임시 저장
-//   - authDir → containerAuthPath (read-only): 호스트의 .claude/ 디렉토리 (.credentials.json, history)
-//   - sibling .claude.json → containerAuthPath sibling (read-only, optional):
-//     Claude 의 메인 설정 파일이 .claude/ 와 같은 부모 디렉토리에 있어 별도 마운트 필요.
+//   - authDir → containerAuthPath (read-write): 호스트의 .claude/ 디렉토리.
+//     Claude CLI 가 세션 history / 일시 상태를 본 디렉토리에 기록하므로 :ro 마운트 불가.
+//     운영자는 본 디렉토리를 통해 세션 기록이 누적될 수 있음을 인지해야 함.
+//   - sibling .claude.json → containerAuthPath sibling (read-write, optional):
+//     Claude 의 메인 설정 파일도 컨테이너가 갱신할 수 있어 read-write 로 마운트.
 //     호스트에 파일이 존재할 때만 마운트 — 신규 사용자(claude CLI 미실행)는 .claude.json 부재 가능.
 //
 // 컨테이너는 `tail -f /dev/null` 로 대기 — docker exec 세션이 올 때까지 유지.
@@ -27,14 +29,14 @@ type execContainerRunner struct{}
 func (r *execContainerRunner) StartContainer(ctx context.Context, image, workDir, authDir, containerAuthPath string, env []string) (string, error) {
 	args := []string{
 		"run", "-d", "--rm",
-		"-v", authDir + ":" + containerAuthPath + ":ro",
+		"-v", authDir + ":" + containerAuthPath,
 	}
 
 	// .claude.json 파일도 함께 마운트 (이슈 #266) — Claude CLI 가 main config 를 sibling 위치에서 찾음.
 	hostJSON := filepath.Join(filepath.Dir(authDir), ".claude.json")
 	if _, err := os.Stat(hostJSON); err == nil {
 		containerJSON := filepath.Join(filepath.Dir(containerAuthPath), ".claude.json")
-		args = append(args, "-v", hostJSON+":"+containerJSON+":ro")
+		args = append(args, "-v", hostJSON+":"+containerJSON)
 	}
 
 	args = append(args,

--- a/internal/processor/parser/rule/claudegen/container.go
+++ b/internal/processor/parser/rule/claudegen/container.go
@@ -6,17 +6,21 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 )
 
 // execContainerRunner 는 실제 docker CLI 를 사용하는 ContainerRunner 구현입니다.
 type execContainerRunner struct{}
 
-// StartContainer 는 workspace + auth 디렉토리를 마운트한 장기 실행 컨테이너를 기동합니다.
+// StartContainer 는 workspace + auth 상태를 마운트한 장기 실행 컨테이너를 기동합니다.
 //
 // 마운트 정책 (이슈 #266):
 //   - workDir → /workspace (read-write): 세션별 페이지 + 출력 임시 저장
-//   - authDir → containerAuthPath (read-only): 호스트의 Claude 구독 인증 토큰 — 컨테이너가 토큰 변조 못하도록 ro
+//   - authDir → containerAuthPath (read-only): 호스트의 .claude/ 디렉토리 (.credentials.json, history)
+//   - sibling .claude.json → containerAuthPath sibling (read-only, optional):
+//     Claude 의 메인 설정 파일이 .claude/ 와 같은 부모 디렉토리에 있어 별도 마운트 필요.
+//     호스트에 파일이 존재할 때만 마운트 — 신규 사용자(claude CLI 미실행)는 .claude.json 부재 가능.
 //
 // 컨테이너는 `tail -f /dev/null` 로 대기 — docker exec 세션이 올 때까지 유지.
 // env 슬라이스의 값은 cmd.Env 로 주입 — args 에 포함하지 않아 ps 에 노출되지 않습니다.
@@ -24,10 +28,21 @@ func (r *execContainerRunner) StartContainer(ctx context.Context, image, workDir
 	args := []string{
 		"run", "-d", "--rm",
 		"-v", authDir + ":" + containerAuthPath + ":ro",
-		"-v", workDir + ":/workspace",
+	}
+
+	// .claude.json 파일도 함께 마운트 (이슈 #266) — Claude CLI 가 main config 를 sibling 위치에서 찾음.
+	hostJSON := filepath.Join(filepath.Dir(authDir), ".claude.json")
+	if _, err := os.Stat(hostJSON); err == nil {
+		containerJSON := filepath.Join(filepath.Dir(containerAuthPath), ".claude.json")
+		args = append(args, "-v", hostJSON+":"+containerJSON+":ro")
+	}
+
+	args = append(args,
+		"-v", workDir+":/workspace",
 		image,
 		"tail", "-f", "/dev/null",
-	}
+	)
+
 	var stdout, stderr bytes.Buffer
 	cmd := exec.CommandContext(ctx, "docker", args...)
 	cmd.Stdout = &stdout

--- a/internal/processor/parser/rule/claudegen/container.go
+++ b/internal/processor/parser/rule/claudegen/container.go
@@ -12,13 +12,18 @@ import (
 // execContainerRunner 는 실제 docker CLI 를 사용하는 ContainerRunner 구현입니다.
 type execContainerRunner struct{}
 
-// StartContainer 는 workspace 를 마운트한 장기 실행 컨테이너를 기동합니다.
+// StartContainer 는 workspace + auth 디렉토리를 마운트한 장기 실행 컨테이너를 기동합니다.
+//
+// 마운트 정책 (이슈 #266):
+//   - workDir → /workspace (read-write): 세션별 페이지 + 출력 임시 저장
+//   - authDir → containerAuthPath (read-only): 호스트의 Claude 구독 인증 토큰 — 컨테이너가 토큰 변조 못하도록 ro
+//
 // 컨테이너는 `tail -f /dev/null` 로 대기 — docker exec 세션이 올 때까지 유지.
 // env 슬라이스의 값은 cmd.Env 로 주입 — args 에 포함하지 않아 ps 에 노출되지 않습니다.
-func (r *execContainerRunner) StartContainer(ctx context.Context, image, workDir string, env []string) (string, error) {
+func (r *execContainerRunner) StartContainer(ctx context.Context, image, workDir, authDir, containerAuthPath string, env []string) (string, error) {
 	args := []string{
 		"run", "-d", "--rm",
-		"-e", "ANTHROPIC_API_KEY",
+		"-v", authDir + ":" + containerAuthPath + ":ro",
 		"-v", workDir + ":/workspace",
 		image,
 		"tail", "-f", "/dev/null",
@@ -35,7 +40,7 @@ func (r *execContainerRunner) StartContainer(ctx context.Context, image, workDir
 }
 
 // ExecSession 은 실행 중인 컨테이너에서 명령을 실행합니다.
-// 컨테이너에 이미 ANTHROPIC_API_KEY 가 설정되어 있으므로 env 전달이 불필요합니다.
+// 인증은 컨테이너에 마운트된 auth_token 디렉토리로 처리됨 (이슈 #266) — env 전달 불필요.
 func (r *execContainerRunner) ExecSession(ctx context.Context, containerID string, args []string) (string, string, error) {
 	fullArgs := append([]string{"exec", containerID}, args...)
 	var stdout, stderr bytes.Buffer

--- a/internal/processor/parser/rule/claudegen/worker.go
+++ b/internal/processor/parser/rule/claudegen/worker.go
@@ -52,10 +52,9 @@ const (
 type ContainerRunner interface {
 	// StartContainer 는 장기 실행 컨테이너를 기동하고 컨테이너 ID 를 반환합니다.
 	//   - workDir: 컨테이너의 /workspace 로 마운트할 호스트 경로 (read-write)
-	//   - authDir: 호스트의 Claude 인증 디렉토리 (read-only 마운트)
+	//   - authDir: 호스트의 Claude 인증 디렉토리 (read-write 마운트 — Claude CLI 가 세션 상태 기록)
 	//   - containerAuthPath: 컨테이너 내 authDir 마운트 대상 경로
-	//   - env: 추가 환경변수 (비밀값은 args 에 포함하지 않음 — ps 노출 방지)
-	StartContainer(ctx context.Context, image, workDir, authDir, containerAuthPath string, env []string) (containerID string, err error)
+	StartContainer(ctx context.Context, image, workDir, authDir, containerAuthPath string) (containerID string, err error)
 
 	// ExecSession 은 실행 중인 컨테이너에서 명령을 실행합니다.
 	ExecSession(ctx context.Context, containerID string, args []string) (stdout, stderr string, err error)
@@ -133,45 +132,50 @@ func NewFromEnv(log *logger.Logger) (*ClaudeWorker, error) {
 //
 // authDir 은 호스트의 Claude 인증 디렉토리, containerAuthPath 는 컨테이너 내 마운트 대상 경로 (이슈 #266).
 // containerAuthPath 가 빈 문자열이면 defaultContainerAuthPath 사용.
+// authDir 은 validateAuthDir 로 절대 경로 정규화 + 존재/디렉토리/읽기 권한 검증 (PR #268 리뷰).
 func New(image, model, authDir, containerAuthPath string, timeout time.Duration, log *logger.Logger) (*ClaudeWorker, error) {
 	if log == nil {
 		return nil, errors.New("claudegen: New requires non-nil logger")
 	}
-	if authDir == "" {
-		return nil, errors.New("claudegen: New requires non-empty authDir")
+	resolved, err := validateAuthDir(authDir)
+	if err != nil {
+		return nil, err
 	}
 	if containerAuthPath == "" {
 		containerAuthPath = defaultContainerAuthPath
 	}
 	return &ClaudeWorker{
 		image: image, model: model,
-		authDir: authDir, containerAuthPath: containerAuthPath,
+		authDir: resolved, containerAuthPath: containerAuthPath,
 		sessionTimeout: timeout, runner: &execContainerRunner{}, log: log,
 	}, nil
 }
 
 // NewWithRunner 는 ContainerRunner 를 주입하는 생성자입니다 (테스트/DI 용).
+// authDir 은 validateAuthDir 로 절대 경로 정규화 + 존재/디렉토리/읽기 권한 검증 (PR #268 리뷰).
 func NewWithRunner(image, model, authDir, containerAuthPath string, timeout time.Duration, runner ContainerRunner, log *logger.Logger) (*ClaudeWorker, error) {
 	if log == nil {
 		return nil, errors.New("claudegen: NewWithRunner requires non-nil logger")
 	}
-	if authDir == "" {
-		return nil, errors.New("claudegen: NewWithRunner requires non-empty authDir")
-	}
 	if runner == nil {
 		return nil, errors.New("claudegen: NewWithRunner requires non-nil runner")
+	}
+	resolved, err := validateAuthDir(authDir)
+	if err != nil {
+		return nil, err
 	}
 	if containerAuthPath == "" {
 		containerAuthPath = defaultContainerAuthPath
 	}
 	return &ClaudeWorker{
 		image: image, model: model,
-		authDir: authDir, containerAuthPath: containerAuthPath,
+		authDir: resolved, containerAuthPath: containerAuthPath,
 		sessionTimeout: timeout, runner: runner, log: log,
 	}, nil
 }
 
 // resolveAuthDir 은 환경변수 또는 $HOME 기반으로 인증 디렉토리를 결정하고 접근성을 검증합니다.
+// validateAuthDir 로 절대 경로 정규화 + 존재/디렉토리/읽기 권한 검증을 위임합니다.
 func resolveAuthDir(envValue string) (string, error) {
 	authDir := envValue
 	if authDir == "" {
@@ -181,14 +185,34 @@ func resolveAuthDir(envValue string) (string, error) {
 		}
 		authDir = filepath.Join(home, ".claude")
 	}
-	info, err := os.Stat(authDir)
+	return validateAuthDir(authDir)
+}
+
+// validateAuthDir 은 인증 디렉토리의 절대 경로를 산출하고 접근성을 검증합니다 (PR #268 리뷰).
+//
+//   - 빈 문자열 거부 (호출자가 빈 값 처리 후 호출)
+//   - filepath.Abs 로 절대 경로 변환 — Docker 마운트 시 상대 경로 모호성 제거
+//   - os.Stat: 존재 + 디렉토리 검증
+//   - os.ReadDir: 읽기 권한 검증 (mode 만 보지 않고 실제로 읽어봄)
+func validateAuthDir(authDir string) (string, error) {
+	if authDir == "" {
+		return "", errors.New("claudegen: authDir must not be empty")
+	}
+	absPath, err := filepath.Abs(authDir)
 	if err != nil {
-		return "", fmt.Errorf("claudegen: auth dir %q not accessible: %w (run `claude` CLI on host to login first)", authDir, err)
+		return "", fmt.Errorf("claudegen: failed to resolve absolute path for %q: %w", authDir, err)
+	}
+	info, err := os.Stat(absPath)
+	if err != nil {
+		return "", fmt.Errorf("claudegen: auth dir %q not accessible: %w (run `claude` CLI on host to login first)", absPath, err)
 	}
 	if !info.IsDir() {
-		return "", fmt.Errorf("claudegen: auth dir %q is not a directory", authDir)
+		return "", fmt.Errorf("claudegen: auth dir %q is not a directory", absPath)
 	}
-	return authDir, nil
+	if _, err := os.ReadDir(absPath); err != nil {
+		return "", fmt.Errorf("claudegen: auth dir %q is not readable: %w", absPath, err)
+	}
+	return absPath, nil
 }
 
 // Start 는 Claude Code 컨테이너를 기동하고 workspace 를 준비합니다.
@@ -206,7 +230,7 @@ func (w *ClaudeWorker) Start(ctx context.Context) error {
 		return fmt.Errorf("create workspace dir: %w", err)
 	}
 
-	containerID, err := w.runner.StartContainer(ctx, w.image, workDir, w.authDir, w.containerAuthPath, nil)
+	containerID, err := w.runner.StartContainer(ctx, w.image, workDir, w.authDir, w.containerAuthPath)
 	if err != nil {
 		os.RemoveAll(workDir)
 		return fmt.Errorf("start claude container: %w", err)
@@ -214,13 +238,17 @@ func (w *ClaudeWorker) Start(ctx context.Context) error {
 
 	w.containerID = containerID
 	w.workDir = workDir
+	// INFO 로그는 운영자가 외부 수집 시스템에서 보는 항목 — 호스트 사용자명/홈 구조 노출 회피 (PR #268 리뷰).
+	// auth_dir 같은 절대 경로는 DEBUG 레벨로 격리.
 	w.log.WithFields(map[string]interface{}{
-		"container_id":        containerID,
-		"image":               w.image,
-		"model":               w.model,
+		"container_id": containerID,
+		"image":        w.image,
+		"model":        w.model,
+	}).Info("claude code container started (warm, subscription auth)")
+	w.log.WithFields(map[string]interface{}{
 		"auth_dir":            w.authDir,
 		"container_auth_path": w.containerAuthPath,
-	}).Info("claude code container started (warm, subscription auth)")
+	}).Debug("claude code auth mount paths")
 	return nil
 }
 

--- a/internal/processor/parser/rule/claudegen/worker.go
+++ b/internal/processor/parser/rule/claudegen/worker.go
@@ -8,12 +8,15 @@
 // 인증 방식 (이슈 #266):
 //
 //	호스트에서 `claude` CLI 로 사전 로그인하여 발급된 OAuth auth_token 을 사용합니다.
-//	호스트의 인증 디렉토리($HOME/.claude 기본)를 컨테이너에 read-only 로 마운트하여
+//	Claude 의 인증 상태는 두 위치에 분산되어 있어 둘 다 컨테이너에 read-only 로 마운트합니다:
+//	  1. ~/.claude/        : 인증 디렉토리 (.credentials.json, history 등)
+//	  2. ~/.claude.json    : 메인 설정 파일 (sibling — .claude/ 와 같은 부모 디렉토리)
+//	두 path 모두 read-only — 컨테이너가 호스트 인증 상태를 변조하지 못하도록 합니다.
 //	구독 quota 안에서 sonnet 호출이 가능합니다. ANTHROPIC_API_KEY 종량제 과금 방식 대체.
 //
 // 환경변수:
 //   - CLAUDE_CODE_AUTH_DIR             : 호스트의 Claude 인증 디렉토리 (기본: $HOME/.claude)
-//   - CLAUDE_CODE_CONTAINER_AUTH_PATH  : 컨테이너 내 마운트 경로 (기본: /root/.claude)
+//   - CLAUDE_CODE_CONTAINER_AUTH_PATH  : 컨테이너 내 디렉토리 마운트 경로 (기본: /root/.claude)
 //   - CLAUDE_CODE_MODEL                : 모델 ID (기본: claude-sonnet-4-6)
 //   - CLAUDE_CODE_IMAGE                : Docker 이미지 (기본: ghcr.io/anthropics/claude-code:latest)
 //   - CLAUDE_CODE_TIMEOUT              : 세션 단위 타임아웃 (기본: 120s, Go duration 형식)

--- a/internal/processor/parser/rule/claudegen/worker.go
+++ b/internal/processor/parser/rule/claudegen/worker.go
@@ -18,7 +18,7 @@
 //   - CLAUDE_CODE_AUTH_DIR             : 호스트의 Claude 인증 디렉토리 (기본: $HOME/.claude)
 //   - CLAUDE_CODE_CONTAINER_AUTH_PATH  : 컨테이너 내 디렉토리 마운트 경로 (기본: /root/.claude)
 //   - CLAUDE_CODE_MODEL                : 모델 ID (기본: claude-sonnet-4-6)
-//   - CLAUDE_CODE_IMAGE                : Docker 이미지 (기본: ghcr.io/anthropics/claude-code:latest)
+//   - CLAUDE_CODE_IMAGE                : Docker 이미지 (기본: issuetracker-claudegen:local — `make claudegen-build` 필요)
 //   - CLAUDE_CODE_TIMEOUT              : 세션 단위 타임아웃 (기본: 120s, Go duration 형식)
 package claudegen
 
@@ -39,7 +39,9 @@ import (
 )
 
 const (
-	defaultImage             = "ghcr.io/anthropics/claude-code:latest"
+	// defaultImage 는 deployments/docker/claudegen/Dockerfile 로 빌드한 자체 이미지 (이슈 #269).
+	// Anthropic 공식 ghcr.io/anthropics/claude-code 는 비공개 상태이므로 `make claudegen-build` 로 사전 빌드 필요.
+	defaultImage             = "issuetracker-claudegen:local"
 	defaultModel             = "claude-sonnet-4-6"
 	defaultSessionTimeout    = 120 * time.Second
 	defaultContainerAuthPath = "/root/.claude" // 컨테이너 내 인증 마운트 경로 (이슈 #266)

--- a/internal/processor/parser/rule/claudegen/worker.go
+++ b/internal/processor/parser/rule/claudegen/worker.go
@@ -1,15 +1,22 @@
 // Package claudegen 은 상시 기동된 Claude Code Docker 컨테이너에 세션을 생성하여
-// HTML 에서 CSS 셀렉터를 추출하는 컴포넌트입니다 (이슈 #256).
+// HTML 에서 CSS 셀렉터를 추출하는 컴포넌트입니다 (이슈 #256, #266).
 //
 // 기존 콜드스타트 방식(docker run --rm)과 달리, 컨테이너를 서비스 기동 시 한 번만 띄우고
 // (Start) 요청마다 docker exec 으로 새 세션을 생성합니다. 컨테이너 초기화 비용을 최초 1회로
 // 상각하여 이후 요청의 레이턴시를 줄입니다.
 //
+// 인증 방식 (이슈 #266):
+//
+//	호스트에서 `claude` CLI 로 사전 로그인하여 발급된 OAuth auth_token 을 사용합니다.
+//	호스트의 인증 디렉토리($HOME/.claude 기본)를 컨테이너에 read-only 로 마운트하여
+//	구독 quota 안에서 sonnet 호출이 가능합니다. ANTHROPIC_API_KEY 종량제 과금 방식 대체.
+//
 // 환경변수:
-//   - ANTHROPIC_API_KEY    : Claude Code 인증 (필수)
-//   - CLAUDE_CODE_MODEL    : 모델 ID (기본: claude-sonnet-4-6)
-//   - CLAUDE_CODE_IMAGE    : Docker 이미지 (기본: ghcr.io/anthropics/claude-code:latest)
-//   - CLAUDE_CODE_TIMEOUT  : 세션 단위 타임아웃 (기본: 120s, Go duration 형식)
+//   - CLAUDE_CODE_AUTH_DIR             : 호스트의 Claude 인증 디렉토리 (기본: $HOME/.claude)
+//   - CLAUDE_CODE_CONTAINER_AUTH_PATH  : 컨테이너 내 마운트 경로 (기본: /root/.claude)
+//   - CLAUDE_CODE_MODEL                : 모델 ID (기본: claude-sonnet-4-6)
+//   - CLAUDE_CODE_IMAGE                : Docker 이미지 (기본: ghcr.io/anthropics/claude-code:latest)
+//   - CLAUDE_CODE_TIMEOUT              : 세션 단위 타임아웃 (기본: 120s, Go duration 형식)
 package claudegen
 
 import (
@@ -29,21 +36,23 @@ import (
 )
 
 const (
-	defaultImage          = "ghcr.io/anthropics/claude-code:latest"
-	defaultModel          = "claude-sonnet-4-6"
-	defaultSessionTimeout = 120 * time.Second
+	defaultImage             = "ghcr.io/anthropics/claude-code:latest"
+	defaultModel             = "claude-sonnet-4-6"
+	defaultSessionTimeout    = 120 * time.Second
+	defaultContainerAuthPath = "/root/.claude" // 컨테이너 내 인증 마운트 경로 (이슈 #266)
 
 	truncateStderrLen = 512 // exec 실패 시 stderr 미리보기 최대 길이
 	truncateStdoutLen = 256 // 파싱 실패 시 stdout 미리보기 최대 길이
 )
 
 // ContainerRunner 는 Docker 컨테이너 생명주기를 추상화합니다 (테스트 mock 교체용).
-//
-// API 키 등 비밀값은 env 슬라이스로 전달 — args 에 포함 시 ps/procfs 로 노출됩니다.
 type ContainerRunner interface {
 	// StartContainer 는 장기 실행 컨테이너를 기동하고 컨테이너 ID 를 반환합니다.
-	// workDir 은 컨테이너의 /workspace 로 마운트할 호스트 경로입니다.
-	StartContainer(ctx context.Context, image, workDir string, env []string) (containerID string, err error)
+	//   - workDir: 컨테이너의 /workspace 로 마운트할 호스트 경로 (read-write)
+	//   - authDir: 호스트의 Claude 인증 디렉토리 (read-only 마운트)
+	//   - containerAuthPath: 컨테이너 내 authDir 마운트 대상 경로
+	//   - env: 추가 환경변수 (비밀값은 args 에 포함하지 않음 — ps 노출 방지)
+	StartContainer(ctx context.Context, image, workDir, authDir, containerAuthPath string, env []string) (containerID string, err error)
 
 	// ExecSession 은 실행 중인 컨테이너에서 명령을 실행합니다.
 	ExecSession(ctx context.Context, containerID string, args []string) (stdout, stderr string, err error)
@@ -62,12 +71,13 @@ type ContainerRunner interface {
 // Extract 는 동시 호출에 안전합니다 — 각 세션이 고유 디렉토리를 사용합니다.
 // Stop 은 진행 중인 모든 Extract 완료를 대기합니다 (graceful shutdown).
 type ClaudeWorker struct {
-	image          string
-	model          string
-	apiKey         string
-	sessionTimeout time.Duration
-	runner         ContainerRunner
-	log            *logger.Logger
+	image             string
+	model             string
+	authDir           string // 호스트 인증 디렉토리 (이슈 #266)
+	containerAuthPath string // 컨테이너 내 마운트 경로 (이슈 #266)
+	sessionTimeout    time.Duration
+	runner            ContainerRunner
+	log               *logger.Logger
 
 	mu          sync.RWMutex
 	containerID string
@@ -81,13 +91,16 @@ func (w *ClaudeWorker) ModelName() string { return w.model }
 
 // NewFromEnv 는 환경변수 기반 ClaudeWorker 를 생성합니다.
 // Start() 를 호출하기 전까지는 컨테이너가 기동되지 않습니다.
+//
+// CLAUDE_CODE_AUTH_DIR 미지정 시 $HOME/.claude 를 사용합니다 (이슈 #266).
+// 인증 디렉토리가 없거나 접근 불가하면 fail-fast — 호스트 `claude` CLI 사전 로그인 필요.
 func NewFromEnv(log *logger.Logger) (*ClaudeWorker, error) {
 	if log == nil {
 		return nil, errors.New("claudegen: NewFromEnv requires non-nil logger")
 	}
-	apiKey := os.Getenv("ANTHROPIC_API_KEY")
-	if apiKey == "" {
-		return nil, errors.New("claudegen: ANTHROPIC_API_KEY is required")
+	authDir, err := resolveAuthDir(os.Getenv("CLAUDE_CODE_AUTH_DIR"))
+	if err != nil {
+		return nil, err
 	}
 	timeout := defaultSessionTimeout
 	if s := os.Getenv("CLAUDE_CODE_TIMEOUT"); s != "" {
@@ -103,44 +116,76 @@ func NewFromEnv(log *logger.Logger) (*ClaudeWorker, error) {
 		}
 	}
 	return &ClaudeWorker{
-		image:          envOr("CLAUDE_CODE_IMAGE", defaultImage),
-		model:          envOr("CLAUDE_CODE_MODEL", defaultModel),
-		apiKey:         apiKey,
-		sessionTimeout: timeout,
-		runner:         &execContainerRunner{},
-		log:            log,
+		image:             envOr("CLAUDE_CODE_IMAGE", defaultImage),
+		model:             envOr("CLAUDE_CODE_MODEL", defaultModel),
+		authDir:           authDir,
+		containerAuthPath: envOr("CLAUDE_CODE_CONTAINER_AUTH_PATH", defaultContainerAuthPath),
+		sessionTimeout:    timeout,
+		runner:            &execContainerRunner{},
+		log:               log,
 	}, nil
 }
 
 // New 는 명시적 파라미터로 ClaudeWorker 를 생성합니다 (DI 용).
-func New(image, model, apiKey string, timeout time.Duration, log *logger.Logger) (*ClaudeWorker, error) {
+//
+// authDir 은 호스트의 Claude 인증 디렉토리, containerAuthPath 는 컨테이너 내 마운트 대상 경로 (이슈 #266).
+// containerAuthPath 가 빈 문자열이면 defaultContainerAuthPath 사용.
+func New(image, model, authDir, containerAuthPath string, timeout time.Duration, log *logger.Logger) (*ClaudeWorker, error) {
 	if log == nil {
 		return nil, errors.New("claudegen: New requires non-nil logger")
 	}
-	if apiKey == "" {
-		return nil, errors.New("claudegen: New requires non-empty apiKey")
+	if authDir == "" {
+		return nil, errors.New("claudegen: New requires non-empty authDir")
+	}
+	if containerAuthPath == "" {
+		containerAuthPath = defaultContainerAuthPath
 	}
 	return &ClaudeWorker{
-		image: image, model: model, apiKey: apiKey,
+		image: image, model: model,
+		authDir: authDir, containerAuthPath: containerAuthPath,
 		sessionTimeout: timeout, runner: &execContainerRunner{}, log: log,
 	}, nil
 }
 
 // NewWithRunner 는 ContainerRunner 를 주입하는 생성자입니다 (테스트/DI 용).
-func NewWithRunner(image, model, apiKey string, timeout time.Duration, runner ContainerRunner, log *logger.Logger) (*ClaudeWorker, error) {
+func NewWithRunner(image, model, authDir, containerAuthPath string, timeout time.Duration, runner ContainerRunner, log *logger.Logger) (*ClaudeWorker, error) {
 	if log == nil {
 		return nil, errors.New("claudegen: NewWithRunner requires non-nil logger")
 	}
-	if apiKey == "" {
-		return nil, errors.New("claudegen: NewWithRunner requires non-empty apiKey")
+	if authDir == "" {
+		return nil, errors.New("claudegen: NewWithRunner requires non-empty authDir")
 	}
 	if runner == nil {
 		return nil, errors.New("claudegen: NewWithRunner requires non-nil runner")
 	}
+	if containerAuthPath == "" {
+		containerAuthPath = defaultContainerAuthPath
+	}
 	return &ClaudeWorker{
-		image: image, model: model, apiKey: apiKey,
+		image: image, model: model,
+		authDir: authDir, containerAuthPath: containerAuthPath,
 		sessionTimeout: timeout, runner: runner, log: log,
 	}, nil
+}
+
+// resolveAuthDir 은 환경변수 또는 $HOME 기반으로 인증 디렉토리를 결정하고 접근성을 검증합니다.
+func resolveAuthDir(envValue string) (string, error) {
+	authDir := envValue
+	if authDir == "" {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return "", fmt.Errorf("claudegen: CLAUDE_CODE_AUTH_DIR not set and cannot determine home dir: %w", err)
+		}
+		authDir = filepath.Join(home, ".claude")
+	}
+	info, err := os.Stat(authDir)
+	if err != nil {
+		return "", fmt.Errorf("claudegen: auth dir %q not accessible: %w (run `claude` CLI on host to login first)", authDir, err)
+	}
+	if !info.IsDir() {
+		return "", fmt.Errorf("claudegen: auth dir %q is not a directory", authDir)
+	}
+	return authDir, nil
 }
 
 // Start 는 Claude Code 컨테이너를 기동하고 workspace 를 준비합니다.
@@ -158,9 +203,7 @@ func (w *ClaudeWorker) Start(ctx context.Context) error {
 		return fmt.Errorf("create workspace dir: %w", err)
 	}
 
-	// ANTHROPIC_API_KEY 는 env 슬라이스로만 전달 — args 포함 시 ps 에 노출됨 (보안).
-	env := []string{"ANTHROPIC_API_KEY=" + w.apiKey}
-	containerID, err := w.runner.StartContainer(ctx, w.image, workDir, env)
+	containerID, err := w.runner.StartContainer(ctx, w.image, workDir, w.authDir, w.containerAuthPath, nil)
 	if err != nil {
 		os.RemoveAll(workDir)
 		return fmt.Errorf("start claude container: %w", err)
@@ -169,10 +212,12 @@ func (w *ClaudeWorker) Start(ctx context.Context) error {
 	w.containerID = containerID
 	w.workDir = workDir
 	w.log.WithFields(map[string]interface{}{
-		"container_id": containerID,
-		"image":        w.image,
-		"model":        w.model,
-	}).Info("claude code container started (warm)")
+		"container_id":        containerID,
+		"image":               w.image,
+		"model":               w.model,
+		"auth_dir":            w.authDir,
+		"container_auth_path": w.containerAuthPath,
+	}).Info("claude code container started (warm, subscription auth)")
 	return nil
 }
 

--- a/internal/processor/parser/rule/claudegen/worker.go
+++ b/internal/processor/parser/rule/claudegen/worker.go
@@ -8,10 +8,10 @@
 // 인증 방식 (이슈 #266):
 //
 //	호스트에서 `claude` CLI 로 사전 로그인하여 발급된 OAuth auth_token 을 사용합니다.
-//	Claude 의 인증 상태는 두 위치에 분산되어 있어 둘 다 컨테이너에 read-only 로 마운트합니다:
-//	  1. ~/.claude/        : 인증 디렉토리 (.credentials.json, history 등)
+//	Claude 의 인증 상태는 두 위치에 분산되어 있어 둘 다 컨테이너에 마운트합니다:
+//	  1. ~/.claude/        : 인증 디렉토리 (.credentials.json, history, 세션 상태 등)
 //	  2. ~/.claude.json    : 메인 설정 파일 (sibling — .claude/ 와 같은 부모 디렉토리)
-//	두 path 모두 read-only — 컨테이너가 호스트 인증 상태를 변조하지 못하도록 합니다.
+//	두 path 모두 read-write — Claude CLI 가 세션 history 등을 직접 기록하므로 :ro 마운트 불가.
 //	구독 quota 안에서 sonnet 호출이 가능합니다. ANTHROPIC_API_KEY 종량제 과금 방식 대체.
 //
 // 환경변수:
@@ -309,7 +309,8 @@ func (w *ClaudeWorker) Extract(ctx context.Context, host string, targetType stor
 	args := []string{
 		"claude",
 		"--model", w.model,
-		"--dangerously-skip-permissions",
+		// --dangerously-skip-permissions 는 root user 환경에서 동작하지 않고, OAuth 인증 + -p 모드는
+		// 본 플래그 없이 정상 동작 — 라이브 검증 시 발견 (이슈 #266).
 		"-p", buildPrompt(host, targetType, sessionContainerPath),
 	}
 

--- a/test/internal/processor/parser/rule/claudegen/worker_test.go
+++ b/test/internal/processor/parser/rule/claudegen/worker_test.go
@@ -31,7 +31,6 @@ type mockContainerRunner struct {
 		workDir           string
 		authDir           string
 		containerAuthPath string
-		env               []string
 	}
 	execedWith struct {
 		containerID string
@@ -39,13 +38,12 @@ type mockContainerRunner struct {
 	}
 }
 
-func (m *mockContainerRunner) StartContainer(_ context.Context, image, workDir, authDir, containerAuthPath string, env []string) (string, error) {
+func (m *mockContainerRunner) StartContainer(_ context.Context, image, workDir, authDir, containerAuthPath string) (string, error) {
 	m.mu.Lock()
 	m.startedWith.image = image
 	m.startedWith.workDir = workDir
 	m.startedWith.authDir = authDir
 	m.startedWith.containerAuthPath = containerAuthPath
-	m.startedWith.env = env
 	m.mu.Unlock()
 	if m.startErr != nil {
 		return "", m.startErr
@@ -102,11 +100,6 @@ func TestClaudeWorker_StartStop(t *testing.T) {
 	// auth_token 마운트 검증 (이슈 #266) — authDir 과 containerAuthPath 가 StartContainer 에 전달됐는지 확인
 	assert.NotEmpty(t, runner.startedWith.authDir, "authDir must be passed to StartContainer")
 	assert.Equal(t, "/root/.claude", runner.startedWith.containerAuthPath)
-
-	// ANTHROPIC_API_KEY 가 더 이상 env 로 주입되지 않는지 확인 (이슈 #266 보안)
-	for _, e := range runner.startedWith.env {
-		assert.NotContains(t, e, "ANTHROPIC_API_KEY", "ANTHROPIC_API_KEY must NOT be in env (auth_token 방식 전환)")
-	}
 
 	require.NoError(t, w.Stop(t.Context()))
 }

--- a/test/internal/processor/parser/rule/claudegen/worker_test.go
+++ b/test/internal/processor/parser/rule/claudegen/worker_test.go
@@ -3,6 +3,8 @@ package claudegen_test
 import (
 	"context"
 	"errors"
+	"os"
+	"path/filepath"
 	"sync"
 	"testing"
 	"time"
@@ -25,9 +27,11 @@ type mockContainerRunner struct {
 
 	mu          sync.Mutex
 	startedWith struct {
-		image   string
-		workDir string
-		env     []string
+		image             string
+		workDir           string
+		authDir           string
+		containerAuthPath string
+		env               []string
 	}
 	execedWith struct {
 		containerID string
@@ -35,10 +39,12 @@ type mockContainerRunner struct {
 	}
 }
 
-func (m *mockContainerRunner) StartContainer(_ context.Context, image, workDir string, env []string) (string, error) {
+func (m *mockContainerRunner) StartContainer(_ context.Context, image, workDir, authDir, containerAuthPath string, env []string) (string, error) {
 	m.mu.Lock()
 	m.startedWith.image = image
 	m.startedWith.workDir = workDir
+	m.startedWith.authDir = authDir
+	m.startedWith.containerAuthPath = containerAuthPath
 	m.startedWith.env = env
 	m.mu.Unlock()
 	if m.startErr != nil {
@@ -59,13 +65,24 @@ func (m *mockContainerRunner) StopContainer(_ context.Context, _ string) error {
 	return m.stopErr
 }
 
+// makeAuthDir 은 테스트용 임시 인증 디렉토리를 생성합니다 (이슈 #266).
+func makeAuthDir(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	// 빈 디렉토리이지만 존재 + 디렉토리 검증을 통과하도록 임시 파일 추가
+	require.NoError(t, os.WriteFile(filepath.Join(dir, ".credentials"), []byte("mock"), 0o600))
+	return dir
+}
+
 func newTestWorker(t *testing.T, runner *mockContainerRunner) *claudegen.ClaudeWorker {
 	t.Helper()
 	log := logger.New(logger.DefaultConfig())
+	authDir := makeAuthDir(t)
 	w, err := claudegen.NewWithRunner(
 		"ghcr.io/anthropics/claude-code:latest",
 		"claude-sonnet-4-6",
-		"test-api-key",
+		authDir,
+		"/root/.claude",
 		10*time.Second,
 		runner,
 		log,
@@ -82,14 +99,14 @@ func TestClaudeWorker_StartStop(t *testing.T) {
 	require.NoError(t, w.Start(t.Context()))
 	assert.Equal(t, "ghcr.io/anthropics/claude-code:latest", runner.startedWith.image)
 
-	// API 키가 env 로 전달됐는지 확인 (ps/proc 노출 방지)
-	found := false
+	// auth_token 마운트 검증 (이슈 #266) — authDir 과 containerAuthPath 가 StartContainer 에 전달됐는지 확인
+	assert.NotEmpty(t, runner.startedWith.authDir, "authDir must be passed to StartContainer")
+	assert.Equal(t, "/root/.claude", runner.startedWith.containerAuthPath)
+
+	// ANTHROPIC_API_KEY 가 더 이상 env 로 주입되지 않는지 확인 (이슈 #266 보안)
 	for _, e := range runner.startedWith.env {
-		if e == "ANTHROPIC_API_KEY=test-api-key" {
-			found = true
-		}
+		assert.NotContains(t, e, "ANTHROPIC_API_KEY", "ANTHROPIC_API_KEY must NOT be in env (auth_token 방식 전환)")
 	}
-	assert.True(t, found, "ANTHROPIC_API_KEY must be in env slice")
 
 	require.NoError(t, w.Stop(t.Context()))
 }
@@ -260,38 +277,77 @@ func TestClaudeWorker_ModelName(t *testing.T) {
 	assert.Equal(t, "claude-sonnet-4-6", w.ModelName())
 }
 
-// TestNewFromEnv_MissingAPIKey 는 ANTHROPIC_API_KEY 없을 때 에러를 반환하는지 검증합니다.
-func TestNewFromEnv_MissingAPIKey(t *testing.T) {
-	t.Setenv("ANTHROPIC_API_KEY", "")
+// ─────────────────────────────────────────────────────────────────────────────
+// 인증 디렉토리 검증 테스트 (이슈 #266)
+// ─────────────────────────────────────────────────────────────────────────────
+
+// TestNewFromEnv_MissingAuthDir 는 CLAUDE_CODE_AUTH_DIR 미존재 경로 지정 시 에러를 반환하는지 검증합니다.
+func TestNewFromEnv_MissingAuthDir(t *testing.T) {
+	t.Setenv("CLAUDE_CODE_AUTH_DIR", "/nonexistent/path/to/claude/auth")
 	log := logger.New(logger.DefaultConfig())
 	_, err := claudegen.NewFromEnv(log)
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "ANTHROPIC_API_KEY")
+	assert.Contains(t, err.Error(), "auth dir")
 }
 
-// TestNew_EmptyAPIKey 는 New() 에 빈 apiKey 전달 시 에러를 반환하는지 검증합니다.
-func TestNew_EmptyAPIKey(t *testing.T) {
+// TestNewFromEnv_AuthDirIsFile 는 CLAUDE_CODE_AUTH_DIR 가 디렉토리가 아닌 파일을 가리킬 때 에러를 반환하는지 검증합니다.
+func TestNewFromEnv_AuthDirIsFile(t *testing.T) {
+	tmpFile := filepath.Join(t.TempDir(), "not-a-dir")
+	require.NoError(t, os.WriteFile(tmpFile, []byte("x"), 0o644))
+	t.Setenv("CLAUDE_CODE_AUTH_DIR", tmpFile)
 	log := logger.New(logger.DefaultConfig())
-	_, err := claudegen.New("image", "model", "", 10*time.Second, log)
+	_, err := claudegen.NewFromEnv(log)
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "apiKey")
+	assert.Contains(t, err.Error(), "not a directory")
 }
 
-// TestNewWithRunner_EmptyAPIKey 는 NewWithRunner() 에 빈 apiKey 전달 시 에러를 반환하는지 검증합니다.
-func TestNewWithRunner_EmptyAPIKey(t *testing.T) {
+// TestNewFromEnv_ValidAuthDir 는 유효한 인증 디렉토리로 NewFromEnv 가 성공하는지 검증합니다.
+func TestNewFromEnv_ValidAuthDir(t *testing.T) {
+	authDir := makeAuthDir(t)
+	t.Setenv("CLAUDE_CODE_AUTH_DIR", authDir)
+	log := logger.New(logger.DefaultConfig())
+	w, err := claudegen.NewFromEnv(log)
+	require.NoError(t, err)
+	assert.NotNil(t, w)
+}
+
+// TestNew_EmptyAuthDir 는 New() 에 빈 authDir 전달 시 에러를 반환하는지 검증합니다.
+func TestNew_EmptyAuthDir(t *testing.T) {
+	log := logger.New(logger.DefaultConfig())
+	_, err := claudegen.New("image", "model", "", "/root/.claude", 10*time.Second, log)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "authDir")
+}
+
+// TestNewWithRunner_EmptyAuthDir 는 NewWithRunner() 에 빈 authDir 전달 시 에러를 반환하는지 검증합니다.
+func TestNewWithRunner_EmptyAuthDir(t *testing.T) {
 	log := logger.New(logger.DefaultConfig())
 	runner := &mockContainerRunner{}
-	_, err := claudegen.NewWithRunner("image", "model", "", 10*time.Second, runner, log)
+	_, err := claudegen.NewWithRunner("image", "model", "", "/root/.claude", 10*time.Second, runner, log)
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "apiKey")
+	assert.Contains(t, err.Error(), "authDir")
 }
 
 // TestNewWithRunner_NilRunner 는 NewWithRunner() 에 nil runner 전달 시 에러를 반환하는지 검증합니다.
 func TestNewWithRunner_NilRunner(t *testing.T) {
 	log := logger.New(logger.DefaultConfig())
-	_, err := claudegen.NewWithRunner("image", "model", "key", 10*time.Second, nil, log)
+	authDir := makeAuthDir(t)
+	_, err := claudegen.NewWithRunner("image", "model", authDir, "/root/.claude", 10*time.Second, nil, log)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "runner")
+}
+
+// TestNewWithRunner_DefaultContainerAuthPath 는 빈 containerAuthPath 전달 시 기본값(/root/.claude)이 적용되는지 검증합니다.
+func TestNewWithRunner_DefaultContainerAuthPath(t *testing.T) {
+	log := logger.New(logger.DefaultConfig())
+	authDir := makeAuthDir(t)
+	runner := &mockContainerRunner{}
+	w, err := claudegen.NewWithRunner("image", "model", authDir, "", 10*time.Second, runner, log)
+	require.NoError(t, err)
+	require.NoError(t, w.Start(t.Context()))
+	t.Cleanup(func() { _ = w.Stop(context.Background()) })
+
+	assert.Equal(t, "/root/.claude", runner.startedWith.containerAuthPath, "빈 containerAuthPath → 기본값 적용")
 }
 
 func containsStr(s, sub string) bool {


### PR DESCRIPTION
## 연관 이슈
Closes #269
Depends on #266 (이슈 #268 PR — 이 PR 은 #266 위에 stack)

## 구현 내용

### 1. `deployments/docker/claudegen/Dockerfile` 신규
- `node:20-slim` 베이스
- `npm install -g @anthropic-ai/claude-code` + `install.cjs` 명시 실행 (postinstall 누락 대응)
- root user 기본 — 호스트 `~/.claude` 가 대부분 root 소유라 권한 일관성 단순
- `tail -f /dev/null` 로 대기 → docker exec 세션 수신

### 2. `Makefile`: `claudegen-build` 타겟
```makefile
CLAUDEGEN_IMAGE_TAG ?= issuetracker-claudegen:local

claudegen-build: ## claudegen 자체 Claude Code 이미지 빌드
	docker build -t $(CLAUDEGEN_IMAGE_TAG) deployments/docker/claudegen/
```

### 3. `claudegen.worker` 변경
- `defaultImage` 상수: `ghcr.io/anthropics/claude-code:latest` → `issuetracker-claudegen:local`
- 운영자가 `CLAUDE_CODE_IMAGE` 환경변수로 override 가능 (Anthropic 향후 공개 시 다시 변경 가능)

### 4. `.env.example`
- `CLAUDE_CODE_IMAGE` 기본값 갱신
- 사전 빌드 안내 (`make claudegen-build`) 추가
- 인증 방식 + read-write 마운트 정책 문서화

## 라이브 검증

본 PR 작업 중 라이브 환경에서 sonnet 호출 검증 완료:

1. **이미지 빌드**: `make claudegen-build` 성공
2. **컨테이너 동작**: `docker run ... claude --version` → `2.1.128 (Claude Code)`
3. **OAuth 인증**: 호스트 `~/.claude/` + `~/.claude.json` 마운트 후 `claude -p "Reply with: HELLO"` → `HELLO`
4. **셀렉터 추출**: sample HTML 입력 → 정확한 CSS selector JSON 반환
   - `title`: `#post-title`
   - `main_content`: `article.post-content p` (multi: true)
   - `author`: `.meta-author`

## CI / 머지 게이트
- [x] `go build ./...` 통과
- [x] `go test -race ./...` 통과
- [x] `gofmt` 적용
- [x] 라이브 sonnet 호출 + 셀렉터 추출 end-to-end 검증

## 변경 영향 범위
- 신규 파일만 추가 (`deployments/docker/claudegen/Dockerfile`)
- `worker.go`: `defaultImage` 상수만 변경 (외부 시그니처 영향 없음)
- `Makefile`: 신규 타겟 추가 — 기존 타겟 영향 없음
- `.env.example`: 운영자 가이드 갱신

## 위험도
낮음 — 자체 빌드 이미지가 없으면 `Start()` 가 fail-fast (이미지 미존재 에러). `make claudegen-build` 한 번 실행하면 해결.

## 롤백 계획
revert. claudegen 패키지는 이슈 #267 wiring 머지 전까지 외부 호출 0이므로 영향 격리.

## 다음 작업
- 이슈 #266 (이미 PR 진행 중) + 본 PR 머지 후
- 이슈 #267 (main.go 배선) 진행 → `LLM_EXTRACTOR=claude-code` 활성화 가능