### PR TITLE
[FEAT#282] stale rule 자동 재학습 + path_pattern version bump

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -152,3 +152,12 @@ FETCHER_EMPTY_BODY_CONTENT_MIN=100
 REFINEMENT_ENABLED=true
 REFINEMENT_INTERVAL=5m
 REFINEMENT_MIN_SAMPLES=5
+
+# Stale rule 자동 재학습 설정 (이슈 #282)
+# parse_failure / empty_selector 가 host 단위 sliding window 로 누적되어 임계 도달 시
+# Generator.EnqueueStale 가 InsertNextVersion 으로 동일 자연키의 다음 version 을 INSERT.
+# Threshold/Window 은 chromedp 자동 전환 (FETCHER_AUTO_UPGRADE_*) 보다 보수적으로 설정 —
+# chromedp 가 먼저 시도되고, 그래도 실패 지속 시 LLM 재학습.
+STALE_RELEARN_ENABLED=true
+STALE_RELEARN_THRESHOLD=10
+STALE_RELEARN_WINDOW=2h

--- a/cmd/issuetracker/main.go
+++ b/cmd/issuetracker/main.go
@@ -440,6 +440,39 @@ func main() {
 		pw.SetPipelineGuard(pipelineGuard)
 	}
 
+	// ── Stale rule 재학습 카운터 (이슈 #282) ───────────────────────────────────
+	// host 단위 stale parse failure 누적 — 임계 도달 시 Generator.EnqueueStale 트리거.
+	// FetcherAutoUpgrade 와 별개 keyspace + 더 긴 윈도우 / 더 높은 임계값 — chromedp 전환이
+	// 먼저 시도되고, 그래도 실패 지속 시 LLM 재학습 (InsertNextVersion 으로 v+1 추가).
+	staleRelearnCfg, err := config.LoadStaleRelearn()
+	if err != nil {
+		log.WithError(err).Fatal("failed to load stale relearn config")
+	}
+	if staleRelearnCfg.Enabled && redisClientShared != nil && llmGen != nil {
+		sc, scErr := llmgen.NewRedisStaleCounter(
+			redisClientShared.Raw(),
+			staleRelearnCfg.Threshold,
+			staleRelearnCfg.Window,
+			"", // default keyPrefix "stale:relearn"
+			log,
+		)
+		if scErr != nil {
+			log.WithError(scErr).Warn("failed to construct redis stale counter, stale relearn disabled at runtime")
+		} else {
+			pw.SetStaleCounter(sc)
+			log.WithFields(map[string]interface{}{
+				"threshold": staleRelearnCfg.Threshold,
+				"window":    staleRelearnCfg.Window.String(),
+			}).Info("stale rule relearn (redis sliding window) enabled")
+		}
+	} else if !staleRelearnCfg.Enabled {
+		log.Info("stale rule relearn disabled (STALE_RELEARN_ENABLED=false)")
+	} else if redisClientShared == nil {
+		log.Warn("redis unavailable, stale rule relearn falls back to noop")
+	} else if llmGen == nil {
+		log.Info("llmgen disabled — stale rule relearn skipped (no enqueue target)")
+	}
+
 	// ── LLM validate 실패 재큐 (이슈 #237) ───────────────────────────────────
 	// selector 검증 실패 시 raw 를 issuetracker.fetched 에 재발행 — 룰 생성 성공 후 재파싱 기회 부여.
 	// llmGen 이 nil(LLM 비활성) 이면 wiring 불필요.

--- a/cmd/issuetracker/main.go
+++ b/cmd/issuetracker/main.go
@@ -459,7 +459,7 @@ func main() {
 		if scErr != nil {
 			log.WithError(scErr).Warn("failed to construct redis stale counter, stale relearn disabled at runtime")
 		} else {
-			pw.SetStaleCounter(sc)
+			pw.SetStaleCounter(sc, staleRelearnCfg.Threshold)
 			log.WithFields(map[string]interface{}{
 				"threshold": staleRelearnCfg.Threshold,
 				"window":    staleRelearnCfg.Window.String(),

--- a/internal/processor/parser/rule/invalidating_repo.go
+++ b/internal/processor/parser/rule/invalidating_repo.go
@@ -62,6 +62,17 @@ func (r *invalidatingRepo) invalidate(host string, t storage.TargetType) {
 	}
 }
 
+// InsertNextVersion wraps inner.InsertNextVersion + invalidates on success or ErrDuplicate (이슈 #282).
+//
+// 같은 (host, target_type) 에 대한 재학습 시 cache 가 stale 일 수 있으므로 invalidate 보장.
+func (r *invalidatingRepo) InsertNextVersion(ctx context.Context, rec *storage.ParsingRuleRecord) error {
+	err := r.inner.InsertNextVersion(ctx, rec)
+	if err == nil || errors.Is(err, storage.ErrDuplicate) {
+		r.invalidate(rec.HostPattern, rec.TargetType)
+	}
+	return err
+}
+
 // Insert wraps inner.Insert + invalidates on success or ErrDuplicate.
 //
 // ErrDuplicate 시에도 invalidate — INSERT 실패했지만 동일 자연키 row 가 이미 DB 에 존재하므로

--- a/internal/processor/parser/rule/llmgen/generator.go
+++ b/internal/processor/parser/rule/llmgen/generator.go
@@ -200,6 +200,24 @@ func New(provider llm.Provider, repo storage.ParsingRuleRepository, resolver *ru
 // 동일 (host, type) 에 대한 in-flight 호출이 이미 있으면 즉시 skip.
 // Stop 호출 후의 Enqueue 는 즉시 noop.
 func (g *Generator) Enqueue(ctx context.Context, host string, targetType storage.TargetType, raw *core.RawContent, llmRetryCount int, crawlerName string, jobTimeout time.Duration) {
+	g.enqueueImpl(ctx, host, targetType, raw, llmRetryCount, crawlerName, jobTimeout, false)
+}
+
+// EnqueueStale 은 stale rule 재학습 모드로 LLM 호출을 비동기 시작합니다 (이슈 #282).
+//
+// 차이점 (vs Enqueue):
+//   - pre-check 의 enabled=true 룰 적중 시 skip 안 함 — v2 학습 진행
+//   - 마지막 INSERT 가 InsertNextVersion 사용 — 기존 v1 보존 + v2 추가
+//
+// 호출 시점: parser_worker 가 ErrParseFailure / ErrEmptySelector 임계 도달 시 호출.
+// disabled 룰 잔존 host 는 운영자 의도 존중 — pre-check 에서 skip.
+func (g *Generator) EnqueueStale(ctx context.Context, host string, targetType storage.TargetType, raw *core.RawContent, llmRetryCount int, crawlerName string, jobTimeout time.Duration) {
+	g.enqueueImpl(ctx, host, targetType, raw, llmRetryCount, crawlerName, jobTimeout, true)
+}
+
+// enqueueImpl 은 Enqueue / EnqueueStale 의 공통 구현입니다 (이슈 #282).
+// stale=true 면 InsertNextVersion 경로 (v2 추가), false 면 기존 Insert 경로 (v1).
+func (g *Generator) enqueueImpl(ctx context.Context, host string, targetType storage.TargetType, raw *core.RawContent, llmRetryCount int, crawlerName string, jobTimeout time.Duration, stale bool) {
 	if g.stopped.Load() {
 		return
 	}
@@ -284,7 +302,7 @@ func (g *Generator) Enqueue(ctx context.Context, host string, targetType storage
 			}
 		}()
 
-		err := g.runOnce(bgCtx, host, targetType, urlSnapshot, htmlSnapshot)
+		err := g.runOnce(bgCtx, host, targetType, urlSnapshot, htmlSnapshot, stale)
 		if err != nil {
 			logger.FromContext(bgCtx).WithFields(map[string]interface{}{
 				"host":        host,
@@ -365,21 +383,31 @@ func (g *Generator) Stop(ctx context.Context) {
 
 // runOnce 는 단일 추출 + validation + INSERT + cache invalidate 의 동기 실행입니다.
 // 호출자 (Enqueue 의 goroutine) 가 in-flight 슬롯 release 책임.
-func (g *Generator) runOnce(ctx context.Context, host string, targetType storage.TargetType, sampleURL, html string) error {
+func (g *Generator) runOnce(ctx context.Context, host string, targetType storage.TargetType, sampleURL, html string, stale bool) error {
 	// 사전 lookup (이슈 #274) — 동일 자연키 룰이 이미 DB 에 존재하면 LLM 호출 회피.
 	// PR #275 리뷰 반영:
 	//   - enabled=true 룰 적중 시에만 skip (resolver 가 enabled=TRUE 만 조회하므로 disabled 는 사실상 부재)
 	//   - ErrNotFound 만 normal miss, 그 외 에러는 warn 로그 — DB 장애 silent fallthrough 회피
+	//   - stale=true (이슈 #282): v2 학습 진행 — pre-check enabled hit 분기에서 skip 안 함
 	existing, err := g.repo.FindByNaturalKey(ctx, LLMAutoSourceName, host, "", targetType, 1)
 	switch {
 	case err == nil && existing != nil && existing.Enabled:
-		g.resolver.Invalidate(host, targetType)
-		g.log.WithFields(map[string]interface{}{
-			"host":        host,
-			"target_type": string(targetType),
-			"rule_id":     existing.ID,
-		}).Info("llmgen pre-check hit — enabled rule already exists, skipping LLM call")
-		return nil
+		if stale {
+			// stale 재학습: v1 enabled 그대로 유지하면서 v2 추가 — pre-check 통과.
+			g.log.WithFields(map[string]interface{}{
+				"host":        host,
+				"target_type": string(targetType),
+				"existing_v1": existing.ID,
+			}).Info("llmgen stale relearn — proceeding to v2 generation (existing v1 preserved)")
+		} else {
+			g.resolver.Invalidate(host, targetType)
+			g.log.WithFields(map[string]interface{}{
+				"host":        host,
+				"target_type": string(targetType),
+				"rule_id":     existing.ID,
+			}).Info("llmgen pre-check hit — enabled rule already exists, skipping LLM call")
+			return nil
+		}
 	case err == nil && existing != nil && !existing.Enabled:
 		// 운영자가 disable 한 룰이 잔존 — 자동 재활성은 정책상 보수적으로 회피.
 		// LLM 재호출도 결과적으로 ErrDuplicate 로 reject 될 것이므로 LLM 비용 절감 + 운영 가시성을 위해 skip + warn.
@@ -469,13 +497,20 @@ func (g *Generator) runOnce(ctx context.Context, host string, targetType storage
 		SourceName:  LLMAutoSourceName,
 		HostPattern: host,
 		TargetType:  targetType,
-		Version:     1,
+		Version:     1,    // stale 모드 시 InsertNextVersion 가 자동으로 max+1 로 덮어씀 (이슈 #282)
 		Enabled:     true, // CSS selector 검증 통과 = 품질 게이트 — 즉시 활성화하여 pending 재투입이 유효하도록
 		Selectors:   selectors,
 		Confidence:  confidence,
 		Description: fmt.Sprintf("%s (sample url: %s, model: %s)", llmAutoDescription, sampleURL, modelName),
 	}
-	if err := g.repo.Insert(ctx, record); err != nil {
+	var insertErr error
+	if stale {
+		// stale 재학습: 기존 v1 보존 + v2 추가 (이슈 #282).
+		insertErr = g.repo.InsertNextVersion(ctx, record)
+	} else {
+		insertErr = g.repo.Insert(ctx, record)
+	}
+	if err := insertErr; err != nil {
 		// 동일 자연키 (source_name, host_pattern, path_pattern, target_type, version) 룰이 이미
 		// DB 에 존재 — 정상 경로로 흡수 (이슈 #274).
 		// 발생 시나리오: 이전 실행이 INSERT 한 룰이 잔존하나 resolver lookup 이 stale 캐시 등으로

--- a/internal/processor/parser/rule/llmgen/stale_counter.go
+++ b/internal/processor/parser/rule/llmgen/stale_counter.go
@@ -95,7 +95,12 @@ func (r *redisStaleCounter) Record(ctx context.Context, host string, t storage.T
 	cutoff := now.Add(-r.window)
 
 	// member 는 unique 보장용 — ns + 8 bytes random hex.
-	nonce := randStaleNonce()
+	// rand.Read 실패 시 nonce 가 빈 문자열이 되면 동일 ns 의 동시 record 가 같은 member 가 되어
+	// ZADD 한 쪽이 무시됨 → 카운트 누락. 명시적으로 error 전파 (PR #294 gemini 피드백).
+	nonce, err := randStaleNonce()
+	if err != nil {
+		return 0, false, fmt.Errorf("stale counter nonce for (%s, %s): %w", host, t, err)
+	}
 	member := strconv.FormatInt(now.UnixNano(), 10) + ":" + nonce
 	score := float64(now.UnixNano())
 
@@ -130,11 +135,13 @@ func (r *redisStaleCounter) Record(ctx context.Context, host string, t storage.T
 	return count, reached, nil
 }
 
-// randStaleNonce 는 ZADD member unique 변별자용 random hex.
-func randStaleNonce() string {
+// randStaleNonce 는 ZADD member unique 변별자용 random hex 를 생성합니다.
+// rand.Read 실패 시 error 반환 — 호출자가 카운팅 자체를 포기 (빈 nonce fallback 은 동시 record
+// 시 member 충돌을 유발하므로 회피, PR #294 gemini 피드백).
+func randStaleNonce() (string, error) {
 	b := make([]byte, 8)
 	if _, err := rand.Read(b); err != nil {
-		return ""
+		return "", fmt.Errorf("randStaleNonce: %w", err)
 	}
-	return hex.EncodeToString(b)
+	return hex.EncodeToString(b), nil
 }

--- a/internal/processor/parser/rule/llmgen/stale_counter.go
+++ b/internal/processor/parser/rule/llmgen/stale_counter.go
@@ -1,0 +1,140 @@
+package llmgen
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"strconv"
+	"time"
+
+	goredis "github.com/redis/go-redis/v9"
+
+	"issuetracker/internal/storage"
+	"issuetracker/pkg/logger"
+)
+
+// StaleCounter 는 stale rule 발생을 (host, target_type) 단위 sliding window 로 카운팅합니다 (이슈 #282).
+//
+// 기존 fetcher 의 FailureCounter (chromedp 업그레이드용) 와 별개의 keyspace / 임계값 보유:
+//   - 임계값: STALE_RELEARN_THRESHOLD (default 10) — chromedp 업그레이드보다 높은 임계
+//     (chromedp 가 먼저 시도되고, 그래도 fail 지속 시 LLM 재학습)
+//   - 윈도우: STALE_RELEARN_WINDOW (default 2h) — 더 긴 관찰 기간
+//
+// thresholdReached=true 시 호출자 (parser_worker) 가 Generator.EnqueueStale 호출.
+// goroutine-safe 필수.
+type StaleCounter interface {
+	// Record 는 (host, target_type) 의 stale parse failure 1건을 누적합니다.
+	// 반환: (count 누적값, thresholdReached 임계 도달 여부, err 카운팅 실패).
+	Record(ctx context.Context, host string, targetType storage.TargetType) (count int, thresholdReached bool, err error)
+}
+
+// noopStaleCounter — 비활성 (STALE_RELEARN_ENABLED=false 또는 Redis 미연결) 시 사용.
+type noopStaleCounter struct{}
+
+// NewNoopStaleCounter 는 항상 (0, false, nil) 을 반환하는 StaleCounter 입니다.
+func NewNoopStaleCounter() StaleCounter { return noopStaleCounter{} }
+
+func (noopStaleCounter) Record(_ context.Context, _ string, _ storage.TargetType) (int, bool, error) {
+	return 0, false, nil
+}
+
+// redisStaleCounter — Redis sorted set 기반 sliding window 구현체.
+//
+// FailureCounter 와 동일 알고리즘 — ZADD + ZREMRANGEBYSCORE + EXPIRE + ZCARD 의 단일 PIPELINE.
+// 차이점: keyspace 분리 ("stale:relearn:<host>:<type>") + 별도 threshold/window.
+type redisStaleCounter struct {
+	client    *goredis.Client
+	threshold int
+	window    time.Duration
+	keyPrefix string
+	now       func() time.Time
+	log       *logger.Logger
+}
+
+// NewRedisStaleCounter 는 Redis 기반 stale counter 를 생성합니다.
+//
+// client nil / threshold<1 / window<=0 시 error.
+// keyPrefix 가 빈 문자열이면 "stale:relearn" 사용.
+func NewRedisStaleCounter(client *goredis.Client, threshold int, window time.Duration, keyPrefix string, log *logger.Logger) (StaleCounter, error) {
+	if client == nil {
+		return nil, errors.New("llmgen: NewRedisStaleCounter requires non-nil redis client")
+	}
+	if threshold < 1 {
+		return nil, fmt.Errorf("llmgen: NewRedisStaleCounter requires threshold >= 1, got %d", threshold)
+	}
+	if window <= 0 {
+		return nil, fmt.Errorf("llmgen: NewRedisStaleCounter requires positive window, got %s", window)
+	}
+	if keyPrefix == "" {
+		keyPrefix = "stale:relearn"
+	}
+	return &redisStaleCounter{
+		client:    client,
+		threshold: threshold,
+		window:    window,
+		keyPrefix: keyPrefix,
+		log:       log,
+	}, nil
+}
+
+func (r *redisStaleCounter) keyFor(host string, t storage.TargetType) string {
+	return r.keyPrefix + ":" + host + ":" + string(t)
+}
+
+func (r *redisStaleCounter) Record(ctx context.Context, host string, t storage.TargetType) (int, bool, error) {
+	if host == "" {
+		return 0, false, nil
+	}
+	now := time.Now()
+	if r.now != nil {
+		now = r.now()
+	}
+	key := r.keyFor(host, t)
+	cutoff := now.Add(-r.window)
+
+	// member 는 unique 보장용 — ns + 8 bytes random hex.
+	nonce := randStaleNonce()
+	member := strconv.FormatInt(now.UnixNano(), 10) + ":" + nonce
+	score := float64(now.UnixNano())
+
+	pipe := r.client.Pipeline()
+	pipe.ZAdd(ctx, key, goredis.Z{Score: score, Member: member})
+	pipe.ZRemRangeByScore(ctx, key, "-inf", strconv.FormatInt(cutoff.UnixNano(), 10))
+	pipe.Expire(ctx, key, 2*r.window)
+	zcard := pipe.ZCard(ctx, key)
+
+	if _, err := pipe.Exec(ctx); err != nil {
+		return 0, false, fmt.Errorf("stale counter pipeline for (%s, %s): %w", host, t, err)
+	}
+
+	count := int(zcard.Val())
+	reached := count >= r.threshold
+
+	if r.log != nil {
+		fields := map[string]interface{}{
+			"host":        host,
+			"target_type": string(t),
+			"count":       count,
+			"threshold":   r.threshold,
+			"window":      r.window.String(),
+		}
+		if reached {
+			r.log.WithFields(fields).Info("stale rule threshold reached — LLM relearn trigger eligible")
+		} else {
+			r.log.WithFields(fields).Debug("stale rule failure recorded")
+		}
+	}
+
+	return count, reached, nil
+}
+
+// randStaleNonce 는 ZADD member unique 변별자용 random hex.
+func randStaleNonce() string {
+	b := make([]byte, 8)
+	if _, err := rand.Read(b); err != nil {
+		return ""
+	}
+	return hex.EncodeToString(b)
+}

--- a/internal/processor/parser/rule/refiner/refiner.go
+++ b/internal/processor/parser/rule/refiner/refiner.go
@@ -11,8 +11,8 @@
 //     d. 실패 + LLMClient != nil 이면 pathinfer.InferLLM(samples) 시도 — 성공하면 llm 방식 채택.
 //     e. 결과 regex 가 비어있으면 skip (다음 polling 에서 재시도 — sample 누적 추가 후 재평가).
 //     f. ParsingRuleRepository.InsertNextVersion — 기존 catch-all (v1) 보존 + 정밀 path_pattern 으로
-//        새 version (v2) INSERT (이슈 #282 Phase 2). v2 가 매칭 안 되는 path 는 v1 (catch-all)
-//        로 fallback — 정밀화 적용 범위가 좁아도 silent miss 없음.
+//     새 version (v2) INSERT (이슈 #282 Phase 2). v2 가 매칭 안 되는 path 는 v1 (catch-all)
+//     로 fallback — 정밀화 적용 범위가 좁아도 silent miss 없음.
 //     g. resolver.Invalidate(host, type) — cache flush (다음 lookup 부터 갱신된 rule 적용).
 //     h. SampleURLRepository.Purge(rule.ID) — 기존 catch-all (v1) 의 sample 정리 (다음 cycle 에서 재누적).
 //

--- a/internal/processor/parser/rule/refiner/refiner.go
+++ b/internal/processor/parser/rule/refiner/refiner.go
@@ -10,9 +10,11 @@
 //     c. pathinfer.InferHeuristic(samples) 시도 — 성공하면 algorithm 방식 채택.
 //     d. 실패 + LLMClient != nil 이면 pathinfer.InferLLM(samples) 시도 — 성공하면 llm 방식 채택.
 //     e. 결과 regex 가 비어있으면 skip (다음 polling 에서 재시도 — sample 누적 추가 후 재평가).
-//     f. ParsingRuleRepository.UpdatePathPattern — rule.PathPattern + description (정밀화 시각/방식) 갱신.
+//     f. ParsingRuleRepository.InsertNextVersion — 기존 catch-all (v1) 보존 + 정밀 path_pattern 으로
+//        새 version (v2) INSERT (이슈 #282 Phase 2). v2 가 매칭 안 되는 path 는 v1 (catch-all)
+//        로 fallback — 정밀화 적용 범위가 좁아도 silent miss 없음.
 //     g. resolver.Invalidate(host, type) — cache flush (다음 lookup 부터 갱신된 rule 적용).
-//     h. SampleURLRepository.Purge(rule.ID) — sample 정리 (다음 cycle 에서 재누적).
+//     h. SampleURLRepository.Purge(rule.ID) — 기존 catch-all (v1) 의 sample 정리 (다음 cycle 에서 재누적).
 //
 // 모든 실패는 non-fatal — 단계별 Warn 로그만 기록하고 다음 rule / 다음 cycle 로 진행.
 //
@@ -314,19 +316,48 @@ func (r *Refiner) refineOne(ctx context.Context, rec *storage.ParsingRuleRecord)
 	}
 
 	desc := buildDescription(rec.Description, method, len(paths))
-	if err := r.rules.UpdatePathPattern(ctx, rec.ID, pattern, desc); err != nil {
+
+	// 이슈 #282 Phase 2: catch-all (v1) 을 보존하고 정밀 path_pattern 으로 새 version (v2) INSERT.
+	// 기존 UpdatePathPattern 은 v1 의 path_pattern 을 직접 mutation 하여 catch-all 을 잃었음 —
+	// 정밀화 적용 범위 (예: /news/123) 외 path 는 매칭되는 룰이 사라져 silent miss 발생.
+	// InsertNextVersion 은 v1 그대로 두고 v2 추가 — Resolver 가 LENGTH(path_pattern) DESC + version DESC
+	// 정렬로 v2 를 우선 시도하고 매칭 실패 시 v1 catch-all 로 자연 fallback.
+	//
+	// 새 record 의 selector / confidence / source / host / target / enabled 는 v1 의 값을 그대로 복사.
+	newRec := &storage.ParsingRuleRecord{
+		SourceName:  rec.SourceName,
+		HostPattern: rec.HostPattern,
+		PathPattern: pattern,
+		TargetType:  rec.TargetType,
+		Enabled:     true,
+		Selectors:   rec.Selectors,
+		Confidence:  rec.Confidence,
+		Description: desc,
+	}
+	if err := r.rules.InsertNextVersion(ctx, newRec); err != nil {
+		// ErrDuplicate 는 race window — 다른 refiner 인스턴스가 이미 동일 자연키로 v+1 INSERT 했음.
+		// 본 cycle 은 결과적으로 no-op 으로 흡수 (samples 는 그대로 두고 다음 cycle 에서 재평가).
+		if errors.Is(err, storage.ErrDuplicate) {
+			rlog.WithFields(map[string]interface{}{
+				"pattern": pattern,
+				"method":  method,
+			}).Debug("insert next version raced with another refiner — skipping")
+			r.metrics.RecordAttempt(ResultSkipped, method)
+			return
+		}
 		rlog.WithFields(map[string]interface{}{
 			"pattern": pattern,
 			"method":  method,
-		}).WithError(err).Warn("update path_pattern failed")
+		}).WithError(err).Warn("insert next version failed")
 		r.metrics.RecordAttempt(ResultError, method)
 		return
 	}
 
-	// 2) cache flush 는 invalidatingRepo decorator 가 UpdatePathPattern 성공 후 자동 호출 (이슈 #288).
+	// 2) cache flush 는 invalidatingRepo decorator 가 InsertNextVersion 성공 후 자동 호출 (이슈 #288).
 	//    refiner 의 명시적 Invalidate 책임 제거 — single source of truth.
 
-	// 3) sample purge — 다음 cycle 에서 재누적 (다른 path 패턴 발견 가능성 대비).
+	// 3) sample purge — 기존 catch-all (v1) 의 누적 sample 정리. 다음 cycle 에서 v2 미매칭 path 가
+	//    v1 으로 fallback 하면 sample 이 다시 v1.ID 에 누적됨 (refiner 가 추가 정밀화 시도).
 	if err := r.samples.Purge(ctx, rec.ID); err != nil {
 		rlog.WithError(err).Warn("sample purge failed (non-fatal — next cycle will re-evaluate)")
 	}
@@ -335,7 +366,9 @@ func (r *Refiner) refineOne(ctx context.Context, rec *storage.ParsingRuleRecord)
 		"pattern":      pattern,
 		"method":       method,
 		"sample_count": len(paths),
-	}).Info("path_pattern refined")
+		"new_rule_id":  newRec.ID,
+		"new_version":  newRec.Version,
+	}).Info("path_pattern refined via version bump (v1 catch-all preserved)")
 	r.metrics.RecordAttempt(ResultSuccess, method)
 }
 

--- a/internal/processor/parser/worker/parser_worker.go
+++ b/internal/processor/parser/worker/parser_worker.go
@@ -87,6 +87,10 @@ type ParserWorker struct {
 	// ErrParseFailure / ErrEmptySelector 발생 시 Record 호출, threshold 도달 시
 	// llmGen.EnqueueStale 트리거.
 	staleCounter llmgen.StaleCounter
+	// staleThreshold: window 내 stale failure 임계값 (이슈 #282, PR #294 CodeRabbit 피드백).
+	// 임계 도달 첫 회 (count == staleThreshold) 만 enqueue — count > threshold 인 후속 호출은
+	// 카운트만 누적하고 enqueue 회피 (window 내 동일 host 의 version churn / 비용 spike 방지).
+	staleThreshold int
 
 	workerCount int
 	log         *logger.Logger
@@ -174,11 +178,15 @@ func (w *ParserWorker) SetPipelineGuard(g PipelineGuard) {
 	w.guard = g
 }
 
-// SetStaleCounter 는 stale rule 재학습 트리거 카운터를 주입합니다 (이슈 #282).
-// nil 주입 시 stale 재학습 비활성 (기존 chromedp 자동 전환만 동작).
+// SetStaleCounter 는 stale rule 재학습 트리거 카운터 + 임계값을 주입합니다 (이슈 #282).
+//
+// nil counter 주입 시 stale 재학습 비활성 (기존 chromedp 자동 전환만 동작).
+// threshold <= 0 이면 threshold-crossing gate 비활성 — counter.Record 의 thresholdReached 만으로 트리거
+// (window 내 매 후속 호출마다 enqueue 가능, 호환 fallback).
 // Start 호출 전 wiring 단계에서 1회 설정.
-func (w *ParserWorker) SetStaleCounter(c llmgen.StaleCounter) {
+func (w *ParserWorker) SetStaleCounter(c llmgen.StaleCounter, threshold int) {
 	w.staleCounter = c
+	w.staleThreshold = threshold
 }
 
 // Start 는 worker goroutines 를 기동합니다 (non-blocking).
@@ -543,6 +551,18 @@ func (w *ParserWorker) recordStaleAndMaybeRelearn(ctx context.Context, host stri
 		return
 	}
 	if !thresholdReached {
+		return
+	}
+	// 이슈 #282 PR #294 CodeRabbit 피드백: thresholdReached 는 window 내 count >= threshold 일 때
+	// 매번 true 이므로, 첫 crossing (count == threshold) 만 enqueue 하여 동일 window 안의 중복
+	// version 생성 / 비용 spike 회피. staleThreshold == 0 이면 호환 모드 (gate 비활성).
+	if w.staleThreshold > 0 && count != w.staleThreshold {
+		mlog.WithFields(map[string]interface{}{
+			"host":        host,
+			"target_type": string(targetType),
+			"count":       count,
+			"threshold":   w.staleThreshold,
+		}).Debug("stale threshold already crossed in current window — skipping duplicate enqueue")
 		return
 	}
 

--- a/internal/processor/parser/worker/parser_worker.go
+++ b/internal/processor/parser/worker/parser_worker.go
@@ -82,6 +82,12 @@ type ParserWorker struct {
 	// nil 허용 — nil 이면 release skip (TTL fallback 으로 자동 회수).
 	guard PipelineGuard
 
+	// staleCounter: stale rule 재학습 트리거 카운터 (이슈 #282).
+	// nil 허용 — nil 이면 stale 재학습 비활성 (chromedp 자동 전환만 동작).
+	// ErrParseFailure / ErrEmptySelector 발생 시 Record 호출, threshold 도달 시
+	// llmGen.EnqueueStale 트리거.
+	staleCounter llmgen.StaleCounter
+
 	workerCount int
 	log         *logger.Logger
 
@@ -166,6 +172,13 @@ func NewParserWorker(
 // nil 주입 시 release 비활성 (TTL fallback). Start 호출 전 wiring 단계에서 1회 설정.
 func (w *ParserWorker) SetPipelineGuard(g PipelineGuard) {
 	w.guard = g
+}
+
+// SetStaleCounter 는 stale rule 재학습 트리거 카운터를 주입합니다 (이슈 #282).
+// nil 주입 시 stale 재학습 비활성 (기존 chromedp 자동 전환만 동작).
+// Start 호출 전 wiring 단계에서 1회 설정.
+func (w *ParserWorker) SetStaleCounter(c llmgen.StaleCounter) {
+	w.staleCounter = c
 }
 
 // Start 는 worker goroutines 를 기동합니다 (non-blocking).
@@ -441,9 +454,11 @@ func (w *ParserWorker) handleRuleError(ctx context.Context, raw *core.RawContent
 		// 이슈 #220: page 단계의 ParseFailure / EmptySelector 만 host 카운터에 누적.
 		// list (category) 는 본질적으로 다른 selector 셋이라 chromedp 전환 신호로 부적절.
 		// 이슈 #221: 같은 시점에 raw_id 를 host 별 추적 — 단계 3 의 republish 대상 수집.
+		// 이슈 #282: 동일 시점에 stale counter 누적 — 임계 도달 시 LLM 재학습 트리거.
 		if targetType == storage.TargetTypePage &&
 			(rerr.Code == rule.ErrParseFailure || rerr.Code == rule.ErrEmptySelector) {
 			w.recordHostFailure(ctx, rerr.Host, rawID, fetcherRule.FailureReasonRuleParseFailure, mlog)
+			w.recordStaleAndMaybeRelearn(ctx, rerr.Host, targetType, raw, llmRetryCount, crawlerName, jobTimeout, mlog)
 		}
 
 		_ = rawID // 본 시그니처에선 rawID 직접 사용 안 함, 향후 audit log 에서 활용
@@ -499,6 +514,66 @@ func (w *ParserWorker) recordHostFailure(ctx context.Context, host, rawID string
 			w.upgrader.Trigger(triggerCtx, host)
 		}()
 	}
+}
+
+// recordStaleAndMaybeRelearn 은 stale rule 발생 1건을 (host, target_type) 카운터에 누적하고
+// 임계 도달 시 LLM 재학습을 트리거합니다 (이슈 #282).
+//
+// 동작 요건 (모두 충족 시만 enqueue):
+//  1. staleCounter / llmGen 둘 다 wiring 됨 (둘 중 하나 nil 이면 noop)
+//  2. host != "" — 빈 host 는 카운팅 skip
+//  3. counter.Record 가 thresholdReached=true 반환
+//  4. resolver 의 HasAnyRule 결과 — 운영자가 모든 rule 을 disable 한 host 는 skip (이슈 #287 동일 정책)
+//
+// 카운팅 / lookup 실패는 non-fatal — warn 로그만 남기고 정상 흐름 유지. 임계 도달 후 EnqueueStale
+// 은 비동기 (Generator 내부 goroutine) 라 본 함수 latency 영향 없음.
+func (w *ParserWorker) recordStaleAndMaybeRelearn(ctx context.Context, host string, targetType storage.TargetType, raw *core.RawContent, llmRetryCount int, crawlerName string, jobTimeout time.Duration, mlog *logger.Logger) {
+	if w.staleCounter == nil || w.llmGen == nil {
+		return
+	}
+	if host == "" {
+		return
+	}
+	count, thresholdReached, err := w.staleCounter.Record(ctx, host, targetType)
+	if err != nil {
+		mlog.WithFields(map[string]interface{}{
+			"host":        host,
+			"target_type": string(targetType),
+		}).WithError(err).Warn("stale counter record failed (non-fatal)")
+		return
+	}
+	if !thresholdReached {
+		return
+	}
+
+	// 운영자 disable 잔존 검증 — 같은 fail-open 정책 (이슈 #287).
+	shouldEnqueue := true
+	if w.resolver != nil {
+		exists, hasEnabled, herr := w.resolver.HasAnyRule(ctx, host, targetType)
+		shouldEnqueue = ShouldEnqueueLLMOnNoRule(exists, hasEnabled, herr)
+		if herr == nil && exists && !hasEnabled {
+			mlog.WithFields(map[string]interface{}{
+				"host":        host,
+				"target_type": string(targetType),
+				"count":       count,
+			}).Warn("stale threshold reached but rule disabled — skipping LLM relearn (manual re-enable required)")
+		} else if herr != nil && ctx.Err() == nil {
+			mlog.WithFields(map[string]interface{}{
+				"host":        host,
+				"target_type": string(targetType),
+			}).WithError(herr).Warn("HasAnyRule lookup failed during stale relearn, falling through to enqueue")
+		}
+	}
+	if !shouldEnqueue {
+		return
+	}
+
+	mlog.WithFields(map[string]interface{}{
+		"host":        host,
+		"target_type": string(targetType),
+		"count":       count,
+	}).Info("stale rule relearn triggered — enqueueing LLM regen via version bump")
+	w.llmGen.EnqueueStale(ctx, host, targetType, raw, llmRetryCount, crawlerName, jobTimeout)
 }
 
 // hostOf 는 raw.URL 에서 host 만 추출합니다 (port 제거).

--- a/internal/storage/parsing_rule.go
+++ b/internal/storage/parsing_rule.go
@@ -208,6 +208,23 @@ type ParsingRuleRepository interface {
 	// FindActiveCandidates 의 첫 항목 (length DESC 정렬, '' 포함) 을 반환합니다.
 	FindActive(ctx context.Context, host string, targetType TargetType) (*ParsingRuleRecord, error)
 
+	// InsertNextVersion 은 (source_name, host_pattern, path_pattern, target_type) 자연키의 다음
+	// version 으로 rec 을 INSERT 합니다 (이슈 #282).
+	//
+	// 사용처:
+	//   - Stale rule 재학습: 기존 v1 (catch-all enabled=true) 잔존 + 신규 v2 (정밀 / 갱신 selector)
+	//     → Resolver 가 LENGTH(path_pattern) DESC + version DESC 로 우선순위 결정
+	//   - Refiner path_pattern 정밀화: catch-all (v1, path="") + 정밀 (v2, path="/news/.*") 공존
+	//     → v2 미매칭 path 는 v1 catch-all 로 fallback (silent miss 회피)
+	//
+	// 동작:
+	//   1. (source_name, host_pattern, path_pattern, target_type) 의 MAX(version) 조회
+	//   2. 없으면 version=1 로 INSERT, 있으면 max+1 로 INSERT
+	//   3. 자연키 충돌 (race window) 시 ErrDuplicate 반환 — 호출자 retry 또는 흡수
+	//
+	// rec.Version 은 입력 무관 (자동 계산). 성공 시 rec.ID / Version / CreatedAt / UpdatedAt 채워짐.
+	InsertNextVersion(ctx context.Context, r *ParsingRuleRecord) error
+
 	// HasAnyRule 은 (host_pattern, target_type) 에 대한 룰 존재 여부를 반환합니다 (이슈 #287).
 	//
 	// FindActiveCandidates 와 달리 enabled 필터 없음 — disabled 룰도 \"존재함\" 으로 카운트.

--- a/internal/storage/postgres/parsing_rule.go
+++ b/internal/storage/postgres/parsing_rule.go
@@ -200,6 +200,35 @@ func (r *pgParsingRuleRepository) FindByNaturalKey(ctx context.Context, sourceNa
 	return rec, nil
 }
 
+const sqlMaxVersionByNaturalKey = `
+SELECT COALESCE(MAX(version), 0)
+FROM parsing_rules
+WHERE source_name = $1
+  AND host_pattern = $2
+  AND path_pattern = $3
+  AND target_type  = $4
+`
+
+// InsertNextVersion 은 자연키의 max(version)+1 로 rec 을 INSERT 합니다 (이슈 #282).
+//
+// race window: MAX 조회와 INSERT 사이에 다른 인스턴스가 같은 version 을 INSERT 할 수 있음.
+// 자연키 unique 제약이 ErrDuplicate 로 반응 — 호출자가 retry 또는 흡수 책임.
+func (r *pgParsingRuleRepository) InsertNextVersion(ctx context.Context, rec *storage.ParsingRuleRecord) error {
+	if rec.PathPattern != "" {
+		if _, reErr := regexp.Compile(rec.PathPattern); reErr != nil {
+			return fmt.Errorf("%w: path_pattern %q is not a valid regex: %v", storage.ErrInvalid, rec.PathPattern, reErr)
+		}
+	}
+	var maxVersion int
+	if err := r.pool.QueryRow(ctx, sqlMaxVersionByNaturalKey,
+		rec.SourceName, rec.HostPattern, rec.PathPattern, string(rec.TargetType),
+	).Scan(&maxVersion); err != nil {
+		return fmt.Errorf("query max version: %w", err)
+	}
+	rec.Version = maxVersion + 1
+	return r.Insert(ctx, rec)
+}
+
 // sqlHasAnyRule 은 (host_pattern, target_type) 에 대한 enabled / disabled 무관 존재 여부를
 // 1 row 로 반환합니다 (이슈 #287).
 //

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -668,6 +668,81 @@ func LoadFetcherAutoUpgrade(envFiles ...string) (FetcherAutoUpgradeConfig, error
 	return cfg, nil
 }
 
+// StaleRelearnConfig 는 stale rule (parse_failure / empty_selector) 누적 → LLM 자동 재학습 정책 설정입니다 (이슈 #282).
+//
+// FetcherAutoUpgrade 와 별개의 keyspace + 더 긴 윈도우 / 더 높은 임계값 — chromedp 자동 전환을
+// 먼저 시도한 후, 그래도 실패가 지속되면 LLM 재학습 트리거. 임계 도달 시 Generator.EnqueueStale
+// 가 InsertNextVersion 으로 동일 자연키 (source, host, path, type) 의 다음 버전을 INSERT.
+type StaleRelearnConfig struct {
+	// Enabled: false 면 카운팅 자체 skip (Noop StaleCounter — 성능 저하 0).
+	// 환경변수 STALE_RELEARN_ENABLED (default true).
+	Enabled bool
+
+	// Threshold: 윈도우 내 stale parse failure 임계값. 환경변수 STALE_RELEARN_THRESHOLD (default 10).
+	// chromedp 자동 전환 (default 5) 보다 높게 — chromedp 가 먼저 시도되도록.
+	Threshold int
+
+	// Window: sliding window 길이. 환경변수 STALE_RELEARN_WINDOW (Go duration, default 2h).
+	// chromedp 자동 전환 (default 1h) 보다 길게 — 더 보수적 관찰 기간.
+	Window time.Duration
+}
+
+// DefaultStaleRelearnConfig 는 기본 StaleRelearnConfig 를 반환합니다.
+func DefaultStaleRelearnConfig() StaleRelearnConfig {
+	return StaleRelearnConfig{
+		Enabled:   true,
+		Threshold: 10,
+		Window:    2 * time.Hour,
+	}
+}
+
+// LoadStaleRelearn 는 .env 를 로드한 후 OS 환경변수로 StaleRelearnConfig 를 구성합니다.
+//
+// 지원 환경변수:
+//   - STALE_RELEARN_ENABLED   : true | false (default true)
+//   - STALE_RELEARN_THRESHOLD : 양의 정수 (default 10)
+//   - STALE_RELEARN_WINDOW    : Go duration (default "2h")
+func LoadStaleRelearn(envFiles ...string) (StaleRelearnConfig, error) {
+	if len(envFiles) == 0 {
+		envFiles = []string{".env"}
+	}
+	if err := godotenv.Load(envFiles...); err != nil && !errors.Is(err, os.ErrNotExist) {
+		return StaleRelearnConfig{}, fmt.Errorf("failed to load env files %v: %w", envFiles, err)
+	}
+
+	cfg := DefaultStaleRelearnConfig()
+
+	if v := os.Getenv("STALE_RELEARN_ENABLED"); v != "" {
+		b, err := strconv.ParseBool(v)
+		if err != nil {
+			return StaleRelearnConfig{}, fmt.Errorf("parse STALE_RELEARN_ENABLED %q: %w", v, err)
+		}
+		cfg.Enabled = b
+	}
+	if v := os.Getenv("STALE_RELEARN_THRESHOLD"); v != "" {
+		n, err := strconv.Atoi(v)
+		if err != nil {
+			return StaleRelearnConfig{}, fmt.Errorf("parse STALE_RELEARN_THRESHOLD %q: %w", v, err)
+		}
+		if n < 1 {
+			return StaleRelearnConfig{}, fmt.Errorf("invalid STALE_RELEARN_THRESHOLD %d: must be 1 or greater", n)
+		}
+		cfg.Threshold = n
+	}
+	if v := os.Getenv("STALE_RELEARN_WINDOW"); v != "" {
+		d, err := time.ParseDuration(v)
+		if err != nil {
+			return StaleRelearnConfig{}, fmt.Errorf("parse STALE_RELEARN_WINDOW %q: %w", v, err)
+		}
+		if d <= 0 {
+			return StaleRelearnConfig{}, fmt.Errorf("invalid STALE_RELEARN_WINDOW %q: must be positive", v)
+		}
+		cfg.Window = d
+	}
+
+	return cfg, nil
+}
+
 // LLMConfig 는 LLM rule generator (이슈 #149) wiring 설정입니다.
 //
 // LLMConfig drives the LLM provider used for auto-generating parsing rules when

--- a/test/internal/processor/parser/rule/invalidating_repo_test.go
+++ b/test/internal/processor/parser/rule/invalidating_repo_test.go
@@ -53,15 +53,23 @@ type recordingRepo struct {
 	getByIDResult *storage.ParsingRuleRecord
 	getByIDErr    error
 
-	insertCalls     int
-	updateCalls     int
-	updatePathCalls int
-	deleteCalls     int
-	getByIDCalls    int
+	insertCalls            int
+	insertNextVersionCalls int
+	updateCalls            int
+	updatePathCalls        int
+	deleteCalls            int
+	getByIDCalls           int
 }
 
 func (r *recordingRepo) Insert(_ context.Context, _ *storage.ParsingRuleRecord) error {
 	r.insertCalls++
+	return r.insertErr
+}
+func (r *recordingRepo) InsertNextVersion(_ context.Context, rec *storage.ParsingRuleRecord) error {
+	r.insertNextVersionCalls++
+	if rec.Version == 0 {
+		rec.Version = 1
+	}
 	return r.insertErr
 }
 func (r *recordingRepo) Update(_ context.Context, _ *storage.ParsingRuleRecord) error {
@@ -121,6 +129,33 @@ func TestInvalidatingRepo_Insert_ErrDuplicate_TriggersInvalidate(t *testing.T) {
 	err := repo.Insert(context.Background(), rec)
 	require.ErrorIs(t, err, storage.ErrDuplicate)
 	assert.Equal(t, 1, inv.callCount(), "ErrDuplicate 도 invalidate — cache 가 stale 일 가능성")
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// InsertNextVersion (이슈 #282)
+// ─────────────────────────────────────────────────────────────────────────────
+
+func TestInvalidatingRepo_InsertNextVersion_Success_TriggersInvalidate(t *testing.T) {
+	inner := &recordingRepo{}
+	inv := &recordingInvalidator{}
+	repo := rule.WrapWithInvalidator(inner, inv)
+
+	rec := &storage.ParsingRuleRecord{HostPattern: "stale.example.com", TargetType: storage.TargetTypePage}
+	err := repo.InsertNextVersion(context.Background(), rec)
+	require.NoError(t, err)
+	assert.Equal(t, 1, inner.insertNextVersionCalls)
+	assert.Equal(t, 1, inv.callCount(), "version bump 후 cache invalidate")
+	assert.Equal(t, invalidateCall{Host: "stale.example.com", Type: storage.TargetTypePage}, inv.lastCall())
+}
+
+func TestInvalidatingRepo_InsertNextVersion_ErrDuplicate_TriggersInvalidate(t *testing.T) {
+	inner := &recordingRepo{insertErr: storage.ErrDuplicate}
+	inv := &recordingInvalidator{}
+	repo := rule.WrapWithInvalidator(inner, inv)
+
+	err := repo.InsertNextVersion(context.Background(), &storage.ParsingRuleRecord{HostPattern: "x", TargetType: storage.TargetTypePage})
+	require.ErrorIs(t, err, storage.ErrDuplicate)
+	assert.Equal(t, 1, inv.callCount(), "ErrDuplicate (race window) 도 invalidate")
 }
 
 func TestInvalidatingRepo_Insert_OtherError_NoInvalidate(t *testing.T) {

--- a/test/internal/processor/parser/rule/llmgen/generator_test.go
+++ b/test/internal/processor/parser/rule/llmgen/generator_test.go
@@ -86,6 +86,12 @@ func (r *recordingRepo) FindActiveCandidates(_ context.Context, _ string, _ stor
 func (r *recordingRepo) HasAnyRule(_ context.Context, _ string, _ storage.TargetType) (bool, bool, error) {
 	return false, false, nil
 }
+func (r *recordingRepo) InsertNextVersion(ctx context.Context, rec *storage.ParsingRuleRecord) error {
+	if rec.Version == 0 {
+		rec.Version = 1
+	}
+	return r.Insert(ctx, rec)
+}
 func (r *recordingRepo) FindByNaturalKey(_ context.Context, _, _, _ string, _ storage.TargetType, _ int) (*storage.ParsingRuleRecord, error) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
@@ -154,6 +160,9 @@ func (noopFindRepo) FindActiveCandidates(_ context.Context, _ string, _ storage.
 }
 func (noopFindRepo) HasAnyRule(_ context.Context, _ string, _ storage.TargetType) (bool, bool, error) {
 	return false, false, nil
+}
+func (noopFindRepo) InsertNextVersion(_ context.Context, _ *storage.ParsingRuleRecord) error {
+	return nil
 }
 func (noopFindRepo) FindByNaturalKey(_ context.Context, _, _, _ string, _ storage.TargetType, _ int) (*storage.ParsingRuleRecord, error) {
 	return nil, storage.ErrNotFound

--- a/test/internal/processor/parser/rule/llmgen/generator_test.go
+++ b/test/internal/processor/parser/rule/llmgen/generator_test.go
@@ -762,3 +762,68 @@ func TestGenerator_PreCheckLookupError_FallthroughToLLM(t *testing.T) {
 	assert.Equal(t, 1, provider.callCount(), "lookup 에러 시 LLM 경로 fallthrough — best-effort 정책")
 	require.Len(t, repo.inserts(), 1, "lookup 에러 후에도 Insert 진행")
 }
+
+// ─────────────────────────────────────────────────────────────────────────────
+// EnqueueStale (이슈 #282)
+// ─────────────────────────────────────────────────────────────────────────────
+
+// EnqueueStale 가 InsertNextVersion 경로로 갈지 검증.
+func TestGenerator_EnqueueStale_InsertNextVersion(t *testing.T) {
+	provider := &fakeProvider{
+		name: "fake",
+		response: `{
+			"title": {"css": "h1.article-title"},
+			"main_content": {"css": "article p", "multi": true}
+		}`,
+	}
+	repo := &recordingRepo{}
+	g, _ := newGenerator(t, provider, repo)
+
+	g.EnqueueStale(context.Background(), "stale.example.com", storage.TargetTypePage, &core.RawContent{
+		URL: "https://stale.example.com/article/1", HTML: samplePageHTML,
+	}, 0, "", 0)
+
+	stopCtx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	g.Stop(stopCtx)
+
+	repo.mu.Lock()
+	defer repo.mu.Unlock()
+	// recordingRepo.Insert 의 호출이 Insert 또는 InsertNextVersion 중 어느 것으로 들어가도
+	// inserted 슬라이스에는 1건 추가됨 (Insert 가 공통 경로). 핵심 검증은 LLM provider 가 호출됐고
+	// inserted 가 1건임 — Stale 분기가 정상 통과한 증거.
+	assert.Equal(t, 1, provider.callCount(), "EnqueueStale 도 LLM 호출은 발생")
+	assert.Len(t, repo.inserted, 1, "InsertNextVersion 경유로 inserted 누적")
+}
+
+// EnqueueStale 의 pre-check 가 enabled=true 룰 적중해도 skip 안 함을 검증 (vs Enqueue 의 skip 동작).
+func TestGenerator_EnqueueStale_BypassesEnabledPreCheck(t *testing.T) {
+	provider := &fakeProvider{
+		name: "fake",
+		response: `{
+			"title": {"css": "h1.article-title"},
+			"main_content": {"css": "article p", "multi": true}
+		}`,
+	}
+	// 사전 lookup 결과 — enabled=true 룰 잔존 (정상적으로 fresh Enqueue 면 skip 대상).
+	repo := &recordingRepo{
+		findByNaturalKeyResult: &storage.ParsingRuleRecord{
+			ID: 1, HostPattern: "stale.example.com", TargetType: storage.TargetTypePage,
+			Version: 1, Enabled: true,
+		},
+	}
+	g, _ := newGenerator(t, provider, repo)
+
+	g.EnqueueStale(context.Background(), "stale.example.com", storage.TargetTypePage, &core.RawContent{
+		URL: "https://stale.example.com/article/1", HTML: samplePageHTML,
+	}, 0, "", 0)
+
+	stopCtx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	g.Stop(stopCtx)
+
+	assert.Equal(t, 1, provider.callCount(), "EnqueueStale 는 enabled 룰 적중해도 LLM 호출 진행 (v2 학습)")
+	repo.mu.Lock()
+	defer repo.mu.Unlock()
+	assert.Len(t, repo.inserted, 1, "v2 INSERT 발생")
+}

--- a/test/internal/processor/parser/rule/llmgen/generator_test.go
+++ b/test/internal/processor/parser/rule/llmgen/generator_test.go
@@ -60,6 +60,11 @@ type recordingRepo struct {
 	// findByNaturalKeyErr: 설정 시 result 무시하고 본 에러 반환 (PR #275 리뷰 — DB 장애 시뮬레이션).
 	findByNaturalKeyErr   error
 	findByNaturalKeyCalls int
+
+	// insertCalls / insertNextVersionCalls: stale 경로가 InsertNextVersion (version bump) 만 사용하고
+	// 일반 경로가 Insert (v=1 신규) 만 사용하는지 명시 검증 (이슈 #282, PR #294 CodeRabbit 피드백).
+	insertCalls            int
+	insertNextVersionCalls int
 }
 
 func (r *recordingRepo) Insert(_ context.Context, rec *storage.ParsingRuleRecord) error {
@@ -68,6 +73,7 @@ func (r *recordingRepo) Insert(_ context.Context, rec *storage.ParsingRuleRecord
 	}
 	r.mu.Lock()
 	defer r.mu.Unlock()
+	r.insertCalls++
 	rec.ID = int64(len(r.inserted) + 1)
 	clone := *rec
 	r.inserted = append(r.inserted, &clone)
@@ -87,9 +93,22 @@ func (r *recordingRepo) HasAnyRule(_ context.Context, _ string, _ storage.Target
 	return false, false, nil
 }
 func (r *recordingRepo) InsertNextVersion(ctx context.Context, rec *storage.ParsingRuleRecord) error {
-	if rec.Version == 0 {
-		rec.Version = 1
+	r.mu.Lock()
+	r.insertNextVersionCalls++
+	// 자연키 (source, host, path, type) 동일 row 의 MAX(version)+1 시뮬레이션 — postgres 구현과 일치.
+	maxVer := 0
+	for _, existing := range r.inserted {
+		if existing.SourceName == rec.SourceName &&
+			existing.HostPattern == rec.HostPattern &&
+			existing.PathPattern == rec.PathPattern &&
+			existing.TargetType == rec.TargetType {
+			if existing.Version > maxVer {
+				maxVer = existing.Version
+			}
+		}
 	}
+	rec.Version = maxVer + 1
+	r.mu.Unlock()
 	return r.Insert(ctx, rec)
 }
 func (r *recordingRepo) FindByNaturalKey(_ context.Context, _, _, _ string, _ storage.TargetType, _ int) (*storage.ParsingRuleRecord, error) {
@@ -789,10 +808,10 @@ func TestGenerator_EnqueueStale_InsertNextVersion(t *testing.T) {
 
 	repo.mu.Lock()
 	defer repo.mu.Unlock()
-	// recordingRepo.Insert 의 호출이 Insert 또는 InsertNextVersion 중 어느 것으로 들어가도
-	// inserted 슬라이스에는 1건 추가됨 (Insert 가 공통 경로). 핵심 검증은 LLM provider 가 호출됐고
-	// inserted 가 1건임 — Stale 분기가 정상 통과한 증거.
+	// PR #294 CodeRabbit 피드백: InsertNextVersion 호출 자체를 명시 검증 — 일반 Insert 로 우회되는
+	// regression 차단. 두 카운터는 상호 배타적으로 1/0 이어야 함 (stale 경로는 항상 InsertNextVersion).
 	assert.Equal(t, 1, provider.callCount(), "EnqueueStale 도 LLM 호출은 발생")
+	assert.Equal(t, 1, repo.insertNextVersionCalls, "EnqueueStale must use InsertNextVersion (not plain Insert)")
 	assert.Len(t, repo.inserted, 1, "InsertNextVersion 경유로 inserted 누적")
 }
 
@@ -806,11 +825,20 @@ func TestGenerator_EnqueueStale_BypassesEnabledPreCheck(t *testing.T) {
 		}`,
 	}
 	// 사전 lookup 결과 — enabled=true 룰 잔존 (정상적으로 fresh Enqueue 면 skip 대상).
+	// 동일 자연키 row 를 inserted 에 미리 시딩하여 InsertNextVersion 의 MAX(version)+1 동작이
+	// v=2 를 산출하도록 — postgres 의 실제 자연키 충돌 회피 동작과 일치.
+	existingV1 := &storage.ParsingRuleRecord{
+		ID:          1,
+		SourceName:  llmgen.LLMAutoSourceName,
+		HostPattern: "stale.example.com",
+		PathPattern: "",
+		TargetType:  storage.TargetTypePage,
+		Version:     1,
+		Enabled:     true,
+	}
 	repo := &recordingRepo{
-		findByNaturalKeyResult: &storage.ParsingRuleRecord{
-			ID: 1, HostPattern: "stale.example.com", TargetType: storage.TargetTypePage,
-			Version: 1, Enabled: true,
-		},
+		inserted:               []*storage.ParsingRuleRecord{existingV1},
+		findByNaturalKeyResult: existingV1,
 	}
 	g, _ := newGenerator(t, provider, repo)
 
@@ -825,5 +853,11 @@ func TestGenerator_EnqueueStale_BypassesEnabledPreCheck(t *testing.T) {
 	assert.Equal(t, 1, provider.callCount(), "EnqueueStale 는 enabled 룰 적중해도 LLM 호출 진행 (v2 학습)")
 	repo.mu.Lock()
 	defer repo.mu.Unlock()
-	assert.Len(t, repo.inserted, 1, "v2 INSERT 발생")
+	// PR #294 CodeRabbit 피드백: InsertNextVersion 사용 여부를 직접 검증 — 일반 Insert 로 v=1 row 생성
+	// 시 자연키 충돌 (이미 enabled v=1 row 존재) 로 stale 경로가 망가짐을 사전 차단.
+	assert.Equal(t, 1, repo.insertNextVersionCalls, "stale path must call InsertNextVersion")
+	assert.Equal(t, 0, repo.insertCalls-repo.insertNextVersionCalls, "no plain Insert (only InsertNextVersion → Insert)")
+	require.Len(t, repo.inserted, 2, "기존 v=1 + 신규 v=2")
+	assert.Equal(t, 1, repo.inserted[0].Version, "기존 v=1 보존")
+	assert.Equal(t, 2, repo.inserted[1].Version, "InsertNextVersion bumps to v=2 (existing enabled v=1 detected)")
 }

--- a/test/internal/processor/parser/rule/llmgen/stale_counter_test.go
+++ b/test/internal/processor/parser/rule/llmgen/stale_counter_test.go
@@ -1,0 +1,31 @@
+package llmgen_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"issuetracker/internal/processor/parser/rule/llmgen"
+	"issuetracker/internal/storage"
+)
+
+// NoopStaleCounter 는 항상 (0, false, nil) 반환을 검증.
+func TestNoopStaleCounter_AlwaysReturnsZero(t *testing.T) {
+	c := llmgen.NewNoopStaleCounter()
+	count, reached, err := c.Record(context.Background(), "example.com", storage.TargetTypePage)
+	require.NoError(t, err)
+	assert.Equal(t, 0, count)
+	assert.False(t, reached)
+}
+
+// NewRedisStaleCounter 의 인자 검증 — nil client / 잘못된 threshold/window 거부.
+//
+// 실제 sliding window 동작은 testcontainers Redis 환경에서 별도 통합 테스트로 검증
+// (FailureCounter 와 동일 알고리즘 — 그쪽 테스트가 sliding window primitive 검증 보유).
+func TestNewRedisStaleCounter_RejectsInvalidArgs(t *testing.T) {
+	_, err := llmgen.NewRedisStaleCounter(nil, 10, 2*time.Hour, "", nil)
+	require.Error(t, err, "nil client 는 거부")
+}

--- a/test/internal/processor/parser/rule/refiner/refiner_test.go
+++ b/test/internal/processor/parser/rule/refiner/refiner_test.go
@@ -26,13 +26,23 @@ import (
 // ─────────────────────────────────────────────────────────────────────────────
 
 // fakeRulesRepo 는 ParsingRuleRepository 의 in-memory 구현입니다.
-// List / UpdatePathPattern / FindActiveCandidates 만 사용 — 나머지는 zero stub.
+// List / InsertNextVersion / FindActiveCandidates 만 사용 — 나머지는 zero stub.
 type fakeRulesRepo struct {
-	mu      sync.Mutex
-	records []*storage.ParsingRuleRecord
-	updates []updateCall
-	listErr error
-	upErr   error
+	mu       sync.Mutex
+	records  []*storage.ParsingRuleRecord
+	inserts  []insertCall   // 이슈 #282 Phase 2: 새 InsertNextVersion 추적
+	updates  []updateCall   // 호환성 — UpdatePathPattern guard 단위 테스트 보존
+	listErr  error
+	insErr   error          // InsertNextVersion 강제 에러 (호환: 기존 upErr 와 의미 통합)
+	insIsDup bool           // InsertNextVersion 가 storage.ErrDuplicate 반환하도록
+	nextID   int64
+}
+
+type insertCall struct {
+	sourceName  string
+	hostPattern string
+	pathPattern string
+	description string
 }
 
 type updateCall struct {
@@ -55,7 +65,41 @@ func (r *fakeRulesRepo) FindActiveCandidates(_ context.Context, _ string, _ stor
 func (r *fakeRulesRepo) HasAnyRule(_ context.Context, _ string, _ storage.TargetType) (bool, bool, error) {
 	return false, false, nil
 }
-func (r *fakeRulesRepo) InsertNextVersion(_ context.Context, _ *storage.ParsingRuleRecord) error {
+
+// InsertNextVersion 은 자연키의 MAX(version)+1 로 새 record 를 기록하고 sequential ID 를 할당합니다 (이슈 #282).
+func (r *fakeRulesRepo) InsertNextVersion(_ context.Context, rec *storage.ParsingRuleRecord) error {
+	if r.insErr != nil {
+		return r.insErr
+	}
+	if r.insIsDup {
+		return storage.ErrDuplicate
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	maxVer := 0
+	for _, existing := range r.records {
+		if existing.SourceName == rec.SourceName &&
+			existing.HostPattern == rec.HostPattern &&
+			existing.PathPattern == rec.PathPattern &&
+			existing.TargetType == rec.TargetType {
+			if existing.Version > maxVer {
+				maxVer = existing.Version
+			}
+		}
+	}
+	r.nextID++
+	rec.ID = r.nextID
+	rec.Version = maxVer + 1
+	rec.CreatedAt = time.Now()
+	rec.UpdatedAt = rec.CreatedAt
+	clone := *rec
+	r.records = append(r.records, &clone)
+	r.inserts = append(r.inserts, insertCall{
+		sourceName:  rec.SourceName,
+		hostPattern: rec.HostPattern,
+		pathPattern: rec.PathPattern,
+		description: rec.Description,
+	})
 	return nil
 }
 
@@ -82,9 +126,6 @@ func (r *fakeRulesRepo) List(_ context.Context, f storage.ParsingRuleFilter) ([]
 }
 func (r *fakeRulesRepo) Delete(_ context.Context, _ int64) error { return nil }
 func (r *fakeRulesRepo) UpdatePathPattern(_ context.Context, id int64, pattern, description string) error {
-	if r.upErr != nil {
-		return r.upErr
-	}
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	for _, rec := range r.records {
@@ -108,6 +149,14 @@ func (r *fakeRulesRepo) updateCalls() []updateCall {
 	defer r.mu.Unlock()
 	out := make([]updateCall, len(r.updates))
 	copy(out, r.updates)
+	return out
+}
+
+func (r *fakeRulesRepo) insertCalls() []insertCall {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	out := make([]insertCall, len(r.inserts))
+	copy(out, r.inserts)
 	return out
 }
 
@@ -213,9 +262,9 @@ func newRefiner(t *testing.T, rules storage.ParsingRuleRepository, samples stora
 // Tests
 // ─────────────────────────────────────────────────────────────────────────────
 
-func TestRunOnce_AlgorithmSuccess_UpdatesPathPattern(t *testing.T) {
+func TestRunOnce_AlgorithmSuccess_InsertsNextVersion(t *testing.T) {
 	rec := newCatchAllRule(1, "news.example.com")
-	rules := &fakeRulesRepo{records: []*storage.ParsingRuleRecord{rec}}
+	rules := &fakeRulesRepo{records: []*storage.ParsingRuleRecord{rec}, nextID: 1}
 	samples := newFakeSamplesRepo()
 
 	// numeric ID 패턴 — InferHeuristic 이 ^/article/(\d+)$ 추론.
@@ -230,11 +279,27 @@ func TestRunOnce_AlgorithmSuccess_UpdatesPathPattern(t *testing.T) {
 	r := newRefiner(t, rules, samples)
 	require.NoError(t, r.RunOnce(context.Background()))
 
-	calls := rules.updateCalls()
-	require.Len(t, calls, 1, "expected 1 UpdatePathPattern call")
-	assert.Equal(t, int64(1), calls[0].id)
-	assert.Contains(t, calls[0].pattern, `(\d+)`, "pattern should contain numeric capture group")
-	assert.Contains(t, calls[0].desc, "method=algorithm")
+	calls := rules.insertCalls()
+	require.Len(t, calls, 1, "expected 1 InsertNextVersion call (catch-all v1 보존 + 정밀 v2 추가)")
+	assert.Equal(t, "news.example.com", calls[0].hostPattern)
+	assert.Contains(t, calls[0].pathPattern, `(\d+)`, "path_pattern should contain numeric capture group")
+	assert.Contains(t, calls[0].description, "method=algorithm")
+
+	// 기존 catch-all (path="") 은 records 에 그대로 보존 + 새 정밀 rule 추가됐어야 함.
+	// path_pattern 자체가 다르므로 새 record 는 자체 자연키의 v=1 이 됨 (catch-all v=1 과 공존).
+	rules.mu.Lock()
+	hasCatchAll, hasRefined := false, false
+	for _, rr := range rules.records {
+		if rr.PathPattern == "" && rr.Enabled {
+			hasCatchAll = true
+		}
+		if rr.PathPattern != "" && rr.Enabled {
+			hasRefined = true
+		}
+	}
+	rules.mu.Unlock()
+	assert.True(t, hasCatchAll, "catch-all must remain after refinement (fallback for non-matching paths)")
+	assert.True(t, hasRefined, "refined record must exist after InsertNextVersion")
 
 	assert.Equal(t, 1, samples.purgeCount(1), "samples should be purged after refinement")
 }
@@ -251,7 +316,7 @@ func TestRunOnce_BelowThreshold_NoUpdate(t *testing.T) {
 	r := newRefiner(t, rules, samples)
 	require.NoError(t, r.RunOnce(context.Background()))
 
-	assert.Empty(t, rules.updateCalls(), "no update expected below threshold")
+	assert.Empty(t, rules.insertCalls(), "no insert expected below threshold")
 	assert.Zero(t, samples.purgeCount(1), "no purge expected below threshold")
 }
 
@@ -268,7 +333,7 @@ func TestRunOnce_AlreadyRefined_Skipped(t *testing.T) {
 	r := newRefiner(t, rules, samples)
 	require.NoError(t, r.RunOnce(context.Background()))
 
-	assert.Empty(t, rules.updateCalls(), "already-refined rule must not be updated")
+	assert.Empty(t, rules.insertCalls(), "already-refined rule must not be re-inserted")
 }
 
 func TestRunOnce_AlgorithmFails_LLMFallback(t *testing.T) {
@@ -291,10 +356,10 @@ func TestRunOnce_AlgorithmFails_LLMFallback(t *testing.T) {
 	r := newRefiner(t, rules, samples, refiner.WithLLMClient(llm))
 	require.NoError(t, r.RunOnce(context.Background()))
 
-	calls := rules.updateCalls()
+	calls := rules.insertCalls()
 	require.Len(t, calls, 1)
-	assert.Equal(t, `^/.+/\d+$`, calls[0].pattern)
-	assert.Contains(t, calls[0].desc, "method=llm")
+	assert.Equal(t, `^/.+/\d+$`, calls[0].pathPattern)
+	assert.Contains(t, calls[0].description, "method=llm")
 	assert.Equal(t, int64(1), atomic.LoadInt64(&llm.hits))
 }
 
@@ -314,7 +379,7 @@ func TestRunOnce_AlgorithmFails_NoLLM_Skipped(t *testing.T) {
 	r := newRefiner(t, rules, samples) // LLM 없음
 	require.NoError(t, r.RunOnce(context.Background()))
 
-	assert.Empty(t, rules.updateCalls())
+	assert.Empty(t, rules.insertCalls())
 	assert.Zero(t, samples.purgeCount(1))
 }
 
@@ -336,7 +401,7 @@ func TestRunOnce_LLMError_NoUpdate(t *testing.T) {
 	r := newRefiner(t, rules, samples, refiner.WithLLMClient(llm))
 	require.NoError(t, r.RunOnce(context.Background()))
 
-	assert.Empty(t, rules.updateCalls(), "LLM error should not result in update")
+	assert.Empty(t, rules.insertCalls(), "LLM error should not result in insert")
 }
 
 func TestRunOnce_NonAutoRule_Skipped(t *testing.T) {
@@ -352,7 +417,7 @@ func TestRunOnce_NonAutoRule_Skipped(t *testing.T) {
 	r := newRefiner(t, rules, samples)
 	require.NoError(t, r.RunOnce(context.Background()))
 
-	assert.Empty(t, rules.updateCalls())
+	assert.Empty(t, rules.insertCalls())
 }
 
 func TestRunOnce_DisabledRule_Skipped(t *testing.T) {
@@ -367,7 +432,7 @@ func TestRunOnce_DisabledRule_Skipped(t *testing.T) {
 	r := newRefiner(t, rules, samples)
 	require.NoError(t, r.RunOnce(context.Background()))
 
-	assert.Empty(t, rules.updateCalls())
+	assert.Empty(t, rules.insertCalls())
 }
 
 func TestRunOnce_ListError_Returned(t *testing.T) {
@@ -381,11 +446,11 @@ func TestRunOnce_ListError_Returned(t *testing.T) {
 	assert.Contains(t, err.Error(), "db down")
 }
 
-func TestRunOnce_UpdateError_NoPurge(t *testing.T) {
+func TestRunOnce_InsertError_NoPurge(t *testing.T) {
 	rec := newCatchAllRule(1, "news.example.com")
 	rules := &fakeRulesRepo{
 		records: []*storage.ParsingRuleRecord{rec},
-		upErr:   errors.New("update failed"),
+		insErr:  errors.New("insert failed"),
 	}
 	samples := newFakeSamplesRepo()
 	for _, u := range []string{
@@ -399,12 +464,36 @@ func TestRunOnce_UpdateError_NoPurge(t *testing.T) {
 	r := newRefiner(t, rules, samples)
 	require.NoError(t, r.RunOnce(context.Background()))
 
-	assert.Zero(t, samples.purgeCount(1), "purge should not run after update failure")
+	assert.Zero(t, samples.purgeCount(1), "purge should not run after insert failure")
 }
 
-// PR #191 CodeRabbit: optimistic guard 가 stale candidate (이미 다른 인스턴스가 정밀화 완료) 에
-// 대해 ErrNotFound 반환 → refiner 가 Invalidate / Purge 모두 skip.
-func TestRunOnce_StaleGuard_NoPurge(t *testing.T) {
+// 이슈 #282 Phase 2: ErrDuplicate (다른 refiner instance 가 이미 동일 자연키로 v+1 INSERT) 시
+// 본 cycle 은 no-op (purge skip). 다음 cycle 에서 재평가.
+func TestRunOnce_InsertDuplicate_Skipped(t *testing.T) {
+	rec := newCatchAllRule(1, "news.example.com")
+	rules := &fakeRulesRepo{
+		records:  []*storage.ParsingRuleRecord{rec},
+		insIsDup: true,
+	}
+	samples := newFakeSamplesRepo()
+	for _, u := range []string{
+		"https://news.example.com/article/100",
+		"https://news.example.com/article/200",
+		"https://news.example.com/article/300",
+	} {
+		require.NoError(t, samples.Insert(context.Background(), 1, u))
+	}
+
+	r := newRefiner(t, rules, samples)
+	require.NoError(t, r.RunOnce(context.Background()))
+
+	assert.Zero(t, samples.purgeCount(1), "duplicate race must not purge — next cycle re-evaluates")
+}
+
+// 호환성: UpdatePathPattern 의 optimistic guard 자체 contract 는 mock 에 보존되어야 함 (PR #191 CodeRabbit).
+// refiner 는 본 메소드를 더 이상 호출하지 않지만 (Phase 2 InsertNextVersion 전환), repository
+// 인터페이스의 contract 자체는 운영 코드 다른 경로에서 사용 — guard 회귀 방지용 테스트.
+func TestRulesRepo_UpdatePathPattern_StaleGuard(t *testing.T) {
 	rec := newCatchAllRule(1, "news.example.com")
 	rules := &fakeRulesRepo{records: []*storage.ParsingRuleRecord{rec}}
 	samples := newFakeSamplesRepo()
@@ -510,13 +599,15 @@ func TestRunOnce_RecordsMetrics(t *testing.T) {
 	rules.mu.Unlock()
 	require.NoError(t, samples.Insert(context.Background(), 2, "https://news2.example.com/article/100"))
 	require.NoError(t, r.RunOnce(context.Background()))
-	// rec1 의 path_pattern 이 (1) 에서 갱신되어 catch-all 필터 skip — 이번 cycle 에서는 rec2 만 평가.
+	// 이슈 #282 Phase 2: rec1 (catch-all) 은 InsertNextVersion 후에도 records 에 보존되며,
+	// 두 번째 cycle 에서 sample 이 0 (purge 직후) 이라 "skipped/none" 으로 다시 카운트됨.
+	// rec2 도 sample 미달로 "skipped/none" — 두 번째 cycle 에서 skipped 가 2 누적.
 
 	expected := `
 # HELP refinement_attempts_total path_pattern refinement attempts labeled by result/method.
 # TYPE refinement_attempts_total counter
 refinement_attempts_total{method="algorithm",result="success"} 1
-refinement_attempts_total{method="none",result="skipped"} 1
+refinement_attempts_total{method="none",result="skipped"} 2
 `
 	require.NoError(t,
 		testutil.GatherAndCompare(registry, strings.NewReader(expected), "refinement_attempts_total"),

--- a/test/internal/processor/parser/rule/refiner/refiner_test.go
+++ b/test/internal/processor/parser/rule/refiner/refiner_test.go
@@ -30,11 +30,11 @@ import (
 type fakeRulesRepo struct {
 	mu       sync.Mutex
 	records  []*storage.ParsingRuleRecord
-	inserts  []insertCall   // 이슈 #282 Phase 2: 새 InsertNextVersion 추적
-	updates  []updateCall   // 호환성 — UpdatePathPattern guard 단위 테스트 보존
+	inserts  []insertCall // 이슈 #282 Phase 2: 새 InsertNextVersion 추적
+	updates  []updateCall // 호환성 — UpdatePathPattern guard 단위 테스트 보존
 	listErr  error
-	insErr   error          // InsertNextVersion 강제 에러 (호환: 기존 upErr 와 의미 통합)
-	insIsDup bool           // InsertNextVersion 가 storage.ErrDuplicate 반환하도록
+	insErr   error // InsertNextVersion 강제 에러 (호환: 기존 upErr 와 의미 통합)
+	insIsDup bool  // InsertNextVersion 가 storage.ErrDuplicate 반환하도록
 	nextID   int64
 }
 

--- a/test/internal/processor/parser/rule/refiner/refiner_test.go
+++ b/test/internal/processor/parser/rule/refiner/refiner_test.go
@@ -31,9 +31,8 @@ type fakeRulesRepo struct {
 	mu       sync.Mutex
 	records  []*storage.ParsingRuleRecord
 	inserts  []insertCall // 이슈 #282 Phase 2: 새 InsertNextVersion 추적
-	updates  []updateCall // 호환성 — UpdatePathPattern guard 단위 테스트 보존
 	listErr  error
-	insErr   error // InsertNextVersion 강제 에러 (호환: 기존 upErr 와 의미 통합)
+	insErr   error // InsertNextVersion 강제 에러
 	insIsDup bool  // InsertNextVersion 가 storage.ErrDuplicate 반환하도록
 	nextID   int64
 }
@@ -43,12 +42,6 @@ type insertCall struct {
 	hostPattern string
 	pathPattern string
 	description string
-}
-
-type updateCall struct {
-	id      int64
-	pattern string
-	desc    string
 }
 
 func (r *fakeRulesRepo) Insert(_ context.Context, _ *storage.ParsingRuleRecord) error { return nil }
@@ -125,31 +118,11 @@ func (r *fakeRulesRepo) List(_ context.Context, f storage.ParsingRuleFilter) ([]
 	return out, nil
 }
 func (r *fakeRulesRepo) Delete(_ context.Context, _ int64) error { return nil }
-func (r *fakeRulesRepo) UpdatePathPattern(_ context.Context, id int64, pattern, description string) error {
-	r.mu.Lock()
-	defer r.mu.Unlock()
-	for _, rec := range r.records {
-		if rec.ID != id {
-			continue
-		}
-		// optimistic guard 미러링 (PR #191 CodeRabbit 피드백): postgres 구현과 동일 contract.
-		if rec.SourceName != llmgen.LLMAutoSourceName || !rec.Enabled || rec.PathPattern != "" {
-			return storage.ErrNotFound
-		}
-		r.updates = append(r.updates, updateCall{id: id, pattern: pattern, desc: description})
-		rec.PathPattern = pattern
-		rec.Description = description
-		return nil
-	}
-	return storage.ErrNotFound
-}
 
-func (r *fakeRulesRepo) updateCalls() []updateCall {
-	r.mu.Lock()
-	defer r.mu.Unlock()
-	out := make([]updateCall, len(r.updates))
-	copy(out, r.updates)
-	return out
+// UpdatePathPattern 은 ParsingRuleRepository 인터페이스 충족용 stub — 이슈 #282 Phase 2 이후
+// refiner 는 본 메소드를 호출하지 않음 (InsertNextVersion 으로 전환). 호출 시 단순 ErrNotFound.
+func (r *fakeRulesRepo) UpdatePathPattern(_ context.Context, _ int64, _, _ string) error {
+	return storage.ErrNotFound
 }
 
 func (r *fakeRulesRepo) insertCalls() []insertCall {
@@ -488,36 +461,6 @@ func TestRunOnce_InsertDuplicate_Skipped(t *testing.T) {
 	require.NoError(t, r.RunOnce(context.Background()))
 
 	assert.Zero(t, samples.purgeCount(1), "duplicate race must not purge — next cycle re-evaluates")
-}
-
-// 호환성: UpdatePathPattern 의 optimistic guard 자체 contract 는 mock 에 보존되어야 함 (PR #191 CodeRabbit).
-// refiner 는 본 메소드를 더 이상 호출하지 않지만 (Phase 2 InsertNextVersion 전환), repository
-// 인터페이스의 contract 자체는 운영 코드 다른 경로에서 사용 — guard 회귀 방지용 테스트.
-func TestRulesRepo_UpdatePathPattern_StaleGuard(t *testing.T) {
-	rec := newCatchAllRule(1, "news.example.com")
-	rules := &fakeRulesRepo{records: []*storage.ParsingRuleRecord{rec}}
-	samples := newFakeSamplesRepo()
-	for _, u := range []string{
-		"https://news.example.com/article/100",
-		"https://news.example.com/article/200",
-		"https://news.example.com/article/300",
-	} {
-		require.NoError(t, samples.Insert(context.Background(), 1, u))
-	}
-
-	// List 직후 다른 instance 가 이미 정밀화 완료 → PathPattern 비어있지 않은 상태로 선반영.
-	// 본 refiner cycle 의 UpdatePathPattern 은 guard 실패로 ErrNotFound 반환되어야 함.
-	rec.PathPattern = `^/article/(\d+)$`
-
-	r := newRefiner(t, rules, samples)
-	require.NoError(t, r.RunOnce(context.Background()))
-
-	// candidates List 시점에 PathPattern != "" 이면 refiner 가 위에서 catch-all 필터링으로 skip —
-	// 본 케이스는 List 시점 catch-all 이었다가 update 직전에 변경된 race 시뮬레이션.
-	// 현재 구조에서는 List 직후 바로 refineOne 들어가므로, race 시뮬은 직접 UpdatePathPattern 호출로 검증.
-	// 본 테스트는 mock 의 guard 동작 자체를 검증.
-	err := rules.UpdatePathPattern(context.Background(), 1, `^/x/(\d+)$`, "stale write")
-	require.ErrorIs(t, err, storage.ErrNotFound, "guard must reject stale (non-catch-all) candidate")
 }
 
 func TestRun_RespectsCancellation(t *testing.T) {

--- a/test/internal/processor/parser/rule/refiner/refiner_test.go
+++ b/test/internal/processor/parser/rule/refiner/refiner_test.go
@@ -55,6 +55,10 @@ func (r *fakeRulesRepo) FindActiveCandidates(_ context.Context, _ string, _ stor
 func (r *fakeRulesRepo) HasAnyRule(_ context.Context, _ string, _ storage.TargetType) (bool, bool, error) {
 	return false, false, nil
 }
+func (r *fakeRulesRepo) InsertNextVersion(_ context.Context, _ *storage.ParsingRuleRecord) error {
+	return nil
+}
+
 func (r *fakeRulesRepo) FindByNaturalKey(_ context.Context, _, _, _ string, _ storage.TargetType, _ int) (*storage.ParsingRuleRecord, error) {
 	return nil, storage.ErrNotFound
 }

--- a/test/internal/processor/parser/rule/resolver_test.go
+++ b/test/internal/processor/parser/rule/resolver_test.go
@@ -308,6 +308,65 @@ func TestResolver_PathPattern_LongerPatternWinsOverCatchAll(t *testing.T) {
 	assert.Equal(t, "h1.default", got.Selectors.Title.CSS, "specific 미매칭 시 catch-all fallback")
 }
 
+// 이슈 #282: stale relearn 으로 같은 path_pattern 의 v=2 가 추가됐을 때, version DESC 정렬상
+// v=2 가 우선 채택. 같은 LENGTH 내 tie-breaker 로 version 작용 검증 (postgres ORDER BY
+// LENGTH DESC, version DESC 와 일치).
+func TestResolver_PathPattern_HigherVersionWinsForSamePattern(t *testing.T) {
+	v1 := samplePageRule("news.example.com")
+	v1.ID = 10
+	v1.Version = 1
+	v1.PathPattern = "^/article/(\\d+)$"
+	v1.Selectors.Title = &storage.FieldSelector{CSS: "h1.old"}
+
+	v2 := samplePageRule("news.example.com")
+	v2.ID = 11
+	v2.Version = 2
+	v2.PathPattern = "^/article/(\\d+)$" // 동일 path_pattern (stale relearn 결과)
+	v2.Selectors.Title = &storage.FieldSelector{CSS: "h1.new"}
+
+	repo := &fakeRepo{rules: []*storage.ParsingRuleRecord{v1, v2}}
+	r, _ := rule.NewResolver(repo)
+
+	got, err := r.Resolve(context.Background(), "news.example.com", "/article/123", storage.TargetTypePage)
+	require.NoError(t, err)
+	assert.Equal(t, "h1.new", got.Selectors.Title.CSS, "동일 path_pattern 은 version DESC 로 더 높은 v 가 우선")
+	assert.Equal(t, 2, got.Version)
+}
+
+// 이슈 #282 Phase 2: refiner 가 catch-all 을 보존하고 정밀 path_pattern 으로 새 row 를 추가했을 때:
+//   - 매칭 path: 정밀 rule 채택 (LENGTH DESC 우선)
+//   - 미매칭 path: catch-all fallback (silent miss 방지)
+func TestResolver_PathPattern_RefinedAndCatchAll_FallbackForNonMatching(t *testing.T) {
+	// catch-all (v1, llm-auto, path="") — 보존된 fallback
+	catchAll := samplePageRule("news.example.com")
+	catchAll.ID = 100
+	catchAll.SourceName = "llm-auto"
+	catchAll.Version = 1
+	catchAll.PathPattern = ""
+	catchAll.Selectors.Title = &storage.FieldSelector{CSS: "h1.catchall"}
+
+	// 정밀 (v1, llm-auto, path="^/article/(\d+)$") — refiner 가 InsertNextVersion 으로 추가
+	refined := samplePageRule("news.example.com")
+	refined.ID = 101
+	refined.SourceName = "llm-auto"
+	refined.Version = 1
+	refined.PathPattern = `^/article/(\d+)$`
+	refined.Selectors.Title = &storage.FieldSelector{CSS: "h1.refined"}
+
+	repo := &fakeRepo{rules: []*storage.ParsingRuleRecord{catchAll, refined}}
+	r, _ := rule.NewResolver(repo)
+
+	// 매칭 path → refined 채택
+	got, err := r.Resolve(context.Background(), "news.example.com", "/article/42", storage.TargetTypePage)
+	require.NoError(t, err)
+	assert.Equal(t, "h1.refined", got.Selectors.Title.CSS, "정밀 path_pattern 이 매칭 path 우선 채택")
+
+	// 미매칭 path → catch-all fallback (silent miss X)
+	got, err = r.Resolve(context.Background(), "news.example.com", "/about/team", storage.TargetTypePage)
+	require.NoError(t, err)
+	assert.Equal(t, "h1.catchall", got.Selectors.Title.CSS, "정밀 미매칭 path 는 catch-all fallback")
+}
+
 // path_pattern 이 모두 매칭 안 되고 catch-all 도 없으면 ErrNoRule.
 func TestResolver_PathPattern_NoMatchReturnsErrNoRule(t *testing.T) {
 	specific := samplePageRule("news.example.com")

--- a/test/internal/processor/parser/rule/resolver_test.go
+++ b/test/internal/processor/parser/rule/resolver_test.go
@@ -95,6 +95,10 @@ func (r *fakeRepo) HasAnyRule(_ context.Context, host string, t storage.TargetTy
 	return r.hasAnyExists, r.hasAnyEnabled, nil
 }
 func (r *fakeRepo) hasAnyCalls() int { return int(atomic.LoadInt64(&r.hasAnyRuleCalls)) }
+func (r *fakeRepo) InsertNextVersion(_ context.Context, _ *storage.ParsingRuleRecord) error {
+	return nil
+}
+
 func (r *fakeRepo) FindByNaturalKey(_ context.Context, _, _, _ string, _ storage.TargetType, _ int) (*storage.ParsingRuleRecord, error) {
 	return nil, storage.ErrNotFound
 }


### PR DESCRIPTION
## 연관 이슈
- Closes #282

## 구현 내용

라이브 검증에서 관찰된 **stale rule 사이트 자가 회복 불가** 문제 해결. `ErrParseFailure` / `ErrEmptySelector` 가 host 단위 임계값에 도달하면 LLM 재학습을 트리거하고, 기존 룰은 보존한 채 version bump 로 새 룰을 INSERT 하여 즉시 적용 + 롤백 가능 상태 유지.

#284 시나리오 #2 (path_pattern 정밀화 후 fallback 부재) 도 같은 메커니즘으로 통합 해결.

### 7개 commit (논리 단위 분할)

1. `[FEAT]: ParsingRuleRepository.InsertNextVersion 추가` (c14710f)
   - 자연키 (source, host, path, target_type) 의 MAX(version)+1 로 INSERT — race window 시 ErrDuplicate 흡수
2. `[FEAT]: StaleCounter (Redis sliding window)` (e90bcf5)
   - FailureCounter 와 별개 keyspace (\"stale:relearn:<host>:<type>\") + 별도 threshold/window
3. `[FEAT]: Generator.EnqueueStale — version bump 경로` (d7e3df2)
   - 기존 Enqueue 와 분리한 stale 모드 — pre-check skip + InsertNextVersion 채택
4. `[FEAT]: parser_worker — stale counter 누적 + 임계 도달 시 LLM 재학습 트리거` (a1332a9)
   - handleRuleError 의 ParseFailure / EmptySelector 분기에서 staleCounter.Record + EnqueueStale
   - 운영자 disable 잔존 host 는 skip (이슈 #287 fail-open 정책 동일)
5. `[REFAC]: refiner — UpdatePathPattern → InsertNextVersion 전환` (Phase 2, 04d162b)
   - catch-all (v=1) 보존 + 정밀 path_pattern 으로 별도 row 추가 — 미매칭 path 가 자연 fallback
6. `[FEAT]: resolver — version bump + catch-all fallback 검증 테스트` (8d5209f)
   - HigherVersionWinsForSamePattern + RefinedAndCatchAll_FallbackForNonMatching
7. `[FEAT]: stale rule 재학습 wiring — config + main.go + .env.example` (5bfe298)
   - StaleRelearnConfig (STALE_RELEARN_ENABLED / THRESHOLD / WINDOW)
   - ParserWorker.SetStaleCounter 로 Redis 카운터 주입

## CI / 머지 게이트 점검

### 변경 영향 범위
- 영향 패키지/모듈:
  - internal/storage (ParsingRuleRepository.InsertNextVersion 추가)
  - internal/storage/postgres (sqlMaxVersionByNaturalKey + 구현)
  - internal/processor/parser/rule (invalidating_repo decorator 확장)
  - internal/processor/parser/rule/llmgen (StaleCounter + Generator.EnqueueStale)
  - internal/processor/parser/rule/refiner (Phase 2 InsertNextVersion 전환)
  - internal/processor/parser/worker (handleRuleError 확장 + SetStaleCounter)
  - cmd/issuetracker (wiring)
  - pkg/config (StaleRelearnConfig)
- 위험도: \`Medium\` — 핫패스 (parser_worker.handleRuleError) 분기 추가 + DB INSERT 경로 신설.
  - 기능 OFF (ENABLED=false / Redis 미연결 / llmGen nil) 시 noop, 기존 동작과 동일
  - InsertNextVersion 의 race window 는 ErrDuplicate 흡수로 idempotent

### Required Status Checks
- 통과 확인 대상 (PR Checks 탭에서 확인):
  - [ ] \`Commit Lint\`
  - [ ] \`PR Title Lint\`
  - [ ] \`Linked Issue Check\`
  - [ ] \`Format Check\`
  - [ ] \`Build\`
  - [ ] \`Test\`
  - [ ] \`Lint\`

### 롤백 계획

`STALE_RELEARN_ENABLED=false` 로 즉시 비활성 가능 — staleCounter / EnqueueStale 경로 noop. version bump 로 INSERT 된 v=N+1 룰은 운영자가 enabled=false 토글하면 Resolver 가 v=N (기존 룰) 으로 fallback.

긴급 롤백: 본 PR revert 후 STALE_RELEARN_ENABLED 환경변수 제거.

## TODO
- 라이브 검증 — 의도적 stale 환경에서 임계 도달 → 새 룰 v=N+1 INSERT → 다음 fetch 부터 새 selector 적용 확인
- 운영 가시성: stale 재학습 발동 횟수 / 호스트별 version 분포 메트릭은 후속 이슈에서 추가

## 논의 사항
- staleCounter 의 threshold (10) / window (2h) 는 chromedp 자동 전환 (5/1h) 보다 보수적으로 설정 — 라이브 검증 후 조정 가능
- 정밀화된 v2 가 안정화되면 catch-all (v1) 을 enabled=false 로 명시 비활성하는 운영 절차는 후속 documentation 이슈로

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added automatic stale rule re-learning functionality that triggers when rule parse failures exceed a configured threshold within a sliding time window.
  * Introduced three new environment variables to control this feature: `STALE_RELEARN_ENABLED`, `STALE_RELEARN_THRESHOLD`, and `STALE_RELEARN_WINDOW`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->