### PR TITLE
[FIX#287] Resolver.HasAnyRule + parser_worker disabled 룰 인식

### DIFF
--- a/internal/processor/parser/rule/resolver.go
+++ b/internal/processor/parser/rule/resolver.go
@@ -54,10 +54,21 @@ type Resolver struct {
 	cache map[cacheKey]cacheEntry
 	now   func() time.Time // 테스트 주입 (실시각 → fake clock)
 
+	// hasAnyCache 는 HasAnyRule 결과 (exists, hasEnabled) 를 보관합니다 (이슈 #287).
+	// negativeCacheTTL 과 동일 짧은 TTL — disabled 룰 토글 / 신규 룰 학습이 빠르게 반영되도록.
+	hasAnyCache map[cacheKey]hasAnyEntry
+
 	// regexCache 는 path_pattern 별 compile 결과를 보관합니다 (이슈 #173).
 	// 같은 패턴의 재컴파일을 회피 — 운영 중 동일 host 의 후보 슬라이스가 cache 만료 시마다
 	// 다시 fetch 되어도 regex 객체는 재사용. sync.Map 으로 lock-free read.
 	regexCache sync.Map // map[string]*compiledPattern
+}
+
+// hasAnyEntry 는 HasAnyRule 결과 캐시 entry 입니다 (이슈 #287).
+type hasAnyEntry struct {
+	exists     bool
+	hasEnabled bool
+	expiresAt  time.Time
 }
 
 // compiledPattern 은 path_pattern 의 컴파일 결과 (또는 컴파일 실패) 를 보관합니다.
@@ -117,6 +128,7 @@ func NewResolver(repo storage.ParsingRuleRepository, opts ...Option) (*Resolver,
 		negativeCacheTTL: DefaultNegativeCacheTTL,
 		maxEntries:       DefaultMaxCacheEntries,
 		cache:            make(map[cacheKey]cacheEntry),
+		hasAnyCache:      make(map[cacheKey]hasAnyEntry),
 		now:              time.Now,
 	}
 	for _, o := range opts {
@@ -213,10 +225,14 @@ func (r *Resolver) compileRegex(pattern string) *compiledPattern {
 }
 
 // Invalidate 는 (host, type) 의 cache entry 를 즉시 제거합니다 — 운영자가 rule 변경 직후 호출.
+//
+// 이슈 #287: hasAnyCache 도 함께 invalidate — 룰 INSERT/UPDATE/DELETE 시 enabled 상태 변동 가능.
 func (r *Resolver) Invalidate(host string, targetType storage.TargetType) {
 	host = strings.ToLower(host)
+	key := cacheKey{host: host, targetType: targetType}
 	r.mu.Lock()
-	delete(r.cache, cacheKey{host: host, targetType: targetType})
+	delete(r.cache, key)
+	delete(r.hasAnyCache, key)
 	r.mu.Unlock()
 }
 
@@ -224,7 +240,48 @@ func (r *Resolver) Invalidate(host string, targetType storage.TargetType) {
 func (r *Resolver) InvalidateAll() {
 	r.mu.Lock()
 	r.cache = make(map[cacheKey]cacheEntry)
+	r.hasAnyCache = make(map[cacheKey]hasAnyEntry)
 	r.mu.Unlock()
+}
+
+// HasAnyRule 은 (host, target_type) 룰의 존재 여부 + enabled 여부를 short-TTL 캐시 + DB lookup 으로 반환합니다 (이슈 #287).
+//
+// 반환:
+//   - exists     : enabled / disabled 무관 row 존재 여부
+//   - hasEnabled : enabled=TRUE row 존재 여부
+//   - err        : DB 조회 실패 (캐시 hit 시 nil)
+//
+// 용도: parser_worker 의 ErrNoRule 분기에서 \"진짜 부재\" 와 \"운영자 disable 잔존\" 을 구분 —
+// 후자는 LLM 재학습 트리거 회피 (수동 재활성 영역).
+//
+// 캐시 정책:
+//   - TTL = negativeCacheTTL (default 30s) — Resolve 의 negative cache 와 동일 짧은 TTL
+//     운영자 enabled 토글 / 신규 INSERT 가 빠르게 반영되도록.
+//   - Invalidate(host, type) 호출 시 본 캐시도 함께 무효화 — Resolve 캐시와 일관.
+func (r *Resolver) HasAnyRule(ctx context.Context, host string, targetType storage.TargetType) (exists, hasEnabled bool, err error) {
+	host = strings.ToLower(host)
+	key := cacheKey{host: host, targetType: targetType}
+
+	r.mu.RLock()
+	if entry, ok := r.hasAnyCache[key]; ok && r.now().Before(entry.expiresAt) {
+		r.mu.RUnlock()
+		return entry.exists, entry.hasEnabled, nil
+	}
+	r.mu.RUnlock()
+
+	exists, hasEnabled, err = r.repo.HasAnyRule(ctx, host, targetType)
+	if err != nil {
+		return false, false, err
+	}
+
+	r.mu.Lock()
+	r.hasAnyCache[key] = hasAnyEntry{
+		exists:     exists,
+		hasEnabled: hasEnabled,
+		expiresAt:  r.now().Add(r.negativeCacheTTL),
+	}
+	r.mu.Unlock()
+	return exists, hasEnabled, nil
 }
 
 // lookupCache 는 캐시 조회 결과를 반환합니다 (이슈 #173).

--- a/internal/processor/parser/rule/resolver.go
+++ b/internal/processor/parser/rule/resolver.go
@@ -275,6 +275,7 @@ func (r *Resolver) HasAnyRule(ctx context.Context, host string, targetType stora
 	}
 
 	r.mu.Lock()
+	r.evictHasAnyExpiringSoon()
 	r.hasAnyCache[key] = hasAnyEntry{
 		exists:     exists,
 		hasEnabled: hasEnabled,
@@ -317,6 +318,27 @@ func (r *Resolver) evictExpiringSoon() {
 	}
 	if !first {
 		delete(r.cache, oldestKey)
+	}
+}
+
+// evictHasAnyExpiringSoon 은 hasAnyCache 가 maxEntries 초과 시 만료 임박 entry 를 제거합니다 (이슈 #287).
+// evictExpiringSoon 과 동일 정책 — host 폭증 시 OOM 방어. 호출자는 r.mu hold.
+func (r *Resolver) evictHasAnyExpiringSoon() {
+	if len(r.hasAnyCache) < r.maxEntries {
+		return
+	}
+	var oldestKey cacheKey
+	var oldestExpiry time.Time
+	first := true
+	for k, e := range r.hasAnyCache {
+		if first || e.expiresAt.Before(oldestExpiry) {
+			oldestKey = k
+			oldestExpiry = e.expiresAt
+			first = false
+		}
+	}
+	if !first {
+		delete(r.hasAnyCache, oldestKey)
 	}
 }
 

--- a/internal/processor/parser/worker/parser_worker.go
+++ b/internal/processor/parser/worker/parser_worker.go
@@ -411,31 +411,31 @@ func (w *ParserWorker) handleRuleError(ctx context.Context, raw *core.RawContent
 		// 이슈 #287: Resolver miss (ErrNoRule) 가 운영자가 의도적으로 disable 한 룰 잔존
 		// 인 경우 LLM 재학습 트리거 회피 — 매 fetch 마다 LLM 호출 → ErrDuplicate 흐름이
 		// 운영자의 의도된 disable 을 무력화하지 않도록.
-		// HasAnyRule lookup 실패는 best-effort (기존 동작 유지하여 LLM enqueue 진행).
-		if rerr.Code == rule.ErrNoRule && w.llmGen != nil && w.resolver != nil {
-			exists, hasEnabled, herr := w.resolver.HasAnyRule(ctx, rerr.Host, targetType)
-			switch {
-			case herr != nil:
-				// lookup 실패 — fail-open (warn 로그 + 기존 LLM enqueue 경로 진행).
-				mlog.WithFields(map[string]interface{}{
-					"host":        rerr.Host,
-					"target_type": string(targetType),
-				}).WithError(herr).Warn("HasAnyRule lookup failed, falling through to LLM enqueue")
-				w.llmGen.Enqueue(ctx, rerr.Host, targetType, raw, llmRetryCount, crawlerName, jobTimeout)
-			case exists && !hasEnabled:
-				// 운영자가 모든 룰을 disable 한 호스트 — LLM 재학습 회피, 운영 가시성 로그.
-				mlog.WithFields(map[string]interface{}{
-					"host":        rerr.Host,
-					"target_type": string(targetType),
-				}).Warn("rule exists but all disabled — skipping LLM regen (manual re-enable required)")
-			default:
-				// !exists 또는 (exists && hasEnabled) — 둘 다 LLM enqueue 진행.
-				// 후자는 cache stale 의심 케이스로 generator pre-check (PR #274) 가 차단.
+		// HasAnyRule lookup 실패는 best-effort (fail-open — 기존 동작 유지하여 LLM enqueue 진행).
+		if rerr.Code == rule.ErrNoRule && w.llmGen != nil {
+			shouldEnqueue := true
+			if w.resolver != nil {
+				exists, hasEnabled, herr := w.resolver.HasAnyRule(ctx, rerr.Host, targetType)
+				shouldEnqueue = ShouldEnqueueLLMOnNoRule(exists, hasEnabled, herr)
+				switch {
+				case herr == nil && exists && !hasEnabled:
+					// 운영자가 모든 룰을 disable 한 호스트 — LLM 재학습 회피, 운영 가시성 로그.
+					mlog.WithFields(map[string]interface{}{
+						"host":        rerr.Host,
+						"target_type": string(targetType),
+					}).Warn("rule exists but all disabled — skipping LLM regen (manual re-enable required)")
+				case herr != nil && ctx.Err() == nil:
+					// lookup 실패 — fail-open (warn 로그 + 기존 LLM enqueue 경로 진행).
+					// ctx.Err() 체크: shutdown 중 cancellation 을 lookup 장애로 오인 회피 (PR #291 gemini).
+					mlog.WithFields(map[string]interface{}{
+						"host":        rerr.Host,
+						"target_type": string(targetType),
+					}).WithError(herr).Warn("HasAnyRule lookup failed, falling through to LLM enqueue")
+				}
+			}
+			if shouldEnqueue {
 				w.llmGen.Enqueue(ctx, rerr.Host, targetType, raw, llmRetryCount, crawlerName, jobTimeout)
 			}
-		} else if rerr.Code == rule.ErrNoRule && w.llmGen != nil {
-			// resolver 미주입 환경 (테스트 등) — 기존 동작 유지.
-			w.llmGen.Enqueue(ctx, rerr.Host, targetType, raw, llmRetryCount, crawlerName, jobTimeout)
 		}
 
 		// 이슈 #220: page 단계의 ParseFailure / EmptySelector 만 host 카운터에 누적.
@@ -790,6 +790,25 @@ func uniqueURLs(items []parser.LinkItem, limit int) []string {
 		}
 	}
 	return urls
+}
+
+// ShouldEnqueueLLMOnNoRule 은 ErrNoRule 상황에서 HasAnyRule 결과로 LLM Enqueue 여부를 결정합니다 (이슈 #287).
+//
+// 정책:
+//   - lookup 실패 (err != nil)         : fail-open — true (기존 동작 유지)
+//   - !exists                          : 진짜 룰 부재 — true
+//   - exists && hasEnabled             : cache stale 의심 — true (Generator pre-check 가 차단)
+//   - exists && !hasEnabled            : 운영자 disable 잔존 — false (수동 재활성 영역)
+//
+// pure function — 외부 의존성 없음. handleRuleError 의 결정 로직만 분리해 단위 테스트 용이.
+func ShouldEnqueueLLMOnNoRule(exists, hasEnabled bool, lookupErr error) bool {
+	if lookupErr != nil {
+		return true
+	}
+	if exists && !hasEnabled {
+		return false
+	}
+	return true
 }
 
 // storageToFetcherTargetType 은 storage.TargetType ("list"/"page") 을

--- a/internal/processor/parser/worker/parser_worker.go
+++ b/internal/processor/parser/worker/parser_worker.go
@@ -407,7 +407,34 @@ func (w *ParserWorker) handleRuleError(ctx context.Context, raw *core.RawContent
 		// ErrNoRule + llmGen 활성화 → LLM 자동 rule 생성 비동기 트리거 (이슈 #149)
 		// crawlerName 은 validate 실패 시 재큐 메시지 헤더 복원용 (이슈 #237 피드백).
 		// jobTimeout 은 pending 재투입 시 카테고리 chained job timeout 보존 (이슈 #262 리뷰).
-		if rerr.Code == rule.ErrNoRule && w.llmGen != nil {
+		//
+		// 이슈 #287: Resolver miss (ErrNoRule) 가 운영자가 의도적으로 disable 한 룰 잔존
+		// 인 경우 LLM 재학습 트리거 회피 — 매 fetch 마다 LLM 호출 → ErrDuplicate 흐름이
+		// 운영자의 의도된 disable 을 무력화하지 않도록.
+		// HasAnyRule lookup 실패는 best-effort (기존 동작 유지하여 LLM enqueue 진행).
+		if rerr.Code == rule.ErrNoRule && w.llmGen != nil && w.resolver != nil {
+			exists, hasEnabled, herr := w.resolver.HasAnyRule(ctx, rerr.Host, targetType)
+			switch {
+			case herr != nil:
+				// lookup 실패 — fail-open (warn 로그 + 기존 LLM enqueue 경로 진행).
+				mlog.WithFields(map[string]interface{}{
+					"host":        rerr.Host,
+					"target_type": string(targetType),
+				}).WithError(herr).Warn("HasAnyRule lookup failed, falling through to LLM enqueue")
+				w.llmGen.Enqueue(ctx, rerr.Host, targetType, raw, llmRetryCount, crawlerName, jobTimeout)
+			case exists && !hasEnabled:
+				// 운영자가 모든 룰을 disable 한 호스트 — LLM 재학습 회피, 운영 가시성 로그.
+				mlog.WithFields(map[string]interface{}{
+					"host":        rerr.Host,
+					"target_type": string(targetType),
+				}).Warn("rule exists but all disabled — skipping LLM regen (manual re-enable required)")
+			default:
+				// !exists 또는 (exists && hasEnabled) — 둘 다 LLM enqueue 진행.
+				// 후자는 cache stale 의심 케이스로 generator pre-check (PR #274) 가 차단.
+				w.llmGen.Enqueue(ctx, rerr.Host, targetType, raw, llmRetryCount, crawlerName, jobTimeout)
+			}
+		} else if rerr.Code == rule.ErrNoRule && w.llmGen != nil {
+			// resolver 미주입 환경 (테스트 등) — 기존 동작 유지.
 			w.llmGen.Enqueue(ctx, rerr.Host, targetType, raw, llmRetryCount, crawlerName, jobTimeout)
 		}
 

--- a/internal/storage/parsing_rule.go
+++ b/internal/storage/parsing_rule.go
@@ -187,6 +187,19 @@ type ParsingRuleRepository interface {
 	// FindActiveCandidates 의 첫 항목 (length DESC 정렬, '' 포함) 을 반환합니다.
 	FindActive(ctx context.Context, host string, targetType TargetType) (*ParsingRuleRecord, error)
 
+	// HasAnyRule 은 (host_pattern, target_type) 에 대한 룰 존재 여부를 반환합니다 (이슈 #287).
+	//
+	// FindActiveCandidates 와 달리 enabled 필터 없음 — disabled 룰도 \"존재함\" 으로 카운트.
+	//
+	// 반환:
+	//   - exists       : 어느 row 라도 (enabled / disabled 무관) 있으면 true
+	//   - hasEnabled   : exists=true 일 때 enabled=TRUE row 가 하나라도 있으면 true
+	//   - err          : DB 조회 실패
+	//
+	// 용도: parser_worker 가 ErrNoRule 시 LLM 재학습 트리거 여부 결정 — disabled 룰만 잔존인
+	// host 는 운영자 수동 재활성 영역으로 분류.
+	HasAnyRule(ctx context.Context, hostPattern string, targetType TargetType) (exists, hasEnabled bool, err error)
+
 	// FindByNaturalKey 는 자연키 (source_name, host_pattern, path_pattern, target_type, version)
 	// 로 단일 rule 을 조회합니다 (이슈 #274). enabled 필터 없음 — disabled 룰도 반환.
 	//

--- a/internal/storage/postgres/parsing_rule.go
+++ b/internal/storage/postgres/parsing_rule.go
@@ -188,6 +188,29 @@ func (r *pgParsingRuleRepository) FindByNaturalKey(ctx context.Context, sourceNa
 	return rec, nil
 }
 
+// sqlHasAnyRule 은 (host_pattern, target_type) 에 대한 enabled / disabled 무관 존재 여부를
+// 1 row 로 반환합니다 (이슈 #287).
+//
+// COALESCE + bool_or 로 NULL 안전성 확보 — row 없으면 (FALSE, FALSE) 반환.
+const sqlHasAnyRule = `
+SELECT
+  EXISTS(SELECT 1 FROM parsing_rules WHERE host_pattern=$1 AND target_type=$2) AS exists_any,
+  COALESCE((SELECT bool_or(enabled) FROM parsing_rules WHERE host_pattern=$1 AND target_type=$2), FALSE) AS has_enabled
+`
+
+// HasAnyRule 은 (host_pattern, target_type) 룰 존재 여부 + enabled 여부를 1 round-trip 으로 반환합니다 (이슈 #287).
+//
+// FindActiveCandidates 와 달리 enabled 필터 없음 — disabled 룰도 \"존재함\" 으로 카운트.
+// 결과는 (exists, hasEnabled).
+func (r *pgParsingRuleRepository) HasAnyRule(ctx context.Context, hostPattern string, targetType storage.TargetType) (bool, bool, error) {
+	row := r.pool.QueryRow(ctx, sqlHasAnyRule, hostPattern, string(targetType))
+	var exists, hasEnabled bool
+	if err := row.Scan(&exists, &hasEnabled); err != nil {
+		return false, false, fmt.Errorf("has any rule (%s, %s): %w", hostPattern, targetType, err)
+	}
+	return exists, hasEnabled, nil
+}
+
 // sqlFindActiveCandidates 는 host + target_type 매칭 활성 rule 들을 후보 슬라이스로 반환합니다 (이슈 #173).
 //
 // 정렬:

--- a/internal/storage/postgres/parsing_rule.go
+++ b/internal/storage/postgres/parsing_rule.go
@@ -191,11 +191,14 @@ func (r *pgParsingRuleRepository) FindByNaturalKey(ctx context.Context, sourceNa
 // sqlHasAnyRule 은 (host_pattern, target_type) 에 대한 enabled / disabled 무관 존재 여부를
 // 1 row 로 반환합니다 (이슈 #287).
 //
-// COALESCE + bool_or 로 NULL 안전성 확보 — row 없으면 (FALSE, FALSE) 반환.
+// 단일 aggregate query — host_pattern + target_type 인덱스 스캔 1회로 exists / has_enabled 동시 산출.
+// 매칭 row 없으면 COUNT(*)=0 / bool_or NULL → COALESCE 로 (FALSE, FALSE) 보장 (PR #291 Copilot 리뷰).
 const sqlHasAnyRule = `
 SELECT
-  EXISTS(SELECT 1 FROM parsing_rules WHERE host_pattern=$1 AND target_type=$2) AS exists_any,
-  COALESCE((SELECT bool_or(enabled) FROM parsing_rules WHERE host_pattern=$1 AND target_type=$2), FALSE) AS has_enabled
+  COUNT(*) > 0                        AS exists_any,
+  COALESCE(bool_or(enabled), FALSE)   AS has_enabled
+FROM parsing_rules
+WHERE host_pattern=$1 AND target_type=$2
 `
 
 // HasAnyRule 은 (host_pattern, target_type) 룰 존재 여부 + enabled 여부를 1 round-trip 으로 반환합니다 (이슈 #287).

--- a/test/internal/processor/parser/rule/llmgen/generator_test.go
+++ b/test/internal/processor/parser/rule/llmgen/generator_test.go
@@ -83,6 +83,9 @@ func (r *recordingRepo) FindActive(_ context.Context, _ string, _ storage.Target
 func (r *recordingRepo) FindActiveCandidates(_ context.Context, _ string, _ storage.TargetType) ([]*storage.ParsingRuleRecord, error) {
 	return nil, nil
 }
+func (r *recordingRepo) HasAnyRule(_ context.Context, _ string, _ storage.TargetType) (bool, bool, error) {
+	return false, false, nil
+}
 func (r *recordingRepo) FindByNaturalKey(_ context.Context, _, _, _ string, _ storage.TargetType, _ int) (*storage.ParsingRuleRecord, error) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
@@ -148,6 +151,9 @@ func (noopFindRepo) FindActive(_ context.Context, _ string, _ storage.TargetType
 }
 func (noopFindRepo) FindActiveCandidates(_ context.Context, _ string, _ storage.TargetType) ([]*storage.ParsingRuleRecord, error) {
 	return nil, nil
+}
+func (noopFindRepo) HasAnyRule(_ context.Context, _ string, _ storage.TargetType) (bool, bool, error) {
+	return false, false, nil
 }
 func (noopFindRepo) FindByNaturalKey(_ context.Context, _, _, _ string, _ storage.TargetType, _ int) (*storage.ParsingRuleRecord, error) {
 	return nil, storage.ErrNotFound

--- a/test/internal/processor/parser/rule/refiner/refiner_test.go
+++ b/test/internal/processor/parser/rule/refiner/refiner_test.go
@@ -52,6 +52,9 @@ func (r *fakeRulesRepo) FindActive(_ context.Context, _ string, _ storage.Target
 func (r *fakeRulesRepo) FindActiveCandidates(_ context.Context, _ string, _ storage.TargetType) ([]*storage.ParsingRuleRecord, error) {
 	return nil, nil
 }
+func (r *fakeRulesRepo) HasAnyRule(_ context.Context, _ string, _ storage.TargetType) (bool, bool, error) {
+	return false, false, nil
+}
 func (r *fakeRulesRepo) FindByNaturalKey(_ context.Context, _, _, _ string, _ storage.TargetType, _ int) (*storage.ParsingRuleRecord, error) {
 	return nil, storage.ErrNotFound
 }

--- a/test/internal/processor/parser/rule/resolver_test.go
+++ b/test/internal/processor/parser/rule/resolver_test.go
@@ -21,6 +21,13 @@ type fakeRepo struct {
 	rules           []*storage.ParsingRuleRecord // FindActiveCandidates 매칭 후보
 	notFound        bool                         // true 면 항상 빈 슬라이스 (negative cache 시뮬레이션)
 	findActiveCalls int64
+
+	// hasAnyRule 시뮬레이션 (이슈 #287)
+	hasAnyExists      bool
+	hasAnyEnabled     bool
+	hasAnyErr         error
+	hasAnyRuleCalls   int64
+	hasAnyRuleAllRows bool // true: rules 슬라이스 기반 동적 결과 (HostPattern/TargetType 매칭)
 }
 
 func (r *fakeRepo) Insert(_ context.Context, _ *storage.ParsingRuleRecord) error { return nil }
@@ -67,6 +74,27 @@ func (r *fakeRepo) FindActiveCandidates(_ context.Context, host string, t storag
 
 func (r *fakeRepo) calls() int { return int(atomic.LoadInt64(&r.findActiveCalls)) }
 
+func (r *fakeRepo) HasAnyRule(_ context.Context, host string, t storage.TargetType) (bool, bool, error) {
+	atomic.AddInt64(&r.hasAnyRuleCalls, 1)
+	if r.hasAnyErr != nil {
+		return false, false, r.hasAnyErr
+	}
+	if r.hasAnyRuleAllRows {
+		// rules 슬라이스 기반 — enabled 무관 매칭 row 가 있으면 exists=true.
+		exists, hasEnabled := false, false
+		for _, rec := range r.rules {
+			if rec.HostPattern == host && rec.TargetType == t {
+				exists = true
+				if rec.Enabled {
+					hasEnabled = true
+				}
+			}
+		}
+		return exists, hasEnabled, nil
+	}
+	return r.hasAnyExists, r.hasAnyEnabled, nil
+}
+func (r *fakeRepo) hasAnyCalls() int { return int(atomic.LoadInt64(&r.hasAnyRuleCalls)) }
 func (r *fakeRepo) FindByNaturalKey(_ context.Context, _, _, _ string, _ storage.TargetType, _ int) (*storage.ParsingRuleRecord, error) {
 	return nil, storage.ErrNotFound
 }
@@ -342,4 +370,72 @@ func TestResolver_ResolveByURL_PathPatternMatching(t *testing.T) {
 	got, err := r.ResolveByURL(context.Background(), "https://news.example.com/article/12345?utm=x", storage.TargetTypePage)
 	require.NoError(t, err)
 	assert.Equal(t, "h1.article", got.Selectors.Title.CSS, "URL.Path 가 path_pattern 매칭")
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// HasAnyRule (이슈 #287)
+// ─────────────────────────────────────────────────────────────────────────────
+
+func TestResolver_HasAnyRule_NoRule(t *testing.T) {
+	repo := &fakeRepo{} // exists=false, enabled=false default
+	r, _ := rule.NewResolver(repo)
+
+	exists, enabled, err := r.HasAnyRule(context.Background(), "example.com", storage.TargetTypePage)
+	require.NoError(t, err)
+	assert.False(t, exists)
+	assert.False(t, enabled)
+}
+
+func TestResolver_HasAnyRule_EnabledRule(t *testing.T) {
+	repo := &fakeRepo{hasAnyExists: true, hasAnyEnabled: true}
+	r, _ := rule.NewResolver(repo)
+
+	exists, enabled, err := r.HasAnyRule(context.Background(), "example.com", storage.TargetTypePage)
+	require.NoError(t, err)
+	assert.True(t, exists)
+	assert.True(t, enabled)
+}
+
+func TestResolver_HasAnyRule_DisabledRuleOnly(t *testing.T) {
+	repo := &fakeRepo{hasAnyExists: true, hasAnyEnabled: false}
+	r, _ := rule.NewResolver(repo)
+
+	exists, enabled, err := r.HasAnyRule(context.Background(), "example.com", storage.TargetTypePage)
+	require.NoError(t, err)
+	assert.True(t, exists, "disabled 룰만 있어도 exists=true")
+	assert.False(t, enabled)
+}
+
+func TestResolver_HasAnyRule_CachesResult(t *testing.T) {
+	repo := &fakeRepo{hasAnyExists: true, hasAnyEnabled: true}
+	r, _ := rule.NewResolver(repo)
+
+	for i := 0; i < 5; i++ {
+		_, _, err := r.HasAnyRule(context.Background(), "example.com", storage.TargetTypePage)
+		require.NoError(t, err)
+	}
+	assert.Equal(t, 1, repo.hasAnyCalls(), "5회 호출 중 DB lookup 은 1회 — 캐시 적중 4회")
+}
+
+func TestResolver_HasAnyRule_InvalidatedOnRuleChange(t *testing.T) {
+	repo := &fakeRepo{hasAnyExists: true, hasAnyEnabled: true}
+	r, _ := rule.NewResolver(repo)
+
+	_, _, err := r.HasAnyRule(context.Background(), "example.com", storage.TargetTypePage)
+	require.NoError(t, err)
+	assert.Equal(t, 1, repo.hasAnyCalls())
+
+	r.Invalidate("example.com", storage.TargetTypePage)
+
+	_, _, err = r.HasAnyRule(context.Background(), "example.com", storage.TargetTypePage)
+	require.NoError(t, err)
+	assert.Equal(t, 2, repo.hasAnyCalls(), "Invalidate 후 lookup 재실행")
+}
+
+func TestResolver_HasAnyRule_LookupErrorPropagated(t *testing.T) {
+	repo := &fakeRepo{hasAnyErr: errors.New("db down")}
+	r, _ := rule.NewResolver(repo)
+
+	_, _, err := r.HasAnyRule(context.Background(), "example.com", storage.TargetTypePage)
+	require.Error(t, err)
 }

--- a/test/internal/processor/parser/worker/should_enqueue_llm_test.go
+++ b/test/internal/processor/parser/worker/should_enqueue_llm_test.go
@@ -1,0 +1,64 @@
+package worker_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"issuetracker/internal/processor/parser/worker"
+)
+
+// TestShouldEnqueueLLMOnNoRule 는 HasAnyRule 결과별 LLM Enqueue 결정을 검증합니다 (이슈 #287).
+func TestShouldEnqueueLLMOnNoRule(t *testing.T) {
+	tests := []struct {
+		name       string
+		exists     bool
+		hasEnabled bool
+		err        error
+		want       bool
+	}{
+		{
+			name:       "lookup error — fail-open enqueue (DB 일시 장애가 LLM 학습을 영구 차단하지 않도록)",
+			exists:     false,
+			hasEnabled: false,
+			err:        errors.New("db down"),
+			want:       true,
+		},
+		{
+			name:       "lookup error with positive cached state — 여전히 fail-open enqueue",
+			exists:     true,
+			hasEnabled: false,
+			err:        errors.New("redis timeout"),
+			want:       true,
+		},
+		{
+			name:       "no rule — enqueue (진짜 룰 부재)",
+			exists:     false,
+			hasEnabled: false,
+			err:        nil,
+			want:       true,
+		},
+		{
+			name:       "enabled rule exists — enqueue (cache stale, generator pre-check 차단 예정)",
+			exists:     true,
+			hasEnabled: true,
+			err:        nil,
+			want:       true,
+		},
+		{
+			name:       "disabled rule only — skip (운영자 의도된 disable 존중)",
+			exists:     true,
+			hasEnabled: false,
+			err:        nil,
+			want:       false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := worker.ShouldEnqueueLLMOnNoRule(tt.exists, tt.hasEnabled, tt.err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}


### PR DESCRIPTION
## 연관 이슈
- Closes #287
- Parent: #284 (시나리오 #1)

<br>

## 구현 내용

이슈 #284 시나리오 #1 — 운영자가 host 룰을 disable 한 후에도 매 fetch 마다 parser_worker 가 ErrNoRule 받아 LLM Enqueue 트리거 → ErrDuplicate 흐름. 운영자의 의도된 disable 이 자동 LLM 재학습으로 무력화됨.

본 PR 은 Resolver 에 **존재 확인 전용** 메소드 (`HasAnyRule`) 를 도입하여 parser_worker 가 \"진짜 부재\" 와 \"운영자 disable 잔존\" 을 구분, 후자에서 LLM 트리거 회피.

### 변경 사항

| 파일 | 내용 |
|---|---|
| `internal/storage/parsing_rule.go` | `ParsingRuleRepository.HasAnyRule(host, type) (exists, hasEnabled, err)` 인터페이스 추가 |
| `internal/storage/postgres/parsing_rule.go` | `EXISTS + bool_or` 1 round-trip SQL 구현 |
| `internal/processor/parser/rule/resolver.go` | `Resolver.HasAnyRule` + short-TTL `hasAnyCache` (negativeCacheTTL 공유). `Invalidate` / `InvalidateAll` 가 함께 비움 |
| `internal/processor/parser/worker/parser_worker.go` | `handleRuleError` 의 ErrNoRule 분기 3-way switch 확장 |

### parser_worker 분기 로직

```
ErrNoRule 발생 (Resolver miss)
   ↓
HasAnyRule lookup
   ├─ err != nil       → fail-open: warn 로그 + LLM Enqueue (기존 동작)
   ├─ !exists          → 진짜 부재 — LLM Enqueue (기존 동작)
   ├─ exists && enabled → cache stale 의심 — LLM Enqueue (Generator pre-check #274 가 차단)
   └─ exists && !enabled → 운영자 disable 잔존 — **LLM Enqueue 회피** + warn (manual re-enable)
```

### 테스트 6건 (`resolver_test.go`)

- 룰 없음 → `(false, false)`
- enabled 룰 → `(true, true)`
- disabled 룰만 → `(true, false)`
- 캐시 적중 (5회 호출 / 1회 lookup)
- `Invalidate` 후 재lookup
- DB 에러 propagation

기존 4개 fake repo 구현체 (resolver / refiner / llmgen / generator) 모두 갱신.

### 기대 효과

- 운영자 disable 후 매 fetch 마다 발동되던 ErrDuplicate / Generator pre-check 호출 0
- LLM 비용 절감 — claudegen sonnet 호출 ~55s/회 회피
- 운영 가시성 — `rule exists but all disabled` warn 로그로 \"수동 재활성 필요\" 신호

<br>

## CI / 머지 게이트 점검

> [CI 운영 규약](docs/ci/conventions.md) 및 [Required Status Checks 단일 소스](docs/ci/status-checks.md)에 따라 작성합니다.

### 변경 영향 범위
- 영향 패키지: `internal/storage`, `internal/processor/parser/rule`, `internal/processor/parser/worker`, `test/...`
- 위험도: `Low` — 기존 동작 보존 (resolver=nil / lookup err 시 기존 LLM Enqueue 경로 유지)

### Required Status Checks
- 통과 확인 대상:
  - [ ] `Commit Lint`
  - [ ] `PR Title Lint`
  - [ ] `Linked Issue Check`
  - [ ] `Build`
  - [ ] `Test`
  - [ ] `Lint`

### 로컬 검증
- `make fmt` 통과
- `make build` 5개 binary 모두 통과
- `go test -race ./...` 전체 통과 (신규 6건 + 4 fake mock 갱신)
- `go vet ./...` 통과

<br>

## 롤백 계획

- HasAnyRule lookup 실패는 fail-open — Redis/DB 장애 시에도 기존 동작 유지
- resolver 미주입 시 기존 LLM Enqueue 그대로
- 단순 revert 만으로 즉시 롤백 가능

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Rule system now intelligently distinguishes between disabled and non-existent rules, reducing unnecessary processing operations.
  * Enhanced rule resolver with targeted queries for rule existence and enabled status checks.

* **Performance**
  * Introduced efficient caching for rule lookups with optimized cache invalidation on rule changes.
  * Improved query performance through reduced redundant repository checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->