### PR TITLE
[FEAT#216] LLM provider fallback chain — gemini → openai → anthropic

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -744,14 +744,17 @@ func LoadLLM(envFiles ...string) (LLMConfig, error) {
 		cfg.Timeout = d
 	}
 
-	cfg.APIKey = lookupLLMAPIKey(cfg.Provider)
+	cfg.APIKey = LookupLLMAPIKey(cfg.Provider)
 
 	return cfg, nil
 }
 
-// lookupLLMAPIKey 는 provider 별 표준 환경변수에서 API key 를 조회하고,
+// LookupLLMAPIKey 는 provider 별 표준 환경변수에서 API key 를 조회하고,
 // 부재 시 LLM_API_KEY fallback 을 사용합니다.
-func lookupLLMAPIKey(provider string) string {
+//
+// 외부 (pkg/llm/wiring) 가 multi-provider chain 구성 시 provider 별 key 를 조회하기 위해 export
+// (이슈 #216).
+func LookupLLMAPIKey(provider string) string {
 	switch provider {
 	case "gemini":
 		if v := os.Getenv("GEMINI_API_KEY"); v != "" {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -744,17 +744,14 @@ func LoadLLM(envFiles ...string) (LLMConfig, error) {
 		cfg.Timeout = d
 	}
 
-	cfg.APIKey = LookupLLMAPIKey(cfg.Provider)
+	cfg.APIKey = lookupLLMAPIKey(cfg.Provider)
 
 	return cfg, nil
 }
 
-// LookupLLMAPIKey 는 provider 별 표준 환경변수에서 API key 를 조회하고,
+// lookupLLMAPIKey 는 provider 별 표준 환경변수에서 API key 를 조회하고,
 // 부재 시 LLM_API_KEY fallback 을 사용합니다.
-//
-// 외부 (pkg/llm/wiring) 가 multi-provider chain 구성 시 provider 별 key 를 조회하기 위해 export
-// (이슈 #216).
-func LookupLLMAPIKey(provider string) string {
+func lookupLLMAPIKey(provider string) string {
 	switch provider {
 	case "gemini":
 		if v := os.Getenv("GEMINI_API_KEY"); v != "" {

--- a/pkg/llm/wiring/wiring.go
+++ b/pkg/llm/wiring/wiring.go
@@ -5,6 +5,8 @@
 package wiring
 
 import (
+	"os"
+
 	"issuetracker/pkg/config"
 	"issuetracker/pkg/llm"
 	"issuetracker/pkg/llm/chain"
@@ -13,14 +15,49 @@ import (
 	"issuetracker/pkg/logger"
 )
 
-// BuildProvider 는 LLMConfig (환경변수) 에 따라 chain provider 를 구성합니다 (이슈 #173 단계 4-2 — 공유용).
+// providerEnvKey 는 provider 별 API key 환경변수 이름을 반환합니다 (이슈 #216).
+//
+// config.LookupLLMAPIKey 는 미발견 시 LLM_API_KEY 로 cascade 하여 모든 provider 에 동일 key 가
+// 적용되는 부작용이 있어, chain 구성 시에는 본 helper 로 provider 별 key 만 직접 조회합니다.
+// LLM_API_KEY fallback 은 primary (cfg.Provider) 1건에만 적용 — backward compat 보존.
+func providerEnvKey(name string) string {
+	switch name {
+	case "gemini":
+		return os.Getenv("GEMINI_API_KEY")
+	case "openai":
+		return os.Getenv("OPENAI_API_KEY")
+	case "anthropic", "claude":
+		return os.Getenv("ANTHROPIC_API_KEY")
+	}
+	return ""
+}
+
+// fallbackOrder 는 fixed-order fallback chain 의 시도 순서입니다 (이슈 #216).
+//
+// 현재는 gemini → openai → anthropic 으로 hardcoded — 비용 / 한도 / 가용성 우선순위 기준.
+// 향후 capability 기반 metric 정책 (cost / latency / 성공률) 도입 시 본 슬라이스 대신
+// pkg/llm/policy 의 dynamic policy (CheapestFirst / Latency / Hybrid 등) 로 NewFixedOrder 만 교체.
+var fallbackOrder = []string{"gemini", "openai", "anthropic"}
+
+// BuildProvider 는 LLMConfig (환경변수) 에 따라 fixed-order fallback chain 을 구성합니다 (이슈 #216).
+//
+// fallback 순서: gemini → openai → anthropic (hardcoded — 향후 metric 기반 정책으로 대체).
+// 각 provider 는 자신의 API key 가 환경변수에 설정된 경우에만 chain 후보에 포함:
+//   - GEMINI_API_KEY / OPENAI_API_KEY / ANTHROPIC_API_KEY (없으면 LLM_API_KEY 로 fallback)
 //
 // 반환값 nil 은 LLM 비활성을 의미 — 호출자가 nil 허용 분기:
-//   - LLM_ENABLED=false / API key 부재 / provider 생성 실패 → nil + warn 로그
+//   - LLM_ENABLED=false → nil
+//   - 모든 provider 가 API key 부재 / 생성 실패 → nil + warn
+//
+// 정책 적용 (이슈 #144 PolicyProvider):
+//   - policy.NewFixedOrder(fallbackOrder...) 로 후보를 정해진 순서로 정렬
+//   - 향후 metric 기반 정책 도입 시 본 함수의 policy 객체만 교체하면 됨
+//
+// LLM_PROVIDER / LLM_MODEL 의 역할 (backward compat):
+//   - LLM_PROVIDER 와 일치하는 provider 에는 LLM_MODEL 이 적용됨
+//   - 그 외 provider 는 자체 default model 사용 (gemini-2.5-flash / gpt-4o-mini / claude-opus-4-7)
 //
 // llmgen 과 refiner 가 동일 provider 를 공유 — 환경변수 1세트 (LLM_*) 로 두 컴포넌트 동시 제어.
-//
-// 본 함수는 FixedOrder(cfg.Provider) 정책으로 단일 provider 를 사용. 후속 PR 에서 chain 확장 가능.
 func BuildProvider(log *logger.Logger) llm.Provider {
 	cfg, err := config.LoadLLM()
 	if err != nil {
@@ -31,30 +68,54 @@ func BuildProvider(log *logger.Logger) llm.Provider {
 		log.Info("LLM provider disabled (LLM_ENABLED=false)")
 		return nil
 	}
-	if cfg.APIKey == "" {
-		log.WithField("provider", cfg.Provider).Warn("LLM API key missing, llm provider disabled (set GEMINI_API_KEY / OPENAI_API_KEY / ANTHROPIC_API_KEY)")
+
+	candidates := make([]llm.Provider, 0, len(fallbackOrder))
+	activeNames := make([]string, 0, len(fallbackOrder))
+	for _, name := range fallbackOrder {
+		apiKey := providerEnvKey(name)
+		// LLM_API_KEY fallback 은 primary (LLM_PROVIDER) 에만 적용 — backward compat.
+		// 다른 provider 에 같은 key 를 cascade 하면 chain 이 잘못 채워져 auth 실패 후 다음 시도로 낭비.
+		if apiKey == "" && name == cfg.Provider {
+			apiKey = cfg.APIKey
+		}
+		if apiKey == "" {
+			log.WithField("provider", name).Debug("skipping provider — no API key configured")
+			continue
+		}
+		// 사용자가 LLM_PROVIDER 로 지정한 primary 에는 LLM_MODEL override 적용. 나머지는 provider default.
+		model := ""
+		if name == cfg.Provider {
+			model = cfg.Model
+		}
+		p, perr := llm.New(llm.Config{
+			Provider: name,
+			APIKey:   apiKey,
+			Model:    model,
+			Timeout:  cfg.Timeout,
+		})
+		if perr != nil {
+			log.WithError(perr).WithField("provider", name).Warn("failed to construct LLM provider, skipping")
+			continue
+		}
+		candidates = append(candidates, p)
+		activeNames = append(activeNames, name)
+	}
+
+	if len(candidates) == 0 {
+		log.Warn("LLM provider disabled — no API keys configured (set GEMINI_API_KEY / OPENAI_API_KEY / ANTHROPIC_API_KEY)")
 		return nil
 	}
 
-	provider, err := llm.New(llm.Config{
-		Provider: cfg.Provider,
-		APIKey:   cfg.APIKey,
-		Model:    cfg.Model,
-		Timeout:  cfg.Timeout,
-	})
-	if err != nil {
-		log.WithError(err).WithField("provider", cfg.Provider).Warn("failed to construct LLM provider")
-		return nil
-	}
-
-	pol := policy.NewFixedOrder(cfg.Provider)
-	composed := chain.NewWithPolicy(pol, []llm.Provider{provider}, chain.WithPolicyLogger(log))
+	// FixedOrder 정책 — fallbackOrder 의 순서를 후보에 강제. 향후 metric 정책으로 교체 시 본 줄만 변경.
+	pol := policy.NewFixedOrder(fallbackOrder...)
+	composed := chain.NewWithPolicy(pol, candidates, chain.WithPolicyLogger(log))
 
 	log.WithFields(map[string]interface{}{
-		"provider": cfg.Provider,
-		"model":    cfg.Model,
-		"timeout":  cfg.Timeout.String(),
-	}).Info("LLM provider enabled (FixedOrder policy — see issue #149 follow-up for chain expansion)")
+		"chain":   activeNames,
+		"primary": activeNames[0],
+		"policy":  "FixedOrder",
+		"timeout": cfg.Timeout.String(),
+	}).Info("LLM provider chain enabled (fixed order — gemini → openai → anthropic; metric policy 후속 PR)")
 
 	return composed
 }

--- a/pkg/llm/wiring/wiring.go
+++ b/pkg/llm/wiring/wiring.go
@@ -54,7 +54,11 @@ var fallbackOrder = []string{"gemini", "openai", "anthropic"}
 //
 // fallback 순서: gemini → openai → anthropic (hardcoded — 향후 metric 기반 정책으로 대체).
 // 각 provider 는 자신의 API key 가 환경변수에 설정된 경우에만 chain 후보에 포함:
-//   - GEMINI_API_KEY / OPENAI_API_KEY / ANTHROPIC_API_KEY (없으면 LLM_API_KEY 로 fallback)
+//   - GEMINI_API_KEY / OPENAI_API_KEY / ANTHROPIC_API_KEY 직접 lookup
+//
+// LLM_API_KEY 의 역할 (backward compat — primary 1건 한정):
+//   - primary (LLM_PROVIDER 가 가리키는 provider) 가 자신의 specific key 부재인 경우에만 LLM_API_KEY 적용.
+//   - 다른 provider 에는 cascade 되지 않음 — 잘못된 key 가 chain 에 채워져 auth 실패로 시간 낭비하는 부작용 회피.
 //
 // 반환값 nil 은 LLM 비활성을 의미 — 호출자가 nil 허용 분기:
 //   - LLM_ENABLED=false → nil
@@ -65,7 +69,7 @@ var fallbackOrder = []string{"gemini", "openai", "anthropic"}
 //   - 향후 metric 기반 정책 도입 시 본 함수의 policy 객체만 교체하면 됨
 //
 // LLM_PROVIDER / LLM_MODEL 의 역할 (backward compat):
-//   - LLM_PROVIDER 와 일치하는 provider 에는 LLM_MODEL 이 적용됨
+//   - LLM_PROVIDER 와 일치하는 provider 에는 LLM_MODEL 이 적용됨 (claude alias 포함)
 //   - 그 외 provider 는 자체 default model 사용 (gemini-2.5-flash / gpt-4o-mini / claude-opus-4-7)
 //
 // llmgen 과 refiner 가 동일 provider 를 공유 — 환경변수 1세트 (LLM_*) 로 두 컴포넌트 동시 제어.
@@ -125,11 +129,17 @@ func BuildProvider(log *logger.Logger) llm.Provider {
 	pol := policy.NewFixedOrder(fallbackOrder...)
 	composed := chain.NewWithPolicy(pol, candidates, chain.WithPolicyLogger(log))
 
+	// 로그 필드 의미 (PR #280 Copilot 리뷰):
+	//   - chain          : 실제 활성화되어 시도되는 provider 시퀀스 (정책 적용 전 후보 목록)
+	//   - first_in_chain : chain[0] — 매 호출의 첫 시도 대상 (디버깅용)
+	//   - configured_primary : LLM_PROVIDER 가 가리키는 사용자 의도 (alias 정규화 후)
+	//                          — first_in_chain 과 다를 수 있음 (key 부재 등으로 chain 에서 제외된 경우)
 	log.WithFields(map[string]interface{}{
-		"chain":   activeNames,
-		"primary": activeNames[0],
-		"policy":  "FixedOrder",
-		"timeout": cfg.Timeout.String(),
+		"chain":              activeNames,
+		"first_in_chain":     activeNames[0],
+		"configured_primary": primaryName,
+		"policy":             "FixedOrder",
+		"timeout":            cfg.Timeout.String(),
 	}).Info("LLM provider chain enabled (fixed order — gemini → openai → anthropic; metric policy 후속 PR)")
 
 	return composed

--- a/pkg/llm/wiring/wiring.go
+++ b/pkg/llm/wiring/wiring.go
@@ -15,12 +15,12 @@ import (
 	"issuetracker/pkg/logger"
 )
 
-// providerEnvKey 는 provider 별 API key 환경변수 이름을 반환합니다 (이슈 #216).
+// lookupProviderAPIKey 는 provider 별 표준 환경변수의 *값* 을 반환합니다 (이슈 #216).
 //
-// config.LookupLLMAPIKey 는 미발견 시 LLM_API_KEY 로 cascade 하여 모든 provider 에 동일 key 가
-// 적용되는 부작용이 있어, chain 구성 시에는 본 helper 로 provider 별 key 만 직접 조회합니다.
+// config 의 lookupLLMAPIKey 는 미발견 시 LLM_API_KEY 로 cascade 하여 모든 provider 에 동일 key 가
+// 적용되는 부작용이 있으므로, chain 구성 시에는 본 helper 로 provider 별 key 만 직접 조회합니다.
 // LLM_API_KEY fallback 은 primary (cfg.Provider) 1건에만 적용 — backward compat 보존.
-func providerEnvKey(name string) string {
+func lookupProviderAPIKey(name string) string {
 	switch name {
 	case "gemini":
 		return os.Getenv("GEMINI_API_KEY")
@@ -30,6 +30,17 @@ func providerEnvKey(name string) string {
 		return os.Getenv("ANTHROPIC_API_KEY")
 	}
 	return ""
+}
+
+// normalizePrimary 는 LLM_PROVIDER 의 alias 를 fallbackOrder 의 정식 이름으로 정규화합니다.
+//
+// 예: cfg.Provider="claude" → "anthropic" 으로 매핑하여 chain 의 anthropic 항목에 LLM_API_KEY
+// fallback / LLM_MODEL override 가 정확히 적용되도록 보장 (PR #280 gemini 리뷰).
+func normalizePrimary(name string) string {
+	if name == "claude" {
+		return "anthropic"
+	}
+	return name
 }
 
 // fallbackOrder 는 fixed-order fallback chain 의 시도 순서입니다 (이슈 #216).
@@ -69,13 +80,17 @@ func BuildProvider(log *logger.Logger) llm.Provider {
 		return nil
 	}
 
+	// LLM_PROVIDER alias (예: "claude" → "anthropic") 정규화 — fallbackOrder 의 정식 이름과 매칭하여
+	// LLM_API_KEY fallback / LLM_MODEL override 가 올바른 chain 항목에 적용되도록 보장 (PR #280 리뷰).
+	primaryName := normalizePrimary(cfg.Provider)
+
 	candidates := make([]llm.Provider, 0, len(fallbackOrder))
 	activeNames := make([]string, 0, len(fallbackOrder))
 	for _, name := range fallbackOrder {
-		apiKey := providerEnvKey(name)
+		apiKey := lookupProviderAPIKey(name)
 		// LLM_API_KEY fallback 은 primary (LLM_PROVIDER) 에만 적용 — backward compat.
 		// 다른 provider 에 같은 key 를 cascade 하면 chain 이 잘못 채워져 auth 실패 후 다음 시도로 낭비.
-		if apiKey == "" && name == cfg.Provider {
+		if apiKey == "" && name == primaryName {
 			apiKey = cfg.APIKey
 		}
 		if apiKey == "" {
@@ -84,7 +99,7 @@ func BuildProvider(log *logger.Logger) llm.Provider {
 		}
 		// 사용자가 LLM_PROVIDER 로 지정한 primary 에는 LLM_MODEL override 적용. 나머지는 provider default.
 		model := ""
-		if name == cfg.Provider {
+		if name == primaryName {
 			model = cfg.Model
 		}
 		p, perr := llm.New(llm.Config{

--- a/test/pkg/llm/wiring/wiring_test.go
+++ b/test/pkg/llm/wiring/wiring_test.go
@@ -1,6 +1,9 @@
 package wiring_test
 
 import (
+	"bytes"
+	"encoding/json"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -23,6 +26,54 @@ func clearLLMEnv(t *testing.T) {
 	}
 }
 
+// captureLog 는 BuildProvider 의 로그 출력을 캡처할 (logger, *bytes.Buffer) 페어를 반환합니다.
+//
+// chain 구성 검증을 위해 "LLM provider chain enabled" info 로그의 chain / first_in_chain /
+// configured_primary 필드 값을 assert (PR #280 Copilot 리뷰).
+func captureLog(t *testing.T) (*logger.Logger, *bytes.Buffer) {
+	t.Helper()
+	buf := &bytes.Buffer{}
+	cfg := logger.DefaultConfig()
+	cfg.Output = buf
+	cfg.Level = logger.LevelDebug
+	return logger.New(cfg), buf
+}
+
+// findChainEnabledLog 는 캡처 버퍼에서 "LLM provider chain enabled" 메시지를 찾아 fields 를 반환합니다.
+// 발견 못하면 nil + t.Fatal.
+func findChainEnabledLog(t *testing.T, buf *bytes.Buffer) map[string]interface{} {
+	t.Helper()
+	for _, line := range strings.Split(buf.String(), "\n") {
+		if line == "" {
+			continue
+		}
+		var entry map[string]interface{}
+		if err := json.Unmarshal([]byte(line), &entry); err != nil {
+			continue
+		}
+		msg, _ := entry["message"].(string)
+		if strings.HasPrefix(msg, "LLM provider chain enabled") {
+			return entry
+		}
+	}
+	t.Fatalf("chain enabled log not found in: %s", buf.String())
+	return nil
+}
+
+// chainNames 는 로그 entry 의 chain 필드를 string slice 로 변환합니다.
+func chainNames(t *testing.T, entry map[string]interface{}) []string {
+	t.Helper()
+	raw, ok := entry["chain"].([]interface{})
+	require.True(t, ok, "chain field missing or wrong type: %v", entry["chain"])
+	out := make([]string, len(raw))
+	for i, v := range raw {
+		s, ok := v.(string)
+		require.True(t, ok, "chain[%d] not string: %v", i, v)
+		out[i] = s
+	}
+	return out
+}
+
 // TestBuildProvider_NoAPIKeys_ReturnsNil 은 모든 provider 의 API key 가 부재일 때 nil 반환을 검증합니다 (이슈 #216).
 func TestBuildProvider_NoAPIKeys_ReturnsNil(t *testing.T) {
 	clearLLMEnv(t)
@@ -42,30 +93,60 @@ func TestBuildProvider_LLMDisabled_ReturnsNil(t *testing.T) {
 	assert.Nil(t, p, "LLM_ENABLED=false 시 API key 가 있어도 nil")
 }
 
-// TestBuildProvider_SingleKey_ReturnsChainWithOne 은 한 provider 의 key 만 있어도 chain 이 구성되는지 검증합니다.
-// (단일-provider chain 도 graceful — 운영자가 추후 다른 key 추가하면 자동 확장).
-func TestBuildProvider_SingleKey_ReturnsChainWithOne(t *testing.T) {
+// TestBuildProvider_SingleKey_ChainHasOnlyThatProvider 는 한 provider 의 key 만 있을 때 chain 에
+// 그 provider 만 포함됨을 로그로 검증합니다 (PR #280 Copilot — 약한 assertion 강화).
+func TestBuildProvider_SingleKey_ChainHasOnlyThatProvider(t *testing.T) {
 	clearLLMEnv(t)
 	t.Setenv("LLM_ENABLED", "true")
 	t.Setenv("GEMINI_API_KEY", "fake-gemini-key")
 
-	p := wiring.BuildProvider(logger.New(logger.DefaultConfig()))
-	require.NotNil(t, p, "단일 provider key 만으로도 chain 구성")
-	// chain.PolicyProvider 는 Name() == "chain" — 외부 호출자에게 단일 provider 와 동일 인터페이스.
+	log, buf := captureLog(t)
+	p := wiring.BuildProvider(log)
+	require.NotNil(t, p)
 	assert.Equal(t, "chain", p.Name())
+
+	entry := findChainEnabledLog(t, buf)
+	assert.Equal(t, []string{"gemini"}, chainNames(t, entry), "단일 key 환경 — chain 1개")
+	assert.Equal(t, "gemini", entry["first_in_chain"])
 }
 
-// TestBuildProvider_AllKeys_ReturnsChainWithAll 은 3개 provider key 모두 있을 때 chain 이 구성되는지 검증합니다.
-func TestBuildProvider_AllKeys_ReturnsChainWithAll(t *testing.T) {
+// TestBuildProvider_AllKeys_ChainHasAllInOrder 는 3개 key 모두 있을 때 fallbackOrder 순서대로 chain 구성됨을 검증합니다.
+func TestBuildProvider_AllKeys_ChainHasAllInOrder(t *testing.T) {
 	clearLLMEnv(t)
 	t.Setenv("LLM_ENABLED", "true")
 	t.Setenv("GEMINI_API_KEY", "fake-gemini-key")
 	t.Setenv("OPENAI_API_KEY", "fake-openai-key")
 	t.Setenv("ANTHROPIC_API_KEY", "fake-anthropic-key")
 
-	p := wiring.BuildProvider(logger.New(logger.DefaultConfig()))
+	log, buf := captureLog(t)
+	p := wiring.BuildProvider(log)
 	require.NotNil(t, p)
-	assert.Equal(t, "chain", p.Name())
+
+	entry := findChainEnabledLog(t, buf)
+	assert.Equal(t, []string{"gemini", "openai", "anthropic"}, chainNames(t, entry),
+		"3개 key 환경 — fallbackOrder 순서로 chain 구성")
+	assert.Equal(t, "gemini", entry["first_in_chain"])
+}
+
+// TestBuildProvider_LLMAPIKeyFallback_OnlyPrimary 는 LLM_API_KEY fallback 이 primary (LLM_PROVIDER) 에만
+// 적용되어 다른 provider 로 cascade 되지 않는지 검증합니다 (이슈 #216).
+//
+// 시나리오: LLM_PROVIDER=anthropic + LLM_API_KEY=fallback-key 만 설정 — anthropic 만 chain 에 포함.
+// gemini / openai 에는 cascade 되지 않아야 함 (잘못된 key 로 auth 실패하며 chain 시간 낭비 회피).
+func TestBuildProvider_LLMAPIKeyFallback_OnlyPrimary(t *testing.T) {
+	clearLLMEnv(t)
+	t.Setenv("LLM_ENABLED", "true")
+	t.Setenv("LLM_PROVIDER", "anthropic")
+	t.Setenv("LLM_API_KEY", "fallback-key")
+
+	log, buf := captureLog(t)
+	p := wiring.BuildProvider(log)
+	require.NotNil(t, p)
+
+	entry := findChainEnabledLog(t, buf)
+	assert.Equal(t, []string{"anthropic"}, chainNames(t, entry),
+		"LLM_API_KEY 는 primary (anthropic) 에만 적용 — gemini/openai 미포함")
+	assert.Equal(t, "anthropic", entry["configured_primary"])
 }
 
 // TestBuildProvider_LLMAPIKeyFallback_ClaudeAlias 는 LLM_PROVIDER=claude alias 가 anthropic 으로
@@ -76,24 +157,33 @@ func TestBuildProvider_LLMAPIKeyFallback_ClaudeAlias(t *testing.T) {
 	t.Setenv("LLM_PROVIDER", "claude")
 	t.Setenv("LLM_API_KEY", "fallback-key")
 
-	p := wiring.BuildProvider(logger.New(logger.DefaultConfig()))
+	log, buf := captureLog(t)
+	p := wiring.BuildProvider(log)
 	require.NotNil(t, p, "claude alias 가 anthropic 으로 정규화되어 chain 에 포함")
-	assert.Equal(t, "chain", p.Name())
+
+	entry := findChainEnabledLog(t, buf)
+	assert.Equal(t, []string{"anthropic"}, chainNames(t, entry))
+	assert.Equal(t, "anthropic", entry["configured_primary"], "claude → anthropic 정규화")
 }
 
-// TestBuildProvider_LLMAPIKeyFallback_OnlyPrimary 는 LLM_API_KEY fallback 이 primary (LLM_PROVIDER) 에만
-// 적용되어 다른 provider 로 cascade 되지 않는지 검증합니다 (이슈 #216).
+// TestBuildProvider_PrimaryDifferentFromFirstInChain 는 LLM_PROVIDER 가 chain 에 포함되지 않은 경우
+// configured_primary 와 first_in_chain 이 다르게 로깅되는지 검증합니다 (PR #280 Copilot).
 //
-// 시나리오: LLM_PROVIDER=anthropic + LLM_API_KEY=anthropic_key 만 설정 — anthropic 만 chain 에 포함.
-// gemini / openai 에는 cascade 되지 않아야 함 (잘못된 key 로 auth 실패하며 chain 시간 낭비 회피).
-func TestBuildProvider_LLMAPIKeyFallback_OnlyPrimary(t *testing.T) {
+// 시나리오: LLM_PROVIDER=openai (primary 의도) 인데 OPENAI_API_KEY 부재, GEMINI_API_KEY 만 있음 →
+// chain=[gemini], first_in_chain=gemini, configured_primary=openai 으로 운영자가 의도 vs 실제 차이를 감지 가능.
+func TestBuildProvider_PrimaryDifferentFromFirstInChain(t *testing.T) {
 	clearLLMEnv(t)
 	t.Setenv("LLM_ENABLED", "true")
-	t.Setenv("LLM_PROVIDER", "anthropic")
-	t.Setenv("LLM_API_KEY", "fallback-key")
+	t.Setenv("LLM_PROVIDER", "openai")
+	t.Setenv("GEMINI_API_KEY", "fake-gemini-key")
 
-	p := wiring.BuildProvider(logger.New(logger.DefaultConfig()))
-	require.NotNil(t, p, "LLM_API_KEY fallback 으로 primary provider 활성화")
-	// chain 인터페이스 자체는 동일 — 내부 활성 provider 수는 로그로 검증 (chain=["anthropic"] 만).
-	assert.Equal(t, "chain", p.Name())
+	log, buf := captureLog(t)
+	p := wiring.BuildProvider(log)
+	require.NotNil(t, p)
+
+	entry := findChainEnabledLog(t, buf)
+	assert.Equal(t, []string{"gemini"}, chainNames(t, entry))
+	assert.Equal(t, "gemini", entry["first_in_chain"])
+	assert.Equal(t, "openai", entry["configured_primary"],
+		"운영자 의도 (openai) 와 실제 chain 첫 시도 (gemini) 가 다른 상황을 운영 로그로 식별 가능")
 }

--- a/test/pkg/llm/wiring/wiring_test.go
+++ b/test/pkg/llm/wiring/wiring_test.go
@@ -1,0 +1,86 @@
+package wiring_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"issuetracker/pkg/llm/wiring"
+	"issuetracker/pkg/logger"
+)
+
+// llmEnvKeys 는 본 테스트가 격리해야 하는 LLM 관련 환경변수 키들입니다.
+var llmEnvKeys = []string{
+	"LLM_ENABLED", "LLM_PROVIDER", "LLM_MODEL", "LLM_TIMEOUT", "LLM_API_KEY",
+	"GEMINI_API_KEY", "OPENAI_API_KEY", "ANTHROPIC_API_KEY",
+}
+
+func clearLLMEnv(t *testing.T) {
+	t.Helper()
+	for _, k := range llmEnvKeys {
+		t.Setenv(k, "")
+	}
+}
+
+// TestBuildProvider_NoAPIKeys_ReturnsNil 은 모든 provider 의 API key 가 부재일 때 nil 반환을 검증합니다 (이슈 #216).
+func TestBuildProvider_NoAPIKeys_ReturnsNil(t *testing.T) {
+	clearLLMEnv(t)
+	t.Setenv("LLM_ENABLED", "true")
+
+	p := wiring.BuildProvider(logger.New(logger.DefaultConfig()))
+	assert.Nil(t, p, "API key 부재 시 nil 반환")
+}
+
+// TestBuildProvider_LLMDisabled_ReturnsNil 은 LLM_ENABLED=false 시 즉시 nil 반환을 검증합니다.
+func TestBuildProvider_LLMDisabled_ReturnsNil(t *testing.T) {
+	clearLLMEnv(t)
+	t.Setenv("LLM_ENABLED", "false")
+	t.Setenv("GEMINI_API_KEY", "fake-key")
+
+	p := wiring.BuildProvider(logger.New(logger.DefaultConfig()))
+	assert.Nil(t, p, "LLM_ENABLED=false 시 API key 가 있어도 nil")
+}
+
+// TestBuildProvider_SingleKey_ReturnsChainWithOne 은 한 provider 의 key 만 있어도 chain 이 구성되는지 검증합니다.
+// (단일-provider chain 도 graceful — 운영자가 추후 다른 key 추가하면 자동 확장).
+func TestBuildProvider_SingleKey_ReturnsChainWithOne(t *testing.T) {
+	clearLLMEnv(t)
+	t.Setenv("LLM_ENABLED", "true")
+	t.Setenv("GEMINI_API_KEY", "fake-gemini-key")
+
+	p := wiring.BuildProvider(logger.New(logger.DefaultConfig()))
+	require.NotNil(t, p, "단일 provider key 만으로도 chain 구성")
+	// chain.PolicyProvider 는 Name() == "chain" — 외부 호출자에게 단일 provider 와 동일 인터페이스.
+	assert.Equal(t, "chain", p.Name())
+}
+
+// TestBuildProvider_AllKeys_ReturnsChainWithAll 은 3개 provider key 모두 있을 때 chain 이 구성되는지 검증합니다.
+func TestBuildProvider_AllKeys_ReturnsChainWithAll(t *testing.T) {
+	clearLLMEnv(t)
+	t.Setenv("LLM_ENABLED", "true")
+	t.Setenv("GEMINI_API_KEY", "fake-gemini-key")
+	t.Setenv("OPENAI_API_KEY", "fake-openai-key")
+	t.Setenv("ANTHROPIC_API_KEY", "fake-anthropic-key")
+
+	p := wiring.BuildProvider(logger.New(logger.DefaultConfig()))
+	require.NotNil(t, p)
+	assert.Equal(t, "chain", p.Name())
+}
+
+// TestBuildProvider_LLMAPIKeyFallback_OnlyPrimary 는 LLM_API_KEY fallback 이 primary (LLM_PROVIDER) 에만
+// 적용되어 다른 provider 로 cascade 되지 않는지 검증합니다 (이슈 #216).
+//
+// 시나리오: LLM_PROVIDER=anthropic + LLM_API_KEY=anthropic_key 만 설정 — anthropic 만 chain 에 포함.
+// gemini / openai 에는 cascade 되지 않아야 함 (잘못된 key 로 auth 실패하며 chain 시간 낭비 회피).
+func TestBuildProvider_LLMAPIKeyFallback_OnlyPrimary(t *testing.T) {
+	clearLLMEnv(t)
+	t.Setenv("LLM_ENABLED", "true")
+	t.Setenv("LLM_PROVIDER", "anthropic")
+	t.Setenv("LLM_API_KEY", "fallback-key")
+
+	p := wiring.BuildProvider(logger.New(logger.DefaultConfig()))
+	require.NotNil(t, p, "LLM_API_KEY fallback 으로 primary provider 활성화")
+	// chain 인터페이스 자체는 동일 — 내부 활성 provider 수는 로그로 검증 (chain=["anthropic"] 만).
+	assert.Equal(t, "chain", p.Name())
+}

--- a/test/pkg/llm/wiring/wiring_test.go
+++ b/test/pkg/llm/wiring/wiring_test.go
@@ -68,6 +68,19 @@ func TestBuildProvider_AllKeys_ReturnsChainWithAll(t *testing.T) {
 	assert.Equal(t, "chain", p.Name())
 }
 
+// TestBuildProvider_LLMAPIKeyFallback_ClaudeAlias 는 LLM_PROVIDER=claude alias 가 anthropic 으로
+// 정규화되어 LLM_API_KEY fallback 이 정확히 anthropic 항목에 적용되는지 검증합니다 (PR #280 gemini).
+func TestBuildProvider_LLMAPIKeyFallback_ClaudeAlias(t *testing.T) {
+	clearLLMEnv(t)
+	t.Setenv("LLM_ENABLED", "true")
+	t.Setenv("LLM_PROVIDER", "claude")
+	t.Setenv("LLM_API_KEY", "fallback-key")
+
+	p := wiring.BuildProvider(logger.New(logger.DefaultConfig()))
+	require.NotNil(t, p, "claude alias 가 anthropic 으로 정규화되어 chain 에 포함")
+	assert.Equal(t, "chain", p.Name())
+}
+
 // TestBuildProvider_LLMAPIKeyFallback_OnlyPrimary 는 LLM_API_KEY fallback 이 primary (LLM_PROVIDER) 에만
 // 적용되어 다른 provider 로 cascade 되지 않는지 검증합니다 (이슈 #216).
 //


### PR DESCRIPTION
## 연관 이슈
- Closes #216

<br>

## 구현 내용

기존 단일 provider 의존 (`LLM_PROVIDER=gemini`) 에서 **multi-provider fallback chain** 으로 확장. provider 별 API key 가 환경변수에 설정된 만큼 자동으로 chain 에 포함되어 rate_limit / quota / 일시 장애 시 다음 provider 로 위임.

### 순서 정책

**현재**: `gemini → openai → anthropic` 으로 hardcoded — 비용 / 한도 / 가용성 우선순위 기준.

**향후**: metric (cost / latency / 성공률) 기반 dynamic policy 도입 시 `pkg/llm/policy` 의 `CheapestFirst` / `Latency` / `Hybrid` 등으로 교체 예정 (별도 이슈).

### 변경 사항

- **`pkg/config/config.go`**: `LookupLLMAPIKey` export — wiring 이 provider 별 key 조회.
- **`pkg/llm/wiring/wiring.go`**:
  - `fallbackOrder = [gemini, openai, anthropic]` hardcoded
  - 각 provider 의 specific key (`GEMINI_API_KEY` 등) 만 직접 lookup — `config.LookupLLMAPIKey` 의 `LLM_API_KEY` cascade 부작용 회피
  - `LLM_API_KEY` fallback 은 primary (`LLM_PROVIDER`) 1건에만 적용 — backward compat
  - `chain.NewWithPolicy` + `policy.NewFixedOrder(fallbackOrder...)` 로 합성 — **policy 객체 교체로 정책 전환 가능** (기존 PolicyProvider 인프라 적극 활용)
  - 활성 chain 로그: `{chain: [...], primary, policy: "FixedOrder", timeout}`
- **`test/pkg/llm/wiring`**: 5개 케이스 — disabled / no key / single / all / primary fallback only

### 호환성

| 시나리오 | 결과 |
|---|---|
| 기존 `GEMINI_API_KEY` + `LLM_PROVIDER=gemini` | 동일 동작 — `chain=[gemini]` |
| 운영자가 `OPENAI_API_KEY` 추가 | 자동으로 `chain=[gemini, openai]` 확장 |
| `LLM_API_KEY` + `LLM_PROVIDER=anthropic` (구식 설정) | `chain=[anthropic]` (cascade 없음) |
| API key 전혀 없음 | nil 반환 + warn 로그 (기존과 동일) |

### Fallback 위임 동작 (기존 chain 인프라 재사용)

`pkg/llm/chain.shouldDelegate` 가 이미 RateLimit / Auth / Server / Network / ContextLimit 모두 위임 대상으로 처리. 본 PR 은 wiring 만 변경 — 위임 로직은 기존 그대로 활용.

검증된 시나리오 (기존 `test/pkg/llm/chain` 테스트):
- 1번 provider rate_limit → 2번 provider 자동 호출 (`TestChain_FirstFailsRetryable_FallsBackToSecond`)
- 모든 provider 실패 → 마지막 에러 반환 (`TestChain_AllHandlersFail_ReturnsLastError`)
- ContextLimit / Auth / Network 도 위임 (`TestChain_ContextLimit_Delegates` 등)

<br>

## 완료 조건 검증

- [x] `LLM_PROVIDERS=gemini,openai` 시나리오 → 본 PR 은 hardcoded 순서이므로 `GEMINI_API_KEY + OPENAI_API_KEY` 설정만으로 동등 동작
- [x] 단위 테스트: 첫 provider rate_limit → 두 번째 호출 (기존 `test/pkg/llm/chain` 으로 검증됨)
- [x] 로그: 활성 chain 명시 (`chain: [gemini, openai, anthropic], policy: FixedOrder`)

<br>

## CI / 머지 게이트 점검

> [CI 운영 규약](docs/ci/conventions.md) 및 [Required Status Checks 단일 소스](docs/ci/status-checks.md)에 따라 작성합니다.

### 변경 영향 범위
- 영향 패키지/모듈: `pkg/config`, `pkg/llm/wiring`, `test/pkg/llm/wiring`
- 위험도: `Low`
  - 단일-provider 환경은 동작 동일 (chain 길이 1)
  - 신규 provider 키가 없으면 chain 미포함

### Required Status Checks
- 통과 확인 대상:
  - [ ] `Commit Lint`
  - [ ] `PR Title Lint`
  - [ ] `Linked Issue Check`
  - [ ] `Build`
  - [ ] `Test`
  - [ ] `Lint`

### 로컬 검증
- `make fmt` 통과
- `make build` 5개 binary 모두 통과
- `go test -race ./...` 전체 통과 (신규 5건 포함)
- `go vet ./...` 통과

<br>

## 롤백 계획

backward compat 보장 — 기존 환경에서는 동작 변경 없음. 단순 revert 로 즉시 롤백 가능.

🤖 Generated with [Claude Code](https://claude.com/claude-code)