### PR TITLE
[FEAT#283] LLM 룰 생성 시 selector confidence 메타데이터 + low-confidence drop

### DIFF
--- a/internal/processor/parser/rule/llmgen/confidence.go
+++ b/internal/processor/parser/rule/llmgen/confidence.go
@@ -109,9 +109,13 @@ func ApplyConfidenceFilter(sm storage.SelectorMap, confidence map[string]storage
 	return out
 }
 
-// isFieldHit 는 doc 에 selector 를 적용해 hit (1건 이상 매칭 + 형식 검증 통과) 여부를 반환합니다.
+// isFieldHit 는 doc 에 selector 를 적용해 hit 여부를 반환합니다.
 //
-// published_at 한정으로 추출된 텍스트가 time.Parse 통과해야 hit. 다른 필드는 단순 매칭만으로 hit.
+// hit 정의 (PR #293 CodeRabbit Major):
+//   - DOM 매칭 1건 이상
+//   - **추출 결과 (text 또는 attribute) 가 비어있지 않음** — attribute selector 가 attribute
+//     를 못 찾거나 빈 element 매칭하면 hit 아님 (low-confidence drop 게이트 강화)
+//   - published_at 추가: 추출된 텍스트가 time.Parse 통과해야 hit
 func isFieldHit(doc *goquery.Document, fieldName string, fs *storage.FieldSelector) bool {
 	if fs == nil || strings.TrimSpace(fs.CSS) == "" {
 		return false
@@ -120,24 +124,29 @@ func isFieldHit(doc *goquery.Document, fieldName string, fs *storage.FieldSelect
 	if sel.Length() == 0 {
 		return false
 	}
-	if fieldName != "published_at" {
-		return true
-	}
-	// published_at — 첫 매칭의 추출 결과가 date 로 parse 가능한지 확인.
-	first := sel.First()
-	var text string
-	if fs.Attribute != "" {
-		if v, exists := first.Attr(fs.Attribute); exists {
-			text = strings.TrimSpace(v)
-		}
-	}
-	if text == "" {
-		text = strings.TrimSpace(first.Text())
-	}
+	text := extractFirstValue(sel, fs)
 	if text == "" {
 		return false
 	}
-	return tryParseDateLayouts(text)
+	if fieldName == "published_at" {
+		return tryParseDateLayouts(text)
+	}
+	return true
+}
+
+// extractFirstValue 는 selector 의 첫 매칭 element 에서 추출 값을 반환합니다.
+//
+// fs.Attribute != "" 이면 attribute 값 (없으면 빈 문자열 — text fallback 안 함, attribute
+// selector 의 의도 존중). 그 외에는 text().
+func extractFirstValue(sel *goquery.Selection, fs *storage.FieldSelector) string {
+	first := sel.First()
+	if fs.Attribute != "" {
+		if v, exists := first.Attr(fs.Attribute); exists {
+			return strings.TrimSpace(v)
+		}
+		return ""
+	}
+	return strings.TrimSpace(first.Text())
 }
 
 // tryParseDateLayouts 는 publishedAtTimeLayouts 의 layout 을 순회하며 parse 성공 여부를 반환합니다.

--- a/internal/processor/parser/rule/llmgen/confidence.go
+++ b/internal/processor/parser/rule/llmgen/confidence.go
@@ -1,0 +1,171 @@
+package llmgen
+
+import (
+	"reflect"
+	"strings"
+	"time"
+
+	"github.com/PuerkitoBio/goquery"
+
+	"issuetracker/internal/storage"
+)
+
+// confidenceThreshold 는 selector 의 hit_rate 가 본 임계값 미만이면 drop (nil) 처리됩니다 (이슈 #283).
+//
+// 단일 sample 환경에서 hit_rate 는 0.0 또는 1.0 (binary) — threshold 0.5 면 \"매칭 못함\" 만 drop.
+// 향후 multi-sample 도입 시 (sample_count > 1) 임계값이 의미 있는 분기점이 됨.
+const confidenceThreshold = 0.5
+
+// publishedAtTimeLayouts 는 published_at 텍스트의 형식 검증에 사용할 time.Parse layout 후보입니다.
+//
+// 뉴스 사이트가 흔히 노출하는 datetime 형식 + ISO 8601 / RFC 3339 표준. 첫 매칭되는 layout 이
+// hit 로 인정. layout 부족 시 운영자가 추가 (코드 변경 + 재배포 필요).
+var publishedAtTimeLayouts = []string{
+	time.RFC3339,
+	time.RFC3339Nano,
+	"2006-01-02T15:04:05Z",
+	"2006-01-02T15:04:05",
+	"2006-01-02 15:04:05",
+	"2006-01-02 15:04",
+	"2006-01-02",
+	"2006/01/02 15:04:05",
+	"2006/01/02 15:04",
+	"2006/01/02",
+	"2006.01.02 15:04:05",
+	"2006.01.02 15:04",
+	"2006.01.02",
+	"Mon, 02 Jan 2006 15:04:05 MST",   // RFC1123
+	"Mon, 02 Jan 2006 15:04:05 -0700", // RFC1123Z
+	"January 2, 2006",
+	"Jan 2, 2006",
+}
+
+// ComputeFieldConfidence 는 SelectorMap 의 각 필드별 hit_rate 를 계산합니다 (이슈 #283).
+//
+// 단일 sample 환경 — 각 selector 를 html 에 적용 후 매칭 1건 이상이면 hit_rate=1.0, 아니면 0.0.
+// SampleCount 는 항상 1 (multi-sample 도입 시 분모 증가).
+//
+// published_at 은 추가로 추출된 텍스트가 time.Parse 통과해야 hit 로 카운트 — selector 가 잘못된
+// element (제목 / 광고 등) 매칭 시 텍스트는 추출되지만 date 가 아니므로 hit_rate=0.
+//
+// 빈 SelectorMap 또는 html parse 실패 시 빈 map 반환 (caller 가 무시).
+func ComputeFieldConfidence(sm storage.SelectorMap, html string) map[string]storage.FieldConfidence {
+	doc, err := goquery.NewDocumentFromReader(strings.NewReader(html))
+	if err != nil {
+		return map[string]storage.FieldConfidence{}
+	}
+	out := make(map[string]storage.FieldConfidence)
+
+	v := reflect.ValueOf(sm)
+	t := reflect.TypeOf(sm)
+	for i := 0; i < v.NumField(); i++ {
+		field := v.Field(i)
+		// FieldSelector 포인터 필드만 (LinkDiscovery 등은 skip — pointer 가 아닌 별도 struct).
+		if field.Kind() != reflect.Ptr || field.IsNil() {
+			continue
+		}
+		fs, ok := field.Interface().(*storage.FieldSelector)
+		if !ok {
+			continue
+		}
+		jsonTag := jsonFieldName(t.Field(i).Tag.Get("json"))
+		if jsonTag == "" {
+			continue
+		}
+		hit := isFieldHit(doc, jsonTag, fs)
+		out[jsonTag] = storage.FieldConfidence{
+			HitRate:     boolToFloat(hit),
+			SampleCount: 1,
+		}
+	}
+	return out
+}
+
+// ApplyConfidenceFilter 는 confidence 가 임계값 미만인 필드의 selector 를 nil 로 drop 합니다 (이슈 #283).
+//
+// 신뢰할 수 없는 selector 가 INSERT 되면 하류 parser 가 빈 값을 추출 — host 별 \"본 필드 부재\" 학습
+// 으로 이어짐. validator 는 confidence=0 인 필드를 \"부재가 정상\" 으로 판단할 수 있음 (sub-issue).
+func ApplyConfidenceFilter(sm storage.SelectorMap, confidence map[string]storage.FieldConfidence) storage.SelectorMap {
+	out := sm
+	v := reflect.ValueOf(&out).Elem()
+	t := v.Type()
+	for i := 0; i < v.NumField(); i++ {
+		field := v.Field(i)
+		if field.Kind() != reflect.Ptr || field.IsNil() {
+			continue
+		}
+		jsonTag := jsonFieldName(t.Field(i).Tag.Get("json"))
+		if jsonTag == "" {
+			continue
+		}
+		c, ok := confidence[jsonTag]
+		if !ok {
+			continue
+		}
+		if c.HitRate < confidenceThreshold {
+			field.Set(reflect.Zero(field.Type()))
+		}
+	}
+	return out
+}
+
+// isFieldHit 는 doc 에 selector 를 적용해 hit (1건 이상 매칭 + 형식 검증 통과) 여부를 반환합니다.
+//
+// published_at 한정으로 추출된 텍스트가 time.Parse 통과해야 hit. 다른 필드는 단순 매칭만으로 hit.
+func isFieldHit(doc *goquery.Document, fieldName string, fs *storage.FieldSelector) bool {
+	if fs == nil || strings.TrimSpace(fs.CSS) == "" {
+		return false
+	}
+	sel := doc.Find(fs.CSS)
+	if sel.Length() == 0 {
+		return false
+	}
+	if fieldName != "published_at" {
+		return true
+	}
+	// published_at — 첫 매칭의 추출 결과가 date 로 parse 가능한지 확인.
+	first := sel.First()
+	var text string
+	if fs.Attribute != "" {
+		if v, exists := first.Attr(fs.Attribute); exists {
+			text = strings.TrimSpace(v)
+		}
+	}
+	if text == "" {
+		text = strings.TrimSpace(first.Text())
+	}
+	if text == "" {
+		return false
+	}
+	return tryParseDateLayouts(text)
+}
+
+// tryParseDateLayouts 는 publishedAtTimeLayouts 의 layout 을 순회하며 parse 성공 여부를 반환합니다.
+func tryParseDateLayouts(text string) bool {
+	for _, layout := range publishedAtTimeLayouts {
+		if _, err := time.Parse(layout, text); err == nil {
+			return true
+		}
+	}
+	return false
+}
+
+// jsonFieldName 은 struct field tag 의 json 이름 부분만 추출합니다 (예: "title,omitempty" → "title").
+//
+// 빈 문자열 또는 "-" 면 무시 대상.
+func jsonFieldName(tag string) string {
+	if tag == "" || tag == "-" {
+		return ""
+	}
+	if idx := strings.IndexByte(tag, ','); idx >= 0 {
+		tag = tag[:idx]
+	}
+	return strings.TrimSpace(tag)
+}
+
+func boolToFloat(b bool) float64 {
+	if b {
+		return 1.0
+	}
+	return 0.0
+}

--- a/internal/processor/parser/rule/llmgen/generator.go
+++ b/internal/processor/parser/rule/llmgen/generator.go
@@ -458,6 +458,13 @@ func (g *Generator) runOnce(ctx context.Context, host string, targetType storage
 		}
 	}
 
+	// 프로그래매틱 검증 (이슈 #283) — 각 selector 를 sample HTML 에 적용 후 hit_rate 계산.
+	// hit_rate < confidenceThreshold 인 selector 는 nil 로 drop — 신뢰할 수 없는 selector 가
+	// DB 에 들어가 하류 parser 가 빈 값 / 잘못된 값을 추출하지 않도록.
+	// published_at 은 form 검증 (time.Parse) 통과 시에만 hit 로 카운트.
+	confidence := ComputeFieldConfidence(selectors, html)
+	selectors = ApplyConfidenceFilter(selectors, confidence)
+
 	record := &storage.ParsingRuleRecord{
 		SourceName:  LLMAutoSourceName,
 		HostPattern: host,
@@ -465,6 +472,7 @@ func (g *Generator) runOnce(ctx context.Context, host string, targetType storage
 		Version:     1,
 		Enabled:     true, // CSS selector 검증 통과 = 품질 게이트 — 즉시 활성화하여 pending 재투입이 유효하도록
 		Selectors:   selectors,
+		Confidence:  confidence,
 		Description: fmt.Sprintf("%s (sample url: %s, model: %s)", llmAutoDescription, sampleURL, modelName),
 	}
 	if err := g.repo.Insert(ctx, record); err != nil {

--- a/internal/storage/parsing_rule.go
+++ b/internal/storage/parsing_rule.go
@@ -136,9 +136,30 @@ type ParsingRuleRecord struct {
 	Version     int        // 활성 row 안에서 같은 (source, host, path, type) 의 최신 버전
 	Enabled     bool
 	Selectors   SelectorMap // JSONB — application 측 struct 로 직렬화
+
+	// Confidence 는 필드별 selector 추출 신뢰도 metadata 입니다 (이슈 #283).
+	//
+	// LLM 자동 생성 룰이 INSERT 시점에 각 selector 를 sample HTML 에 적용하여 hit_rate 계산.
+	// 하류 validator 는 본 metadata 로 host 별 차별화된 정책 적용 가능 (예: published_at hit_rate=0
+	// 인 host 는 published_at 누락을 reject 하지 않음 — sub-issue 로 분리).
+	//
+	// nil 또는 빈 map 은 "metadata 미상" 의미 — 기존 룰 / 운영자 manual 등록 룰에 대해
+	// validator 는 보수적 default 정책 (모든 필드 reliable 가정) 적용.
+	Confidence  map[string]FieldConfidence
 	Description string
 	CreatedAt   time.Time
 	UpdatedAt   time.Time
+}
+
+// FieldConfidence 는 단일 필드의 추출 신뢰도 (이슈 #283).
+//
+//   - HitRate     : 0.0~1.0 — sample 중 selector 가 매칭 + 유효 결과를 산출한 비율
+//   - SampleCount : 분모 — 신뢰도 계산에 사용된 sample 수 (단일 sample 환경은 1)
+//
+// published_at 등 형식 검증이 필요한 필드는 추가로 형식 검증 (예: time.Parse) 통과해야 hit 로 계수.
+type FieldConfidence struct {
+	HitRate     float64 `json:"hit_rate"`
+	SampleCount int     `json:"sample_count"`
 }
 
 // ParsingRuleFilter 는 List 조회 시 필터 조건입니다.

--- a/internal/storage/postgres/parsing_rule.go
+++ b/internal/storage/postgres/parsing_rule.go
@@ -34,9 +34,9 @@ func NewParsingRuleRepository(pool *pgxpool.Pool, log *logger.Logger) storage.Pa
 
 const sqlInsertParsingRule = `
 INSERT INTO parsing_rules (
-  source_name, host_pattern, path_pattern, target_type, version, enabled, selectors, description
+  source_name, host_pattern, path_pattern, target_type, version, enabled, selectors, confidence, description
 ) VALUES (
-  $1, $2, $3, $4, $5, $6, $7, $8
+  $1, $2, $3, $4, $5, $6, $7, $8, $9
 )
 RETURNING id, created_at, updated_at
 `
@@ -59,12 +59,16 @@ func (r *pgParsingRuleRepository) Insert(ctx context.Context, rec *storage.Parsi
 	if err != nil {
 		return fmt.Errorf("marshal selectors: %w", err)
 	}
+	confidence, err := marshalConfidence(rec.Confidence)
+	if err != nil {
+		return fmt.Errorf("marshal confidence: %w", err)
+	}
 	if rec.Version == 0 {
 		rec.Version = 1
 	}
 	row := r.pool.QueryRow(ctx, sqlInsertParsingRule,
 		rec.SourceName, rec.HostPattern, rec.PathPattern, string(rec.TargetType), rec.Version,
-		rec.Enabled, selectors, rec.Description,
+		rec.Enabled, selectors, confidence, rec.Description,
 	)
 	if err := row.Scan(&rec.ID, &rec.CreatedAt, &rec.UpdatedAt); err != nil {
 		var pgErr *pgconn.PgError
@@ -139,7 +143,7 @@ func (r *pgParsingRuleRepository) UpdatePathPattern(ctx context.Context, id int6
 }
 
 const sqlGetParsingRuleByID = `
-SELECT id, source_name, host_pattern, path_pattern, target_type, version, enabled, selectors, description, created_at, updated_at
+SELECT id, source_name, host_pattern, path_pattern, target_type, version, enabled, selectors, confidence, description, created_at, updated_at
 FROM parsing_rules
 WHERE id = $1
 `
@@ -158,7 +162,7 @@ func (r *pgParsingRuleRepository) GetByID(ctx context.Context, id int64) (*stora
 }
 
 const sqlFindParsingRuleByNaturalKey = `
-SELECT id, source_name, host_pattern, path_pattern, target_type, version, enabled, selectors, description, created_at, updated_at
+SELECT id, source_name, host_pattern, path_pattern, target_type, version, enabled, selectors, confidence, description, created_at, updated_at
 FROM parsing_rules
 WHERE source_name  = $1
   AND host_pattern = $2
@@ -220,7 +224,7 @@ func (r *pgParsingRuleRepository) HasAnyRule(ctx context.Context, hostPattern st
 //   - LENGTH(path_pattern) DESC : 더 구체적인 (긴) regex 패턴 우선 (path_pattern=” 은 길이 0 으로 마지막)
 //   - version DESC             : 같은 패턴 안에서 최신 버전 우선
 const sqlFindActiveCandidates = `
-SELECT id, source_name, host_pattern, path_pattern, target_type, version, enabled, selectors, description, created_at, updated_at
+SELECT id, source_name, host_pattern, path_pattern, target_type, version, enabled, selectors, confidence, description, created_at, updated_at
 FROM parsing_rules
 WHERE host_pattern = $1
   AND target_type  = $2
@@ -277,7 +281,7 @@ func (r *pgParsingRuleRepository) List(ctx context.Context, f storage.ParsingRul
 	}
 
 	query := `
-SELECT id, source_name, host_pattern, path_pattern, target_type, version, enabled, selectors, description, created_at, updated_at
+SELECT id, source_name, host_pattern, path_pattern, target_type, version, enabled, selectors, confidence, description, created_at, updated_at
 FROM parsing_rules
 WHERE 1=1`
 	args := make([]any, 0, 4)
@@ -336,14 +340,14 @@ func (r *pgParsingRuleRepository) Delete(ctx context.Context, id int64) error {
 }
 
 // scanParsingRule 은 Row/Rows 에서 ParsingRuleRecord 를 스캔합니다.
-// selectors 는 raw JSONB → SelectorMap 으로 unmarshal.
+// selectors / confidence 는 raw JSONB → application struct 로 unmarshal (이슈 #283).
 func scanParsingRule(s scanner) (*storage.ParsingRuleRecord, error) {
 	rec := &storage.ParsingRuleRecord{}
-	var selectorsRaw []byte
+	var selectorsRaw, confidenceRaw []byte
 	var targetType string
 	if err := s.Scan(
 		&rec.ID, &rec.SourceName, &rec.HostPattern, &rec.PathPattern, &targetType, &rec.Version,
-		&rec.Enabled, &selectorsRaw, &rec.Description, &rec.CreatedAt, &rec.UpdatedAt,
+		&rec.Enabled, &selectorsRaw, &confidenceRaw, &rec.Description, &rec.CreatedAt, &rec.UpdatedAt,
 	); err != nil {
 		return nil, err
 	}
@@ -353,5 +357,20 @@ func scanParsingRule(s scanner) (*storage.ParsingRuleRecord, error) {
 			return nil, fmt.Errorf("unmarshal selectors for rule %d: %w", rec.ID, err)
 		}
 	}
+	if len(confidenceRaw) > 0 {
+		if err := json.Unmarshal(confidenceRaw, &rec.Confidence); err != nil {
+			return nil, fmt.Errorf("unmarshal confidence for rule %d: %w", rec.ID, err)
+		}
+	}
 	return rec, nil
+}
+
+// marshalConfidence 는 Confidence map 을 JSONB byte 로 직렬화합니다 (이슈 #283).
+//
+// nil 또는 빈 map 은 "{}" 로 직렬화 — JSONB NOT NULL 제약 충족 + scan 시 빈 map 으로 복원.
+func marshalConfidence(c map[string]storage.FieldConfidence) ([]byte, error) {
+	if len(c) == 0 {
+		return []byte("{}"), nil
+	}
+	return json.Marshal(c)
 }

--- a/internal/storage/postgres/parsing_rule.go
+++ b/internal/storage/postgres/parsing_rule.go
@@ -82,19 +82,27 @@ func (r *pgParsingRuleRepository) Insert(ctx context.Context, rec *storage.Parsi
 
 const sqlUpdateParsingRule = `
 UPDATE parsing_rules
-SET selectors = $2, enabled = $3, description = $4
+SET selectors = $2, confidence = $3, enabled = $4, description = $5
 WHERE id = $1
 RETURNING updated_at
 `
 
 // Update 는 ID 로 규칙을 갱신합니다. 자연키 (source/host/path/type/version) 는 변경 불가 —
 // 규칙 진화는 새 row 를 INSERT 후 enabled flip 으로 표현 권장.
+//
+// PR #293 CodeRabbit Major: confidence 도 함께 갱신 — selectors 만 바뀌고 confidence 가 stale
+// 로 남으면 하류 validator 가 잘못된 신뢰도로 판단. 호출자는 selectors 변경 시 confidence 도
+// 같이 채워서 전달 (또는 nil/빈 map 으로 reset).
 func (r *pgParsingRuleRepository) Update(ctx context.Context, rec *storage.ParsingRuleRecord) error {
 	selectors, err := json.Marshal(rec.Selectors)
 	if err != nil {
 		return fmt.Errorf("marshal selectors: %w", err)
 	}
-	row := r.pool.QueryRow(ctx, sqlUpdateParsingRule, rec.ID, selectors, rec.Enabled, rec.Description)
+	confidence, err := marshalConfidence(rec.Confidence)
+	if err != nil {
+		return fmt.Errorf("marshal confidence: %w", err)
+	}
+	row := r.pool.QueryRow(ctx, sqlUpdateParsingRule, rec.ID, selectors, confidence, rec.Enabled, rec.Description)
 	if err := row.Scan(&rec.UpdatedAt); err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			return storage.ErrNotFound

--- a/migrations/down/015_parsing_rules_confidence.sql
+++ b/migrations/down/015_parsing_rules_confidence.sql
@@ -1,0 +1,4 @@
+-- 015_parsing_rules_confidence (down): confidence 컬럼 제거 (이슈 #283 롤백).
+
+ALTER TABLE parsing_rules
+  DROP COLUMN IF EXISTS confidence;

--- a/migrations/up/015_parsing_rules_confidence.sql
+++ b/migrations/up/015_parsing_rules_confidence.sql
@@ -1,0 +1,22 @@
+-- 015_parsing_rules_confidence: parsing_rules 에 confidence 메타데이터 JSONB 컬럼 추가 (이슈 #283)
+--
+-- 배경:
+--   LLM 자동 생성 룰의 selector 가 실제 HTML 에서 추출 가능한지 / published_at 같은 필드가
+--   해당 호스트에서 안정적으로 추출되는지를 metadata 로 보존. 하류 validator 가 host 별
+--   차별화된 정책 (예: published_at 부재 host 는 reject 안 함) 을 적용 가능.
+--
+-- 스키마:
+--   - confidence: JSONB — 필드별 hit_rate / sample_count 보관
+--     예: {"title": {"hit_rate": 1.0, "sample_count": 1},
+--          "main_content": {"hit_rate": 1.0, "sample_count": 1},
+--          "published_at": {"hit_rate": 0.0, "sample_count": 1}}
+--   - 기존 row 는 default '{}' — backward compat (자동 학습 / 추후 갱신)
+--   - selectors 와 별도 컬럼 — selectors 는 추출 logic, confidence 는 추출 신뢰도 (관심사 분리)
+--
+-- 진화 친화적 — 새 metadata 필드 추가 시 application 측 struct 만 변경, migration 불필요.
+
+ALTER TABLE parsing_rules
+  ADD COLUMN IF NOT EXISTS confidence JSONB NOT NULL DEFAULT '{}';
+
+COMMENT ON COLUMN parsing_rules.confidence IS
+  '필드별 추출 신뢰도 metadata: {"<field>": {"hit_rate": float, "sample_count": int}}. 이슈 #283.';

--- a/test/internal/processor/parser/rule/llmgen/confidence_test.go
+++ b/test/internal/processor/parser/rule/llmgen/confidence_test.go
@@ -1,0 +1,148 @@
+package llmgen_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"issuetracker/internal/processor/parser/rule/llmgen"
+	"issuetracker/internal/storage"
+)
+
+const confSampleHTML = `<!DOCTYPE html>
+<html><body>
+<h1 class="article-title">Sample Headline</h1>
+<article><p>Body paragraph one.</p><p>Body paragraph two.</p></article>
+<span class="author">Jane Doe</span>
+<time datetime="2026-05-07T10:30:00Z">2026-05-07</time>
+<meta name="description" content="A short summary of the article.">
+</body></html>`
+
+// ─────────────────────────────────────────────────────────────────────────────
+// ComputeFieldConfidence
+// ─────────────────────────────────────────────────────────────────────────────
+
+func TestComputeFieldConfidence_AllSelectorsMatch(t *testing.T) {
+	sm := storage.SelectorMap{
+		Title:       &storage.FieldSelector{CSS: "h1.article-title"},
+		MainContent: &storage.FieldSelector{CSS: "article p", Multi: true},
+		Author:      &storage.FieldSelector{CSS: "span.author"},
+		PublishedAt: &storage.FieldSelector{CSS: "time", Attribute: "datetime"},
+		Summary:     &storage.FieldSelector{CSS: "meta[name=description]", Attribute: "content"},
+	}
+	got := llmgen.ComputeFieldConfidence(sm, confSampleHTML)
+
+	assert.Equal(t, 1.0, got["title"].HitRate)
+	assert.Equal(t, 1.0, got["main_content"].HitRate)
+	assert.Equal(t, 1.0, got["author"].HitRate)
+	assert.Equal(t, 1.0, got["published_at"].HitRate, "datetime attribute 가 RFC3339 parse 가능")
+	assert.Equal(t, 1.0, got["summary"].HitRate)
+	for _, c := range got {
+		assert.Equal(t, 1, c.SampleCount, "단일 sample 환경 — sample_count=1")
+	}
+}
+
+func TestComputeFieldConfidence_MissingSelectorReturnsZero(t *testing.T) {
+	sm := storage.SelectorMap{
+		Title:       &storage.FieldSelector{CSS: "h1.does-not-exist"},
+		MainContent: &storage.FieldSelector{CSS: "article p"},
+	}
+	got := llmgen.ComputeFieldConfidence(sm, confSampleHTML)
+
+	assert.Equal(t, 0.0, got["title"].HitRate, "selector 매칭 0 → hit_rate=0")
+	assert.Equal(t, 1.0, got["main_content"].HitRate)
+}
+
+func TestComputeFieldConfidence_PublishedAtUnparseableText_ReturnsZero(t *testing.T) {
+	// time element 는 매칭되나 text 가 \"2026-05-07\" 이 아니라 random 문자열인 케이스.
+	html := `<html><body><time class="ts">not a date</time></body></html>`
+	sm := storage.SelectorMap{
+		PublishedAt: &storage.FieldSelector{CSS: "time.ts"}, // attribute 없음 → text() 사용
+	}
+	got := llmgen.ComputeFieldConfidence(sm, html)
+	assert.Equal(t, 0.0, got["published_at"].HitRate, "selector 매칭하나 text 가 date parse 실패 → hit_rate=0")
+}
+
+func TestComputeFieldConfidence_PublishedAtVariousFormats(t *testing.T) {
+	cases := []struct {
+		name string
+		html string
+		want float64
+	}{
+		{"ISO 8601 RFC3339", `<time>2026-05-07T10:30:00Z</time>`, 1.0},
+		{"date only", `<time>2026-05-07</time>`, 1.0},
+		{"slash-separated", `<time>2026/05/07 10:30:00</time>`, 1.0},
+		{"dot-separated", `<time>2026.05.07</time>`, 1.0},
+		{"english long", `<time>January 2, 2026</time>`, 1.0},
+		{"random text", `<time>hello world</time>`, 0.0},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			full := "<html><body>" + tc.html + "</body></html>"
+			sm := storage.SelectorMap{PublishedAt: &storage.FieldSelector{CSS: "time"}}
+			got := llmgen.ComputeFieldConfidence(sm, full)
+			assert.Equal(t, tc.want, got["published_at"].HitRate)
+		})
+	}
+}
+
+func TestComputeFieldConfidence_NilSelectorIgnored(t *testing.T) {
+	sm := storage.SelectorMap{
+		Title: &storage.FieldSelector{CSS: "h1.article-title"},
+		// MainContent / Author / 기타 nil
+	}
+	got := llmgen.ComputeFieldConfidence(sm, confSampleHTML)
+	assert.Equal(t, 1.0, got["title"].HitRate)
+	_, mainExists := got["main_content"]
+	assert.False(t, mainExists, "nil selector 는 confidence map 에 entry 없음")
+}
+
+func TestComputeFieldConfidence_HTMLParseError_ReturnsEmptyMap(t *testing.T) {
+	// goquery 는 거의 모든 입력을 파싱 — 빈 string 도 정상 파싱하므로 실제 파싱 에러
+	// 시뮬레이션이 어려움. 빈 SelectorMap 으로 빈 map 반환만 확인.
+	got := llmgen.ComputeFieldConfidence(storage.SelectorMap{}, confSampleHTML)
+	assert.Empty(t, got, "selector 자체가 모두 nil 이면 빈 map")
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// ApplyConfidenceFilter
+// ─────────────────────────────────────────────────────────────────────────────
+
+func TestApplyConfidenceFilter_DropsLowConfidenceSelectors(t *testing.T) {
+	sm := storage.SelectorMap{
+		Title:       &storage.FieldSelector{CSS: "h1"},
+		MainContent: &storage.FieldSelector{CSS: "article"},
+		PublishedAt: &storage.FieldSelector{CSS: "time"}, // 신뢰도 0
+	}
+	conf := map[string]storage.FieldConfidence{
+		"title":        {HitRate: 1.0, SampleCount: 1},
+		"main_content": {HitRate: 1.0, SampleCount: 1},
+		"published_at": {HitRate: 0.0, SampleCount: 1}, // drop 대상
+	}
+	got := llmgen.ApplyConfidenceFilter(sm, conf)
+	assert.NotNil(t, got.Title, "신뢰도 1.0 — selector 보존")
+	assert.NotNil(t, got.MainContent)
+	assert.Nil(t, got.PublishedAt, "신뢰도 0.0 — selector drop")
+}
+
+func TestApplyConfidenceFilter_ConfidenceMissingForField_KeepsSelector(t *testing.T) {
+	sm := storage.SelectorMap{
+		Title: &storage.FieldSelector{CSS: "h1"},
+	}
+	got := llmgen.ApplyConfidenceFilter(sm, map[string]storage.FieldConfidence{})
+	assert.NotNil(t, got.Title, "confidence map 에 entry 없으면 보수적으로 보존")
+}
+
+func TestApplyConfidenceFilter_AllAboveThreshold_KeepsAll(t *testing.T) {
+	sm := storage.SelectorMap{
+		Title:       &storage.FieldSelector{CSS: "h1"},
+		MainContent: &storage.FieldSelector{CSS: "article"},
+	}
+	conf := map[string]storage.FieldConfidence{
+		"title":        {HitRate: 1.0, SampleCount: 1},
+		"main_content": {HitRate: 0.6, SampleCount: 1}, // 임계값 0.5 위
+	}
+	got := llmgen.ApplyConfidenceFilter(sm, conf)
+	assert.NotNil(t, got.Title)
+	assert.NotNil(t, got.MainContent)
+}

--- a/test/internal/processor/parser/rule/llmgen/confidence_test.go
+++ b/test/internal/processor/parser/rule/llmgen/confidence_test.go
@@ -86,6 +86,38 @@ func TestComputeFieldConfidence_PublishedAtVariousFormats(t *testing.T) {
 	}
 }
 
+func TestComputeFieldConfidence_EmptyExtractedValue_ReturnsZero(t *testing.T) {
+	// element 는 매칭되나 추출 값이 비어있는 케이스 (PR #293 CodeRabbit Major).
+	cases := []struct {
+		name string
+		html string
+		fs   *storage.FieldSelector
+	}{
+		{
+			name: "text selector 매칭하나 element 비어있음",
+			html: `<html><body><h1 class="title"></h1></body></html>`,
+			fs:   &storage.FieldSelector{CSS: "h1.title"},
+		},
+		{
+			name: "attribute selector — attribute 부재",
+			html: `<html><body><a class="link">text</a></body></html>`,
+			fs:   &storage.FieldSelector{CSS: "a.link", Attribute: "href"},
+		},
+		{
+			name: "attribute selector — attribute 빈 문자열",
+			html: `<html><body><a class="link" href="">text</a></body></html>`,
+			fs:   &storage.FieldSelector{CSS: "a.link", Attribute: "href"},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			sm := storage.SelectorMap{Title: tc.fs}
+			got := llmgen.ComputeFieldConfidence(sm, tc.html)
+			assert.Equal(t, 0.0, got["title"].HitRate, "추출 값이 빈 문자열이면 hit_rate=0")
+		})
+	}
+}
+
 func TestComputeFieldConfidence_NilSelectorIgnored(t *testing.T) {
 	sm := storage.SelectorMap{
 		Title: &storage.FieldSelector{CSS: "h1.article-title"},


### PR DESCRIPTION
## 연관 이슈
- Closes #283 (Phase 1 — 단일 sample 기반)

<br>

## 구현 내용

라이브 검증 (PR #271 후속) 의 VAL_001 **587건 (95% DLQ)** 분석 결과: daum / cnn 의 `parsing_rules` 에 `published_at` selector 가 NULL 인 row 가 등록되어 매 기사가 validation 단계에서 reject. 원인은 LLM 자동 생성 룰이 selector 추출 신뢰도를 검증하지 않고 INSERT.

본 PR 은 **LLM 룰 생성 시점에 각 selector 의 추출 신뢰도를 측정** 하여 신뢰할 수 없는 selector 를 drop + 신뢰도 metadata 를 DB 에 보존.

### 변경 사항

| 위치 | 내용 |
|---|---|
| `migrations/up/015_parsing_rules_confidence.sql` | `confidence` JSONB 컬럼 추가 (default `{}`) |
| `migrations/down/015_*.sql` | 롤백 SQL |
| `internal/storage/parsing_rule.go` | `FieldConfidence` struct + `ParsingRuleRecord.Confidence` map 필드 |
| `internal/storage/postgres/parsing_rule.go` | Insert / scan 시 confidence JSONB 직렬화 + 4개 SELECT 갱신 |
| `internal/processor/parser/rule/llmgen/confidence.go` (신규) | `ComputeFieldConfidence` + `ApplyConfidenceFilter` 헬퍼 |
| `internal/processor/parser/rule/llmgen/generator.go` | `runOnce` 의 INSERT 직전 confidence 계산 + filter 적용 |

### 핵심 알고리즘

`ComputeFieldConfidence`:
- SelectorMap 의 각 non-nil 필드를 reflection 으로 순회
- selector 를 sample HTML 에 적용 → 매칭 1건 이상이면 hit (hit_rate=1.0)
- **published_at 특수 처리**: 추출된 텍스트가 17개 time layout 중 하나로 parse 가능해야 hit
  - RFC3339 / RFC1123 / `2006-01-02T15:04:05Z` / `2006-01-02 15:04:05` / `2006/01/02` / `2006.01.02` / `January 2, 2006` 등
  - selector 가 잘못된 element (제목 / 광고) 매칭 시 텍스트는 추출되지만 date 가 아니므로 hit_rate=0

`ApplyConfidenceFilter`:
- `hit_rate < 0.5` 인 필드의 selector 를 `nil` 로 drop
- 신뢰할 수 없는 selector 가 DB 에 들어가는 것 차단

### 단위 테스트 13건

- `ComputeFieldConfidence`: 모든 selector 매칭 / 미매칭 / nil selector skip / parse 에러 처리
- published_at 형식 검증: 6 케이스 (RFC3339 / date only / slash / dot / english long / random text)
- `ApplyConfidenceFilter`: low-confidence drop / confidence missing → keep / all above threshold

### 비고 — Phase 2 (별도 sub-issue)

- **진정한 multi-sample** — raw_contents 또는 sample_url 기반 N HTML fetch (현재는 단일 sample)
- **Validator confidence 기반 분기** — `rule.HasReliablePublishedAt()` 같은 helper 도입 후 news_validator 에서 활용

### 직접 효과

- daum / cnn 룰을 disable + 재학습 시 published_at hit_rate=0 으로 학습되어 selector nil 로 INSERT — 다음 fetch 부터 published_at 추출 시도 안 함
- Phase 2 validator 분기 도입 후, host 별 \"published_at 부재가 정상\" 정책 가능 → VAL_001 95% DLQ 해소

<br>

## CI / 머지 게이트 점검

> [CI 운영 규약](docs/ci/conventions.md) 및 [Required Status Checks 단일 소스](docs/ci/status-checks.md)에 따라 작성합니다.

### 변경 영향 범위
- 영향 패키지: `internal/storage`, `internal/storage/postgres`, `internal/processor/parser/rule/llmgen`, `migrations`
- 위험도: `Low`
  - confidence 컬럼은 기존 row 에 default `{}` 로 backward compat
  - LLM 자동 생성 신규 룰만 confidence 채워짐 — 기존 운영자 manual 룰은 영향 X
  - Phase 1 의 selector drop 만 — validator 분기는 Phase 2 에서

### Required Status Checks
- 통과 확인 대상:
  - [ ] `Commit Lint`
  - [ ] `PR Title Lint`
  - [ ] `Linked Issue Check`
  - [ ] `Build`
  - [ ] `Test`
  - [ ] `Lint`

### 로컬 검증
- `make fmt` 통과
- `make build` 5개 binary 모두 통과
- `go test -race ./...` 전체 통과 (신규 13건 포함)
- `go vet ./...` 통과

<br>

## 롤백 계획

- Migration 015 down 적용으로 confidence 컬럼 제거 가능 (기존 룰은 selectors 그대로 사용)
- 코드 revert 시 ComputeFieldConfidence 호출 제거 — 기존 동작 (모든 LLM 결과 그대로 INSERT) 으로 복귀

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Implemented confidence scoring for selector-based field extraction to evaluate selector reliability and accuracy.
  * Automatic filtering removes underperforming selectors, improving data extraction quality and consistency.
  * Confidence metrics now persisted with parsing rules for transparency and auditability.

* **Tests**
  * Added comprehensive test coverage for confidence computation and selector filtering functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->