### PR TITLE
[REFAC#285] 통합 PipelineGuard — Scheduler/Publisher 일관 적용 + Category 단명 TTL

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -30,6 +30,10 @@ REDIS_WRITE_TIMEOUT=3s
 REDIS_POOL_SIZE=10
 # Ingestion 중복 제거 lock TTL (이슈 #178)
 REDIS_INGESTION_LOCK_TTL=24h
+# PipelineGuard 의 Category target 전용 단명 TTL (이슈 #285)
+# - Category 는 정기 갱신이 본질이므로 cycle 진행 중 overlap 방지용 짧은 TTL
+# - 정상 흐름은 명시적 Release, 본 TTL 은 worker 충돌 시 fallback
+PIPELINE_GUARD_CATEGORY_TTL=60s
 
 # Kafka 연결 설정 (pkg/queue/config.go 기본값: localhost:9092)
 # 현재 코드에서 환경변수로 read 하지 않음. 별도 이슈에서 wiring 예정.

--- a/cmd/issuetracker/main.go
+++ b/cmd/issuetracker/main.go
@@ -238,13 +238,19 @@ func main() {
 		defer retrySchedulerStop()
 	}
 
-	// URL dedup — Ingestion Lock (이슈 #178, 이슈 #126 의 단일 책임화):
-	// Publisher 가 Kafka enqueue 직전에 정규화 + atomic SETNX 로 진입 marker 잡기.
-	// 진입 후에는 다운스트림 어느 worker 에서도 동일 URL 의 추가 fetch 발생 X (TTL 만료 시까지).
+	// URL dedup — Ingestion Lock (이슈 #178) → Pipeline Guard (이슈 #285) 통합:
+	// Publisher / Scheduler / ParserWorker 가 동일 guard 를 공유하여 target type 별 정책 적용:
+	//   - Article: 24h TTL (기존 IngestionLock 정책 유지)
+	//   - Category: 단명 TTL (default 60s) — cycle 종료 시 명시적 release + TTL fallback
 	jobPublisher.SetNormalizer(links.NewNormalizer())
+	var pipelineGuard *locks.PipelineGuard
 	if ingestionLock != nil {
-		jobPublisher.SetIngestionLock(ingestionLock)
-		log.WithField("ttl", redisCfg.IngestionLockTTL.String()).Info("publisher ingestion lock enabled")
+		pipelineGuard = locks.NewPipelineGuard(ingestionLock, redisCfg.PipelineGuardCategoryTTL)
+		jobPublisher.SetPipelineGuard(pipelineGuard)
+		log.WithFields(map[string]interface{}{
+			"article_ttl":  redisCfg.IngestionLockTTL.String(),
+			"category_ttl": redisCfg.PipelineGuardCategoryTTL.String(),
+		}).Info("publisher pipeline guard enabled (Article 24h / Category 단명)")
 	}
 
 	managerCfg := crawlerWorker.ManagerConfig{
@@ -425,6 +431,12 @@ func main() {
 		log,
 	)
 
+	// ── Pipeline Guard release (이슈 #285) ─────────────────────────────────────
+	// Category cycle 종료 시 marker release — scheduler 다음 주기에 즉시 진입 가능.
+	if pipelineGuard != nil {
+		pw.SetPipelineGuard(pipelineGuard)
+	}
+
 	// ── LLM validate 실패 재큐 (이슈 #237) ───────────────────────────────────
 	// selector 검증 실패 시 raw 를 issuetracker.fetched 에 재발행 — 룰 생성 성공 후 재파싱 기회 부여.
 	// llmGen 이 nil(LLM 비활성) 이면 wiring 불필요.
@@ -501,6 +513,10 @@ func main() {
 	}
 
 	emitter := scheduler.NewJobEmitter(crawlerProducer, log)
+	if pipelineGuard != nil {
+		emitter.SetGuard(pipelineGuard)
+		log.Info("scheduler emitter pipeline guard enabled (이슈 #285)")
+	}
 	entries := scheduler.DefaultEntries(schedulerCfg)
 	sched := scheduler.New(entries, emitter, log, schedulerCfg.MaxRetries)
 

--- a/cmd/issuetracker/main.go
+++ b/cmd/issuetracker/main.go
@@ -515,6 +515,8 @@ func main() {
 	emitter := scheduler.NewJobEmitter(crawlerProducer, log)
 	if pipelineGuard != nil {
 		emitter.SetGuard(pipelineGuard)
+		// publisher 와 동일 normalizer 공유 — marker 키 일관성 (PR #286 gemini 리뷰).
+		emitter.SetNormalizer(links.NewNormalizer())
 		log.Info("scheduler emitter pipeline guard enabled (이슈 #285)")
 	}
 	entries := scheduler.DefaultEntries(schedulerCfg)

--- a/internal/locks/ingestion_lock.go
+++ b/internal/locks/ingestion_lock.go
@@ -39,6 +39,12 @@ type IngestionLock interface {
 	// 두 URL 이 다른 marker 를 갖지 않도록.
 	Acquire(ctx context.Context, url string) (acquired bool, err error)
 
+	// AcquireWithTTL 은 Acquire 와 동일하되 호출별 TTL 을 지정합니다 (이슈 #285).
+	//
+	// 용도: PipelineGuard 가 target type 에 따라 Article (24h) / Category (단명) 로 다른
+	// TTL 적용. ttl<=0 이면 default TTL fallback.
+	AcquireWithTTL(ctx context.Context, url string, ttl time.Duration) (acquired bool, err error)
+
 	// Invalidate 는 명시적으로 URL marker 를 제거합니다 — 운영자 강제 재크롤 시.
 	// 정상 흐름에선 호출하지 않음 (TTL 자연 만료).
 	Invalidate(ctx context.Context, url string) error
@@ -82,6 +88,19 @@ func (l *RedisIngestionLock) Acquire(ctx context.Context, url string) (bool, err
 	return l.locker.AcquireLock(ctx, ingestionKey(url), l.ttl)
 }
 
+// AcquireWithTTL 은 호출별 TTL 로 marker 를 set 시도합니다 (이슈 #285).
+//
+// ttl<=0 이면 RedisIngestionLock 의 default TTL 사용. nil receiver / nil locker 보호는 Acquire 와 동일.
+func (l *RedisIngestionLock) AcquireWithTTL(ctx context.Context, url string, ttl time.Duration) (bool, error) {
+	if l == nil || l.locker == nil {
+		return false, errors.New("ingestion lock locker is nil")
+	}
+	if ttl <= 0 {
+		ttl = l.ttl
+	}
+	return l.locker.AcquireLock(ctx, ingestionKey(url), ttl)
+}
+
 // Invalidate 는 URL marker 를 즉시 제거합니다.
 //
 // nil receiver / nil locker 보호 — Acquire 와 동일 정책.
@@ -110,6 +129,11 @@ type NoopIngestionLock struct{}
 
 // Acquire always returns acquired=true (Noop).
 func (NoopIngestionLock) Acquire(_ context.Context, _ string) (bool, error) { return true, nil }
+
+// AcquireWithTTL always returns acquired=true (Noop) — TTL 인자는 무시.
+func (NoopIngestionLock) AcquireWithTTL(_ context.Context, _ string, _ time.Duration) (bool, error) {
+	return true, nil
+}
 
 // Invalidate is a no-op.
 func (NoopIngestionLock) Invalidate(_ context.Context, _ string) error { return nil }

--- a/internal/locks/pipeline_guard.go
+++ b/internal/locks/pipeline_guard.go
@@ -1,0 +1,83 @@
+package locks
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"issuetracker/internal/processor/fetcher/core"
+)
+
+// DefaultCategoryTTL 은 Category target 의 pipeline guard TTL default 입니다 (이슈 #285).
+//
+// Category 는 정기 갱신이 본질이므로 Article (24h) 보다 훨씬 짧은 TTL.
+// fetch + ParseLinks 한 사이클이 완료될 때까지만 marker 가 유지되도록 — 운영 환경의
+// SCHEDULER_JOB_TIMEOUT (default 30s) 의 2배 정도가 안전망. 명시적 Release 가 정상 흐름이고
+// TTL 은 fallback (worker 가 release 호출 못 하고 죽은 경우 자동 회수).
+const DefaultCategoryTTL = 60 * time.Second
+
+// PipelineGuard 는 publish 진입점에서 \"이 URL 이 현재 파이프라인에 있는가\" 를 체크하는 통합
+// 게이트입니다 (이슈 #285).
+//
+// 의도:
+//
+//	"Scheduler / Publisher / 그 외 publish 진입점이 일관된 시맨틱으로 pipeline 진입을 통제."
+//
+// IngestionLock 을 wrap 하여 target type 별 TTL 정책을 적용:
+//   - Category: 단명 TTL (default 60s) — cycle 완료 시 release 또는 TTL fallback
+//   - Article : 24h TTL (기존 IngestionLock 정책 유지)
+//
+// 향후 다른 target type 추가 시 본 wrapper 만 확장 — 호출자 측 코드 변경 없이.
+type PipelineGuard struct {
+	lock        IngestionLock
+	categoryTTL time.Duration
+}
+
+// NewPipelineGuard 는 IngestionLock 위에 target type 별 TTL 정책을 부여하는 PipelineGuard 를
+// 반환합니다.
+//
+// categoryTTL <= 0 이면 DefaultCategoryTTL 사용.
+// lock 이 nil 이면 NoopIngestionLock 으로 fallback — Redis 미설정 환경에서도 panic 없이 동작.
+func NewPipelineGuard(lock IngestionLock, categoryTTL time.Duration) *PipelineGuard {
+	if lock == nil {
+		lock = NoopIngestionLock{}
+	}
+	if categoryTTL <= 0 {
+		categoryTTL = DefaultCategoryTTL
+	}
+	return &PipelineGuard{lock: lock, categoryTTL: categoryTTL}
+}
+
+// CheckAndAcquire 는 url 의 pipeline 진입 marker 를 target type 에 맞는 TTL 로 set 시도합니다.
+//
+// 반환값:
+//   - acquired=true  : 신규 진입 — 호출자가 publish 진행
+//   - acquired=false : 이미 pipeline 안 (다른 publish 가 marker 점유) — 호출자가 skip
+//   - err != nil     : Redis 일시 장애 등 — 호출자 정책 (보통 fail-open) 으로 처리
+//
+// targetType 별 TTL:
+//   - core.TargetTypeCategory : categoryTTL (단명, default 60s)
+//   - 그 외 (Article 등)       : IngestionLock 의 default TTL (24h)
+func (g *PipelineGuard) CheckAndAcquire(ctx context.Context, url string, targetType core.TargetType) (bool, error) {
+	if g == nil || g.lock == nil {
+		return false, errors.New("pipeline guard lock is nil")
+	}
+	if targetType == core.TargetTypeCategory {
+		return g.lock.AcquireWithTTL(ctx, url, g.categoryTTL)
+	}
+	return g.lock.Acquire(ctx, url)
+}
+
+// Release 는 url 의 pipeline marker 를 즉시 제거합니다.
+//
+// Category cycle 완료 시 fetcher / parser worker 가 호출 — 다음 scheduler 주기에 즉시 진입
+// 가능하도록. Article 도 명시적 release 가능하나 정상 흐름은 24h TTL 만료 (운영자 강제 재크롤
+// 케이스에 한함).
+//
+// nil receiver / nil lock 보호 — Acquire 와 동일.
+func (g *PipelineGuard) Release(ctx context.Context, url string) error {
+	if g == nil || g.lock == nil {
+		return errors.New("pipeline guard lock is nil")
+	}
+	return g.lock.Invalidate(ctx, url)
+}

--- a/internal/locks/pipeline_guard.go
+++ b/internal/locks/pipeline_guard.go
@@ -55,17 +55,24 @@ func NewPipelineGuard(lock IngestionLock, categoryTTL time.Duration) *PipelineGu
 //   - acquired=false : 이미 pipeline 안 (다른 publish 가 marker 점유) — 호출자가 skip
 //   - err != nil     : Redis 일시 장애 등 — 호출자 정책 (보통 fail-open) 으로 처리
 //
-// targetType 별 TTL:
+// targetType 별 TTL (PR #286 gemini 리뷰 — 명시적 switch 로 안전성 강화):
 //   - core.TargetTypeCategory : categoryTTL (단명, default 60s)
-//   - 그 외 (Article 등)       : IngestionLock 의 default TTL (24h)
+//   - core.TargetTypeArticle  : IngestionLock 의 default TTL (24h)
+//   - 그 외 (Sitemap 등 미래 target type) : IngestionLock default TTL fallback
+//     — 새 target type 도입 시 본 switch 에 명시적 case 추가 권장.
 func (g *PipelineGuard) CheckAndAcquire(ctx context.Context, url string, targetType core.TargetType) (bool, error) {
 	if g == nil || g.lock == nil {
 		return false, errors.New("pipeline guard lock is nil")
 	}
-	if targetType == core.TargetTypeCategory {
+	switch targetType {
+	case core.TargetTypeCategory:
 		return g.lock.AcquireWithTTL(ctx, url, g.categoryTTL)
+	case core.TargetTypeArticle:
+		return g.lock.Acquire(ctx, url)
+	default:
+		// 알려지지 않은 target type — default TTL 적용 + Sitemap 등 추가 시 명시적 case 도입 권장.
+		return g.lock.Acquire(ctx, url)
 	}
-	return g.lock.Acquire(ctx, url)
 }
 
 // Release 는 url 의 pipeline marker 를 즉시 제거합니다.

--- a/internal/processor/parser/worker/parser_worker.go
+++ b/internal/processor/parser/worker/parser_worker.go
@@ -78,10 +78,22 @@ type ParserWorker struct {
 	emptyBodyTitleMin   int
 	emptyBodyContentMin int
 
+	// guard: PipelineGuard — Category cycle 종료 시 Release 호출용 (이슈 #285).
+	// nil 허용 — nil 이면 release skip (TTL fallback 으로 자동 회수).
+	guard PipelineGuard
+
 	workerCount int
 	log         *logger.Logger
 
 	wg sync.WaitGroup
+}
+
+// PipelineGuard 는 Category cycle 종료 시 marker 를 release 하기 위한 인터페이스입니다 (이슈 #285).
+//
+// parser_worker 가 internal/locks 를 직접 import 하지 않도록 별도 정의 — 구조적 타이핑으로
+// locks.PipelineGuard 가 그대로 만족.
+type PipelineGuard interface {
+	Release(ctx context.Context, url string) error
 }
 
 // NewParserWorker 는 ParserWorker 를 생성합니다.
@@ -148,6 +160,12 @@ func NewParserWorker(
 		workerCount:         workerCount,
 		log:                 log,
 	}
+}
+
+// SetPipelineGuard 는 Category cycle 완료 시 marker release 용 PipelineGuard 를 주입합니다 (이슈 #285).
+// nil 주입 시 release 비활성 (TTL fallback). Start 호출 전 wiring 단계에서 1회 설정.
+func (w *ParserWorker) SetPipelineGuard(g PipelineGuard) {
+	w.guard = g
 }
 
 // Start 는 worker goroutines 를 기동합니다 (non-blocking).
@@ -285,6 +303,11 @@ func (w *ParserWorker) processMessage(ctx context.Context, msg *queue.Message) e
 }
 
 func (w *ParserWorker) processCategoryPage(ctx context.Context, raw *core.RawContent, rawID, crawlerName string, jobTimeout time.Duration, llmRetryCount int, mlog *logger.Logger) error {
+	// Category cycle 종료 시 PipelineGuard marker release (이슈 #285) — defer 로 어떤 경로
+	// (성공 / handleRuleError / 0 links / publish 실패) 든 release 보장. Release 실패는 non-fatal
+	// (TTL fallback 으로 자동 회수).
+	defer w.releaseCategoryMarker(ctx, raw.URL, mlog)
+
 	if w.parser == nil || w.publisher == nil {
 		mlog.Debug("parser or publisher not configured, skipping category job")
 		w.deleteRaw(ctx, rawID, mlog)
@@ -314,6 +337,23 @@ func (w *ParserWorker) processCategoryPage(ctx context.Context, raw *core.RawCon
 	// 카테고리 페이지는 contents/news_articles 에 저장하지 않음 — raw 즉시 정리
 	w.deleteRaw(ctx, rawID, mlog)
 	return nil
+}
+
+// releaseCategoryMarker 는 Category cycle 종료 시 PipelineGuard marker 를 release 합니다 (이슈 #285).
+//
+// guard 미설정 시 noop. Release 실패는 non-fatal — TTL 만료 fallback 으로 자동 회수.
+// ctx.WithoutCancel 로 parent ctx 취소 신호 분리 — shutdown 중에도 release 시도 보장.
+func (w *ParserWorker) releaseCategoryMarker(ctx context.Context, url string, mlog *logger.Logger) {
+	if w.guard == nil {
+		return
+	}
+	releaseCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 5*time.Second)
+	defer cancel()
+	if err := w.guard.Release(releaseCtx, url); err != nil {
+		mlog.WithFields(map[string]interface{}{
+			"url": url,
+		}).WithError(err).Warn("pipeline guard release failed (non-fatal — TTL fallback)")
+	}
 }
 
 func (w *ParserWorker) processArticlePage(ctx context.Context, raw *core.RawContent, rawID, crawlerName string, llmRetryCount int, mlog *logger.Logger) error {

--- a/internal/processor/parser/worker/parser_worker.go
+++ b/internal/processor/parser/worker/parser_worker.go
@@ -88,10 +88,10 @@ type ParserWorker struct {
 	wg sync.WaitGroup
 }
 
-// PipelineGuard 는 Category cycle 종료 시 marker 를 release 하기 위한 인터페이스입니다 (이슈 #285).
+// PipelineGuard 는 Category cycle 종료 시 marker 를 release 하기 위한 최소 인터페이스입니다 (이슈 #285).
 //
-// parser_worker 가 internal/locks 를 직접 import 하지 않도록 별도 정의 — 구조적 타이핑으로
-// locks.PipelineGuard 가 그대로 만족.
+// parser_worker 는 release 만 필요하므로 locks.PipelineGuard 의 전체 surface 가 아닌 Release 만
+// 노출 — interface segregation 원칙. locks.PipelineGuard 는 구조적 타이핑으로 본 인터페이스 만족.
 type PipelineGuard interface {
 	Release(ctx context.Context, url string) error
 }

--- a/internal/publisher/publisher.go
+++ b/internal/publisher/publisher.go
@@ -38,6 +38,18 @@ type PriorityResolver interface {
 // 구현체는 goroutine-safe 해야 합니다.
 type IngestionLock interface {
 	Acquire(ctx context.Context, url string) (bool, error)
+	// AcquireWithTTL 은 호출별 TTL 로 marker 를 set 시도합니다 (이슈 #285).
+	// publisher 가 target type 별로 다른 TTL (Article=24h / Category=단명) 을 적용.
+	// ttl<=0 이면 구현체 default TTL 적용.
+	AcquireWithTTL(ctx context.Context, url string, ttl time.Duration) (bool, error)
+}
+
+// PipelineGuard 는 publish 진입 시 URL 의 pipeline membership 을 target type 별 정책으로 체크합니다 (이슈 #285).
+//
+// publisher 가 internal/locks 를 직접 import 하지 않도록 별도 정의 — 구조적 타이핑으로
+// locks.PipelineGuard 가 그대로 만족.
+type PipelineGuard interface {
+	CheckAndAcquire(ctx context.Context, url string, targetType core.TargetType) (bool, error)
 }
 
 // Publisher는 크롤된 페이지에서 발견된 URL을 새 CrawlJob으로 변환하여
@@ -64,6 +76,7 @@ type Publisher struct {
 	gate       atomic.Pointer[urlguard.Gate]
 	normalizer atomic.Pointer[links.Normalizer]
 	lock       atomic.Pointer[ingestionLockRef]
+	guard      atomic.Pointer[guardRef]
 	log        *logger.Logger
 }
 
@@ -71,6 +84,11 @@ type Publisher struct {
 // IngestionLock 인터페이스를 감싸 atomic 교체를 지원하는 wrapper 입니다.
 type ingestionLockRef struct {
 	l IngestionLock
+}
+
+// guardRef 는 PipelineGuard 의 atomic 교체용 wrapper 입니다 (이슈 #285).
+type guardRef struct {
+	g PipelineGuard
 }
 
 // New는 새 Publisher를 생성합니다.
@@ -103,12 +121,28 @@ func (p *Publisher) SetNormalizer(n *links.Normalizer) {
 // 설정합니다 (이슈 #178). nil 전달 시 dedup 비활성 (기존 동작 유지).
 //
 // atomic 으로 race-safe 한 swap 보장.
+//
+// Deprecated (이슈 #285): SetPipelineGuard 사용 권장 — target type 별 TTL 정책 적용.
+// 본 메소드는 backward compat 로 유지 — guard 미설정 시 fallback 으로 사용됨.
 func (p *Publisher) SetIngestionLock(l IngestionLock) {
 	if l == nil {
 		p.lock.Store(nil)
 		return
 	}
 	p.lock.Store(&ingestionLockRef{l: l})
+}
+
+// SetPipelineGuard 는 publish 진입 시 target type 별 정책으로 marker 를 잡을 PipelineGuard 를
+// 설정합니다 (이슈 #285).
+//
+// guard 가 설정되어 있으면 IngestionLock 보다 우선 — 모든 target type 에 적용 (Article 24h,
+// Category 단명 TTL). nil 전달 시 가드 비활성 — IngestionLock fallback (있으면).
+func (p *Publisher) SetPipelineGuard(g PipelineGuard) {
+	if g == nil {
+		p.guard.Store(nil)
+		return
+	}
+	p.guard.Store(&guardRef{g: g})
 }
 
 // Publish는 발견된 URL 목록으로 CrawlJob을 생성하고 한 번의 배치 요청으로 Kafka에 발행합니다.
@@ -147,11 +181,17 @@ func (p *Publisher) Publish(
 		}
 	}
 
-	// Ingestion Lock (이슈 #178): atomic SETNX 로 진입 marker 잡기
-	// - TargetTypeCategory 는 lock 미적용 (카테고리는 매 주기 새 기사 추출이 목적)
-	// - lock 조회 실패는 fail-open (해당 URL 통과 + WARN 로그) — Redis 일시 장애로
-	//   publish 가 멈추지 않도록
-	if r := p.lock.Load(); r != nil && targetType != core.TargetTypeCategory {
+	// Pipeline Guard (이슈 #285) / Ingestion Lock (이슈 #178):
+	// - PipelineGuard 우선 — target type 별 TTL 정책 (Article 24h / Category 단명)
+	// - IngestionLock fallback — Article 만 적용 (Category 우회) — backward compat
+	// - 둘 다 미설정 시 dedup 비활성
+	// - 조회 실패는 fail-open — Redis 일시 장애가 publish 를 영구 차단하지 않도록
+	if gr := p.guard.Load(); gr != nil {
+		urls = p.acquireViaGuard(ctx, urls, crawlerName, gr.g, targetType)
+		if len(urls) == 0 {
+			return nil
+		}
+	} else if r := p.lock.Load(); r != nil && targetType != core.TargetTypeCategory {
 		urls = p.acquireIngestion(ctx, urls, crawlerName, r.l)
 		if len(urls) == 0 {
 			return nil
@@ -236,6 +276,39 @@ func (p *Publisher) normalizeURLs(urls []string, n *links.Normalizer, crawlerNam
 // 결과 슬라이스는 입력과 다른 underlying array 로 새로 할당됩니다 (입력 mutate 없음).
 //
 // 성능: crawler/stage sub-logger 를 루프 외부에서 1회 생성하여 재사용.
+// acquireViaGuard 는 PipelineGuard 로 target type 별 TTL 정책을 적용하여 진입 marker 를 잡습니다 (이슈 #285).
+//
+// 동작 정책은 acquireIngestion 과 동일 — fail-open / ctx 취소 / 정규화 가정 등.
+// 차이점: lock.Acquire 대신 guard.CheckAndAcquire(targetType) 호출 — Category 는 단명 TTL 적용.
+func (p *Publisher) acquireViaGuard(ctx context.Context, urls []string, crawlerName string, guard PipelineGuard, targetType core.TargetType) []string {
+	out := make([]string, 0, len(urls))
+	l := p.log.WithFields(map[string]interface{}{
+		"crawler":     crawlerName,
+		"stage":       "publisher",
+		"target_type": string(targetType),
+	})
+
+	for i, url := range urls {
+		if err := ctx.Err(); err != nil {
+			l.WithError(err).Warn("context cancelled during pipeline guard acquire, allowing remaining URLs")
+			return append(out, urls[i:]...)
+		}
+
+		acquired, err := guard.CheckAndAcquire(ctx, url, targetType)
+		if err != nil {
+			l.WithField("url", url).WithError(err).Warn("pipeline guard check failed, allowing publish")
+			out = append(out, url)
+			continue
+		}
+		if !acquired {
+			l.WithField("url", url).Debug("url already in pipeline, skipping publish")
+			continue
+		}
+		out = append(out, url)
+	}
+	return out
+}
+
 func (p *Publisher) acquireIngestion(ctx context.Context, urls []string, crawlerName string, lock IngestionLock) []string {
 	out := make([]string, 0, len(urls))
 	l := p.log.WithFields(map[string]interface{}{

--- a/internal/publisher/publisher.go
+++ b/internal/publisher/publisher.go
@@ -38,10 +38,6 @@ type PriorityResolver interface {
 // 구현체는 goroutine-safe 해야 합니다.
 type IngestionLock interface {
 	Acquire(ctx context.Context, url string) (bool, error)
-	// AcquireWithTTL 은 호출별 TTL 로 marker 를 set 시도합니다 (이슈 #285).
-	// publisher 가 target type 별로 다른 TTL (Article=24h / Category=단명) 을 적용.
-	// ttl<=0 이면 구현체 default TTL 적용.
-	AcquireWithTTL(ctx context.Context, url string, ttl time.Duration) (bool, error)
 }
 
 // PipelineGuard 는 publish 진입 시 URL 의 pipeline membership 을 target type 별 정책으로 체크합니다 (이슈 #285).

--- a/internal/publisher/publisher.go
+++ b/internal/publisher/publisher.go
@@ -263,19 +263,6 @@ func (p *Publisher) normalizeURLs(urls []string, n *links.Normalizer, crawlerNam
 	return out
 }
 
-// acquireIngestion 은 IngestionLock 으로 atomic SETNX 시도 후 marker 를 잡은 URL 만
-// 반환합니다 (이슈 #178).
-//
-//   - acquired=true  : 신규 진입 marker 획득 — 결과 슬라이스에 포함
-//   - acquired=false : 이미 다른 publisher 또는 재배달이 marker 점유 — DEBUG 로그 후 제외
-//   - 조회 실패      : fail-open (결과 슬라이스에 포함) + WARN 로그 — Redis 일시 장애가
-//     publish 를 영구 차단하지 않도록
-//   - ctx 취소       : 즉시 종료하고 남은 URL 은 fail-open 으로 그대로 통과 — 셧다운 중
-//     무의미한 lock 호출/WARN 누적 회피. 후속 PublishBatch 가 ctx 에러로 자연 실패.
-//
-// 결과 슬라이스는 입력과 다른 underlying array 로 새로 할당됩니다 (입력 mutate 없음).
-//
-// 성능: crawler/stage sub-logger 를 루프 외부에서 1회 생성하여 재사용.
 // acquireViaGuard 는 PipelineGuard 로 target type 별 TTL 정책을 적용하여 진입 marker 를 잡습니다 (이슈 #285).
 //
 // 동작 정책은 acquireIngestion 과 동일 — fail-open / ctx 취소 / 정규화 가정 등.
@@ -309,6 +296,22 @@ func (p *Publisher) acquireViaGuard(ctx context.Context, urls []string, crawlerN
 	return out
 }
 
+// acquireIngestion 은 IngestionLock 으로 atomic SETNX 시도 후 marker 를 잡은 URL 만
+// 반환합니다 (이슈 #178).
+//
+//   - acquired=true  : 신규 진입 marker 획득 — 결과 슬라이스에 포함
+//   - acquired=false : 이미 다른 publisher 또는 재배달이 marker 점유 — DEBUG 로그 후 제외
+//   - 조회 실패      : fail-open (결과 슬라이스에 포함) + WARN 로그 — Redis 일시 장애가
+//     publish 를 영구 차단하지 않도록
+//   - ctx 취소       : 즉시 종료하고 남은 URL 은 fail-open 으로 그대로 통과 — 셧다운 중
+//     무의미한 lock 호출/WARN 누적 회피. 후속 PublishBatch 가 ctx 에러로 자연 실패.
+//
+// 결과 슬라이스는 입력과 다른 underlying array 로 새로 할당됩니다 (입력 mutate 없음).
+//
+// 성능: crawler/stage sub-logger 를 루프 외부에서 1회 생성하여 재사용.
+//
+// Deprecated (이슈 #285): SetPipelineGuard 사용 시 acquireViaGuard 가 우선 — 본 메소드는
+// guard 미주입 환경의 backward compat fallback.
 func (p *Publisher) acquireIngestion(ctx context.Context, urls []string, crawlerName string, lock IngestionLock) []string {
 	out := make([]string, 0, len(urls))
 	l := p.log.WithFields(map[string]interface{}{

--- a/internal/publisher/publisher.go
+++ b/internal/publisher/publisher.go
@@ -57,15 +57,18 @@ type PipelineGuard interface {
 //   - 미설정 시 가드 비활성 (기존 동작 유지)
 //   - atomic.Pointer 로 race-safe 한 lock-free 설정/조회 — 워커 동시 실행 중 변경에도 race 없음
 //
-// URL dedup — Ingestion Lock (이슈 #178, 이슈 #126 의 단일 책임화):
+// URL dedup — Pipeline Guard (이슈 #285) / Ingestion Lock (이슈 #178):
 //   - SetNormalizer 로 pkg/links.Normalizer 를 주입하면 publish 직전 모든 URL 정규화
-//     (정규화된 URL 이 Ingestion Lock 키 / Kafka payload / 다운스트림 dedup 모두에 일관)
-//   - SetIngestionLock 으로 IngestionLock 을 설정하면 message build 직전에 atomic SETNX
-//     — 이미 진입한 URL 은 publish 에서 제외 (다운스트림 worker 에서도 다시 차단 불필요)
-//   - TargetTypeCategory 는 lock 미적용 (카테고리 페이지는 매 주기 새 기사 추출이 목적)
+//     (정규화된 URL 이 marker 키 / Kafka payload / 다운스트림 dedup 모두에 일관)
+//   - SetPipelineGuard 우선 — 모든 target type 에 적용:
+//     · TargetTypeCategory: 단명 TTL (default 60s, PIPELINE_GUARD_CATEGORY_TTL)
+//     · TargetTypeArticle : default TTL (24h, REDIS_INGESTION_LOCK_TTL)
+//   - SetIngestionLock fallback (backward compat) — guard 미주입 시:
+//     · TargetTypeArticle 만 적용
+//     · TargetTypeCategory 는 lock 미적용 (legacy 경로 — 카테고리 매 주기 갱신 의도)
 //   - lock 조회 실패는 fail-open (해당 URL publish 진행) — Redis 일시 장애로 publish 가
 //     멈추지 않도록
-//   - 미설정 시 dedup 비활성 (기존 동작 유지)
+//   - 둘 다 미설정 시 dedup 비활성 (기존 동작 유지)
 type Publisher struct {
 	producer   queue.Producer
 	resolver   PriorityResolver

--- a/internal/scheduler/emitter.go
+++ b/internal/scheduler/emitter.go
@@ -19,10 +19,14 @@ var ErrEmitSkipped = errors.New("emit skipped — url already in pipeline")
 
 // PipelineGuard 는 publish 진입 시 URL 의 pipeline membership 을 체크하는 인터페이스입니다 (이슈 #285).
 //
-// emitter 가 internal/locks 를 직접 import 하지 않도록 별도 정의 — 구조적 타이핑으로
-// locks.PipelineGuard 가 그대로 만족.
+// emitter 가 internal/locks 의 전체 surface 가 아닌 필요한 메소드만 노출 — interface segregation.
+// locks.PipelineGuard 는 구조적 타이핑으로 본 인터페이스 만족.
+//
+// Release: CheckAndAcquire 가 marker 를 잡았으나 후속 producer.Publish 가 실패한 경우 marker 를
+// 즉시 해제 — 다음 retry 가 silent skip 으로 잃어버리지 않도록 (PR #286 CodeRabbit 리뷰).
 type PipelineGuard interface {
 	CheckAndAcquire(ctx context.Context, url string, targetType core.TargetType) (bool, error)
+	Release(ctx context.Context, url string) error
 }
 
 // JobEmitter는 Scheduler 전용 Emitter 구현체입니다.
@@ -60,16 +64,18 @@ func (e *JobEmitter) SetNormalizer(n *links.Normalizer) { e.normalizer = n }
 // PipelineGuard 가 주입되어 있고 같은 URL 의 cycle 이 진행 중이면 (acquired=false) silent skip
 // (debug 로그 + nil 반환). guard 조회 실패는 fail-open (warn 로그 + publish 진행).
 func (e *JobEmitter) Emit(ctx context.Context, job *core.CrawlJob) error {
-	if e.guard != nil {
-		// guard 키 일관성 (PR #286 gemini): publisher 도 동일 normalizer 적용 후 CheckAndAcquire 함.
-		// scheduler 에서도 같은 정규형으로 marker 잡아야 동일 URL 이 두 입구에서 같은 키 사용.
-		// 정규화 실패는 fail-open — 원본으로 fallback (정규화 자체 장애가 emit 차단 회피).
-		guardURL := job.Target.URL
-		if e.normalizer != nil {
-			if normalized, nerr := e.normalizer.Normalize(guardURL); nerr == nil && normalized != "" {
-				guardURL = normalized
-			}
+	// guard 키 일관성 (PR #286 gemini): publisher 도 동일 normalizer 적용 후 CheckAndAcquire 함.
+	// scheduler 에서도 같은 정규형으로 marker 잡아야 동일 URL 이 두 입구에서 같은 키 사용.
+	// 정규화 실패는 fail-open — 원본으로 fallback (정규화 자체 장애가 emit 차단 회피).
+	guardURL := job.Target.URL
+	if e.normalizer != nil {
+		if normalized, nerr := e.normalizer.Normalize(guardURL); nerr == nil && normalized != "" {
+			guardURL = normalized
 		}
+	}
+	guardAcquired := false // publish 실패 시 release 호출 여부 추적 (PR #286 CodeRabbit 리뷰)
+
+	if e.guard != nil {
 		acquired, gerr := e.guard.CheckAndAcquire(ctx, guardURL, job.Target.Type)
 		if gerr != nil {
 			e.log.WithFields(map[string]interface{}{
@@ -85,11 +91,14 @@ func (e *JobEmitter) Emit(ctx context.Context, job *core.CrawlJob) error {
 				"target_type": string(job.Target.Type),
 			}).Debug("scheduler emit skipped — url already in pipeline")
 			return ErrEmitSkipped
+		} else {
+			guardAcquired = true
 		}
 	}
 
 	data, err := job.Marshal()
 	if err != nil {
+		e.releaseGuardOnFailure(ctx, guardURL, guardAcquired, job)
 		return fmt.Errorf("marshal job %s: %w", job.ID, err)
 	}
 
@@ -106,6 +115,9 @@ func (e *JobEmitter) Emit(ctx context.Context, job *core.CrawlJob) error {
 	}
 
 	if err := e.producer.Publish(ctx, msg); err != nil {
+		// publish 실패 시 marker 즉시 해제 — 다음 retry 가 false acquired 로 silent skip 되지 않도록
+		// (PR #286 CodeRabbit 리뷰).
+		e.releaseGuardOnFailure(ctx, guardURL, guardAcquired, job)
 		return fmt.Errorf("emit job %s to %s: %w", job.ID, topic, err)
 	}
 
@@ -118,6 +130,23 @@ func (e *JobEmitter) Emit(ctx context.Context, job *core.CrawlJob) error {
 	}).Debug("seed job emitted to kafka")
 
 	return nil
+}
+
+// releaseGuardOnFailure 는 CheckAndAcquire 가 marker 를 잡았으나 후속 marshal/publish 가 실패한 경우
+// marker 를 즉시 해제합니다 (PR #286 CodeRabbit 리뷰).
+//
+// guardAcquired=false 이거나 guard=nil 이면 noop. Release 실패는 non-fatal — TTL fallback 으로
+// 자연 해제 (Category 60s).
+func (e *JobEmitter) releaseGuardOnFailure(ctx context.Context, url string, guardAcquired bool, job *core.CrawlJob) {
+	if !guardAcquired || e.guard == nil {
+		return
+	}
+	if rerr := e.guard.Release(ctx, url); rerr != nil {
+		e.log.WithFields(map[string]interface{}{
+			"job_id": job.ID,
+			"url":    url,
+		}).WithError(rerr).Warn("pipeline guard release failed after publish error (TTL fallback applies)")
+	}
 }
 
 // crawlTopic은 Priority에 대응하는 Kafka crawl 토픽 이름을 반환합니다.

--- a/internal/scheduler/emitter.go
+++ b/internal/scheduler/emitter.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 
 	"issuetracker/internal/processor/fetcher/core"
+	"issuetracker/pkg/links"
 	"issuetracker/pkg/logger"
 	"issuetracker/pkg/queue"
 )
@@ -32,9 +33,10 @@ type PipelineGuard interface {
 // cycle 이 진행 중이면 silent skip. Scheduler 의 정기 갱신 의도는 보존 (다음 주기 자연 진입).
 // 미주입 (nil) 이면 가드 비활성 (기존 동작 유지).
 type JobEmitter struct {
-	producer queue.Producer
-	guard    PipelineGuard
-	log      *logger.Logger
+	producer   queue.Producer
+	guard      PipelineGuard
+	normalizer *links.Normalizer
+	log        *logger.Logger
 }
 
 // NewJobEmitter는 새 JobEmitter를 생성합니다.
@@ -46,13 +48,29 @@ func NewJobEmitter(producer queue.Producer, log *logger.Logger) *JobEmitter {
 // nil 주입 시 가드 비활성. Emit 호출 도중 변경하지 말 것 (race) — wiring 단계에서 1회.
 func (e *JobEmitter) SetGuard(g PipelineGuard) { e.guard = g }
 
+// SetNormalizer 는 guard 호출 전 URL 정규화에 사용할 Normalizer 를 주입합니다 (PR #286 gemini 리뷰).
+//
+// publisher 가 SetNormalizer 로 사용하는 것과 동일 normalizer 를 공유해야 marker 키가 일치 —
+// 같은 logical URL 이 다른 입구 (scheduler / publisher) 에서 다른 Redis 키를 갖지 않도록.
+// nil 주입 시 정규화 비활성 (entry.URL 원본 그대로 guard 에 전달).
+func (e *JobEmitter) SetNormalizer(n *links.Normalizer) { e.normalizer = n }
+
 // Emit은 job.Priority에 따라 Kafka crawl 토픽에 CrawlJob을 발행합니다.
 //
 // PipelineGuard 가 주입되어 있고 같은 URL 의 cycle 이 진행 중이면 (acquired=false) silent skip
 // (debug 로그 + nil 반환). guard 조회 실패는 fail-open (warn 로그 + publish 진행).
 func (e *JobEmitter) Emit(ctx context.Context, job *core.CrawlJob) error {
 	if e.guard != nil {
-		acquired, gerr := e.guard.CheckAndAcquire(ctx, job.Target.URL, job.Target.Type)
+		// guard 키 일관성 (PR #286 gemini): publisher 도 동일 normalizer 적용 후 CheckAndAcquire 함.
+		// scheduler 에서도 같은 정규형으로 marker 잡아야 동일 URL 이 두 입구에서 같은 키 사용.
+		// 정규화 실패는 fail-open — 원본으로 fallback (정규화 자체 장애가 emit 차단 회피).
+		guardURL := job.Target.URL
+		if e.normalizer != nil {
+			if normalized, nerr := e.normalizer.Normalize(guardURL); nerr == nil && normalized != "" {
+				guardURL = normalized
+			}
+		}
+		acquired, gerr := e.guard.CheckAndAcquire(ctx, guardURL, job.Target.Type)
 		if gerr != nil {
 			e.log.WithFields(map[string]interface{}{
 				"job_id":  job.ID,

--- a/internal/scheduler/emitter.go
+++ b/internal/scheduler/emitter.go
@@ -2,12 +2,19 @@ package scheduler
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"issuetracker/internal/processor/fetcher/core"
 	"issuetracker/pkg/logger"
 	"issuetracker/pkg/queue"
 )
+
+// ErrEmitSkipped 는 PipelineGuard 가 \"이미 in-pipeline\" 으로 판단해 emit 을 건너뛴 경우 반환됩니다 (이슈 #285).
+//
+// 호출자는 errors.Is(err, ErrEmitSkipped) 로 분기하여 \"failed to publish\" / \"scheduled\" 로그를
+// 모두 생략 — 실제로 발행되지 않은 job 이 발행된 것처럼 보이는 misleading 로그 회피 (PR #286 리뷰).
+var ErrEmitSkipped = errors.New("emit skipped — url already in pipeline")
 
 // PipelineGuard 는 publish 진입 시 URL 의 pipeline membership 을 체크하는 인터페이스입니다 (이슈 #285).
 //
@@ -59,7 +66,7 @@ func (e *JobEmitter) Emit(ctx context.Context, job *core.CrawlJob) error {
 				"url":         job.Target.URL,
 				"target_type": string(job.Target.Type),
 			}).Debug("scheduler emit skipped — url already in pipeline")
-			return nil
+			return ErrEmitSkipped
 		}
 	}
 

--- a/internal/scheduler/emitter.go
+++ b/internal/scheduler/emitter.go
@@ -9,11 +9,24 @@ import (
 	"issuetracker/pkg/queue"
 )
 
+// PipelineGuard 는 publish 진입 시 URL 의 pipeline membership 을 체크하는 인터페이스입니다 (이슈 #285).
+//
+// emitter 가 internal/locks 를 직접 import 하지 않도록 별도 정의 — 구조적 타이핑으로
+// locks.PipelineGuard 가 그대로 만족.
+type PipelineGuard interface {
+	CheckAndAcquire(ctx context.Context, url string, targetType core.TargetType) (bool, error)
+}
+
 // JobEmitter는 Scheduler 전용 Emitter 구현체입니다.
 // ScheduleEntry에 이미 결정된 Priority를 그대로 사용하여 Kafka crawl 토픽에 직접 발행합니다.
 // 우선순위 재결정이 필요한 체이닝 발행은 internal/publisher 패키지를 사용하세요.
+//
+// PipelineGuard (이슈 #285): SetGuard 로 주입 시 Emit 직전에 CheckAndAcquire 호출 — 같은 URL 의
+// cycle 이 진행 중이면 silent skip. Scheduler 의 정기 갱신 의도는 보존 (다음 주기 자연 진입).
+// 미주입 (nil) 이면 가드 비활성 (기존 동작 유지).
 type JobEmitter struct {
 	producer queue.Producer
+	guard    PipelineGuard
 	log      *logger.Logger
 }
 
@@ -22,8 +35,34 @@ func NewJobEmitter(producer queue.Producer, log *logger.Logger) *JobEmitter {
 	return &JobEmitter{producer: producer, log: log}
 }
 
+// SetGuard 는 PipelineGuard 를 주입합니다 (이슈 #285).
+// nil 주입 시 가드 비활성. Emit 호출 도중 변경하지 말 것 (race) — wiring 단계에서 1회.
+func (e *JobEmitter) SetGuard(g PipelineGuard) { e.guard = g }
+
 // Emit은 job.Priority에 따라 Kafka crawl 토픽에 CrawlJob을 발행합니다.
+//
+// PipelineGuard 가 주입되어 있고 같은 URL 의 cycle 이 진행 중이면 (acquired=false) silent skip
+// (debug 로그 + nil 반환). guard 조회 실패는 fail-open (warn 로그 + publish 진행).
 func (e *JobEmitter) Emit(ctx context.Context, job *core.CrawlJob) error {
+	if e.guard != nil {
+		acquired, gerr := e.guard.CheckAndAcquire(ctx, job.Target.URL, job.Target.Type)
+		if gerr != nil {
+			e.log.WithFields(map[string]interface{}{
+				"job_id":  job.ID,
+				"crawler": job.CrawlerName,
+				"url":     job.Target.URL,
+			}).WithError(gerr).Warn("pipeline guard check failed, allowing emit")
+		} else if !acquired {
+			e.log.WithFields(map[string]interface{}{
+				"job_id":      job.ID,
+				"crawler":     job.CrawlerName,
+				"url":         job.Target.URL,
+				"target_type": string(job.Target.Type),
+			}).Debug("scheduler emit skipped — url already in pipeline")
+			return nil
+		}
+	}
+
 	data, err := job.Marshal()
 	if err != nil {
 		return fmt.Errorf("marshal job %s: %w", job.ID, err)

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/rand"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"sync"
 	"sync/atomic"
@@ -177,6 +178,11 @@ func (s *Scheduler) publish(ctx context.Context, entry ScheduleEntry) {
 	}
 
 	if err := s.emitter.Emit(ctx, job); err != nil {
+		// ErrEmitSkipped (이슈 #285): PipelineGuard 가 cycle 진행 중 판단으로 skip — non-fatal.
+		// "scheduled" / "failed" 양쪽 로그 모두 생략 (실제 발행 안 된 job 이 발행된 것처럼 보이지 않게).
+		if errors.Is(err, ErrEmitSkipped) {
+			return
+		}
 		s.log.WithFields(map[string]interface{}{
 			"job_id":  job.ID,
 			"crawler": entry.CrawlerName,

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -887,20 +887,27 @@ type RedisConfig struct {
 	// publisher 가 atomic SETNX 로 marker 를 잡고, 본 TTL 만료 시 자연스럽게 재크롤 가능.
 	// 환경변수: REDIS_INGESTION_LOCK_TTL (default 24h).
 	IngestionLockTTL time.Duration
+
+	// PipelineGuardCategoryTTL: PipelineGuard 의 Category target 전용 단명 TTL (이슈 #285).
+	// fetch + ParseLinks 한 cycle 진행 중에만 marker 유지 — 정상 흐름은 명시적 Release,
+	// 본 TTL 은 fallback (worker 가 release 호출 못 하고 죽은 경우 자동 회수).
+	// 환경변수: PIPELINE_GUARD_CATEGORY_TTL (default 60s).
+	PipelineGuardCategoryTTL time.Duration
 }
 
 // DefaultRedisConfig는 로컬 개발 환경용 기본 RedisConfig를 반환합니다.
 func DefaultRedisConfig() RedisConfig {
 	return RedisConfig{
-		Host:             "localhost",
-		Port:             6379,
-		Password:         "",
-		DB:               0,
-		DialTimeout:      5 * time.Second,
-		ReadTimeout:      3 * time.Second,
-		WriteTimeout:     3 * time.Second,
-		PoolSize:         10,
-		IngestionLockTTL: 24 * time.Hour,
+		Host:                     "localhost",
+		Port:                     6379,
+		Password:                 "",
+		DB:                       0,
+		DialTimeout:              5 * time.Second,
+		ReadTimeout:              3 * time.Second,
+		WriteTimeout:             3 * time.Second,
+		PoolSize:                 10,
+		IngestionLockTTL:         24 * time.Hour,
+		PipelineGuardCategoryTTL: 60 * time.Second,
 	}
 }
 
@@ -991,6 +998,16 @@ func LoadRedis(envFiles ...string) (RedisConfig, error) {
 			return RedisConfig{}, fmt.Errorf("invalid REDIS_INGESTION_LOCK_TTL %q: must be positive", v)
 		}
 		cfg.IngestionLockTTL = d
+	}
+	if v := os.Getenv("PIPELINE_GUARD_CATEGORY_TTL"); v != "" {
+		d, err := time.ParseDuration(v)
+		if err != nil {
+			return RedisConfig{}, fmt.Errorf("parse PIPELINE_GUARD_CATEGORY_TTL %q: %w", v, err)
+		}
+		if d <= 0 {
+			return RedisConfig{}, fmt.Errorf("invalid PIPELINE_GUARD_CATEGORY_TTL %q: must be positive", v)
+		}
+		cfg.PipelineGuardCategoryTTL = d
 	}
 
 	return cfg, nil

--- a/test/internal/locks/pipeline_guard_test.go
+++ b/test/internal/locks/pipeline_guard_test.go
@@ -1,0 +1,122 @@
+package locks_test
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"issuetracker/internal/locks"
+	"issuetracker/internal/processor/fetcher/core"
+)
+
+// recordingLocker — TTL 기록 가능한 fakeRedisLocker variant. category vs article TTL 검증용.
+type recordingLocker struct {
+	mu      sync.Mutex
+	keys    map[string]struct{}
+	lastTTL time.Duration
+}
+
+func (r *recordingLocker) AcquireLock(_ context.Context, key string, ttl time.Duration) (bool, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.lastTTL = ttl
+	if _, ok := r.keys[key]; ok {
+		return false, nil
+	}
+	r.keys[key] = struct{}{}
+	return true, nil
+}
+
+func (r *recordingLocker) ReleaseLock(_ context.Context, key string) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	delete(r.keys, key)
+	return nil
+}
+
+func (r *recordingLocker) ttl() time.Duration {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.lastTTL
+}
+
+// TestPipelineGuard_CategoryUsesShortTTL 는 Category target 호출 시 short TTL 이 적용되는지 검증합니다 (이슈 #285).
+func TestPipelineGuard_CategoryUsesShortTTL(t *testing.T) {
+	rl := &recordingLocker{keys: make(map[string]struct{})}
+	lock := locks.NewRedisIngestionLock(rl, 24*time.Hour)
+	guard := locks.NewPipelineGuard(lock, 60*time.Second)
+
+	acquired, err := guard.CheckAndAcquire(context.Background(), "https://example.com/category", core.TargetTypeCategory)
+	require.NoError(t, err)
+	assert.True(t, acquired)
+	assert.Equal(t, 60*time.Second, rl.ttl(), "Category 는 단명 TTL 적용")
+}
+
+// TestPipelineGuard_ArticleUsesDefaultTTL 는 Article target 호출 시 IngestionLock default TTL (24h) 적용을 검증합니다.
+func TestPipelineGuard_ArticleUsesDefaultTTL(t *testing.T) {
+	rl := &recordingLocker{keys: make(map[string]struct{})}
+	lock := locks.NewRedisIngestionLock(rl, 24*time.Hour)
+	guard := locks.NewPipelineGuard(lock, 60*time.Second)
+
+	acquired, err := guard.CheckAndAcquire(context.Background(), "https://example.com/article", core.TargetTypeArticle)
+	require.NoError(t, err)
+	assert.True(t, acquired)
+	assert.Equal(t, 24*time.Hour, rl.ttl(), "Article 은 IngestionLock default TTL (24h) 적용")
+}
+
+// TestPipelineGuard_DuplicateAcquireReturnsFalse 는 같은 URL 두 번 acquire 시 두 번째는 false 반환을 검증합니다.
+func TestPipelineGuard_DuplicateAcquireReturnsFalse(t *testing.T) {
+	rl := &recordingLocker{keys: make(map[string]struct{})}
+	lock := locks.NewRedisIngestionLock(rl, 24*time.Hour)
+	guard := locks.NewPipelineGuard(lock, 60*time.Second)
+	url := "https://example.com/x"
+
+	acquired1, err := guard.CheckAndAcquire(context.Background(), url, core.TargetTypeCategory)
+	require.NoError(t, err)
+	assert.True(t, acquired1)
+
+	acquired2, err := guard.CheckAndAcquire(context.Background(), url, core.TargetTypeCategory)
+	require.NoError(t, err)
+	assert.False(t, acquired2, "이미 marker 점유 — 두 번째는 false")
+}
+
+// TestPipelineGuard_ReleaseAllowsReacquire 는 Release 후 다시 acquire 가능한지 검증합니다.
+func TestPipelineGuard_ReleaseAllowsReacquire(t *testing.T) {
+	rl := &recordingLocker{keys: make(map[string]struct{})}
+	lock := locks.NewRedisIngestionLock(rl, 24*time.Hour)
+	guard := locks.NewPipelineGuard(lock, 60*time.Second)
+	url := "https://example.com/x"
+
+	_, err := guard.CheckAndAcquire(context.Background(), url, core.TargetTypeCategory)
+	require.NoError(t, err)
+
+	require.NoError(t, guard.Release(context.Background(), url))
+
+	acquired, err := guard.CheckAndAcquire(context.Background(), url, core.TargetTypeCategory)
+	require.NoError(t, err)
+	assert.True(t, acquired, "Release 후 즉시 재진입 가능")
+}
+
+// TestPipelineGuard_NilLockFallsBackToNoop 는 lock=nil 주입 시 NoopIngestionLock 으로 fallback 되는지 검증합니다.
+func TestPipelineGuard_NilLockFallsBackToNoop(t *testing.T) {
+	guard := locks.NewPipelineGuard(nil, 60*time.Second)
+	acquired, err := guard.CheckAndAcquire(context.Background(), "x", core.TargetTypeCategory)
+	require.NoError(t, err)
+	assert.True(t, acquired, "Noop fallback — 항상 acquired=true")
+	require.NoError(t, guard.Release(context.Background(), "x"), "Noop fallback — Release 도 noop")
+}
+
+// TestPipelineGuard_ZeroTTLUsesDefault 는 categoryTTL=0 주입 시 DefaultCategoryTTL fallback 검증.
+func TestPipelineGuard_ZeroTTLUsesDefault(t *testing.T) {
+	rl := &recordingLocker{keys: make(map[string]struct{})}
+	lock := locks.NewRedisIngestionLock(rl, 24*time.Hour)
+	guard := locks.NewPipelineGuard(lock, 0)
+
+	_, err := guard.CheckAndAcquire(context.Background(), "x", core.TargetTypeCategory)
+	require.NoError(t, err)
+	assert.Equal(t, locks.DefaultCategoryTTL, rl.ttl())
+}

--- a/test/internal/publisher/publisher_ingestion_lock_test.go
+++ b/test/internal/publisher/publisher_ingestion_lock_test.go
@@ -43,6 +43,10 @@ func (f *fakeIngestionLock) Acquire(_ context.Context, url string) (bool, error)
 	return true, nil
 }
 
+func (f *fakeIngestionLock) AcquireWithTTL(ctx context.Context, url string, _ time.Duration) (bool, error) {
+	return f.Acquire(ctx, url)
+}
+
 // PublishBatch payload helpers reused from gate test pattern.
 type lockMockProducer struct {
 	mu       sync.Mutex

--- a/test/internal/publisher/publisher_ingestion_lock_test.go
+++ b/test/internal/publisher/publisher_ingestion_lock_test.go
@@ -43,10 +43,6 @@ func (f *fakeIngestionLock) Acquire(_ context.Context, url string) (bool, error)
 	return true, nil
 }
 
-func (f *fakeIngestionLock) AcquireWithTTL(ctx context.Context, url string, _ time.Duration) (bool, error) {
-	return f.Acquire(ctx, url)
-}
-
 // PublishBatch payload helpers reused from gate test pattern.
 type lockMockProducer struct {
 	mu       sync.Mutex


### PR DESCRIPTION
## 연관 이슈
- Closes #285

<br>

## 구현 내용

라이브 검증 (2026-05-06, 1h 53m) 의 `url already in pipeline` **11,391건** 노이즈 분석 결과, parser 가 카테고리 페이지에서 article URL 을 추출해 publish 할 때 24h IngestionLock 이 정상 차단하지만 publish 시도 자체 (정규화 / Gate / Redis SETNX) 비용이 발생. 또한 시나리오 C (카테고리 URL 이 article 로 잘못 추출) 도 동일 경로로만 차단.

본 PR 은 **IngestionLock 의 적용 범위를 모든 publish 진입점으로 확장** + **Category 에 단명 TTL 도입** — Scheduler 의 정기 갱신 의도는 보존.

### 변경점 8가지

| # | 위치 | 내용 |
|---|---|---|
| 1 | `internal/locks/ingestion_lock.go` | `IngestionLock` 인터페이스에 `AcquireWithTTL` 추가 (호출별 TTL override). RedisIngestionLock / NoopIngestionLock 양쪽 구현 |
| 2 | `internal/locks/pipeline_guard.go` (신규) | `PipelineGuard` 신설. Category=단명 TTL / Article=default TTL. `Release` 메소드 |
| 3 | `pkg/config/config.go` | `PIPELINE_GUARD_CATEGORY_TTL` 환경변수 (default 60s) |
| 4 | `internal/scheduler/emitter.go` | `JobEmitter.SetGuard` + Emit 직전 CheckAndAcquire |
| 5 | `internal/publisher/publisher.go` | `SetPipelineGuard` 추가. guard 우선, IngestionLock fallback (backward compat). Category 우회 제거 |
| 6 | `internal/processor/parser/worker/parser_worker.go` | `SetPipelineGuard` + processCategoryPage defer 로 release 호출 |
| 7 | `cmd/issuetracker/main.go` | pipelineGuard 구성 후 publisher / emitter / pw 모두에 주입 |
| 8 | `.env.example` | `PIPELINE_GUARD_CATEGORY_TTL` 주석 + default |

### 테스트 6건 (`test/internal/locks/pipeline_guard_test.go`)

- Category 단명 TTL 적용 검증
- Article default TTL 적용 검증
- 중복 acquire false 반환
- Release 후 재진입
- nil lock fallback (Noop)
- 0 TTL fallback to DefaultCategoryTTL

### 기대 효과 (라이브 검증 기준)

| 항목 | 현재 | 적용 후 |
|---|---|---|
| `url already in pipeline` Debug 로그 | 11,391건 | 거의 0 (publish 시도 전 차단) |
| Publisher 호출 비용 (정규화 / Gate / Redis) | 11,391회 발생 | 시도 자체 차단 |
| 카테고리 cycle overlap | 가능 (lock 우회) | 차단 |
| Scheduler 정기 갱신 (2h 주기) | 정상 | 동일 (TTL 60s 라 영향 없음) |

<br>

## CI / 머지 게이트 점검

> [CI 운영 규약](docs/ci/conventions.md) 및 [Required Status Checks 단일 소스](docs/ci/status-checks.md)에 따라 작성합니다.

### 변경 영향 범위
- 영향 패키지: `internal/locks`, `internal/scheduler`, `internal/publisher`, `internal/processor/parser/worker`, `pkg/config`, `cmd/issuetracker`
- 위험도: `Medium`
  - PipelineGuard 미주입 시 기존 IngestionLock fallback 으로 backward compat 보장
  - Redis 일시 장애 시 fail-open (publish 진행)
  - Release 실패는 non-fatal (TTL fallback)

### Required Status Checks
- 통과 확인 대상:
  - [ ] `Commit Lint`
  - [ ] `PR Title Lint`
  - [ ] `Linked Issue Check`
  - [ ] `Build`
  - [ ] `Test`
  - [ ] `Lint`

### 로컬 검증
- `make fmt` 통과
- `make build` 5개 binary 모두 통과
- `go test -race ./...` 전체 통과 (신규 6건 포함)
- `go vet ./...` 통과

<br>

## 롤백 계획

- 모든 새 메소드는 backward compat — guard 미주입 시 기존 동작 유지
- 환경변수 미설정 시 default 60s 적용 (운영 영향 없음)
- 단순 revert 만으로 즉시 롤백 가능

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Pipeline processing now includes coordinated handling mechanisms across all processing stages
  * Improved system resilience with automatic fallback mechanisms for critical operations

* **Configuration**
  * Added `PIPELINE_GUARD_CATEGORY_TTL` environment variable (default: 60s) for configuring category processing behavior

* **Tests**
  * Comprehensive test coverage added for pipeline coordination and fallback scenarios

<!-- end of auto-generated comment: release notes by coderabbit.ai -->