### PR TITLE
[FEAT#267] claudegen.ClaudeWorker main.go 배선 — LLM_EXTRACTOR 환경변수 스위치

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -68,8 +68,14 @@ LLM_API_KEY=
 # LLM prompt 디렉토리 override (default: scripts/prompts)
 # ISSUETRACKER_PROMPTS_DIR=scripts/prompts
 
-# Claude Code 웜 컨테이너 셀렉터 추출기 설정 (이슈 #256, #266, #269)
-# LLM_PROVIDER=gemini 대신 Claude Code Docker 를 추출기로 사용할 때 설정.
+# 셀렉터 추출기 선택 (이슈 #267)
+# - "" 또는 "gemini" (기본): buildLLMGenerator 가 설정한 LLM provider (Gemini Flash 등) 추출
+# - "claude-code": Claude Code 웜 컨테이너 (sonnet) 추출 — 사전에 make claudegen-build + claude CLI 로그인 필요
+# 활성화 실패 시 (Start 오류) 기본 추출기로 graceful fallback.
+# LLM_EXTRACTOR=claude-code
+
+# Claude Code 웜 컨테이너 셀렉터 추출기 설정 (이슈 #256, #266, #267, #269)
+# LLM_EXTRACTOR=claude-code 일 때 사용되는 환경변수.
 #
 # 인증 방식 (이슈 #266 — auth_token 구독 방식):
 #   1. 호스트에서 `claude` CLI 1회 로그인 → ~/.claude/ + ~/.claude.json 에 OAuth token 저장

--- a/cmd/issuetracker/main.go
+++ b/cmd/issuetracker/main.go
@@ -20,6 +20,7 @@ import (
 	fetcherRule "issuetracker/internal/processor/fetcher/rule"
 	crawlerWorker "issuetracker/internal/processor/fetcher/worker"
 	"issuetracker/internal/processor/parser/rule"
+	"issuetracker/internal/processor/parser/rule/claudegen"
 	"issuetracker/internal/processor/parser/rule/llmgen"
 	"issuetracker/internal/processor/parser/rule/refiner"
 	"issuetracker/internal/processor/parser/rule/validator"
@@ -449,6 +450,25 @@ func main() {
 		log.Info("llmgen: 의미 검증 ValidatorPool 활성화")
 	}
 
+	// ── Claude Code 추출기 (이슈 #267) ──────────────────────────────────────
+	// LLM_EXTRACTOR=claude-code 일 때 활성화 — Claude 구독 환경의 sonnet 으로 셀렉터 추출.
+	// 미지정 / gemini (기본) 일 때는 buildLLMGenerator 가 설정한 기본 LLM provider 추출.
+	// Start 실패 시 Gemini 경로로 graceful fallback (fatal 아님).
+	// 종료 시 stages.Stop 이후 worker.Stop 호출 — llmGen.Stop 으로 in-flight Extract 완료 보장 후 컨테이너 정리.
+	var claudegenWorker *claudegen.ClaudeWorker
+	if llmGen != nil && os.Getenv("LLM_EXTRACTOR") == "claude-code" {
+		worker, werr := claudegen.NewFromEnv(log)
+		if werr != nil {
+			log.WithError(werr).Warn("claudegen worker construction failed, falling back to default extractor")
+		} else if serr := worker.Start(ctx); serr != nil {
+			log.WithError(serr).Warn("claudegen worker start failed, falling back to default extractor")
+		} else {
+			llmGen.SetExtractor(worker)
+			claudegenWorker = worker
+			log.Info("llmgen: Claude Code 웜 컨테이너 추출기 활성화")
+		}
+	}
+
 	// ── Refiner (이슈 #173 단계 4-2) ──────────────────────────────────────────
 	// catch-all + llm-auto rule 의 누적 sample URL 로부터 path_pattern 정밀화.
 	// REFINEMENT_ENABLED=false 또는 config 실패 시 nil — 기존 catch-all rule 그대로 동작.
@@ -596,6 +616,16 @@ func main() {
 			log.WithFields(map[string]interface{}{"stage": s.Name()}).WithError(err).Error("error during stage shutdown")
 		} else {
 			log.WithField("stage", s.Name()).Info("pipeline stage stopped")
+		}
+	}
+
+	// Claude Code 컨테이너 종료 (이슈 #267) — stages.Stop 으로 llmGen 의 모든 in-flight Extract 가
+	// 완료된 이후 호출. Worker.Stop 이 실행 중인 docker exec 세션 완료 대기 + 컨테이너 정리.
+	if claudegenWorker != nil {
+		if err := claudegenWorker.Stop(shutdownCtx); err != nil {
+			log.WithError(err).Error("claudegen worker stop failed")
+		} else {
+			log.Info("claudegen worker stopped")
 		}
 	}
 

--- a/cmd/issuetracker/main.go
+++ b/cmd/issuetracker/main.go
@@ -456,7 +456,14 @@ func main() {
 	// Start 실패 시 Gemini 경로로 graceful fallback (fatal 아님).
 	// 종료 시 stages.Stop 이후 worker.Stop 호출 — llmGen.Stop 으로 in-flight Extract 완료 보장 후 컨테이너 정리.
 	var claudegenWorker *claudegen.ClaudeWorker
-	if llmGen != nil && os.Getenv("LLM_EXTRACTOR") == "claude-code" {
+	llmExtractor := os.Getenv("LLM_EXTRACTOR")
+	switch {
+	case llmExtractor != "claude-code":
+		// 기본 경로 — 분기 미발생 (Gemini 등 buildLLMGenerator 의 provider 사용).
+	case llmGen == nil:
+		// LLM_ENABLED=false / API key 부재 등으로 llmGen 비활성 — silent skip 회피 (PR #271 리뷰).
+		log.Warn("LLM_EXTRACTOR=claude-code requested but LLM generator is disabled (check LLM_ENABLED / API key); claudegen extractor not registered")
+	default:
 		worker, werr := claudegen.NewFromEnv(log)
 		if werr != nil {
 			log.WithError(werr).Warn("claudegen worker construction failed, falling back to default extractor")
@@ -621,12 +628,18 @@ func main() {
 
 	// Claude Code 컨테이너 종료 (이슈 #267) — stages.Stop 으로 llmGen 의 모든 in-flight Extract 가
 	// 완료된 이후 호출. Worker.Stop 이 실행 중인 docker exec 세션 완료 대기 + 컨테이너 정리.
+	//
+	// shutdownCtx 가 stages.Stop 에서 timeout 으로 cancel 되더라도 docker rm -f 자체는 반드시 시도되어야
+	// 컨테이너 누수가 발생하지 않으므로, 별도의 cleanupCtx 를 사용 (PR #271 리뷰).
 	if claudegenWorker != nil {
-		if err := claudegenWorker.Stop(shutdownCtx); err != nil {
+		cleanupCtx, cleanupCancel := context.WithTimeout(context.Background(), 10*time.Second)
+		cleanupCtx = log.ToContext(cleanupCtx)
+		if err := claudegenWorker.Stop(cleanupCtx); err != nil {
 			log.WithError(err).Error("claudegen worker stop failed")
 		} else {
 			log.Info("claudegen worker stopped")
 		}
+		cleanupCancel()
 	}
 
 	log.Info("shutdown completed")


### PR DESCRIPTION
## 연관 이슈
Closes #267

## 구현 내용

`claudegen.ClaudeWorker` 패키지 (이슈 #256) 와 인증/이미지 인프라 (이슈 #266 / #269) 가 모두 머지된 상태에서, 마지막으로 main.go 배선만 추가하여 sonnet 추출 경로를 활성화 가능하도록 했습니다.

### 1. 환경변수 스위치
```
LLM_EXTRACTOR= 또는 gemini  (기본): buildLLMGenerator 가 설정한 LLM provider 추출 (Gemini Flash)
LLM_EXTRACTOR=claude-code        : Claude Code 웜 컨테이너 (sonnet) 추출
```

### 2. `cmd/issuetracker/main.go`
- `import "issuetracker/internal/processor/parser/rule/claudegen"`
- validator.Pool wiring 직후 분기 추가:
  ```go
  if llmGen != nil && os.Getenv("LLM_EXTRACTOR") == "claude-code" {
      worker, werr := claudegen.NewFromEnv(log)
      if werr != nil { /* warn + fallback */ }
      else if serr := worker.Start(ctx); serr != nil { /* warn + fallback */ }
      else {
          llmGen.SetExtractor(worker)
          claudegenWorker = worker
      }
  }
  ```
- 종료 흐름: stages.Stop (llmGen 의 in-flight Extract 완료 보장) 후 `claudegenWorker.Stop(shutdownCtx)` 호출

### 3. `.env.example`
- `LLM_EXTRACTOR` 항목 추가 + 활성화 조건 안내
- claudegen 환경변수 그룹 (CLAUDE_CODE_*) 정리

## 라이브 검증

| 시나리오 | 결과 |
|---|---|
| `LLM_EXTRACTOR` 미설정 (default) | ✅ claudegen 비활성, Gemini 경로 정상 기동 |
| `LLM_EXTRACTOR=claude-code` + 정상 image | ✅ 컨테이너 기동 + Extract 등록 + SIGTERM 시 정상 종료 |
| `LLM_EXTRACTOR=claude-code` + 잘못된 image | ✅ warn 로그 + Gemini 경로로 graceful fallback |

라이브 로그 발췌:
```
INFO  claude code container started (warm, subscription auth) image=issuetracker-claudegen:local model=claude-sonnet-4-6
INFO  llmgen: Claude Code 웜 컨테이너 추출기 활성화
...
INFO  claude code container stopped
INFO  claudegen worker stopped (shutting_down=true)
```

## CI / 머지 게이트
- [x] `go build ./...` 통과
- [x] `go test -race ./...` 통과
- [x] `gofmt` 적용
- [x] 라이브 wiring 검증 (3가지 시나리오 모두 정상)

## 변경 영향 범위
- `cmd/issuetracker/main.go`: import 1개 + 분기 블록 1개 + 종료 시 Stop 호출 1개 추가
- `.env.example`: `LLM_EXTRACTOR` 항목 추가
- 기존 Gemini 경로는 100% 보존 (backward-compatible)

## 위험도
낮음 — `LLM_EXTRACTOR` 미지정 시 기존 동작 그대로. 활성화 실패 시 fatal 아닌 graceful fallback.

## 롤백 계획
revert. 환경변수만 제거하면 됨.

## 후속 / 관련
- 이슈 #254 (파싱 룰 생성/검증 파이프라인 재설계) 의 4-stage 마무리:
  - ✅ #256 claudegen 패키지
  - ✅ #266 auth_token 인증
  - ✅ #269 자체 Dockerfile
  - ✅ #267 main.go 배선 (본 PR)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Configuration**
  * Introduced `LLM_EXTRACTOR` environment variable to configure which LLM extraction method to use, with fallback behavior if the selected method is unavailable.

* **New Features**
  * Added Claude Code as an alternative LLM extraction method alongside existing options.
  * Implemented graceful shutdown handling for extraction components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->