### PR TITLE
[REFAC#274] llmgen ErrDuplicate 흡수 + 사전 룰 체크

### DIFF
--- a/internal/processor/parser/rule/llmgen/generator.go
+++ b/internal/processor/parser/rule/llmgen/generator.go
@@ -436,6 +436,18 @@ func (g *Generator) runOnce(ctx context.Context, host string, targetType storage
 		Description: fmt.Sprintf("%s (sample url: %s, model: %s)", llmAutoDescription, sampleURL, modelName),
 	}
 	if err := g.repo.Insert(ctx, record); err != nil {
+		// 동일 자연키 (source_name, host_pattern, path_pattern, target_type, version) 룰이 이미
+		// DB 에 존재 — 우리가 원하던 최종 상태와 동일하므로 정상 경로로 흡수 (이슈 #274).
+		// 발생 시나리오: 이전 실행이 INSERT 한 룰이 잔존하나 resolver lookup 이 stale 캐시 등으로
+		// 룰을 찾지 못해 generate() 진입한 케이스.
+		if errors.Is(err, storage.ErrDuplicate) {
+			g.resolver.Invalidate(host, targetType)
+			g.log.WithFields(map[string]interface{}{
+				"host":        host,
+				"target_type": string(targetType),
+			}).Info("llmgen rule already exists in DB, invalidating cache and continuing")
+			return nil
+		}
 		return fmt.Errorf("insert parsing rule: %w", err)
 	}
 

--- a/internal/processor/parser/rule/llmgen/generator.go
+++ b/internal/processor/parser/rule/llmgen/generator.go
@@ -366,6 +366,20 @@ func (g *Generator) Stop(ctx context.Context) {
 // runOnce 는 단일 추출 + validation + INSERT + cache invalidate 의 동기 실행입니다.
 // 호출자 (Enqueue 의 goroutine) 가 in-flight 슬롯 release 책임.
 func (g *Generator) runOnce(ctx context.Context, host string, targetType storage.TargetType, sampleURL, html string) error {
+	// 사전 lookup (이슈 #274) — 동일 자연키 룰이 이미 DB 에 존재하면 LLM 호출 회피.
+	// resolver lookup 이 stale 캐시 / disabled 룰 등으로 못 찾는 케이스를 LLM 호출 (~55s sonnet)
+	// 으로 가지 않게 차단. lookup 실패는 best-effort — 에러는 무시하고 LLM 경로로 진행.
+	if existing, err := g.repo.FindByNaturalKey(ctx, LLMAutoSourceName, host, "", targetType, 1); err == nil && existing != nil {
+		g.resolver.Invalidate(host, targetType)
+		g.log.WithFields(map[string]interface{}{
+			"host":        host,
+			"target_type": string(targetType),
+			"rule_id":     existing.ID,
+			"enabled":     existing.Enabled,
+		}).Info("llmgen pre-check hit — rule already exists, skipping LLM call")
+		return nil
+	}
+
 	var (
 		selectors storage.SelectorMap
 		modelName string

--- a/internal/processor/parser/rule/llmgen/generator.go
+++ b/internal/processor/parser/rule/llmgen/generator.go
@@ -367,17 +367,35 @@ func (g *Generator) Stop(ctx context.Context) {
 // 호출자 (Enqueue 의 goroutine) 가 in-flight 슬롯 release 책임.
 func (g *Generator) runOnce(ctx context.Context, host string, targetType storage.TargetType, sampleURL, html string) error {
 	// 사전 lookup (이슈 #274) — 동일 자연키 룰이 이미 DB 에 존재하면 LLM 호출 회피.
-	// resolver lookup 이 stale 캐시 / disabled 룰 등으로 못 찾는 케이스를 LLM 호출 (~55s sonnet)
-	// 으로 가지 않게 차단. lookup 실패는 best-effort — 에러는 무시하고 LLM 경로로 진행.
-	if existing, err := g.repo.FindByNaturalKey(ctx, LLMAutoSourceName, host, "", targetType, 1); err == nil && existing != nil {
+	// PR #275 리뷰 반영:
+	//   - enabled=true 룰 적중 시에만 skip (resolver 가 enabled=TRUE 만 조회하므로 disabled 는 사실상 부재)
+	//   - ErrNotFound 만 normal miss, 그 외 에러는 warn 로그 — DB 장애 silent fallthrough 회피
+	existing, err := g.repo.FindByNaturalKey(ctx, LLMAutoSourceName, host, "", targetType, 1)
+	switch {
+	case err == nil && existing != nil && existing.Enabled:
 		g.resolver.Invalidate(host, targetType)
 		g.log.WithFields(map[string]interface{}{
 			"host":        host,
 			"target_type": string(targetType),
 			"rule_id":     existing.ID,
-			"enabled":     existing.Enabled,
-		}).Info("llmgen pre-check hit — rule already exists, skipping LLM call")
+		}).Info("llmgen pre-check hit — enabled rule already exists, skipping LLM call")
 		return nil
+	case err == nil && existing != nil && !existing.Enabled:
+		// 운영자가 disable 한 룰이 잔존 — 자동 재활성은 정책상 보수적으로 회피.
+		// LLM 재호출도 결과적으로 ErrDuplicate 로 reject 될 것이므로 LLM 비용 절감 + 운영 가시성을 위해 skip + warn.
+		g.log.WithFields(map[string]interface{}{
+			"host":        host,
+			"target_type": string(targetType),
+			"rule_id":     existing.ID,
+		}).Warn("llmgen pre-check hit — disabled rule exists, skipping LLM call (manual re-enable required)")
+		return nil
+	case err != nil && !errors.Is(err, storage.ErrNotFound):
+		g.log.WithFields(map[string]interface{}{
+			"host":        host,
+			"target_type": string(targetType),
+		}).WithError(err).Warn("llmgen pre-check lookup failed — proceeding to LLM (best-effort)")
+		// fallthrough 로 LLM 경로 진행 — 후속 Insert 도 동일 원인으로 실패할 수 있으나
+		// best-effort 정책 유지 (DB 일시 장애가 rule 학습 파이프라인을 영구 차단하지 않도록).
 	}
 
 	var (
@@ -451,15 +469,28 @@ func (g *Generator) runOnce(ctx context.Context, host string, targetType storage
 	}
 	if err := g.repo.Insert(ctx, record); err != nil {
 		// 동일 자연키 (source_name, host_pattern, path_pattern, target_type, version) 룰이 이미
-		// DB 에 존재 — 우리가 원하던 최종 상태와 동일하므로 정상 경로로 흡수 (이슈 #274).
+		// DB 에 존재 — 정상 경로로 흡수 (이슈 #274).
 		// 발생 시나리오: 이전 실행이 INSERT 한 룰이 잔존하나 resolver lookup 이 stale 캐시 등으로
-		// 룰을 찾지 못해 generate() 진입한 케이스.
+		// 룰을 찾지 못해 generate() 진입한 케이스. 또는 사전 lookup 후 race window 에서 다른
+		// 인스턴스가 INSERT 완료한 케이스.
+		//
+		// PR #275 리뷰 반영: enabled 여부 / rule_id 를 로그에 포함하여 운영 가시성 ↑.
+		// disabled 룰 잔존이면 warn — 운영자가 수동 재활성 결정을 해야 함을 명시.
 		if errors.Is(err, storage.ErrDuplicate) {
 			g.resolver.Invalidate(host, targetType)
-			g.log.WithFields(map[string]interface{}{
+			fields := map[string]interface{}{
 				"host":        host,
 				"target_type": string(targetType),
-			}).Info("llmgen rule already exists in DB, invalidating cache and continuing")
+			}
+			if existing, ferr := g.repo.FindByNaturalKey(ctx, LLMAutoSourceName, host, "", targetType, 1); ferr == nil && existing != nil {
+				fields["existing_rule_id"] = existing.ID
+				fields["existing_enabled"] = existing.Enabled
+				if !existing.Enabled {
+					g.log.WithFields(fields).Warn("llmgen Insert ErrDuplicate — existing rule is disabled (manual re-enable required)")
+					return nil
+				}
+			}
+			g.log.WithFields(fields).Info("llmgen Insert ErrDuplicate absorbed — rule already exists, cache invalidated")
 			return nil
 		}
 		return fmt.Errorf("insert parsing rule: %w", err)

--- a/internal/storage/parsing_rule.go
+++ b/internal/storage/parsing_rule.go
@@ -187,6 +187,15 @@ type ParsingRuleRepository interface {
 	// FindActiveCandidates 의 첫 항목 (length DESC 정렬, '' 포함) 을 반환합니다.
 	FindActive(ctx context.Context, host string, targetType TargetType) (*ParsingRuleRecord, error)
 
+	// FindByNaturalKey 는 자연키 (source_name, host_pattern, path_pattern, target_type, version)
+	// 로 단일 rule 을 조회합니다 (이슈 #274). enabled 필터 없음 — disabled 룰도 반환.
+	//
+	// 용도: llmgen.Generator 가 Insert 전에 동일 자연키 룰의 존재 여부를 확인하여 LLM 호출을
+	// 회피하는 사전 lookup. Insert 시 ErrDuplicate 위반과 동일한 자연키를 검사합니다.
+	//
+	// 매칭 없으면 ErrNotFound.
+	FindByNaturalKey(ctx context.Context, sourceName, hostPattern, pathPattern string, targetType TargetType, version int) (*ParsingRuleRecord, error)
+
 	// FindActiveCandidates 는 host + target_type 매칭 활성 rule 들을 LENGTH(path_pattern) DESC,
 	// version DESC 정렬로 반환합니다 (이슈 #173 단계 1).
 	//

--- a/internal/storage/postgres/parsing_rule.go
+++ b/internal/storage/postgres/parsing_rule.go
@@ -157,6 +157,37 @@ func (r *pgParsingRuleRepository) GetByID(ctx context.Context, id int64) (*stora
 	return rec, nil
 }
 
+const sqlFindParsingRuleByNaturalKey = `
+SELECT id, source_name, host_pattern, path_pattern, target_type, version, enabled, selectors, description, created_at, updated_at
+FROM parsing_rules
+WHERE source_name  = $1
+  AND host_pattern = $2
+  AND path_pattern = $3
+  AND target_type  = $4
+  AND version      = $5
+`
+
+// FindByNaturalKey 는 자연키로 단일 rule 을 조회합니다 (이슈 #274).
+//
+// Insert 의 unique constraint 와 동일한 키 — enabled 필터 없음.
+// 매칭 없으면 storage.ErrNotFound.
+//
+// 용도: llmgen.Generator 가 LLM 호출 전 사전 lookup 으로 사용. 이미 같은 자연키 룰이
+// 존재하면 LLM 호출 (~55s sonnet) 을 회피하여 비용 절감.
+func (r *pgParsingRuleRepository) FindByNaturalKey(ctx context.Context, sourceName, hostPattern, pathPattern string, targetType storage.TargetType, version int) (*storage.ParsingRuleRecord, error) {
+	row := r.pool.QueryRow(ctx, sqlFindParsingRuleByNaturalKey,
+		sourceName, hostPattern, pathPattern, string(targetType), version,
+	)
+	rec, err := scanParsingRule(row)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, storage.ErrNotFound
+		}
+		return nil, fmt.Errorf("find parsing rule by natural key: %w", err)
+	}
+	return rec, nil
+}
+
 // sqlFindActiveCandidates 는 host + target_type 매칭 활성 rule 들을 후보 슬라이스로 반환합니다 (이슈 #173).
 //
 // 정렬:

--- a/test/internal/processor/parser/rule/llmgen/generator_test.go
+++ b/test/internal/processor/parser/rule/llmgen/generator_test.go
@@ -57,7 +57,9 @@ type recordingRepo struct {
 
 	// findByNaturalKeyResult: 사전 lookup 시뮬레이션 (이슈 #274). nil 이면 ErrNotFound.
 	findByNaturalKeyResult *storage.ParsingRuleRecord
-	findByNaturalKeyCalls  int
+	// findByNaturalKeyErr: 설정 시 result 무시하고 본 에러 반환 (PR #275 리뷰 — DB 장애 시뮬레이션).
+	findByNaturalKeyErr   error
+	findByNaturalKeyCalls int
 }
 
 func (r *recordingRepo) Insert(_ context.Context, rec *storage.ParsingRuleRecord) error {
@@ -85,6 +87,9 @@ func (r *recordingRepo) FindByNaturalKey(_ context.Context, _, _, _ string, _ st
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	r.findByNaturalKeyCalls++
+	if r.findByNaturalKeyErr != nil {
+		return nil, r.findByNaturalKeyErr
+	}
 	if r.findByNaturalKeyResult != nil {
 		return r.findByNaturalKeyResult, nil
 	}
@@ -689,4 +694,56 @@ func TestGenerator_PreCheckMiss_ProceedsToLLM(t *testing.T) {
 	repo.mu.Lock()
 	assert.Equal(t, 1, repo.findByNaturalKeyCalls, "사전 lookup 1회 호출")
 	repo.mu.Unlock()
+}
+
+// TestGenerator_PreCheckHit_DisabledRule_SkipsLLM 은 사전 lookup 적중이지만 enabled=false 일 때
+// LLM 호출 없이 warn 로그만 남기고 종료하는지 검증합니다 (PR #275 리뷰).
+func TestGenerator_PreCheckHit_DisabledRule_SkipsLLM(t *testing.T) {
+	provider := &fakeProvider{name: "fake", response: `{"title":{"css":"h1"}}`}
+	repo := &recordingRepo{
+		findByNaturalKeyResult: &storage.ParsingRuleRecord{
+			ID:          99,
+			SourceName:  llmgen.LLMAutoSourceName,
+			HostPattern: "example.com",
+			TargetType:  storage.TargetTypePage,
+			Version:     1,
+			Enabled:     false, // 운영자 disabled — 자동 재활성 회피
+		},
+	}
+	g, _ := newGenerator(t, provider, repo)
+
+	g.Enqueue(context.Background(), "example.com", storage.TargetTypePage, &core.RawContent{
+		URL: "https://example.com/article/1", HTML: samplePageHTML,
+	}, 0, "", 0)
+
+	stopCtx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	g.Stop(stopCtx)
+
+	assert.Equal(t, 0, provider.callCount(), "disabled 룰 적중 시 LLM 호출 미발생")
+	assert.Empty(t, repo.inserts(), "disabled 룰 적중 시 Insert 미발생")
+}
+
+// TestGenerator_PreCheckLookupError_FallthroughToLLM 은 사전 lookup 이 ErrNotFound 외 에러를
+// 반환할 때 LLM 경로로 fallthrough 하는지 검증합니다 (PR #275 리뷰 — DB 장애 best-effort 정책).
+func TestGenerator_PreCheckLookupError_FallthroughToLLM(t *testing.T) {
+	provider := &fakeProvider{
+		name: "fake",
+		response: `{
+			"title": {"css": "h1.article-title"},
+			"main_content": {"css": "article p", "multi": true}
+		}`,
+	}
+	// 일시 DB 장애 시뮬레이션 — ErrNotFound 외 에러
+	repo := &recordingRepo{findByNaturalKeyErr: errors.New("db connection refused")}
+	g, _ := newGenerator(t, provider, repo)
+
+	g.Enqueue(context.Background(), "example.com", storage.TargetTypePage, &core.RawContent{
+		URL: "https://example.com/article/1", HTML: samplePageHTML,
+	}, 0, "", 0)
+
+	waitForInserts(t, repo, 1, 2*time.Second)
+
+	assert.Equal(t, 1, provider.callCount(), "lookup 에러 시 LLM 경로 fallthrough — best-effort 정책")
+	require.Len(t, repo.inserts(), 1, "lookup 에러 후에도 Insert 진행")
 }

--- a/test/internal/processor/parser/rule/llmgen/generator_test.go
+++ b/test/internal/processor/parser/rule/llmgen/generator_test.go
@@ -54,6 +54,10 @@ type recordingRepo struct {
 	mu       sync.Mutex
 	inserted []*storage.ParsingRuleRecord
 	insertEr error
+
+	// findByNaturalKeyResult: 사전 lookup 시뮬레이션 (이슈 #274). nil 이면 ErrNotFound.
+	findByNaturalKeyResult *storage.ParsingRuleRecord
+	findByNaturalKeyCalls  int
 }
 
 func (r *recordingRepo) Insert(_ context.Context, rec *storage.ParsingRuleRecord) error {
@@ -76,6 +80,15 @@ func (r *recordingRepo) FindActive(_ context.Context, _ string, _ storage.Target
 }
 func (r *recordingRepo) FindActiveCandidates(_ context.Context, _ string, _ storage.TargetType) ([]*storage.ParsingRuleRecord, error) {
 	return nil, nil
+}
+func (r *recordingRepo) FindByNaturalKey(_ context.Context, _, _, _ string, _ storage.TargetType, _ int) (*storage.ParsingRuleRecord, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.findByNaturalKeyCalls++
+	if r.findByNaturalKeyResult != nil {
+		return r.findByNaturalKeyResult, nil
+	}
+	return nil, storage.ErrNotFound
 }
 func (r *recordingRepo) List(_ context.Context, _ storage.ParsingRuleFilter) ([]*storage.ParsingRuleRecord, error) {
 	return nil, nil
@@ -130,6 +143,9 @@ func (noopFindRepo) FindActive(_ context.Context, _ string, _ storage.TargetType
 }
 func (noopFindRepo) FindActiveCandidates(_ context.Context, _ string, _ storage.TargetType) ([]*storage.ParsingRuleRecord, error) {
 	return nil, nil
+}
+func (noopFindRepo) FindByNaturalKey(_ context.Context, _, _, _ string, _ storage.TargetType, _ int) (*storage.ParsingRuleRecord, error) {
+	return nil, storage.ErrNotFound
 }
 func (noopFindRepo) List(_ context.Context, _ storage.ParsingRuleFilter) ([]*storage.ParsingRuleRecord, error) {
 	return nil, nil

--- a/test/internal/processor/parser/rule/llmgen/generator_test.go
+++ b/test/internal/processor/parser/rule/llmgen/generator_test.go
@@ -600,3 +600,93 @@ func (s *slowProvider) Generate(ctx context.Context, req llm.Request) (*llm.Resp
 	}
 	return s.fakeProvider.Generate(ctx, req)
 }
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 이슈 #274 — ErrDuplicate 흡수 + 사전 lookup
+// ─────────────────────────────────────────────────────────────────────────────
+
+// TestGenerator_DuplicateInsert_AbsorbedAsSuccess 는 Insert 가 ErrDuplicate 를 반환할 때
+// generator 가 정상 경로로 흡수하여 selectorValidationError 분기 없이 종료되는지 검증합니다 (이슈 #274 — A).
+func TestGenerator_DuplicateInsert_AbsorbedAsSuccess(t *testing.T) {
+	provider := &fakeProvider{
+		name: "fake",
+		response: `{
+			"title": {"css": "h1.article-title"},
+			"main_content": {"css": "article p", "multi": true}
+		}`,
+	}
+	// Insert 가 ErrDuplicate 를 반환하도록 구성. inserted 슬라이스는 비어있어야 함 (race 없음).
+	repo := &recordingRepo{insertEr: storage.ErrDuplicate}
+	g, _ := newGenerator(t, provider, repo)
+
+	g.Enqueue(context.Background(), "example.com", storage.TargetTypePage, &core.RawContent{
+		URL: "https://example.com/article/1", HTML: samplePageHTML,
+	}, 0, "", 0)
+
+	// Stop 으로 in-flight goroutine 종료 대기 — provider 호출은 발생했어야 함.
+	stopCtx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	g.Stop(stopCtx)
+
+	assert.Equal(t, 1, provider.callCount(), "LLM 호출은 발생해야 함 (사전 lookup miss)")
+	assert.Empty(t, repo.inserts(), "Insert ErrDuplicate 시 inserted 누적 없음 (recordingRepo 의 insertEr 분기)")
+	// 핵심 회귀 방어: validateFailureHandler 등록 없이 ErrDuplicate 가 selectorValidationError 로
+	// wrap 되지 않고 정상 종료됨 — 패닉 / 무한 루프 / requeue 폭주 없음.
+}
+
+// TestGenerator_PreCheckHit_SkipsLLMCall 은 사전 lookup 적중 시 LLM 호출이 발생하지 않는지 검증합니다 (이슈 #274 — B).
+func TestGenerator_PreCheckHit_SkipsLLMCall(t *testing.T) {
+	provider := &fakeProvider{name: "fake", response: `{"title":{"css":"h1"}}`}
+	repo := &recordingRepo{
+		findByNaturalKeyResult: &storage.ParsingRuleRecord{
+			ID:          42,
+			SourceName:  llmgen.LLMAutoSourceName,
+			HostPattern: "example.com",
+			TargetType:  storage.TargetTypePage,
+			Version:     1,
+			Enabled:     true,
+		},
+	}
+	g, _ := newGenerator(t, provider, repo)
+
+	g.Enqueue(context.Background(), "example.com", storage.TargetTypePage, &core.RawContent{
+		URL: "https://example.com/article/1", HTML: samplePageHTML,
+	}, 0, "", 0)
+
+	stopCtx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	g.Stop(stopCtx)
+
+	assert.Equal(t, 0, provider.callCount(), "사전 lookup 적중 시 LLM 호출 미발생")
+	assert.Empty(t, repo.inserts(), "사전 lookup 적중 시 Insert 호출 미발생")
+	repo.mu.Lock()
+	assert.Equal(t, 1, repo.findByNaturalKeyCalls, "사전 lookup 1회 호출")
+	repo.mu.Unlock()
+}
+
+// TestGenerator_PreCheckMiss_ProceedsToLLM 는 사전 lookup miss 시 기존 경로 (LLM 호출 + Insert) 가
+// 정상 동작하는지 검증합니다 (이슈 #274 — B).
+func TestGenerator_PreCheckMiss_ProceedsToLLM(t *testing.T) {
+	provider := &fakeProvider{
+		name: "fake",
+		response: `{
+			"title": {"css": "h1.article-title"},
+			"main_content": {"css": "article p", "multi": true}
+		}`,
+	}
+	// findByNaturalKeyResult 미설정 → ErrNotFound 반환 → LLM 경로 진행.
+	repo := &recordingRepo{}
+	g, _ := newGenerator(t, provider, repo)
+
+	g.Enqueue(context.Background(), "example.com", storage.TargetTypePage, &core.RawContent{
+		URL: "https://example.com/article/1", HTML: samplePageHTML,
+	}, 0, "", 0)
+
+	waitForInserts(t, repo, 1, 2*time.Second)
+
+	assert.Equal(t, 1, provider.callCount(), "사전 lookup miss 시 LLM 호출 발생")
+	require.Len(t, repo.inserts(), 1)
+	repo.mu.Lock()
+	assert.Equal(t, 1, repo.findByNaturalKeyCalls, "사전 lookup 1회 호출")
+	repo.mu.Unlock()
+}

--- a/test/internal/processor/parser/rule/refiner/refiner_test.go
+++ b/test/internal/processor/parser/rule/refiner/refiner_test.go
@@ -52,6 +52,9 @@ func (r *fakeRulesRepo) FindActive(_ context.Context, _ string, _ storage.Target
 func (r *fakeRulesRepo) FindActiveCandidates(_ context.Context, _ string, _ storage.TargetType) ([]*storage.ParsingRuleRecord, error) {
 	return nil, nil
 }
+func (r *fakeRulesRepo) FindByNaturalKey(_ context.Context, _, _, _ string, _ storage.TargetType, _ int) (*storage.ParsingRuleRecord, error) {
+	return nil, storage.ErrNotFound
+}
 func (r *fakeRulesRepo) List(_ context.Context, f storage.ParsingRuleFilter) ([]*storage.ParsingRuleRecord, error) {
 	if r.listErr != nil {
 		return nil, r.listErr

--- a/test/internal/processor/parser/rule/resolver_test.go
+++ b/test/internal/processor/parser/rule/resolver_test.go
@@ -67,6 +67,10 @@ func (r *fakeRepo) FindActiveCandidates(_ context.Context, host string, t storag
 
 func (r *fakeRepo) calls() int { return int(atomic.LoadInt64(&r.findActiveCalls)) }
 
+func (r *fakeRepo) FindByNaturalKey(_ context.Context, _, _, _ string, _ storage.TargetType, _ int) (*storage.ParsingRuleRecord, error) {
+	return nil, storage.ErrNotFound
+}
+
 // sortByPathPatternLengthDesc 는 LENGTH(path_pattern) DESC, version DESC 정렬을 수행합니다.
 // postgres 의 ORDER BY LENGTH(path_pattern) DESC, version DESC 와 동일 동작 (PR #181 gemini 피드백).
 func sortByPathPatternLengthDesc(s []*storage.ParsingRuleRecord) {


### PR DESCRIPTION
## 연관 이슈
- Closes #274

<br>

## 구현 내용

PR #271 머지 직후 라이브 검증에서 llmgen 실패 74건 중 **30건이 \`insert parsing rule: duplicate record\`** Warn 로그였습니다. 이미 Redis SETNX 기반 `RedisInflightLocker`가 적용되어 있으나 (이슈 #261), 발생 host 분포가 모두 다른 host (policy.daum.net, channel.daum.net 등) — **race가 아닌 이전 실행에서 INSERT 된 룰의 잔존**이 원인.

### 변경 사항 (2-layer 대책)

#### A. Generator: ErrDuplicate 정상 경로 흡수
[`internal/processor/parser/rule/llmgen/generator.go:438`](internal/processor/parser/rule/llmgen/generator.go#L438)
- `g.repo.Insert` 가 `storage.ErrDuplicate` 반환 시 `resolver.Invalidate` 후 nil 반환.
- warn 로그 → info 로그로 격하.
- `selectorValidationError` 분기 미발생 → requeue 폭주 회피.

#### B. 사전 lookup: 불필요한 LLM 호출 회피 (비용 최적화)
- `internal/storage/parsing_rule.go`: `ParsingRuleRepository` 인터페이스에 `FindByNaturalKey` 메소드 추가.
- `internal/storage/postgres/parsing_rule.go`: SELECT 구현 추가 (Insert 의 unique key 와 동일).
- `internal/processor/parser/rule/llmgen/generator.go:runOnce` 진입 시 사전 lookup. 적중 시 LLM 호출 skip + cache invalidate.
- 3개 fake repo 구현체 (resolver_test, refiner_test, generator_test) 업데이트.

#### 단위 테스트 (3건 추가)
- `TestGenerator_DuplicateInsert_AbsorbedAsSuccess`: Insert ErrDuplicate → 정상 종료
- `TestGenerator_PreCheckHit_SkipsLLMCall`: 사전 lookup 적중 → LLM 호출 0회
- `TestGenerator_PreCheckMiss_ProceedsToLLM`: 사전 lookup miss → 기존 경로 정상

### 비용 효과 (sonnet 활성 환경 추정)

- 30건 duplicate × 평균 55s LLM 호출 = **약 27.5분 분량 절감 / 10분 실행**
- claudegen 컨테이너 idle 자원 효율 ↑
- subscription quota 소모 감소

<br>

## CI / 머지 게이트 점검

> [CI 운영 규약](docs/ci/conventions.md) 및 [Required Status Checks 단일 소스](docs/ci/status-checks.md)에 따라 작성합니다.

### 변경 영향 범위
- 영향 패키지/모듈: `internal/processor/parser/rule/llmgen`, `internal/storage`, `internal/storage/postgres`, `test/internal/processor/parser/rule/{llmgen,refiner,resolver}`
- 위험도: `Low`
  - A: 에러 분기 처리 변경만 — 기존 정상 경로 영향 없음
  - B: 신규 SELECT 1회 추가 — 적중 시 LLM 호출 skip, miss 시 기존 경로

### Required Status Checks
- 통과 확인 대상:
  - [ ] `Commit Lint`
  - [ ] `PR Title Lint`
  - [ ] `Linked Issue Check`
  - [ ] `Build`
  - [ ] `Test`
  - [ ] `Lint`

### 로컬 검증
- `make fmt` 통과
- `make build` 5개 binary 빌드 통과
- `go test -race ./...` 전체 통과 (신규 테스트 3건 포함)
- `go vet ./...` 통과

<br>

## 롤백 계획

본 PR 은 신규 코드 path 추가 (사전 lookup) + 에러 분기 변경 (ErrDuplicate 흡수) 만 포함. 데이터 마이그레이션 없음. 단순 revert 만으로 즉시 롤백 가능.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added intelligent pre-validation for parsing rule creation to avoid redundant processing.

* **Bug Fixes**
  * Improved handling of duplicate rule scenarios during creation—conflicts are now resolved gracefully instead of failing.
  * Enhanced parsing rule lookup and verification for more reliable operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->