### PR TITLE
[FEAT#295] page-parse 블랙리스트 — 카테고리 링크 추출 유지 + article fetch/parse 차단

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -153,6 +153,12 @@ REFINEMENT_ENABLED=true
 REFINEMENT_INTERVAL=5m
 REFINEMENT_MIN_SAMPLES=5
 
+# Page-parse 블랙리스트 (이슈 #295)
+# 카테고리 → article job 발행 단계에서 매칭 URL drop. parsing_blacklist 테이블 (host_pattern,
+# path_pattern, source, enabled) 기반. 광고/redirect/sponsored 등 의미 없는 URL 차단으로
+# fetch / parse 비용 절감 + chromedp 자동 전환 / stale relearn trigger 노이즈 회피.
+BLACKLIST_ENABLED=true
+
 # Stale rule 자동 재학습 설정 (이슈 #282)
 # parse_failure / empty_selector 가 host 단위 sliding window 로 누적되어 임계 도달 시
 # Generator.EnqueueStale 가 InsertNextVersion 으로 동일 자연키의 다음 version 을 INSERT.

--- a/cmd/issuetracker/main.go
+++ b/cmd/issuetracker/main.go
@@ -148,11 +148,10 @@ func main() {
 		if bmErr != nil {
 			log.WithError(bmErr).Fatal("failed to construct blacklist matcher")
 		}
-		// invalidatingBlacklistRepo decorator — mutation → host cache invalidate 자동 결합 (PR #296 gemini).
-		// blacklistRepo 변수에 재할당하여 향후 application 코드 (운영 CLI / 자동 색출 등) 가 본
-		// 변수를 통해 mutation 호출 시 cache invalidate 가 자동 결합되도록 — parsing_rules 의 동일 패턴.
-		blacklistRepo = rule.WrapBlacklistWithInvalidator(blacklistRepo, bm)
-		_ = blacklistRepo // 본 PR scope 에서는 mutation 경로 부재 — 향후 wiring 대비 wrapper 보존
+		// invalidatingBlacklistRepo decorator 는 본 PR scope 에서 wiring 하지 않음 (PR #296 gemini).
+		// 본 PR 은 read-only 경로 (Matcher.Filter) 만 사용 — application 측 mutation 경로 부재.
+		// 운영 CLI / 자동 색출 후속 이슈에서 decorator 도입 + 변수 재할당으로 invalidate 결합.
+		// (decorator 코드 자체는 blacklist_matcher.go 에 보존, unit test 로 검증.)
 		blacklistMatcher = bm
 		log.Info("page-parse blacklist enabled (parsing_blacklist DB-backed)")
 	} else {

--- a/cmd/issuetracker/main.go
+++ b/cmd/issuetracker/main.go
@@ -148,8 +148,11 @@ func main() {
 		if bmErr != nil {
 			log.WithError(bmErr).Fatal("failed to construct blacklist matcher")
 		}
-		// invalidatingBlacklistRepo decorator — mutation → host cache invalidate 자동 결합.
-		_ = rule.WrapBlacklistWithInvalidator(blacklistRepo, bm)
+		// invalidatingBlacklistRepo decorator — mutation → host cache invalidate 자동 결합 (PR #296 gemini).
+		// blacklistRepo 변수에 재할당하여 향후 application 코드 (운영 CLI / 자동 색출 등) 가 본
+		// 변수를 통해 mutation 호출 시 cache invalidate 가 자동 결합되도록 — parsing_rules 의 동일 패턴.
+		blacklistRepo = rule.WrapBlacklistWithInvalidator(blacklistRepo, bm)
+		_ = blacklistRepo // 본 PR scope 에서는 mutation 경로 부재 — 향후 wiring 대비 wrapper 보존
 		blacklistMatcher = bm
 		log.Info("page-parse blacklist enabled (parsing_blacklist DB-backed)")
 	} else {

--- a/cmd/issuetracker/main.go
+++ b/cmd/issuetracker/main.go
@@ -135,6 +135,27 @@ func main() {
 		log.WithError(err).Fatal("failed to construct rule parser")
 	}
 
+	// 이슈 #295: page-parse 블랙리스트 — 카테고리 → article job 발행 단계에서 매칭 URL 차단.
+	// Enabled=false 시 Matcher 미주입 → parser_worker 가 모든 링크 그대로 발행 (기능 OFF).
+	blacklistCfg, err := config.LoadBlacklist()
+	if err != nil {
+		log.WithError(err).Fatal("failed to load blacklist config")
+	}
+	var blacklistMatcher *rule.BlacklistMatcher
+	if blacklistCfg.Enabled {
+		blacklistRepo := pgstore.NewBlacklistRepository(pool, log)
+		bm, bmErr := rule.NewBlacklistMatcher(blacklistRepo)
+		if bmErr != nil {
+			log.WithError(bmErr).Fatal("failed to construct blacklist matcher")
+		}
+		// invalidatingBlacklistRepo decorator — mutation → host cache invalidate 자동 결합.
+		_ = rule.WrapBlacklistWithInvalidator(blacklistRepo, bm)
+		blacklistMatcher = bm
+		log.Info("page-parse blacklist enabled (parsing_blacklist DB-backed)")
+	} else {
+		log.Info("page-parse blacklist disabled (BLACKLIST_ENABLED=false)")
+	}
+
 	// Readiness check: 사이트 등록 전 parsing_rules 가 seed 됐는지 검증.
 	// 부재 시 fail-fast — 실행 중 모든 ParsePage/ParseLinks 가 ErrNoRule 로 죽는 것보다 즉시 종료.
 	// migration 007 (또는 동등한 운영자 seed) 가 적용되어야 통과.
@@ -438,6 +459,13 @@ func main() {
 	// Category cycle 종료 시 marker release — scheduler 다음 주기에 즉시 진입 가능.
 	if pipelineGuard != nil {
 		pw.SetPipelineGuard(pipelineGuard)
+	}
+
+	// ── Page-parse 블랙리스트 (이슈 #295) ───────────────────────────────────────
+	// 카테고리에서 추출된 article URL 중 blacklist 매칭은 publisher.Publish 직전 drop.
+	// Matcher 가 nil (BLACKLIST_ENABLED=false) 이면 setter noop — 모든 링크 그대로 발행.
+	if blacklistMatcher != nil {
+		pw.SetBlacklist(blacklistMatcher)
 	}
 
 	// ── Stale rule 재학습 카운터 (이슈 #282) ───────────────────────────────────

--- a/internal/processor/parser/rule/blacklist_matcher.go
+++ b/internal/processor/parser/rule/blacklist_matcher.go
@@ -25,6 +25,13 @@ const DefaultBlacklistNegativeCacheTTL = 30 * time.Second
 // DefaultBlacklistMaxCacheEntries 는 host 단위 cache 의 최대 entry 수입니다.
 const DefaultBlacklistMaxCacheEntries = 10_000
 
+// DefaultBlacklistMaxRegexEntries 는 path_pattern regex 컴파일 결과 cache 의 최대 entry 수입니다.
+//
+// PR #296 gemini 피드백: sync.Map 은 키 공간이 작고 bounded 일 때만 권장 — 향후 auto source
+// 등장 시 unique pattern 수가 증가할 수 있어 메모리 unbounded growth 가능. cap + simple evict
+// 로 보호.
+const DefaultBlacklistMaxRegexEntries = 10_000
+
 // BlacklistMatcher 는 (host, path) 매칭으로 blacklist 차단 여부를 판단합니다 (이슈 #295).
 //
 // Resolver 와 동일 패턴 — host 단위 후보 슬라이스를 cache + DB lookup, application 측에서
@@ -37,11 +44,13 @@ type BlacklistMatcher struct {
 	cacheTTL         time.Duration
 	negativeCacheTTL time.Duration
 	maxEntries       int
+	maxRegexEntries  int
 
 	mu    sync.RWMutex
 	cache map[string]blacklistCacheEntry // key: host
 
-	regexCache sync.Map // pattern (string) → *blacklistCompiledPattern
+	regexMu    sync.RWMutex
+	regexCache map[string]*blacklistCompiledPattern // pattern → compiled (cap + simple evict)
 
 	now func() time.Time
 }
@@ -86,6 +95,15 @@ func WithBlacklistMaxCacheEntries(n int) BlacklistMatcherOption {
 	}
 }
 
+// WithBlacklistMaxRegexEntries 는 path_pattern regex 컴파일 cache 의 최대 entry 수를 override 합니다 (PR #296 gemini).
+func WithBlacklistMaxRegexEntries(n int) BlacklistMatcherOption {
+	return func(m *BlacklistMatcher) {
+		if n > 0 {
+			m.maxRegexEntries = n
+		}
+	}
+}
+
 // NewBlacklistMatcher 는 BlacklistRepository 를 사용하는 Matcher 를 생성합니다.
 // repo 가 nil 이면 error — 호출자 (cmd/main) 가 boot fatal 처리.
 func NewBlacklistMatcher(repo storage.BlacklistRepository, opts ...BlacklistMatcherOption) (*BlacklistMatcher, error) {
@@ -97,7 +115,9 @@ func NewBlacklistMatcher(repo storage.BlacklistRepository, opts ...BlacklistMatc
 		cacheTTL:         DefaultBlacklistCacheTTL,
 		negativeCacheTTL: DefaultBlacklistNegativeCacheTTL,
 		maxEntries:       DefaultBlacklistMaxCacheEntries,
+		maxRegexEntries:  DefaultBlacklistMaxRegexEntries,
 		cache:            make(map[string]blacklistCacheEntry),
+		regexCache:       make(map[string]*blacklistCompiledPattern),
 		now:              time.Now,
 	}
 	for _, o := range opts {
@@ -222,14 +242,36 @@ func (m *BlacklistMatcher) pathMatches(pattern, path string) bool {
 	return cp.re.MatchString(path)
 }
 
+// compileRegex 는 pattern 의 컴파일 결과를 cache + reuse 합니다 (PR #296 gemini 피드백 반영).
+//
+// sync.Map 대신 mutex-protected map 으로 변경 — maxRegexEntries cap 적용 + simple evict (1 random).
+// auto source 등 unique pattern 수 증가 시 unbounded growth 회피.
 func (m *BlacklistMatcher) compileRegex(pattern string) *blacklistCompiledPattern {
-	if v, ok := m.regexCache.Load(pattern); ok {
-		return v.(*blacklistCompiledPattern)
+	m.regexMu.RLock()
+	if cp, ok := m.regexCache[pattern]; ok {
+		m.regexMu.RUnlock()
+		return cp
 	}
+	m.regexMu.RUnlock()
+
 	re, err := regexp.Compile(pattern)
 	cp := &blacklistCompiledPattern{re: re, err: err}
-	actual, _ := m.regexCache.LoadOrStore(pattern, cp)
-	return actual.(*blacklistCompiledPattern)
+
+	m.regexMu.Lock()
+	defer m.regexMu.Unlock()
+	// race winner 가 이미 채워뒀으면 그쪽 결과 반환 (LoadOrStore 동등 동작).
+	if existing, ok := m.regexCache[pattern]; ok {
+		return existing
+	}
+	if len(m.regexCache) >= m.maxRegexEntries {
+		// cache map 와 동일 정책 — 임의 1개 evict (LRU 도입 비용 대비 효과 낮음).
+		for k := range m.regexCache {
+			delete(m.regexCache, k)
+			break
+		}
+	}
+	m.regexCache[pattern] = cp
+	return cp
 }
 
 // invalidatingBlacklistRepo 는 BlacklistRepository 를 wrap 하여 mutation 후 자동으로 Matcher 의

--- a/internal/processor/parser/rule/blacklist_matcher.go
+++ b/internal/processor/parser/rule/blacklist_matcher.go
@@ -277,11 +277,21 @@ func (r *invalidatingBlacklistRepo) Insert(ctx context.Context, rec *storage.Bla
 }
 
 func (r *invalidatingBlacklistRepo) Update(ctx context.Context, rec *storage.BlacklistRecord) error {
-	err := r.inner.Update(ctx, rec)
-	if err == nil {
+	// PR #296 CodeRabbit 피드백: Update 는 host 변경 안 하므로 호출자가 rec.HostPattern 을 비워
+	// 보내도 정당. 사전 GetByID 로 authoritative host 를 얻어 invalidate — Delete 와 동일 패턴.
+	// pre-fetch 실패 시 fallback 으로 rec.HostPattern (비어있지 않을 때만) 사용.
+	before, lookupErr := r.inner.GetByID(ctx, rec.ID)
+	if err := r.inner.Update(ctx, rec); err != nil {
+		return err
+	}
+	if lookupErr == nil && before != nil {
+		r.invalidate(before.HostPattern)
+		return nil
+	}
+	if rec.HostPattern != "" {
 		r.invalidate(rec.HostPattern)
 	}
-	return err
+	return nil
 }
 
 func (r *invalidatingBlacklistRepo) Delete(ctx context.Context, id int64) error {

--- a/internal/processor/parser/rule/blacklist_matcher.go
+++ b/internal/processor/parser/rule/blacklist_matcher.go
@@ -1,0 +1,311 @@
+package rule
+
+import (
+	"context"
+	"errors"
+	"regexp"
+	"strings"
+	"sync"
+	"time"
+
+	"issuetracker/internal/storage"
+)
+
+// DefaultBlacklistCacheTTL 은 BlacklistMatcher 의 기본 양성 캐시 TTL 입니다 (이슈 #295).
+//
+// Resolver (5m) 와 동일 — 운영자가 manual 등록 / disable 토글 후 약간의 지연을 허용하되,
+// 핫패스 lookup 의 DB 부담은 거의 0 으로.
+const DefaultBlacklistCacheTTL = 5 * time.Minute
+
+// DefaultBlacklistNegativeCacheTTL 은 host 매칭 row 부재 (빈 슬라이스) 의 캐시 TTL 입니다.
+//
+// 양성보다 짧게 — 운영자가 신규 host 를 등록한 직후 빠르게 반영되도록.
+const DefaultBlacklistNegativeCacheTTL = 30 * time.Second
+
+// DefaultBlacklistMaxCacheEntries 는 host 단위 cache 의 최대 entry 수입니다.
+const DefaultBlacklistMaxCacheEntries = 10_000
+
+// BlacklistMatcher 는 (host, path) 매칭으로 blacklist 차단 여부를 판단합니다 (이슈 #295).
+//
+// Resolver 와 동일 패턴 — host 단위 후보 슬라이스를 cache + DB lookup, application 측에서
+// path regex 매칭. catch-all (path_pattern="") 은 LENGTH DESC 정렬상 가장 마지막에 평가.
+//
+// goroutine-safe.
+type BlacklistMatcher struct {
+	repo storage.BlacklistRepository
+
+	cacheTTL         time.Duration
+	negativeCacheTTL time.Duration
+	maxEntries       int
+
+	mu    sync.RWMutex
+	cache map[string]blacklistCacheEntry // key: host
+
+	regexCache sync.Map // pattern (string) → *blacklistCompiledPattern
+
+	now func() time.Time
+}
+
+type blacklistCacheEntry struct {
+	rows      []*storage.BlacklistRecord // 빈 슬라이스 = negative cache
+	expiresAt time.Time
+}
+
+type blacklistCompiledPattern struct {
+	re  *regexp.Regexp // 컴파일 실패 또는 빈 패턴이면 nil
+	err error
+}
+
+// BlacklistMatcherOption 은 BlacklistMatcher 생성 옵션입니다.
+type BlacklistMatcherOption func(*BlacklistMatcher)
+
+// WithBlacklistCacheTTL 는 양성 lookup 결과 cache TTL 을 override 합니다.
+func WithBlacklistCacheTTL(d time.Duration) BlacklistMatcherOption {
+	return func(m *BlacklistMatcher) {
+		if d > 0 {
+			m.cacheTTL = d
+		}
+	}
+}
+
+// WithBlacklistNegativeCacheTTL 는 미매칭 (빈 슬라이스) cache TTL 을 override 합니다.
+func WithBlacklistNegativeCacheTTL(d time.Duration) BlacklistMatcherOption {
+	return func(m *BlacklistMatcher) {
+		if d > 0 {
+			m.negativeCacheTTL = d
+		}
+	}
+}
+
+// WithBlacklistMaxCacheEntries 는 host 단위 cache 의 최대 entry 수를 override 합니다.
+func WithBlacklistMaxCacheEntries(n int) BlacklistMatcherOption {
+	return func(m *BlacklistMatcher) {
+		if n > 0 {
+			m.maxEntries = n
+		}
+	}
+}
+
+// NewBlacklistMatcher 는 BlacklistRepository 를 사용하는 Matcher 를 생성합니다.
+// repo 가 nil 이면 error — 호출자 (cmd/main) 가 boot fatal 처리.
+func NewBlacklistMatcher(repo storage.BlacklistRepository, opts ...BlacklistMatcherOption) (*BlacklistMatcher, error) {
+	if repo == nil {
+		return nil, errors.New("rule: NewBlacklistMatcher requires non-nil repo")
+	}
+	m := &BlacklistMatcher{
+		repo:             repo,
+		cacheTTL:         DefaultBlacklistCacheTTL,
+		negativeCacheTTL: DefaultBlacklistNegativeCacheTTL,
+		maxEntries:       DefaultBlacklistMaxCacheEntries,
+		cache:            make(map[string]blacklistCacheEntry),
+		now:              time.Now,
+	}
+	for _, o := range opts {
+		o(m)
+	}
+	return m, nil
+}
+
+// IsBlocked 는 rawURL 이 enabled blacklist row 에 매칭되는지 반환합니다.
+//
+// 흐름:
+//  1. URL parse 실패 → false (차단하지 않음 — 안전 fallback)
+//  2. host cache hit → 후보 슬라이스에서 path 매칭
+//  3. cache miss → repo.FindEnabledByHost → cache + path 매칭
+//
+// 어느 한 row 라도 path 매칭하면 true. DB 에러는 best-effort — false + error 반환 (호출자가
+// 에러 무시하면 차단 안 함, 운영 안전성 우선).
+func (m *BlacklistMatcher) IsBlocked(ctx context.Context, rawURL string) (bool, error) {
+	host, path, err := extractHostPath(rawURL)
+	if err != nil {
+		return false, nil
+	}
+	host = strings.ToLower(host)
+
+	rows, lookupErr := m.lookup(ctx, host)
+	if lookupErr != nil {
+		return false, lookupErr
+	}
+	for _, r := range rows {
+		if m.pathMatches(r.PathPattern, path) {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+// Filter 는 입력 URL 슬라이스에서 blacklist 매칭 항목을 제거하여 반환합니다.
+//
+// 동일 호스트가 반복되는 카테고리 페이지 링크 시나리오에서 host cache 가 재사용되어 비용
+// 거의 없음. 개별 IsBlocked 호출 에러는 best-effort — 해당 URL 만 통과 (차단 안 함).
+func (m *BlacklistMatcher) Filter(ctx context.Context, urls []string) []string {
+	if len(urls) == 0 {
+		return urls
+	}
+	out := make([]string, 0, len(urls))
+	for _, u := range urls {
+		blocked, err := m.IsBlocked(ctx, u)
+		if err != nil {
+			// best-effort: lookup 에러 시 차단 안 함 (안전 fallback) — 호출자에게 별도 통지 X.
+			out = append(out, u)
+			continue
+		}
+		if !blocked {
+			out = append(out, u)
+		}
+	}
+	return out
+}
+
+// Invalidate 는 host 단위 cache entry 를 즉시 제거합니다.
+//
+// 운영자가 row insert/update/delete 직후 호출 — 다음 lookup 부터 fresh DB 결과 적용.
+// invalidatingBlacklistRepo decorator (별도) 가 mutation 후 자동 호출.
+func (m *BlacklistMatcher) Invalidate(host string) {
+	host = strings.ToLower(host)
+	m.mu.Lock()
+	delete(m.cache, host)
+	m.mu.Unlock()
+}
+
+// InvalidateAll 은 모든 cache 를 비웁니다.
+func (m *BlacklistMatcher) InvalidateAll() {
+	m.mu.Lock()
+	m.cache = make(map[string]blacklistCacheEntry)
+	m.mu.Unlock()
+}
+
+// lookup 은 cache hit 시 후보 슬라이스를 반환, miss 시 DB 조회 후 cache 에 저장합니다.
+func (m *BlacklistMatcher) lookup(ctx context.Context, host string) ([]*storage.BlacklistRecord, error) {
+	now := m.now()
+	m.mu.RLock()
+	entry, ok := m.cache[host]
+	m.mu.RUnlock()
+	if ok && now.Before(entry.expiresAt) {
+		return entry.rows, nil
+	}
+
+	fetched, err := m.repo.FindEnabledByHost(ctx, host)
+	if err != nil {
+		return nil, err
+	}
+	ttl := m.cacheTTL
+	if len(fetched) == 0 {
+		ttl = m.negativeCacheTTL
+	}
+
+	m.mu.Lock()
+	if len(m.cache) >= m.maxEntries {
+		// 가장 단순한 evict: 임의 1개 제거 (Resolver 와 동일 정책 — LRU 도입 비용 대비 효과 낮음).
+		for k := range m.cache {
+			delete(m.cache, k)
+			break
+		}
+	}
+	m.cache[host] = blacklistCacheEntry{rows: fetched, expiresAt: now.Add(ttl)}
+	m.mu.Unlock()
+	return fetched, nil
+}
+
+// pathMatches 는 path_pattern 이 path 와 매칭되는지 확인합니다 (Resolver.pathMatches 와 동일 정책).
+//
+//   - pattern="" → 모든 path 매칭 (catch-all)
+//   - 컴파일 실패한 패턴은 매칭 안 됨 (negative cache 로 보관)
+func (m *BlacklistMatcher) pathMatches(pattern, path string) bool {
+	if pattern == "" {
+		return true
+	}
+	cp := m.compileRegex(pattern)
+	if cp.re == nil {
+		return false
+	}
+	return cp.re.MatchString(path)
+}
+
+func (m *BlacklistMatcher) compileRegex(pattern string) *blacklistCompiledPattern {
+	if v, ok := m.regexCache.Load(pattern); ok {
+		return v.(*blacklistCompiledPattern)
+	}
+	re, err := regexp.Compile(pattern)
+	cp := &blacklistCompiledPattern{re: re, err: err}
+	actual, _ := m.regexCache.LoadOrStore(pattern, cp)
+	return actual.(*blacklistCompiledPattern)
+}
+
+// invalidatingBlacklistRepo 는 BlacklistRepository 를 wrap 하여 mutation 후 자동으로 Matcher 의
+// host cache 를 invalidate 하는 decorator 입니다 (이슈 #295, parsing_rules 의 invalidatingRepo
+// 와 동일 패턴).
+//
+// 적용 정책:
+//   - Insert 성공          → Invalidate (host)
+//   - Insert ErrDuplicate  → Invalidate (다른 인스턴스가 INSERT 했을 가능성 — cache stale)
+//   - Update 성공          → 사전 GetByID 로 host lookup 후 Invalidate
+//   - Delete 성공          → 사전 GetByID 로 host lookup 후 Invalidate
+type invalidatingBlacklistRepo struct {
+	inner storage.BlacklistRepository
+	inv   BlacklistInvalidator
+}
+
+// BlacklistInvalidator 는 host cache invalidate 의 최소 인터페이스입니다.
+// BlacklistMatcher 가 본 인터페이스를 만족.
+type BlacklistInvalidator interface {
+	Invalidate(host string)
+}
+
+// WrapBlacklistWithInvalidator 는 BlacklistRepository 를 invalidatingBlacklistRepo 로 wrap 합니다.
+//
+// inner nil 이면 panic — wiring 버그. inv nil 이면 wrapper 만 (invalidate skip).
+func WrapBlacklistWithInvalidator(inner storage.BlacklistRepository, inv BlacklistInvalidator) storage.BlacklistRepository {
+	if inner == nil {
+		panic("rule: WrapBlacklistWithInvalidator requires non-nil inner repository")
+	}
+	return &invalidatingBlacklistRepo{inner: inner, inv: inv}
+}
+
+func (r *invalidatingBlacklistRepo) invalidate(host string) {
+	if r.inv != nil {
+		r.inv.Invalidate(host)
+	}
+}
+
+func (r *invalidatingBlacklistRepo) Insert(ctx context.Context, rec *storage.BlacklistRecord) error {
+	err := r.inner.Insert(ctx, rec)
+	if err == nil || errors.Is(err, storage.ErrDuplicate) {
+		r.invalidate(rec.HostPattern)
+	}
+	return err
+}
+
+func (r *invalidatingBlacklistRepo) Update(ctx context.Context, rec *storage.BlacklistRecord) error {
+	err := r.inner.Update(ctx, rec)
+	if err == nil {
+		r.invalidate(rec.HostPattern)
+	}
+	return err
+}
+
+func (r *invalidatingBlacklistRepo) Delete(ctx context.Context, id int64) error {
+	rec, lookupErr := r.inner.GetByID(ctx, id)
+	if err := r.inner.Delete(ctx, id); err != nil {
+		return err
+	}
+	if lookupErr == nil && rec != nil {
+		r.invalidate(rec.HostPattern)
+	}
+	return nil
+}
+
+// 이하 read-only 위임.
+
+func (r *invalidatingBlacklistRepo) GetByID(ctx context.Context, id int64) (*storage.BlacklistRecord, error) {
+	return r.inner.GetByID(ctx, id)
+}
+func (r *invalidatingBlacklistRepo) FindEnabledByHost(ctx context.Context, host string) ([]*storage.BlacklistRecord, error) {
+	return r.inner.FindEnabledByHost(ctx, host)
+}
+func (r *invalidatingBlacklistRepo) List(ctx context.Context, f storage.BlacklistFilter) ([]*storage.BlacklistRecord, error) {
+	return r.inner.List(ctx, f)
+}
+
+// _ 컴파일 타임 인터페이스 만족 검증.
+var _ storage.BlacklistRepository = (*invalidatingBlacklistRepo)(nil)

--- a/internal/processor/parser/worker/parser_worker.go
+++ b/internal/processor/parser/worker/parser_worker.go
@@ -82,6 +82,11 @@ type ParserWorker struct {
 	// nil 허용 — nil 이면 release skip (TTL fallback 으로 자동 회수).
 	guard PipelineGuard
 
+	// blacklist: page-parse 블랙리스트 Matcher (이슈 #295).
+	// nil 허용 — nil 이면 차단 비활성 (모든 카테고리 링크가 그대로 발행).
+	// processCategoryPage 의 publisher.Publish 직전에 Filter 호출.
+	blacklist *rule.BlacklistMatcher
+
 	// staleCounter: stale rule 재학습 트리거 카운터 (이슈 #282).
 	// nil 허용 — nil 이면 stale 재학습 비활성 (chromedp 자동 전환만 동작).
 	// ErrParseFailure / ErrEmptySelector 발생 시 Record 호출, threshold 도달 시
@@ -176,6 +181,14 @@ func NewParserWorker(
 // nil 주입 시 release 비활성 (TTL fallback). Start 호출 전 wiring 단계에서 1회 설정.
 func (w *ParserWorker) SetPipelineGuard(g PipelineGuard) {
 	w.guard = g
+}
+
+// SetBlacklist 는 page-parse 블랙리스트 Matcher 를 주입합니다 (이슈 #295).
+//
+// nil 주입 시 차단 비활성 (모든 카테고리 링크가 그대로 article job 으로 발행).
+// Start 호출 전 wiring 단계에서 1회 설정.
+func (w *ParserWorker) SetBlacklist(b *rule.BlacklistMatcher) {
+	w.blacklist = b
 }
 
 // SetStaleCounter 는 stale rule 재학습 트리거 카운터 + 임계값을 주입합니다 (이슈 #282).
@@ -346,13 +359,32 @@ func (w *ParserWorker) processCategoryPage(ctx context.Context, raw *core.RawCon
 	}
 
 	urls := uniqueURLs(items, maxChainedURLs)
+
+	// 이슈 #295: page-parse 블랙리스트 적용 — 매칭 URL 은 article job 발행 단계에서 drop.
+	// fetch / parse 자체가 발생 안 함. Matcher 미설정 (nil) 이면 모든 URL 통과.
+	blockedCount := 0
+	if w.blacklist != nil && len(urls) > 0 {
+		filtered := w.blacklist.Filter(ctx, urls)
+		blockedCount = len(urls) - len(filtered)
+		urls = filtered
+		if len(urls) == 0 {
+			mlog.WithFields(map[string]interface{}{
+				"crawler":       crawlerName,
+				"blocked_count": blockedCount,
+			}).Info("all category links blocked by blacklist — no chained jobs published")
+			w.deleteRaw(ctx, rawID, mlog)
+			return nil
+		}
+	}
+
 	if err := w.publisher.Publish(ctx, crawlerName, urls, core.TargetTypeArticle, jobTimeout); err != nil {
 		return fmt.Errorf("publish chained article jobs: %w", err)
 	}
 
 	mlog.WithFields(map[string]interface{}{
-		"crawler":   crawlerName,
-		"url_count": len(urls),
+		"crawler":       crawlerName,
+		"url_count":     len(urls),
+		"blocked_count": blockedCount,
 	}).Info("chained article jobs published from category page")
 
 	// 카테고리 페이지는 contents/news_articles 에 저장하지 않음 — raw 즉시 정리

--- a/internal/storage/blacklist.go
+++ b/internal/storage/blacklist.go
@@ -1,0 +1,80 @@
+package storage
+
+import (
+	"context"
+	"time"
+)
+
+// BlacklistSource 는 블랙리스트 row 의 등록 출처입니다 (이슈 #295).
+//
+//   - BlacklistSourceManual : 운영자가 명시적으로 등록 (광고 / sponsored / redirect 등 도메인 지식 기반)
+//   - BlacklistSourceAuto   : 시스템이 시그널 누적으로 자동 등록 (후속 이슈 — 본 PR scope 외)
+//
+// CHECK 제약으로 DB 레벨에서 두 값만 허용. 운영 가시성 + 자동 vs 수동 분리 정책 (예: auto 만
+// 일괄 disable, manual 은 보존) 을 위해 컬럼화.
+type BlacklistSource string
+
+const (
+	BlacklistSourceManual BlacklistSource = "manual"
+	BlacklistSourceAuto   BlacklistSource = "auto"
+)
+
+// BlacklistRecord 는 parsing_blacklist 테이블의 단일 행입니다 (이슈 #295).
+//
+// page-parse 차단 정책 — 매칭 URL 은 article job 발행 단계에서 drop:
+//   - HostPattern : URL host 매칭 (정확 일치, 호출자가 normalize)
+//   - PathPattern : URL path 매칭 RE2 regex. "" 이면 host 전체 차단 (catch-all).
+//                   pattern 검증은 Insert 시 application 측 RE2 컴파일.
+//   - Reason      : 운영 가시성 ("ad" / "redirect" / "sponsored" / ...)
+//   - Source      : "manual" | "auto"
+//   - Enabled     : 토글 — false 면 매칭 무시 (DELETE 대안, 임시 비활성)
+type BlacklistRecord struct {
+	ID          int64
+	HostPattern string
+	PathPattern string
+	Reason      string
+	Source      BlacklistSource
+	Enabled     bool
+	CreatedAt   time.Time
+	UpdatedAt   time.Time
+}
+
+// BlacklistFilter 는 List 조회 시 필터 조건입니다.
+type BlacklistFilter struct {
+	HostPattern string          // 빈 문자열이면 전체
+	Source      BlacklistSource // 빈 문자열이면 전체
+	OnlyEnabled bool            // true 면 enabled=true 만
+	Limit       int             // 0 이면 기본값 (50)
+	Offset      int
+}
+
+// BlacklistRepository 는 parsing_blacklist 테이블에 대한 데이터 접근 인터페이스입니다 (이슈 #295).
+//
+// goroutine-safe: 모든 구현은 동시 호출 안전해야 함.
+type BlacklistRepository interface {
+	// Insert 는 새 블랙리스트 row 를 저장합니다. 자연키 (host_pattern, path_pattern) 충돌 시
+	// ErrDuplicate 반환. PathPattern 이 빈 문자열이 아니면 RE2 컴파일 검증 — 실패 시 ErrInvalid.
+	// 성공 시 r.ID / CreatedAt / UpdatedAt 채워짐.
+	Insert(ctx context.Context, r *BlacklistRecord) error
+
+	// Update 는 ID 로 row 를 갱신합니다 (자연키 변경 불가). Enabled / Reason / Source 만 변경 가능.
+	// 존재하지 않으면 ErrNotFound.
+	Update(ctx context.Context, r *BlacklistRecord) error
+
+	// Delete 는 ID 로 row 를 삭제합니다. 존재하지 않아도 nil 반환 (idempotent).
+	Delete(ctx context.Context, id int64) error
+
+	// GetByID 는 ID 로 row 를 조회합니다.
+	GetByID(ctx context.Context, id int64) (*BlacklistRecord, error)
+
+	// FindEnabledByHost 는 host_pattern 매칭 enabled=TRUE row 들을 반환합니다 (Matcher 핫패스).
+	//
+	// 정렬: LENGTH(path_pattern) DESC — 더 구체적인 path 가 먼저 평가되도록 (parsing_rules 의
+	// FindActiveCandidates 와 동일 정책). path_pattern="" (catch-all) 은 가장 마지막.
+	//
+	// 매칭 없으면 빈 슬라이스 + nil error.
+	FindEnabledByHost(ctx context.Context, host string) ([]*BlacklistRecord, error)
+
+	// List 는 필터 조건에 맞는 row 들을 반환합니다 (운영 대시보드용).
+	List(ctx context.Context, filter BlacklistFilter) ([]*BlacklistRecord, error)
+}

--- a/internal/storage/blacklist.go
+++ b/internal/storage/blacklist.go
@@ -24,7 +24,7 @@ const (
 // page-parse 차단 정책 — 매칭 URL 은 article job 발행 단계에서 drop:
 //   - HostPattern : URL host 매칭 (정확 일치, 호출자가 normalize)
 //   - PathPattern : URL path 매칭 RE2 regex. "" 이면 host 전체 차단 (catch-all).
-//                   pattern 검증은 Insert 시 application 측 RE2 컴파일.
+//     pattern 검증은 Insert 시 application 측 RE2 컴파일.
 //   - Reason      : 운영 가시성 ("ad" / "redirect" / "sponsored" / ...)
 //   - Source      : "manual" | "auto"
 //   - Enabled     : 토글 — false 면 매칭 무시 (DELETE 대안, 임시 비활성)

--- a/internal/storage/postgres/blacklist.go
+++ b/internal/storage/postgres/blacklist.go
@@ -1,0 +1,207 @@
+package postgres
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"regexp"
+
+	"github.com/jackc/pgerrcode"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"issuetracker/internal/storage"
+	"issuetracker/pkg/logger"
+)
+
+// pgBlacklistRepository 는 pgx/v5 기반 BlacklistRepository 구현체입니다 (이슈 #295).
+type pgBlacklistRepository struct {
+	pool *pgxpool.Pool
+}
+
+// NewBlacklistRepository 는 pgxpool 기반 BlacklistRepository 를 생성합니다.
+// log 인자는 향후 query latency / error log 등 운영 가시성 추가용 — 현재 미사용.
+func NewBlacklistRepository(pool *pgxpool.Pool, log *logger.Logger) storage.BlacklistRepository {
+	_ = log
+	return &pgBlacklistRepository{pool: pool}
+}
+
+const sqlInsertBlacklist = `
+INSERT INTO parsing_blacklist (host_pattern, path_pattern, reason, source, enabled)
+VALUES ($1, $2, $3, $4, $5)
+RETURNING id, created_at, updated_at
+`
+
+// Insert 는 새 row 를 저장합니다. 자연키 (host_pattern, path_pattern) 충돌 시 ErrDuplicate.
+//
+// path_pattern 이 비어있지 않으면 RE2 컴파일 검증 — parsing_rules.Insert 와 동일 정책 (DB write
+// 전 잘못된 regex 거부, 운영 가시성 ↑ + Matcher 가 매 호출마다 negative cache 로 흡수하지 않도록).
+func (r *pgBlacklistRepository) Insert(ctx context.Context, rec *storage.BlacklistRecord) error {
+	if rec.PathPattern != "" {
+		if _, reErr := regexp.Compile(rec.PathPattern); reErr != nil {
+			return fmt.Errorf("%w: path_pattern %q is not a valid regex: %v", storage.ErrInvalid, rec.PathPattern, reErr)
+		}
+	}
+	if rec.Source == "" {
+		rec.Source = storage.BlacklistSourceManual
+	}
+	row := r.pool.QueryRow(ctx, sqlInsertBlacklist,
+		rec.HostPattern, rec.PathPattern, rec.Reason, string(rec.Source), rec.Enabled,
+	)
+	if err := row.Scan(&rec.ID, &rec.CreatedAt, &rec.UpdatedAt); err != nil {
+		var pgErr *pgconn.PgError
+		if errors.As(err, &pgErr) && pgErr.Code == pgerrcode.UniqueViolation {
+			return storage.ErrDuplicate
+		}
+		return fmt.Errorf("insert blacklist: %w", err)
+	}
+	return nil
+}
+
+const sqlUpdateBlacklist = `
+UPDATE parsing_blacklist
+SET reason = $2, source = $3, enabled = $4, updated_at = NOW()
+WHERE id = $1
+RETURNING updated_at
+`
+
+// Update 는 ID 로 row 의 mutable 필드 (reason / source / enabled) 만 갱신합니다.
+// 자연키 (host_pattern, path_pattern) 는 변경 불가 — 의도가 다르면 Delete + Insert.
+func (r *pgBlacklistRepository) Update(ctx context.Context, rec *storage.BlacklistRecord) error {
+	row := r.pool.QueryRow(ctx, sqlUpdateBlacklist,
+		rec.ID, rec.Reason, string(rec.Source), rec.Enabled,
+	)
+	if err := row.Scan(&rec.UpdatedAt); err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return storage.ErrNotFound
+		}
+		return fmt.Errorf("update blacklist: %w", err)
+	}
+	return nil
+}
+
+const sqlDeleteBlacklist = `DELETE FROM parsing_blacklist WHERE id = $1`
+
+// Delete 는 ID 로 row 를 삭제합니다. 존재하지 않아도 nil 반환 (idempotent).
+func (r *pgBlacklistRepository) Delete(ctx context.Context, id int64) error {
+	if _, err := r.pool.Exec(ctx, sqlDeleteBlacklist, id); err != nil {
+		return fmt.Errorf("delete blacklist: %w", err)
+	}
+	return nil
+}
+
+const sqlGetBlacklistByID = `
+SELECT id, host_pattern, path_pattern, reason, source, enabled, created_at, updated_at
+FROM parsing_blacklist
+WHERE id = $1
+`
+
+// GetByID 는 ID 로 row 를 조회합니다.
+func (r *pgBlacklistRepository) GetByID(ctx context.Context, id int64) (*storage.BlacklistRecord, error) {
+	row := r.pool.QueryRow(ctx, sqlGetBlacklistByID, id)
+	rec, err := scanBlacklist(row)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, storage.ErrNotFound
+		}
+		return nil, fmt.Errorf("get blacklist by id: %w", err)
+	}
+	return rec, nil
+}
+
+const sqlFindEnabledBlacklistByHost = `
+SELECT id, host_pattern, path_pattern, reason, source, enabled, created_at, updated_at
+FROM parsing_blacklist
+WHERE host_pattern = $1 AND enabled = TRUE
+ORDER BY LENGTH(path_pattern) DESC, id DESC
+`
+
+// FindEnabledByHost 는 (host) 매칭 enabled=TRUE row 들을 LENGTH(path_pattern) DESC 정렬로 반환합니다.
+//
+// parsing_rules.FindActiveCandidates 와 동일 정책 — 더 구체적인 path 우선 평가, catch-all (path="")
+// 이 가장 마지막. tie-break 로 id DESC (최근 등록 우선) 사용.
+func (r *pgBlacklistRepository) FindEnabledByHost(ctx context.Context, host string) ([]*storage.BlacklistRecord, error) {
+	rows, err := r.pool.Query(ctx, sqlFindEnabledBlacklistByHost, host)
+	if err != nil {
+		return nil, fmt.Errorf("query blacklist by host: %w", err)
+	}
+	defer rows.Close()
+
+	out := make([]*storage.BlacklistRecord, 0)
+	for rows.Next() {
+		rec, scanErr := scanBlacklist(rows)
+		if scanErr != nil {
+			return nil, fmt.Errorf("scan blacklist row: %w", scanErr)
+		}
+		out = append(out, rec)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate blacklist rows: %w", err)
+	}
+	return out, nil
+}
+
+// List 는 필터 조건에 맞는 row 들을 반환합니다 (운영 대시보드용).
+func (r *pgBlacklistRepository) List(ctx context.Context, f storage.BlacklistFilter) ([]*storage.BlacklistRecord, error) {
+	limit := f.Limit
+	if limit <= 0 {
+		limit = 50
+	}
+	q := `
+SELECT id, host_pattern, path_pattern, reason, source, enabled, created_at, updated_at
+FROM parsing_blacklist
+WHERE ($1 = '' OR host_pattern = $1)
+  AND ($2 = '' OR source = $2)
+  AND (NOT $3 OR enabled = TRUE)
+ORDER BY id DESC
+LIMIT $4 OFFSET $5
+`
+	rows, err := r.pool.Query(ctx, q,
+		f.HostPattern, string(f.Source), f.OnlyEnabled, limit, f.Offset,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("list blacklist: %w", err)
+	}
+	defer rows.Close()
+
+	out := make([]*storage.BlacklistRecord, 0)
+	for rows.Next() {
+		rec, scanErr := scanBlacklist(rows)
+		if scanErr != nil {
+			return nil, fmt.Errorf("scan blacklist row: %w", scanErr)
+		}
+		out = append(out, rec)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate blacklist rows: %w", err)
+	}
+	return out, nil
+}
+
+// scanBlacklist 는 pgx Row / Rows scanner 를 통합 처리합니다.
+type rowScanner interface {
+	Scan(dest ...any) error
+}
+
+func scanBlacklist(s rowScanner) (*storage.BlacklistRecord, error) {
+	rec := &storage.BlacklistRecord{}
+	var source string
+	if err := s.Scan(
+		&rec.ID,
+		&rec.HostPattern,
+		&rec.PathPattern,
+		&rec.Reason,
+		&source,
+		&rec.Enabled,
+		&rec.CreatedAt,
+		&rec.UpdatedAt,
+	); err != nil {
+		return nil, err
+	}
+	rec.Source = storage.BlacklistSource(source)
+	return rec, nil
+}
+
+// 컴파일 타임 인터페이스 만족 검증.
+var _ storage.BlacklistRepository = (*pgBlacklistRepository)(nil)

--- a/internal/storage/postgres/blacklist.go
+++ b/internal/storage/postgres/blacklist.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"regexp"
+	"strings"
 
 	"github.com/jackc/pgerrcode"
 	"github.com/jackc/pgx/v5"
@@ -37,12 +38,16 @@ RETURNING id, created_at, updated_at
 //
 // path_pattern 이 비어있지 않으면 RE2 컴파일 검증 — parsing_rules.Insert 와 동일 정책 (DB write
 // 전 잘못된 regex 거부, 운영 가시성 ↑ + Matcher 가 매 호출마다 negative cache 로 흡수하지 않도록).
+//
+// PR #296 gemini 피드백: HostPattern 을 lowercase 로 정규화 — BlacklistMatcher 가 host 를
+// lowercase 로 lookup 하므로 저장 시점에도 동일 정규화 필수 (대소문자 섞인 등록 시 미스매치 회피).
 func (r *pgBlacklistRepository) Insert(ctx context.Context, rec *storage.BlacklistRecord) error {
 	if rec.PathPattern != "" {
 		if _, reErr := regexp.Compile(rec.PathPattern); reErr != nil {
 			return fmt.Errorf("%w: path_pattern %q is not a valid regex: %v", storage.ErrInvalid, rec.PathPattern, reErr)
 		}
 	}
+	rec.HostPattern = strings.ToLower(rec.HostPattern)
 	if rec.Source == "" {
 		rec.Source = storage.BlacklistSourceManual
 	}
@@ -121,8 +126,11 @@ ORDER BY LENGTH(path_pattern) DESC, id DESC
 //
 // parsing_rules.FindActiveCandidates 와 동일 정책 — 더 구체적인 path 우선 평가, catch-all (path="")
 // 이 가장 마지막. tie-break 로 id DESC (최근 등록 우선) 사용.
+//
+// host 는 lowercase 로 정규화된 상태 가정 (Matcher 가 lowercase 로 호출). DB 에 저장된 host_pattern
+// 도 Insert 시 lowercase 정규화 (PR #296 gemini 피드백) — 양쪽 일치 보장.
 func (r *pgBlacklistRepository) FindEnabledByHost(ctx context.Context, host string) ([]*storage.BlacklistRecord, error) {
-	rows, err := r.pool.Query(ctx, sqlFindEnabledBlacklistByHost, host)
+	rows, err := r.pool.Query(ctx, sqlFindEnabledBlacklistByHost, strings.ToLower(host))
 	if err != nil {
 		return nil, fmt.Errorf("query blacklist by host: %w", err)
 	}
@@ -157,8 +165,10 @@ WHERE ($1 = '' OR host_pattern = $1)
 ORDER BY id DESC
 LIMIT $4 OFFSET $5
 `
+	// HostPattern 을 lowercase 로 정규화 — Insert 와 동일 정책 (PR #296 gemini 피드백).
+	// 저장은 lowercase 이므로 검색 조건도 lowercase 여야 일치.
 	rows, err := r.pool.Query(ctx, q,
-		f.HostPattern, string(f.Source), f.OnlyEnabled, limit, f.Offset,
+		strings.ToLower(f.HostPattern), string(f.Source), f.OnlyEnabled, limit, f.Offset,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("list blacklist: %w", err)

--- a/migrations/down/016_parsing_blacklist.sql
+++ b/migrations/down/016_parsing_blacklist.sql
@@ -1,0 +1,4 @@
+-- 016_parsing_blacklist (down): parsing_blacklist 테이블 제거 (이슈 #295 롤백).
+
+DROP INDEX IF EXISTS idx_parsing_blacklist_host_enabled;
+DROP TABLE IF EXISTS parsing_blacklist;

--- a/migrations/up/016_parsing_blacklist.sql
+++ b/migrations/up/016_parsing_blacklist.sql
@@ -1,0 +1,38 @@
+-- 016_parsing_blacklist: page-parse 블랙리스트 테이블 (이슈 #295)
+--
+-- 배경:
+--   카테고리 페이지에서 발견되지만 article 단계에서 의미 있는 컨텐츠가 없는 URL (광고 /
+--   sponsored / redirect / 비-article 영역) 을 운영자가 명시적으로 제외하기 위한 저장소.
+--   매칭된 URL 은 publisher.Publish 직전에 제거 → fetch / parse 자체 발생 X.
+--
+-- 스키마:
+--   - host_pattern : URL host 매칭 (예: "n.news.naver.com")
+--   - path_pattern : URL path RE2 regex. "" 이면 host 전체 차단 (catch-all)
+--   - reason       : 운영 가시성 (ad / redirect / sponsored / ...)
+--   - source       : 'manual' (운영자 등록) | 'auto' (시스템 자동 색출 — 후속 이슈)
+--   - enabled      : 토글 — 운영자가 임시 비활성 가능
+--
+-- 자연키 (host_pattern, path_pattern) UNIQUE — 동일 매칭 룰 중복 방지.
+-- parsing_rules 와 의미 분리: rule 부재 ≠ blacklist (rule disable 은 \"학습 안 함\",
+-- blacklist 는 \"발행 자체 차단\").
+
+CREATE TABLE IF NOT EXISTS parsing_blacklist (
+  id            BIGSERIAL    PRIMARY KEY,
+  host_pattern  TEXT         NOT NULL,
+  path_pattern  TEXT         NOT NULL DEFAULT '',
+  reason        TEXT         NOT NULL DEFAULT '',
+  source        TEXT         NOT NULL CHECK (source IN ('manual', 'auto')),
+  enabled       BOOLEAN      NOT NULL DEFAULT TRUE,
+  created_at    TIMESTAMPTZ  NOT NULL DEFAULT NOW(),
+  updated_at    TIMESTAMPTZ  NOT NULL DEFAULT NOW(),
+  UNIQUE (host_pattern, path_pattern)
+);
+
+-- enabled row 의 host 단위 lookup 가속 — Matcher 의 (host) → 후보 슬라이스 fetch 핫패스.
+CREATE INDEX IF NOT EXISTS idx_parsing_blacklist_host_enabled
+  ON parsing_blacklist (host_pattern)
+  WHERE enabled = TRUE;
+
+COMMENT ON TABLE  parsing_blacklist                 IS 'page-parse 블랙리스트 (이슈 #295) — 매칭 URL 은 article job 발행 단계에서 drop.';
+COMMENT ON COLUMN parsing_blacklist.path_pattern    IS 'RE2 regex. 빈 문자열이면 host 전체 차단 (catch-all).';
+COMMENT ON COLUMN parsing_blacklist.source          IS 'manual: 운영자 등록 / auto: 시스템 자동 색출 (후속 이슈).';

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -743,6 +743,43 @@ func LoadStaleRelearn(envFiles ...string) (StaleRelearnConfig, error) {
 	return cfg, nil
 }
 
+// BlacklistConfig 는 page-parse 블랙리스트 wiring 설정입니다 (이슈 #295).
+//
+// Enabled=false 면 BlacklistMatcher 미주입 — parser_worker.processCategoryPage 가 모든 카테고리
+// 링크를 그대로 article job 으로 발행 (기능 OFF). 운영 toggle 용도.
+type BlacklistConfig struct {
+	// Enabled: 환경변수 BLACKLIST_ENABLED (default true).
+	Enabled bool
+}
+
+// DefaultBlacklistConfig 는 기본 BlacklistConfig 를 반환합니다.
+func DefaultBlacklistConfig() BlacklistConfig {
+	return BlacklistConfig{Enabled: true}
+}
+
+// LoadBlacklist 는 .env 를 로드한 후 OS 환경변수로 BlacklistConfig 를 구성합니다.
+//
+// 지원 환경변수:
+//   - BLACKLIST_ENABLED: true | false (default true)
+func LoadBlacklist(envFiles ...string) (BlacklistConfig, error) {
+	if len(envFiles) == 0 {
+		envFiles = []string{".env"}
+	}
+	if err := godotenv.Load(envFiles...); err != nil && !errors.Is(err, os.ErrNotExist) {
+		return BlacklistConfig{}, fmt.Errorf("failed to load env files %v: %w", envFiles, err)
+	}
+
+	cfg := DefaultBlacklistConfig()
+	if v := os.Getenv("BLACKLIST_ENABLED"); v != "" {
+		b, err := strconv.ParseBool(v)
+		if err != nil {
+			return BlacklistConfig{}, fmt.Errorf("parse BLACKLIST_ENABLED %q: %w", v, err)
+		}
+		cfg.Enabled = b
+	}
+	return cfg, nil
+}
+
 // LLMConfig 는 LLM rule generator (이슈 #149) wiring 설정입니다.
 //
 // LLMConfig drives the LLM provider used for auto-generating parsing rules when

--- a/test/internal/processor/parser/rule/blacklist_matcher_test.go
+++ b/test/internal/processor/parser/rule/blacklist_matcher_test.go
@@ -349,6 +349,24 @@ func TestInvalidatingBlacklistRepo_Update_Success_Invalidates(t *testing.T) {
 	assert.Equal(t, []string{"ads.example.com"}, inv.snapshot())
 }
 
+// PR #296 CodeRabbit Major: Update 는 host 변경 안 하므로 호출자가 rec.HostPattern 을 비워
+// 보낼 수 있음. 사전 GetByID 로 authoritative host 를 얻어 invalidate 해야 cache 누락 0.
+func TestInvalidatingBlacklistRepo_Update_EmptyHostInArg_StillInvalidatesActualHost(t *testing.T) {
+	inner := &fakeBlacklistRepo{rows: []*storage.BlacklistRecord{
+		{ID: 1, HostPattern: "ads.example.com", Enabled: true},
+	}}
+	inv := &recordingBlacklistInvalidator{}
+	repo := rule.WrapBlacklistWithInvalidator(inner, inv)
+
+	// 호출자가 host 비워 보내도 (Update 는 host 변경 안 함이라 정당) DB 의 실제 host 로 invalidate.
+	err := repo.Update(context.Background(), &storage.BlacklistRecord{
+		ID: 1, Reason: "updated", Enabled: false,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, []string{"ads.example.com"}, inv.snapshot(),
+		"empty HostPattern arg 여도 사전 GetByID 로 실제 host 발견 후 invalidate")
+}
+
 func TestInvalidatingBlacklistRepo_Delete_PrefetchesAndInvalidates(t *testing.T) {
 	inner := &fakeBlacklistRepo{rows: []*storage.BlacklistRecord{
 		{ID: 1, HostPattern: "ads.example.com", Enabled: true},

--- a/test/internal/processor/parser/rule/blacklist_matcher_test.go
+++ b/test/internal/processor/parser/rule/blacklist_matcher_test.go
@@ -1,0 +1,406 @@
+package rule_test
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"issuetracker/internal/processor/parser/rule"
+	"issuetracker/internal/storage"
+)
+
+// fakeBlacklistRepo 는 in-memory BlacklistRepository — Matcher / decorator 단위 테스트용.
+type fakeBlacklistRepo struct {
+	rows         []*storage.BlacklistRecord
+	findCalls    int64
+	getByIDCalls int64
+	findErr      error
+	insertErr    error
+	getByIDErr   error
+	updateErr    error
+	deleteErr    error
+}
+
+func (r *fakeBlacklistRepo) Insert(_ context.Context, rec *storage.BlacklistRecord) error {
+	if r.insertErr != nil {
+		return r.insertErr
+	}
+	rec.ID = int64(len(r.rows) + 1)
+	r.rows = append(r.rows, rec)
+	return nil
+}
+
+func (r *fakeBlacklistRepo) Update(_ context.Context, rec *storage.BlacklistRecord) error {
+	if r.updateErr != nil {
+		return r.updateErr
+	}
+	for _, existing := range r.rows {
+		if existing.ID == rec.ID {
+			existing.Reason = rec.Reason
+			existing.Source = rec.Source
+			existing.Enabled = rec.Enabled
+			return nil
+		}
+	}
+	return storage.ErrNotFound
+}
+
+func (r *fakeBlacklistRepo) Delete(_ context.Context, id int64) error {
+	if r.deleteErr != nil {
+		return r.deleteErr
+	}
+	out := r.rows[:0]
+	for _, existing := range r.rows {
+		if existing.ID != id {
+			out = append(out, existing)
+		}
+	}
+	r.rows = out
+	return nil
+}
+
+func (r *fakeBlacklistRepo) GetByID(_ context.Context, id int64) (*storage.BlacklistRecord, error) {
+	atomic.AddInt64(&r.getByIDCalls, 1)
+	if r.getByIDErr != nil {
+		return nil, r.getByIDErr
+	}
+	for _, existing := range r.rows {
+		if existing.ID == id {
+			return existing, nil
+		}
+	}
+	return nil, storage.ErrNotFound
+}
+
+func (r *fakeBlacklistRepo) FindEnabledByHost(_ context.Context, host string) ([]*storage.BlacklistRecord, error) {
+	atomic.AddInt64(&r.findCalls, 1)
+	if r.findErr != nil {
+		return nil, r.findErr
+	}
+	out := make([]*storage.BlacklistRecord, 0)
+	for _, existing := range r.rows {
+		if existing.HostPattern == host && existing.Enabled {
+			out = append(out, existing)
+		}
+	}
+	return out, nil
+}
+
+func (r *fakeBlacklistRepo) List(_ context.Context, _ storage.BlacklistFilter) ([]*storage.BlacklistRecord, error) {
+	return r.rows, nil
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// IsBlocked / Filter 매칭 동작
+// ─────────────────────────────────────────────────────────────────────────────
+
+func TestBlacklistMatcher_HostCatchAllBlocksAllPaths(t *testing.T) {
+	repo := &fakeBlacklistRepo{rows: []*storage.BlacklistRecord{
+		{ID: 1, HostPattern: "ads.example.com", PathPattern: "", Source: storage.BlacklistSourceManual, Enabled: true},
+	}}
+	m, err := rule.NewBlacklistMatcher(repo)
+	require.NoError(t, err)
+
+	for _, u := range []string{
+		"https://ads.example.com/",
+		"https://ads.example.com/anything",
+		"https://ads.example.com/some/deep/path",
+	} {
+		blocked, err := m.IsBlocked(context.Background(), u)
+		require.NoError(t, err)
+		assert.True(t, blocked, "host catch-all 은 모든 path 차단: %s", u)
+	}
+}
+
+func TestBlacklistMatcher_PathPatternBlocksMatchingOnly(t *testing.T) {
+	repo := &fakeBlacklistRepo{rows: []*storage.BlacklistRecord{
+		{ID: 1, HostPattern: "news.example.com", PathPattern: `^/promotion/.*$`, Source: storage.BlacklistSourceManual, Enabled: true},
+	}}
+	m, err := rule.NewBlacklistMatcher(repo)
+	require.NoError(t, err)
+
+	blocked, _ := m.IsBlocked(context.Background(), "https://news.example.com/promotion/123")
+	assert.True(t, blocked, "정밀 path 는 매칭 path 만 차단")
+
+	blocked, _ = m.IsBlocked(context.Background(), "https://news.example.com/article/123")
+	assert.False(t, blocked, "정밀 path 는 미매칭 path 통과")
+}
+
+func TestBlacklistMatcher_DisabledRowsIgnored(t *testing.T) {
+	repo := &fakeBlacklistRepo{rows: []*storage.BlacklistRecord{
+		{ID: 1, HostPattern: "ads.example.com", PathPattern: "", Source: storage.BlacklistSourceManual, Enabled: false},
+	}}
+	m, _ := rule.NewBlacklistMatcher(repo)
+
+	blocked, _ := m.IsBlocked(context.Background(), "https://ads.example.com/x")
+	assert.False(t, blocked, "disabled row 는 무시")
+}
+
+func TestBlacklistMatcher_HostMismatchPasses(t *testing.T) {
+	repo := &fakeBlacklistRepo{rows: []*storage.BlacklistRecord{
+		{ID: 1, HostPattern: "ads.example.com", PathPattern: "", Source: storage.BlacklistSourceManual, Enabled: true},
+	}}
+	m, _ := rule.NewBlacklistMatcher(repo)
+
+	blocked, _ := m.IsBlocked(context.Background(), "https://news.example.com/x")
+	assert.False(t, blocked, "다른 host 는 통과")
+}
+
+func TestBlacklistMatcher_InvalidURLDoesNotBlock(t *testing.T) {
+	repo := &fakeBlacklistRepo{}
+	m, _ := rule.NewBlacklistMatcher(repo)
+
+	blocked, err := m.IsBlocked(context.Background(), "::not a url")
+	require.NoError(t, err)
+	assert.False(t, blocked, "URL parse 실패는 안전하게 false (차단 안 함)")
+}
+
+func TestBlacklistMatcher_HostNormalizedLowercase(t *testing.T) {
+	repo := &fakeBlacklistRepo{rows: []*storage.BlacklistRecord{
+		{ID: 1, HostPattern: "ads.example.com", PathPattern: "", Source: storage.BlacklistSourceManual, Enabled: true},
+	}}
+	m, _ := rule.NewBlacklistMatcher(repo)
+
+	blocked, _ := m.IsBlocked(context.Background(), "https://ADS.EXAMPLE.COM/x")
+	assert.True(t, blocked, "host 는 lowercase 정규화 후 매칭")
+}
+
+func TestBlacklistMatcher_InvalidRegexFallsThrough(t *testing.T) {
+	// 잘못된 regex 는 컴파일 실패 — 매칭 안 됨으로 처리, 다른 row 가 catch-all 이면 그쪽 적용.
+	repo := &fakeBlacklistRepo{rows: []*storage.BlacklistRecord{
+		{ID: 1, HostPattern: "news.example.com", PathPattern: "[unclosed", Source: storage.BlacklistSourceManual, Enabled: true},
+		{ID: 2, HostPattern: "news.example.com", PathPattern: "", Source: storage.BlacklistSourceManual, Enabled: true},
+	}}
+	m, _ := rule.NewBlacklistMatcher(repo)
+
+	blocked, _ := m.IsBlocked(context.Background(), "https://news.example.com/article/1")
+	assert.True(t, blocked, "잘못된 regex 는 skip 되고 catch-all 로 차단")
+}
+
+func TestBlacklistMatcher_DBErrorPropagates(t *testing.T) {
+	repo := &fakeBlacklistRepo{findErr: errors.New("db down")}
+	m, _ := rule.NewBlacklistMatcher(repo)
+
+	blocked, err := m.IsBlocked(context.Background(), "https://news.example.com/x")
+	require.Error(t, err, "DB 에러는 호출자에게 전파")
+	assert.False(t, blocked, "에러 시 차단 안 함 (안전 fallback)")
+}
+
+func TestBlacklistMatcher_Filter_RemovesBlockedURLs(t *testing.T) {
+	repo := &fakeBlacklistRepo{rows: []*storage.BlacklistRecord{
+		{ID: 1, HostPattern: "ads.example.com", PathPattern: "", Source: storage.BlacklistSourceManual, Enabled: true},
+		{ID: 2, HostPattern: "news.example.com", PathPattern: `^/promotion/.*$`, Source: storage.BlacklistSourceManual, Enabled: true},
+	}}
+	m, _ := rule.NewBlacklistMatcher(repo)
+
+	in := []string{
+		"https://news.example.com/article/1",
+		"https://ads.example.com/banner",
+		"https://news.example.com/promotion/123",
+		"https://news.example.com/article/2",
+	}
+	out := m.Filter(context.Background(), in)
+	assert.Equal(t, []string{
+		"https://news.example.com/article/1",
+		"https://news.example.com/article/2",
+	}, out)
+}
+
+func TestBlacklistMatcher_Filter_EmptyInputReturnsAsIs(t *testing.T) {
+	repo := &fakeBlacklistRepo{}
+	m, _ := rule.NewBlacklistMatcher(repo)
+
+	out := m.Filter(context.Background(), nil)
+	assert.Empty(t, out)
+}
+
+func TestBlacklistMatcher_Filter_DBErrorPassesThroughURL(t *testing.T) {
+	repo := &fakeBlacklistRepo{findErr: errors.New("db down")}
+	m, _ := rule.NewBlacklistMatcher(repo)
+
+	in := []string{"https://news.example.com/article/1"}
+	out := m.Filter(context.Background(), in)
+	assert.Equal(t, in, out, "Filter 의 lookup 에러는 best-effort — 해당 URL 통과 (차단 안 함)")
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Cache 동작
+// ─────────────────────────────────────────────────────────────────────────────
+
+func TestBlacklistMatcher_Cache_HitsAvoidRepoCall(t *testing.T) {
+	repo := &fakeBlacklistRepo{rows: []*storage.BlacklistRecord{
+		{ID: 1, HostPattern: "news.example.com", PathPattern: "", Source: storage.BlacklistSourceManual, Enabled: true},
+	}}
+	m, _ := rule.NewBlacklistMatcher(repo)
+
+	for i := 0; i < 5; i++ {
+		_, err := m.IsBlocked(context.Background(), "https://news.example.com/x")
+		require.NoError(t, err)
+	}
+	assert.Equal(t, int64(1), atomic.LoadInt64(&repo.findCalls), "cache hit 후엔 repo 호출 0")
+}
+
+func TestBlacklistMatcher_NegativeCache_AvoidsRepoCallForMissingHost(t *testing.T) {
+	repo := &fakeBlacklistRepo{}
+	m, _ := rule.NewBlacklistMatcher(repo)
+
+	for i := 0; i < 5; i++ {
+		_, _ = m.IsBlocked(context.Background(), "https://nothere.example.com/x")
+	}
+	assert.Equal(t, int64(1), atomic.LoadInt64(&repo.findCalls), "negative cache 도 hit")
+}
+
+func TestBlacklistMatcher_Invalidate_ForcesRepoCall(t *testing.T) {
+	repo := &fakeBlacklistRepo{rows: []*storage.BlacklistRecord{
+		{ID: 1, HostPattern: "news.example.com", PathPattern: "", Source: storage.BlacklistSourceManual, Enabled: true},
+	}}
+	m, _ := rule.NewBlacklistMatcher(repo)
+
+	_, _ = m.IsBlocked(context.Background(), "https://news.example.com/x")
+	_, _ = m.IsBlocked(context.Background(), "https://news.example.com/x")
+	require.Equal(t, int64(1), atomic.LoadInt64(&repo.findCalls))
+
+	m.Invalidate("news.example.com")
+	_, _ = m.IsBlocked(context.Background(), "https://news.example.com/x")
+	assert.Equal(t, int64(2), atomic.LoadInt64(&repo.findCalls), "Invalidate 후 다음 lookup 은 repo 재호출")
+}
+
+func TestBlacklistMatcher_InvalidateAll_ClearsCache(t *testing.T) {
+	repo := &fakeBlacklistRepo{rows: []*storage.BlacklistRecord{
+		{ID: 1, HostPattern: "a.example.com", PathPattern: "", Source: storage.BlacklistSourceManual, Enabled: true},
+		{ID: 2, HostPattern: "b.example.com", PathPattern: "", Source: storage.BlacklistSourceManual, Enabled: true},
+	}}
+	m, _ := rule.NewBlacklistMatcher(repo)
+
+	_, _ = m.IsBlocked(context.Background(), "https://a.example.com/x")
+	_, _ = m.IsBlocked(context.Background(), "https://b.example.com/x")
+	require.Equal(t, int64(2), atomic.LoadInt64(&repo.findCalls))
+
+	m.InvalidateAll()
+	_, _ = m.IsBlocked(context.Background(), "https://a.example.com/x")
+	_, _ = m.IsBlocked(context.Background(), "https://b.example.com/x")
+	assert.Equal(t, int64(4), atomic.LoadInt64(&repo.findCalls))
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// invalidatingBlacklistRepo decorator
+// ─────────────────────────────────────────────────────────────────────────────
+
+type recordingBlacklistInvalidator struct {
+	mu    sync.Mutex
+	hosts []string
+}
+
+func (r *recordingBlacklistInvalidator) Invalidate(host string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.hosts = append(r.hosts, host)
+}
+
+func (r *recordingBlacklistInvalidator) snapshot() []string {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	out := make([]string, len(r.hosts))
+	copy(out, r.hosts)
+	return out
+}
+
+func TestInvalidatingBlacklistRepo_Insert_Success_Invalidates(t *testing.T) {
+	inner := &fakeBlacklistRepo{}
+	inv := &recordingBlacklistInvalidator{}
+	repo := rule.WrapBlacklistWithInvalidator(inner, inv)
+
+	err := repo.Insert(context.Background(), &storage.BlacklistRecord{
+		HostPattern: "ads.example.com", Source: storage.BlacklistSourceManual, Enabled: true,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, []string{"ads.example.com"}, inv.snapshot())
+}
+
+func TestInvalidatingBlacklistRepo_Insert_DuplicateAlsoInvalidates(t *testing.T) {
+	inner := &fakeBlacklistRepo{insertErr: storage.ErrDuplicate}
+	inv := &recordingBlacklistInvalidator{}
+	repo := rule.WrapBlacklistWithInvalidator(inner, inv)
+
+	err := repo.Insert(context.Background(), &storage.BlacklistRecord{
+		HostPattern: "ads.example.com", Source: storage.BlacklistSourceManual, Enabled: true,
+	})
+	require.ErrorIs(t, err, storage.ErrDuplicate)
+	assert.Equal(t, []string{"ads.example.com"}, inv.snapshot(), "ErrDuplicate 도 invalidate")
+}
+
+func TestInvalidatingBlacklistRepo_Update_Success_Invalidates(t *testing.T) {
+	inner := &fakeBlacklistRepo{rows: []*storage.BlacklistRecord{
+		{ID: 1, HostPattern: "ads.example.com", Enabled: true},
+	}}
+	inv := &recordingBlacklistInvalidator{}
+	repo := rule.WrapBlacklistWithInvalidator(inner, inv)
+
+	err := repo.Update(context.Background(), &storage.BlacklistRecord{
+		ID: 1, HostPattern: "ads.example.com", Reason: "updated", Enabled: false,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, []string{"ads.example.com"}, inv.snapshot())
+}
+
+func TestInvalidatingBlacklistRepo_Delete_PrefetchesAndInvalidates(t *testing.T) {
+	inner := &fakeBlacklistRepo{rows: []*storage.BlacklistRecord{
+		{ID: 1, HostPattern: "ads.example.com", Enabled: true},
+	}}
+	inv := &recordingBlacklistInvalidator{}
+	repo := rule.WrapBlacklistWithInvalidator(inner, inv)
+
+	err := repo.Delete(context.Background(), 1)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"ads.example.com"}, inv.snapshot())
+}
+
+func TestInvalidatingBlacklistRepo_Delete_PrefetchFails_NoInvalidate(t *testing.T) {
+	inner := &fakeBlacklistRepo{getByIDErr: errors.New("db down")}
+	inv := &recordingBlacklistInvalidator{}
+	repo := rule.WrapBlacklistWithInvalidator(inner, inv)
+
+	err := repo.Delete(context.Background(), 1)
+	require.NoError(t, err, "Delete 자체는 성공할 수 있음")
+	assert.Empty(t, inv.snapshot(), "pre-fetch 실패 시 invalidate skip — TTL fallback")
+}
+
+func TestInvalidatingBlacklistRepo_NilInvalidator_NoOp(t *testing.T) {
+	inner := &fakeBlacklistRepo{}
+	repo := rule.WrapBlacklistWithInvalidator(inner, nil)
+
+	err := repo.Insert(context.Background(), &storage.BlacklistRecord{
+		HostPattern: "ads.example.com", Source: storage.BlacklistSourceManual, Enabled: true,
+	})
+	require.NoError(t, err)
+	// nil invalidator 일 때 panic 없이 통과만 검증.
+}
+
+func TestBlacklistMatcher_NewWithNilRepo_Errors(t *testing.T) {
+	_, err := rule.NewBlacklistMatcher(nil)
+	require.Error(t, err)
+}
+
+// 이슈 #295: Cache TTL 짧게 설정 후 만료 후 재fetch 검증.
+func TestBlacklistMatcher_CacheTTL_ExpiresAfterDuration(t *testing.T) {
+	repo := &fakeBlacklistRepo{rows: []*storage.BlacklistRecord{
+		{ID: 1, HostPattern: "news.example.com", PathPattern: "", Source: storage.BlacklistSourceManual, Enabled: true},
+	}}
+	m, _ := rule.NewBlacklistMatcher(repo,
+		rule.WithBlacklistCacheTTL(50*time.Millisecond),
+	)
+
+	_, _ = m.IsBlocked(context.Background(), "https://news.example.com/x")
+	_, _ = m.IsBlocked(context.Background(), "https://news.example.com/y")
+	require.Equal(t, int64(1), atomic.LoadInt64(&repo.findCalls))
+
+	time.Sleep(80 * time.Millisecond)
+	_, _ = m.IsBlocked(context.Background(), "https://news.example.com/z")
+	assert.Equal(t, int64(2), atomic.LoadInt64(&repo.findCalls), "TTL 만료 후 재fetch")
+}


### PR DESCRIPTION
## 연관 이슈
- Closes #295

## 구현 내용

광고 / sponsored / redirect 등 카테고리에서는 발견되지만 article 단계에서 가치 없는 URL 을
**publisher.Publish 직전에 drop** — fetch / parse 자체가 발생 안 하므로 chromedp 자동 전환
(#220/#221) / stale relearn (#282) trigger 노이즈도 자동 차단.

### 7개 commit (논리 단위 분할)

1. \`[FEAT]: migration 016 — parsing_blacklist 테이블\`
   - host_pattern + path_pattern (RE2) 자연키, source ('manual'/'auto'), enabled 토글
   - idx_parsing_blacklist_host_enabled 부분 인덱스 (Matcher 핫패스)
2. \`[FEAT]: BlacklistRepository — domain model + postgres 구현\`
   - Insert RE2 컴파일 검증, FindEnabledByHost LENGTH(path_pattern) DESC 정렬
3. \`[FEAT]: BlacklistMatcher + invalidatingBlacklistRepo\`
   - host 단위 cache (positive 5m / negative 30s) + path regex 매칭
   - mutation → host cache invalidate decorator (parsing_rules 와 동일 패턴)
4. \`[FEAT]: parser_worker — processCategoryPage 에 Filter 통합\`
   - SetBlacklist setter (nil 허용)
   - 전부 차단 시 publish skip + raw 즉시 정리 + Info 로그
5. \`[FEAT]: BlacklistMatcher + invalidatingBlacklistRepo 단위 테스트\`
   - host catch-all / 정밀 path / disabled / invalid regex / DB 에러 / cache TTL / decorator 모든 분기
6. \`[FEAT]: 블랙리스트 wiring — config + main.go + .env.example\`
   - BlacklistConfig (BLACKLIST_ENABLED) + ParserWorker.SetBlacklist 주입

## CI / 머지 게이트 점검

### 변경 영향 범위
- 영향 패키지/모듈:
  - migrations (016 신규 — 단순 CREATE TABLE)
  - internal/storage (BlacklistRepository / BlacklistRecord)
  - internal/storage/postgres (pg 구현)
  - internal/processor/parser/rule (BlacklistMatcher + invalidatingBlacklistRepo)
  - internal/processor/parser/worker (Filter 통합)
  - cmd/issuetracker (wiring)
  - pkg/config (BlacklistConfig)
- 위험도: \`Low\` — 신규 기능. BLACKLIST_ENABLED=false 또는 Matcher 미주입 시 기존 동작과 동일.

### Required Status Checks
- 통과 확인 대상 (PR Checks 탭에서 확인):
  - [ ] \`Commit Lint\`
  - [ ] \`PR Title Lint\`
  - [ ] \`Linked Issue Check\`
  - [ ] \`Format Check\`
  - [ ] \`Build\`
  - [ ] \`Test\`
  - [ ] \`Lint\`

### 롤백 계획

\`BLACKLIST_ENABLED=false\` 로 즉시 비활성 — Matcher 미주입 → 모든 카테고리 링크 그대로 발행
(기존 동작 복원). 본 PR revert 시 테이블만 잔존하나 read 경로 부재로 운영 영향 없음.
긴급 롤백: PR revert + migration 016 down (\`migrate-down\` 바이너리).

## TODO
- 라이브 검증 — 운영자가 \`parsing_blacklist\` 에 의도 광고 host 등록 후 fetch / parse 회피 + chromedp/stale trigger 미발동 확인
- 후속 이슈로 분리: 자동 색출 (semantic reject 시그널 → \`source='auto'\` 자동 등록)
- 후속 이슈로 분리: 운영 CLI (\`cmd/blacklist add/list/disable/delete\`)

## 논의 사항
- 차단 시점은 \"publisher.Publish 직전\" 으로 결정 — fetch 비용 0 + 변경 영역 최소
- 자동 색출은 본 PR scope 외 — 어떤 시그널을 trigger 로 쓸지 정책 결정이 필요해 분리

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added URL blacklist functionality to exclude specified URLs from parsing based on host and path patterns.
  * Blacklist rules can be created, updated, and deleted with manual or automatic source tracking.
  * Dashboard support for filtering and managing blacklist entries.

* **Configuration**
  * Added `BLACKLIST_ENABLED` environment variable to toggle the feature (default: enabled).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->