### PR TITLE
[FIX#288] parsing_rules mutation→cache invalidate decorator

### DIFF
--- a/cmd/issuetracker/main.go
+++ b/cmd/issuetracker/main.go
@@ -127,6 +127,9 @@ func main() {
 	if err != nil {
 		log.WithError(err).Fatal("failed to construct rule resolver")
 	}
+	// 이슈 #288: parsing_rules mutation → cache invalidate 자동 결합 (decorator 패턴).
+	// 호출처가 명시적 Invalidate 를 까먹어도 stale cache 발생 X — single source of truth.
+	parsingRuleRepo = rule.WrapWithInvalidator(parsingRuleRepo, ruleResolver)
 	ruleParser, err := rule.NewParser(ruleResolver)
 	if err != nil {
 		log.WithError(err).Fatal("failed to construct rule parser")

--- a/internal/processor/parser/rule/invalidating_repo.go
+++ b/internal/processor/parser/rule/invalidating_repo.go
@@ -26,13 +26,13 @@ type CacheInvalidator interface {
 //   - Insert 성공          → Invalidate (host, target_type)
 //   - Insert ErrDuplicate  → Invalidate (row 가 DB 에 이미 존재 — cache 불일치 가능성)
 //   - Update 성공          → Invalidate (host, target_type)
-//   - UpdatePathPattern 성공 → Invalidate (record 의 host/type 사전 lookup 필요 — 후술)
-//   - Delete 성공          → ID 만 알 수 있어 host/type 미상 — 호출자가 명시적 Invalidate 책임 (또는 InvalidateAll 권장)
+//   - UpdatePathPattern 성공 → 사전 GetByID 로 host/type lookup 후 Invalidate
+//   - Delete 성공          → 사전 GetByID 로 host/type lookup 후 Invalidate (PR #292 gemini 리뷰 — 일관성)
 //
-// UpdatePathPattern 의 호스트 정보 부재:
+// UpdatePathPattern / Delete 의 호스트 정보 부재:
 //
-//	본 메소드는 ID 인자만 받음 — host/type 을 모름. 추가 GetByID round-trip 으로 사전 조회 후 invalidate.
-//	refiner 는 호출 빈도 낮으므로 (default 5분 주기) 추가 read 부담 무시 수준.
+//	두 메소드는 ID 인자만 받음 — host/type 을 모름. 추가 GetByID round-trip 으로 사전 조회 후 invalidate.
+//	refiner / admin 도구는 호출 빈도 낮으므로 추가 read 부담 무시 수준.
 //
 // CacheInvalidator 가 nil 이면 noop wrapper — invalidate 만 skip 하고 inner 호출은 그대로 진행.
 type invalidatingRepo struct {
@@ -102,11 +102,19 @@ func (r *invalidatingRepo) UpdatePathPattern(ctx context.Context, id int64, patt
 	return nil
 }
 
-// Delete wraps inner.Delete. ID 만 받으므로 host/type 미상 — 호출자가 사전 GetByID 로 lookup
-// 하여 결과를 토대로 명시 Invalidate 호출 책임. 본 decorator 는 GetByID round-trip 을 강제하지
-// 않음 (Delete 가 정상 흐름에선 거의 호출되지 않으며, 운영자 admin 도구가 호출할 가능성 큼).
+// Delete wraps inner.Delete + 사전 GetByID 로 host/type 조회 후 invalidate (PR #292 gemini 리뷰).
+//
+// UpdatePathPattern 과 동일 패턴 — decorator 의 일관성 보장 (mutation→invalidate 결합 누락 0).
+// pre-fetch 실패 시 invalidate skip — TTL fallback 으로 자연 회수.
 func (r *invalidatingRepo) Delete(ctx context.Context, id int64) error {
-	return r.inner.Delete(ctx, id)
+	rec, lookupErr := r.inner.GetByID(ctx, id)
+	if err := r.inner.Delete(ctx, id); err != nil {
+		return err
+	}
+	if lookupErr == nil && rec != nil {
+		r.invalidate(rec.HostPattern, rec.TargetType)
+	}
+	return nil
 }
 
 // 이하 read-only / find 메소드는 단순 위임 — invalidate 트리거 없음.

--- a/internal/processor/parser/rule/invalidating_repo.go
+++ b/internal/processor/parser/rule/invalidating_repo.go
@@ -1,0 +1,139 @@
+package rule
+
+import (
+	"context"
+	"errors"
+
+	"issuetracker/internal/storage"
+)
+
+// CacheInvalidator 는 (host, target_type) 튜플의 cache entry 를 무효화하는 최소 인터페이스입니다 (이슈 #288).
+//
+// Resolver 가 본 인터페이스를 만족 — invalidatingRepo 가 internal/storage 를 거꾸로 import 하지 않도록
+// 별도 정의. 향후 다른 cache 보유 컴포넌트도 본 인터페이스만 구현하면 decorator 와 결합 가능.
+type CacheInvalidator interface {
+	Invalidate(host string, targetType storage.TargetType)
+}
+
+// invalidatingRepo 는 ParsingRuleRepository 를 wrap 하여 mutation 메소드 호출 후 자동으로
+// CacheInvalidator.Invalidate 를 호출하는 decorator 입니다 (이슈 #288).
+//
+// 의도:
+//
+//	"mutation→invalidate 결합을 단일 책임 지점에 모아 — 호출처가 까먹어도 cache 누락 0."
+//
+// 적용 정책:
+//   - Insert 성공          → Invalidate (host, target_type)
+//   - Insert ErrDuplicate  → Invalidate (row 가 DB 에 이미 존재 — cache 불일치 가능성)
+//   - Update 성공          → Invalidate (host, target_type)
+//   - UpdatePathPattern 성공 → Invalidate (record 의 host/type 사전 lookup 필요 — 후술)
+//   - Delete 성공          → ID 만 알 수 있어 host/type 미상 — 호출자가 명시적 Invalidate 책임 (또는 InvalidateAll 권장)
+//
+// UpdatePathPattern 의 호스트 정보 부재:
+//
+//	본 메소드는 ID 인자만 받음 — host/type 을 모름. 추가 GetByID round-trip 으로 사전 조회 후 invalidate.
+//	refiner 는 호출 빈도 낮으므로 (default 5분 주기) 추가 read 부담 무시 수준.
+//
+// CacheInvalidator 가 nil 이면 noop wrapper — invalidate 만 skip 하고 inner 호출은 그대로 진행.
+type invalidatingRepo struct {
+	inner storage.ParsingRuleRepository
+	inv   CacheInvalidator
+}
+
+// WrapWithInvalidator 는 ParsingRuleRepository 를 invalidatingRepo 로 wrap 합니다 (이슈 #288).
+//
+// 사용 예 (cmd/issuetracker/main.go):
+//
+//	parsingRuleRepo := pgstore.NewParsingRuleRepository(pool, log)
+//	parsingRuleRepo = rule.WrapWithInvalidator(parsingRuleRepo, ruleResolver)
+//
+// inner 가 nil 이면 panic — wiring 버그 (호출자가 nil 검사 필요).
+// inv 가 nil 이면 wrapper 역할만 (invalidate skip, 향후 wiring 단계에서 쉽게 토글).
+func WrapWithInvalidator(inner storage.ParsingRuleRepository, inv CacheInvalidator) storage.ParsingRuleRepository {
+	if inner == nil {
+		panic("rule: WrapWithInvalidator requires non-nil inner repository")
+	}
+	return &invalidatingRepo{inner: inner, inv: inv}
+}
+
+func (r *invalidatingRepo) invalidate(host string, t storage.TargetType) {
+	if r.inv != nil {
+		r.inv.Invalidate(host, t)
+	}
+}
+
+// Insert wraps inner.Insert + invalidates on success or ErrDuplicate.
+//
+// ErrDuplicate 시에도 invalidate — INSERT 실패했지만 동일 자연키 row 가 이미 DB 에 존재하므로
+// cache 가 stale 일 가능성 (다른 인스턴스가 INSERT 했거나 운영자 manual). 이슈 #274 의 사후
+// invalidate 로직을 본 decorator 로 통합.
+func (r *invalidatingRepo) Insert(ctx context.Context, rec *storage.ParsingRuleRecord) error {
+	err := r.inner.Insert(ctx, rec)
+	if err == nil || errors.Is(err, storage.ErrDuplicate) {
+		r.invalidate(rec.HostPattern, rec.TargetType)
+	}
+	return err
+}
+
+// Update wraps inner.Update + invalidates on success.
+func (r *invalidatingRepo) Update(ctx context.Context, rec *storage.ParsingRuleRecord) error {
+	err := r.inner.Update(ctx, rec)
+	if err == nil {
+		r.invalidate(rec.HostPattern, rec.TargetType)
+	}
+	return err
+}
+
+// UpdatePathPattern wraps inner.UpdatePathPattern + invalidates on success.
+//
+// 본 메소드는 host/type 을 직접 받지 않으므로 사전 GetByID 로 lookup 후 invalidate.
+// inner.UpdatePathPattern 이 ErrNotFound 반환하면 lookup 결과 무관하게 단순 전파.
+func (r *invalidatingRepo) UpdatePathPattern(ctx context.Context, id int64, pattern, description string) error {
+	rec, lookupErr := r.inner.GetByID(ctx, id)
+	if err := r.inner.UpdatePathPattern(ctx, id, pattern, description); err != nil {
+		return err
+	}
+	if lookupErr == nil && rec != nil {
+		r.invalidate(rec.HostPattern, rec.TargetType)
+	}
+	// lookupErr != nil — pre-fetch 실패 시 invalidate skip. caller (refiner) 가 명시 호출
+	// 하지 않으면 cache stale 가능성 — 운영 환경에서는 GetByID 가 ErrNotFound 외 실패할 일은
+	// DB 장애뿐이며, 그 경우 본 mutation 자체도 동일 사유로 실패할 가능성 높음 (TTL fallback).
+	return nil
+}
+
+// Delete wraps inner.Delete. ID 만 받으므로 host/type 미상 — 호출자가 사전 GetByID 로 lookup
+// 하여 결과를 토대로 명시 Invalidate 호출 책임. 본 decorator 는 GetByID round-trip 을 강제하지
+// 않음 (Delete 가 정상 흐름에선 거의 호출되지 않으며, 운영자 admin 도구가 호출할 가능성 큼).
+func (r *invalidatingRepo) Delete(ctx context.Context, id int64) error {
+	return r.inner.Delete(ctx, id)
+}
+
+// 이하 read-only / find 메소드는 단순 위임 — invalidate 트리거 없음.
+
+func (r *invalidatingRepo) GetByID(ctx context.Context, id int64) (*storage.ParsingRuleRecord, error) {
+	return r.inner.GetByID(ctx, id)
+}
+
+func (r *invalidatingRepo) FindActive(ctx context.Context, host string, t storage.TargetType) (*storage.ParsingRuleRecord, error) {
+	return r.inner.FindActive(ctx, host, t)
+}
+
+func (r *invalidatingRepo) FindActiveCandidates(ctx context.Context, host string, t storage.TargetType) ([]*storage.ParsingRuleRecord, error) {
+	return r.inner.FindActiveCandidates(ctx, host, t)
+}
+
+func (r *invalidatingRepo) HasAnyRule(ctx context.Context, host string, t storage.TargetType) (bool, bool, error) {
+	return r.inner.HasAnyRule(ctx, host, t)
+}
+
+func (r *invalidatingRepo) FindByNaturalKey(ctx context.Context, sourceName, hostPattern, pathPattern string, t storage.TargetType, version int) (*storage.ParsingRuleRecord, error) {
+	return r.inner.FindByNaturalKey(ctx, sourceName, hostPattern, pathPattern, t, version)
+}
+
+func (r *invalidatingRepo) List(ctx context.Context, f storage.ParsingRuleFilter) ([]*storage.ParsingRuleRecord, error) {
+	return r.inner.List(ctx, f)
+}
+
+// 컴파일 타임 인터페이스 만족 검증.
+var _ storage.ParsingRuleRepository = (*invalidatingRepo)(nil)

--- a/internal/processor/parser/rule/llmgen/generator.go
+++ b/internal/processor/parser/rule/llmgen/generator.go
@@ -477,7 +477,8 @@ func (g *Generator) runOnce(ctx context.Context, host string, targetType storage
 		// PR #275 리뷰 반영: enabled 여부 / rule_id 를 로그에 포함하여 운영 가시성 ↑.
 		// disabled 룰 잔존이면 warn — 운영자가 수동 재활성 결정을 해야 함을 명시.
 		if errors.Is(err, storage.ErrDuplicate) {
-			g.resolver.Invalidate(host, targetType)
+			// 이슈 #288: cache invalidate 는 invalidatingRepo decorator 가 ErrDuplicate
+			// 시에도 자동 호출 — 본 함수는 순수 로깅 / 분기 책임만.
 			fields := map[string]interface{}{
 				"host":        host,
 				"target_type": string(targetType),
@@ -496,8 +497,7 @@ func (g *Generator) runOnce(ctx context.Context, host string, targetType storage
 		return fmt.Errorf("insert parsing rule: %w", err)
 	}
 
-	// negative cache 무효화 — 다음 lookup 부터 새 rule 이 즉시 반영되도록.
-	g.resolver.Invalidate(host, targetType)
+	// 이슈 #288: cache invalidate 는 invalidatingRepo decorator 가 자동 호출.
 
 	g.log.WithFields(map[string]interface{}{
 		"host":        host,

--- a/internal/processor/parser/rule/refiner/refiner.go
+++ b/internal/processor/parser/rule/refiner/refiner.go
@@ -323,8 +323,8 @@ func (r *Refiner) refineOne(ctx context.Context, rec *storage.ParsingRuleRecord)
 		return
 	}
 
-	// 2) cache flush — 다음 lookup 부터 갱신된 rule 적용.
-	r.resolver.Invalidate(rec.HostPattern, rec.TargetType)
+	// 2) cache flush 는 invalidatingRepo decorator 가 UpdatePathPattern 성공 후 자동 호출 (이슈 #288).
+	//    refiner 의 명시적 Invalidate 책임 제거 — single source of truth.
 
 	// 3) sample purge — 다음 cycle 에서 재누적 (다른 path 패턴 발견 가능성 대비).
 	if err := r.samples.Purge(ctx, rec.ID); err != nil {

--- a/test/internal/processor/parser/rule/invalidating_repo_test.go
+++ b/test/internal/processor/parser/rule/invalidating_repo_test.go
@@ -1,0 +1,244 @@
+package rule_test
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"issuetracker/internal/processor/parser/rule"
+	"issuetracker/internal/storage"
+)
+
+// recordingInvalidator 는 Invalidate 호출을 기록하는 fake CacheInvalidator 입니다.
+type recordingInvalidator struct {
+	mu    sync.Mutex
+	calls []invalidateCall
+}
+
+type invalidateCall struct {
+	Host string
+	Type storage.TargetType
+}
+
+func (i *recordingInvalidator) Invalidate(host string, t storage.TargetType) {
+	i.mu.Lock()
+	defer i.mu.Unlock()
+	i.calls = append(i.calls, invalidateCall{Host: host, Type: t})
+}
+
+func (i *recordingInvalidator) callCount() int {
+	i.mu.Lock()
+	defer i.mu.Unlock()
+	return len(i.calls)
+}
+
+func (i *recordingInvalidator) lastCall() invalidateCall {
+	i.mu.Lock()
+	defer i.mu.Unlock()
+	if len(i.calls) == 0 {
+		return invalidateCall{}
+	}
+	return i.calls[len(i.calls)-1]
+}
+
+// recordingRepo — invalidating_repo decorator 의 inner repo 시뮬레이션.
+type recordingRepo struct {
+	insertErr     error
+	updateErr     error
+	updatePathErr error
+	getByIDResult *storage.ParsingRuleRecord
+	getByIDErr    error
+
+	insertCalls     int
+	updateCalls     int
+	updatePathCalls int
+	deleteCalls     int
+	getByIDCalls    int
+}
+
+func (r *recordingRepo) Insert(_ context.Context, _ *storage.ParsingRuleRecord) error {
+	r.insertCalls++
+	return r.insertErr
+}
+func (r *recordingRepo) Update(_ context.Context, _ *storage.ParsingRuleRecord) error {
+	r.updateCalls++
+	return r.updateErr
+}
+func (r *recordingRepo) UpdatePathPattern(_ context.Context, _ int64, _, _ string) error {
+	r.updatePathCalls++
+	return r.updatePathErr
+}
+func (r *recordingRepo) Delete(_ context.Context, _ int64) error {
+	r.deleteCalls++
+	return nil
+}
+func (r *recordingRepo) GetByID(_ context.Context, _ int64) (*storage.ParsingRuleRecord, error) {
+	r.getByIDCalls++
+	return r.getByIDResult, r.getByIDErr
+}
+func (r *recordingRepo) FindActive(_ context.Context, _ string, _ storage.TargetType) (*storage.ParsingRuleRecord, error) {
+	return nil, storage.ErrNotFound
+}
+func (r *recordingRepo) FindActiveCandidates(_ context.Context, _ string, _ storage.TargetType) ([]*storage.ParsingRuleRecord, error) {
+	return nil, nil
+}
+func (r *recordingRepo) HasAnyRule(_ context.Context, _ string, _ storage.TargetType) (bool, bool, error) {
+	return false, false, nil
+}
+func (r *recordingRepo) FindByNaturalKey(_ context.Context, _, _, _ string, _ storage.TargetType, _ int) (*storage.ParsingRuleRecord, error) {
+	return nil, storage.ErrNotFound
+}
+func (r *recordingRepo) List(_ context.Context, _ storage.ParsingRuleFilter) ([]*storage.ParsingRuleRecord, error) {
+	return nil, nil
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Insert
+// ─────────────────────────────────────────────────────────────────────────────
+
+func TestInvalidatingRepo_Insert_Success_TriggersInvalidate(t *testing.T) {
+	inner := &recordingRepo{}
+	inv := &recordingInvalidator{}
+	repo := rule.WrapWithInvalidator(inner, inv)
+
+	rec := &storage.ParsingRuleRecord{HostPattern: "example.com", TargetType: storage.TargetTypePage}
+	err := repo.Insert(context.Background(), rec)
+	require.NoError(t, err)
+	assert.Equal(t, 1, inv.callCount(), "Insert 성공 시 Invalidate 호출")
+	assert.Equal(t, invalidateCall{Host: "example.com", Type: storage.TargetTypePage}, inv.lastCall())
+}
+
+func TestInvalidatingRepo_Insert_ErrDuplicate_TriggersInvalidate(t *testing.T) {
+	inner := &recordingRepo{insertErr: storage.ErrDuplicate}
+	inv := &recordingInvalidator{}
+	repo := rule.WrapWithInvalidator(inner, inv)
+
+	rec := &storage.ParsingRuleRecord{HostPattern: "example.com", TargetType: storage.TargetTypePage}
+	err := repo.Insert(context.Background(), rec)
+	require.ErrorIs(t, err, storage.ErrDuplicate)
+	assert.Equal(t, 1, inv.callCount(), "ErrDuplicate 도 invalidate — cache 가 stale 일 가능성")
+}
+
+func TestInvalidatingRepo_Insert_OtherError_NoInvalidate(t *testing.T) {
+	inner := &recordingRepo{insertErr: errors.New("db down")}
+	inv := &recordingInvalidator{}
+	repo := rule.WrapWithInvalidator(inner, inv)
+
+	rec := &storage.ParsingRuleRecord{HostPattern: "example.com", TargetType: storage.TargetTypePage}
+	err := repo.Insert(context.Background(), rec)
+	require.Error(t, err)
+	assert.Equal(t, 0, inv.callCount(), "기타 에러 (DB 장애 등) 시 invalidate 안 함 — cache 보존")
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Update
+// ─────────────────────────────────────────────────────────────────────────────
+
+func TestInvalidatingRepo_Update_Success_TriggersInvalidate(t *testing.T) {
+	inner := &recordingRepo{}
+	inv := &recordingInvalidator{}
+	repo := rule.WrapWithInvalidator(inner, inv)
+
+	rec := &storage.ParsingRuleRecord{HostPattern: "example.com", TargetType: storage.TargetTypeList}
+	err := repo.Update(context.Background(), rec)
+	require.NoError(t, err)
+	assert.Equal(t, 1, inv.callCount())
+	assert.Equal(t, invalidateCall{Host: "example.com", Type: storage.TargetTypeList}, inv.lastCall())
+}
+
+func TestInvalidatingRepo_Update_Error_NoInvalidate(t *testing.T) {
+	inner := &recordingRepo{updateErr: errors.New("constraint violation")}
+	inv := &recordingInvalidator{}
+	repo := rule.WrapWithInvalidator(inner, inv)
+
+	err := repo.Update(context.Background(), &storage.ParsingRuleRecord{})
+	require.Error(t, err)
+	assert.Equal(t, 0, inv.callCount())
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// UpdatePathPattern
+// ─────────────────────────────────────────────────────────────────────────────
+
+func TestInvalidatingRepo_UpdatePathPattern_Success_PrefetchesAndInvalidates(t *testing.T) {
+	inner := &recordingRepo{
+		getByIDResult: &storage.ParsingRuleRecord{
+			ID: 42, HostPattern: "yna.co.kr", TargetType: storage.TargetTypePage,
+		},
+	}
+	inv := &recordingInvalidator{}
+	repo := rule.WrapWithInvalidator(inner, inv)
+
+	err := repo.UpdatePathPattern(context.Background(), 42, "/news/.*", "refiner v1")
+	require.NoError(t, err)
+	assert.Equal(t, 1, inner.getByIDCalls, "host/type 미지로 사전 GetByID 1회")
+	assert.Equal(t, 1, inner.updatePathCalls)
+	assert.Equal(t, 1, inv.callCount())
+	assert.Equal(t, invalidateCall{Host: "yna.co.kr", Type: storage.TargetTypePage}, inv.lastCall())
+}
+
+func TestInvalidatingRepo_UpdatePathPattern_Error_NoInvalidate(t *testing.T) {
+	inner := &recordingRepo{
+		getByIDResult: &storage.ParsingRuleRecord{HostPattern: "x.com", TargetType: storage.TargetTypePage},
+		updatePathErr: errors.New("not found"),
+	}
+	inv := &recordingInvalidator{}
+	repo := rule.WrapWithInvalidator(inner, inv)
+
+	err := repo.UpdatePathPattern(context.Background(), 1, "/", "")
+	require.Error(t, err)
+	assert.Equal(t, 0, inv.callCount(), "update 실패 시 invalidate 안 함")
+}
+
+func TestInvalidatingRepo_UpdatePathPattern_PrefetchFails_NoInvalidate(t *testing.T) {
+	inner := &recordingRepo{
+		getByIDErr: errors.New("db down"),
+	}
+	inv := &recordingInvalidator{}
+	repo := rule.WrapWithInvalidator(inner, inv)
+
+	// pre-fetch 실패해도 update 자체는 진행 (성공 가정).
+	err := repo.UpdatePathPattern(context.Background(), 1, "/", "")
+	require.NoError(t, err)
+	assert.Equal(t, 0, inv.callCount(), "pre-fetch 실패 시 host/type 미상으로 invalidate skip")
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Delete
+// ─────────────────────────────────────────────────────────────────────────────
+
+func TestInvalidatingRepo_Delete_NoInvalidate(t *testing.T) {
+	inner := &recordingRepo{}
+	inv := &recordingInvalidator{}
+	repo := rule.WrapWithInvalidator(inner, inv)
+
+	err := repo.Delete(context.Background(), 1)
+	require.NoError(t, err)
+	assert.Equal(t, 1, inner.deleteCalls)
+	assert.Equal(t, 0, inv.callCount(),
+		"Delete 는 ID 만 받음 — host/type 미상이라 호출자가 명시 Invalidate 책임 (decorator 가 강제하지 않음)")
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// nil invalidator (wrapping 단계에서 비활성)
+// ─────────────────────────────────────────────────────────────────────────────
+
+func TestInvalidatingRepo_NilInvalidator_NoOp(t *testing.T) {
+	inner := &recordingRepo{}
+	repo := rule.WrapWithInvalidator(inner, nil)
+
+	err := repo.Insert(context.Background(), &storage.ParsingRuleRecord{HostPattern: "x", TargetType: storage.TargetTypePage})
+	require.NoError(t, err)
+	assert.Equal(t, 1, inner.insertCalls, "inner 호출은 정상")
+	// invalidator 가 nil 이라 panic 없이 통과 — 정상 동작 확인 만으로 충분.
+}
+
+func TestWrapWithInvalidator_NilInner_Panics(t *testing.T) {
+	assert.Panics(t, func() {
+		_ = rule.WrapWithInvalidator(nil, &recordingInvalidator{})
+	}, "nil inner 는 wiring 버그 — panic 으로 즉시 노출")
+}

--- a/test/internal/processor/parser/rule/invalidating_repo_test.go
+++ b/test/internal/processor/parser/rule/invalidating_repo_test.go
@@ -211,16 +211,35 @@ func TestInvalidatingRepo_UpdatePathPattern_PrefetchFails_NoInvalidate(t *testin
 // Delete
 // ─────────────────────────────────────────────────────────────────────────────
 
-func TestInvalidatingRepo_Delete_NoInvalidate(t *testing.T) {
-	inner := &recordingRepo{}
+func TestInvalidatingRepo_Delete_Success_PrefetchesAndInvalidates(t *testing.T) {
+	inner := &recordingRepo{
+		getByIDResult: &storage.ParsingRuleRecord{
+			ID: 99, HostPattern: "delete.example.com", TargetType: storage.TargetTypePage,
+		},
+	}
+	inv := &recordingInvalidator{}
+	repo := rule.WrapWithInvalidator(inner, inv)
+
+	err := repo.Delete(context.Background(), 99)
+	require.NoError(t, err)
+	assert.Equal(t, 1, inner.getByIDCalls, "host/type 미지로 사전 GetByID 1회")
+	assert.Equal(t, 1, inner.deleteCalls)
+	assert.Equal(t, 1, inv.callCount())
+	assert.Equal(t, invalidateCall{Host: "delete.example.com", Type: storage.TargetTypePage}, inv.lastCall())
+}
+
+func TestInvalidatingRepo_Delete_PrefetchFails_NoInvalidate(t *testing.T) {
+	inner := &recordingRepo{
+		getByIDErr: errors.New("db down"),
+	}
 	inv := &recordingInvalidator{}
 	repo := rule.WrapWithInvalidator(inner, inv)
 
 	err := repo.Delete(context.Background(), 1)
 	require.NoError(t, err)
-	assert.Equal(t, 1, inner.deleteCalls)
+	assert.Equal(t, 1, inner.deleteCalls, "Delete 자체는 진행")
 	assert.Equal(t, 0, inv.callCount(),
-		"Delete 는 ID 만 받음 — host/type 미상이라 호출자가 명시 Invalidate 책임 (decorator 가 강제하지 않음)")
+		"pre-fetch 실패 시 host/type 미상으로 invalidate skip (TTL fallback)")
 }
 
 // ─────────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## 연관 이슈
- Closes #288
- Parent: #284 (시나리오 #3)

<br>

## 구현 내용

### Audit 결과

이슈 #288 의 mutation 경로 audit 결과, 현재 모든 호출처가 명시적 Invalidate 를 정상 호출하여 **누락 없음**:

| Mutation | 호출처 | Invalidate 호출 | 상태 |
|---|---|---|---|
| `Insert` | `llmgen/generator.go:470` | line 480 (ErrDuplicate) + line 500 (성공) | ✅ |
| `UpdatePathPattern` | `refiner/refiner.go:317` | line 327 | ✅ |
| `Update` / `Delete` | 호출처 없음 | — | N/A |

### 본 PR 의 가치 — decorator 패턴 도입

현재는 누락 없으나, **향후 mutation 호출처 추가 시 invalidate 까먹을 가능성** 이 systemic 위험. 본 PR 은 `invalidatingRepo` decorator 를 도입하여 mutation→invalidate 결합을 단일 책임 지점에 모음.

### 변경 사항

**신규**: `internal/processor/parser/rule/invalidating_repo.go`

- `CacheInvalidator` 인터페이스 — Resolver 가 구조적 타이핑으로 만족
- `WrapWithInvalidator(inner, invalidator)` — Repository decorator
- 정책:
  - `Insert` 성공 / `ErrDuplicate` → `Invalidate(host, target_type)`
  - `Update` 성공 → `Invalidate`
  - `UpdatePathPattern` 성공 → 사전 `GetByID` 로 host/type lookup → `Invalidate`
  - `Delete` → ID 만 받음, 호출자 책임 (decorator 미강제)

**Wiring**: `cmd/issuetracker/main.go`

```go
parsingRuleRepo := pgstore.NewParsingRuleRepository(pool, log)
parsingRuleRepo = rule.WrapWithInvalidator(parsingRuleRepo, ruleResolver)
```

**기존 명시적 Invalidate 호출 정리** (decorator 책임 위임):
- `llmgen/generator.go`: Insert ErrDuplicate / 성공 시 Invalidate 제거
- `refiner/refiner.go`: UpdatePathPattern 성공 후 Invalidate 제거
- 단, `generator.go:376` 의 **pre-check** Invalidate 는 유지 — mutation 이 아닌 stale cache 감지 경로

### 테스트 10건

`test/internal/processor/parser/rule/invalidating_repo_test.go`:
- Insert 성공 / ErrDuplicate / 일반 에러 — 처음 두 건만 invalidate
- Update 성공 / 실패
- UpdatePathPattern 성공 (사전 GetByID + invalidate) / update 실패 / pre-fetch 실패
- Delete (invalidate 미호출)
- nil invalidator wrapping (no-op)
- nil inner (panic)

### 비고

이슈 본문의 작업 #2 (Negative cache TTL 단축) — `DefaultNegativeCacheTTL` 이 이미 30s 로 설정되어 있어 별도 변경 없음 (이슈 본문이 stale).

<br>

## CI / 머지 게이트 점검

> [CI 운영 규약](docs/ci/conventions.md) 및 [Required Status Checks 단일 소스](docs/ci/status-checks.md)에 따라 작성합니다.

### 변경 영향 범위
- 영향 패키지: `internal/processor/parser/rule`, `internal/processor/parser/rule/{llmgen,refiner}`, `cmd/issuetracker`, `test/...`
- 위험도: `Low`
  - 기존 명시적 Invalidate 호출은 decorator 가 동등하게 호출 (정상 흐름 보존)
  - decorator 미주입 시 inner repo 동작 동일 (graceful fallback)

### Required Status Checks
- 통과 확인 대상:
  - [ ] `Commit Lint`
  - [ ] `PR Title Lint`
  - [ ] `Linked Issue Check`
  - [ ] `Build`
  - [ ] `Test`
  - [ ] `Lint`

### 로컬 검증
- `make fmt` 통과
- `make build` 5개 binary 모두 통과
- `go test -race ./...` 전체 통과 (신규 10건)
- `go vet ./...` 통과

<br>

## 롤백 계획

- decorator 미주입 시 inner repo 그대로 사용 — 기존 명시적 Invalidate 호출이 제거됐으므로 cache stale 위험 발생 가능. 롤백 시 explicit 호출 복원 필요 (또는 decorator wiring 만 토글)
- 단순 revert 만으로 즉시 롤백 가능

🤖 Generated with [Claude Code](https://claude.com/claude-code)