### PR TITLE
[FEAT#297] page-parse 블랙리스트 mode 컬럼 — 'extract_links_only' 모드 도입

### DIFF
--- a/internal/processor/parser/rule/blacklist_matcher.go
+++ b/internal/processor/parser/rule/blacklist_matcher.go
@@ -158,6 +158,9 @@ func (m *BlacklistMatcher) IsBlocked(ctx context.Context, rawURL string) (bool, 
 //
 // 동일 호스트가 반복되는 카테고리 페이지 링크 시나리오에서 host cache 가 재사용되어 비용
 // 거의 없음. 개별 IsBlocked 호출 에러는 best-effort — 해당 URL 만 통과 (차단 안 함).
+//
+// Deprecated: 이슈 #297 에서 mode 컬럼 도입 후 Classify 사용 권장 — Filter 는 Allowed 만 반환하여
+// 'extract_links_only' 모드의 URL 도 함께 drop 됨. 호환성을 위해 메소드는 유지.
 func (m *BlacklistMatcher) Filter(ctx context.Context, urls []string) []string {
 	if len(urls) == 0 {
 		return urls
@@ -175,6 +178,75 @@ func (m *BlacklistMatcher) Filter(ctx context.Context, urls []string) []string {
 		}
 	}
 	return out
+}
+
+// BlacklistDecision 은 Classify 의 결과 — mode 별로 URL 슬라이스를 분리합니다 (이슈 #297).
+//
+// 호출자 (parser_worker) 는 슬라이스별로 다른 publish 분기를 적용:
+//   - Allowed          : blacklist 매칭 X 또는 lookup 에러 (best-effort 통과) — 정상 article 발행
+//   - ExtractLinksOnly : mode='extract_links_only' 매칭 — list 로 강제 발행 (ParseLinks 만)
+//   - 'drop' 매칭 URL 은 어느 슬라이스에도 들어가지 않음 (완전 drop)
+type BlacklistDecision struct {
+	Allowed          []string
+	ExtractLinksOnly []string
+}
+
+// Classify 는 입력 URL 슬라이스를 mode 별로 분류합니다 (이슈 #297).
+//
+// 매칭 정책:
+//  1. blacklist row 매칭 X → Allowed
+//  2. lookup 에러 → Allowed (best-effort, 안전 fallback)
+//  3. mode='extract_links_only' 매칭 → ExtractLinksOnly
+//  4. mode='drop' 매칭 → 어느 슬라이스에도 미포함 (완전 drop)
+//
+// 같은 host 의 여러 row 가 매칭하면 LENGTH(path_pattern) DESC 정렬상 첫 매칭 row 의 mode 채택.
+func (m *BlacklistMatcher) Classify(ctx context.Context, urls []string) BlacklistDecision {
+	out := BlacklistDecision{
+		Allowed:          make([]string, 0, len(urls)),
+		ExtractLinksOnly: make([]string, 0),
+	}
+	for _, u := range urls {
+		mode, err := m.matchedMode(ctx, u)
+		if err != nil {
+			// best-effort: lookup 에러 시 Allowed 통과 — Filter 와 동일 정책.
+			out.Allowed = append(out.Allowed, u)
+			continue
+		}
+		switch mode {
+		case "":
+			out.Allowed = append(out.Allowed, u)
+		case storage.BlacklistModeExtractLinksOnly:
+			out.ExtractLinksOnly = append(out.ExtractLinksOnly, u)
+		case storage.BlacklistModeDrop:
+			// 완전 drop — 어느 슬라이스에도 미포함.
+		default:
+			// 알 수 없는 mode (DB CHECK 가 막지만 방어 fallback) — drop 으로 간주하여 미포함.
+		}
+	}
+	return out
+}
+
+// matchedMode 는 rawURL 에 매칭되는 첫 blacklist row 의 mode 를 반환합니다.
+//
+// 매칭 없음: ("", nil). lookup 에러: ("", err). 매칭됨: (mode, nil).
+// LENGTH(path_pattern) DESC 정렬 후보에서 첫 매칭 row 의 mode 사용 — 더 구체적 path 우선.
+func (m *BlacklistMatcher) matchedMode(ctx context.Context, rawURL string) (storage.BlacklistMode, error) {
+	host, path, err := extractHostPath(rawURL)
+	if err != nil {
+		return "", nil
+	}
+	host = strings.ToLower(host)
+
+	rows, lookupErr := m.lookup(ctx, host)
+	if lookupErr != nil {
+		return "", lookupErr
+	}
+	for _, r := range rows {
+		if m.pathMatches(r.PathPattern, path) {
+			return r.Mode, nil
+		}
+	}
+	return "", nil
 }
 
 // Invalidate 는 host 단위 cache entry 를 즉시 제거합니다.

--- a/internal/processor/parser/worker/parser_worker.go
+++ b/internal/processor/parser/worker/parser_worker.go
@@ -360,32 +360,47 @@ func (w *ParserWorker) processCategoryPage(ctx context.Context, raw *core.RawCon
 
 	urls := uniqueURLs(items, maxChainedURLs)
 
-	// 이슈 #295: page-parse 블랙리스트 적용 — 매칭 URL 은 article job 발행 단계에서 drop.
-	// fetch / parse 자체가 발생 안 함. Matcher 미설정 (nil) 이면 모든 URL 통과.
-	blockedCount := 0
+	// 이슈 #295/#297: page-parse 블랙리스트 적용 — mode 별 분기:
+	//   - 'drop' 매칭     : 어느 슬라이스에도 미포함 (완전 drop, fetch / parse 안 함)
+	//   - 'extract_links_only' 매칭 : list 로 강제 발행 → fetch + ParseLinks 만 진행 (ParsePage skip)
+	//   - 매칭 X         : 정상 article 로 발행
+	// Matcher 미설정 (nil) 이면 모든 URL 을 article 로 통과 (기능 OFF).
+	articleURLs := urls
+	var listURLs []string
+	droppedCount := 0
 	if w.blacklist != nil && len(urls) > 0 {
-		filtered := w.blacklist.Filter(ctx, urls)
-		blockedCount = len(urls) - len(filtered)
-		urls = filtered
-		if len(urls) == 0 {
-			mlog.WithFields(map[string]interface{}{
-				"crawler":       crawlerName,
-				"blocked_count": blockedCount,
-			}).Info("all category links blocked by blacklist — no chained jobs published")
-			w.deleteRaw(ctx, rawID, mlog)
-			return nil
+		decision := w.blacklist.Classify(ctx, urls)
+		articleURLs = decision.Allowed
+		listURLs = decision.ExtractLinksOnly
+		droppedCount = len(urls) - len(decision.Allowed) - len(decision.ExtractLinksOnly)
+	}
+
+	if len(articleURLs) == 0 && len(listURLs) == 0 {
+		mlog.WithFields(map[string]interface{}{
+			"crawler":       crawlerName,
+			"dropped_count": droppedCount,
+		}).Info("all category links blocked by blacklist — no chained jobs published")
+		w.deleteRaw(ctx, rawID, mlog)
+		return nil
+	}
+
+	if len(articleURLs) > 0 {
+		if err := w.publisher.Publish(ctx, crawlerName, articleURLs, core.TargetTypeArticle, jobTimeout); err != nil {
+			return fmt.Errorf("publish chained article jobs: %w", err)
+		}
+	}
+	if len(listURLs) > 0 {
+		if err := w.publisher.Publish(ctx, crawlerName, listURLs, core.TargetTypeCategory, jobTimeout); err != nil {
+			return fmt.Errorf("publish chained list jobs (extract_links_only): %w", err)
 		}
 	}
 
-	if err := w.publisher.Publish(ctx, crawlerName, urls, core.TargetTypeArticle, jobTimeout); err != nil {
-		return fmt.Errorf("publish chained article jobs: %w", err)
-	}
-
 	mlog.WithFields(map[string]interface{}{
-		"crawler":       crawlerName,
-		"url_count":     len(urls),
-		"blocked_count": blockedCount,
-	}).Info("chained article jobs published from category page")
+		"crawler":            crawlerName,
+		"article_count":      len(articleURLs),
+		"list_count":         len(listURLs),
+		"dropped_count":      droppedCount,
+	}).Info("chained jobs published from category page")
 
 	// 카테고리 페이지는 contents/news_articles 에 저장하지 않음 — raw 즉시 정리
 	w.deleteRaw(ctx, rawID, mlog)

--- a/internal/processor/parser/worker/parser_worker.go
+++ b/internal/processor/parser/worker/parser_worker.go
@@ -396,10 +396,10 @@ func (w *ParserWorker) processCategoryPage(ctx context.Context, raw *core.RawCon
 	}
 
 	mlog.WithFields(map[string]interface{}{
-		"crawler":            crawlerName,
-		"article_count":      len(articleURLs),
-		"list_count":         len(listURLs),
-		"dropped_count":      droppedCount,
+		"crawler":       crawlerName,
+		"article_count": len(articleURLs),
+		"list_count":    len(listURLs),
+		"dropped_count": droppedCount,
 	}).Info("chained jobs published from category page")
 
 	// 카테고리 페이지는 contents/news_articles 에 저장하지 않음 — raw 즉시 정리

--- a/internal/storage/blacklist.go
+++ b/internal/storage/blacklist.go
@@ -22,10 +22,10 @@ const (
 // BlacklistMode 는 매칭된 URL 에 적용할 차단 정책입니다 (이슈 #297).
 //
 //   - BlacklistModeDrop             : URL 자체 drop — fetch / parse / 링크추출 모두 안 함 (default).
-//                                      광고 / sponsored / redirect 처럼 그 안의 링크도 가치 없는 케이스.
+//     광고 / sponsored / redirect 처럼 그 안의 링크도 가치 없는 케이스.
 //   - BlacklistModeExtractLinksOnly : list 로 강제 발행 — fetch + ParseLinks 만, ParsePage skip.
-//                                      비-article 영역 (about / login / sitemap / menu) 처럼 그 안에
-//                                      정상 article 링크가 있어 cascade 보존이 필요한 케이스.
+//     비-article 영역 (about / login / sitemap / menu) 처럼 그 안에
+//     정상 article 링크가 있어 cascade 보존이 필요한 케이스.
 //
 // CHECK 제약으로 DB 레벨에서 두 값만 허용. 기존 row 는 default 'drop' (migration 017 후방 호환).
 type BlacklistMode string

--- a/internal/storage/blacklist.go
+++ b/internal/storage/blacklist.go
@@ -19,6 +19,22 @@ const (
 	BlacklistSourceAuto   BlacklistSource = "auto"
 )
 
+// BlacklistMode 는 매칭된 URL 에 적용할 차단 정책입니다 (이슈 #297).
+//
+//   - BlacklistModeDrop             : URL 자체 drop — fetch / parse / 링크추출 모두 안 함 (default).
+//                                      광고 / sponsored / redirect 처럼 그 안의 링크도 가치 없는 케이스.
+//   - BlacklistModeExtractLinksOnly : list 로 강제 발행 — fetch + ParseLinks 만, ParsePage skip.
+//                                      비-article 영역 (about / login / sitemap / menu) 처럼 그 안에
+//                                      정상 article 링크가 있어 cascade 보존이 필요한 케이스.
+//
+// CHECK 제약으로 DB 레벨에서 두 값만 허용. 기존 row 는 default 'drop' (migration 017 후방 호환).
+type BlacklistMode string
+
+const (
+	BlacklistModeDrop             BlacklistMode = "drop"
+	BlacklistModeExtractLinksOnly BlacklistMode = "extract_links_only"
+)
+
 // BlacklistRecord 는 parsing_blacklist 테이블의 단일 행입니다 (이슈 #295).
 //
 // page-parse 차단 정책 — 매칭 URL 은 article job 발행 단계에서 drop:
@@ -34,6 +50,7 @@ type BlacklistRecord struct {
 	PathPattern string
 	Reason      string
 	Source      BlacklistSource
+	Mode        BlacklistMode // 'drop' (default) | 'extract_links_only' (이슈 #297)
 	Enabled     bool
 	CreatedAt   time.Time
 	UpdatedAt   time.Time

--- a/internal/storage/postgres/blacklist.go
+++ b/internal/storage/postgres/blacklist.go
@@ -29,8 +29,8 @@ func NewBlacklistRepository(pool *pgxpool.Pool, log *logger.Logger) storage.Blac
 }
 
 const sqlInsertBlacklist = `
-INSERT INTO parsing_blacklist (host_pattern, path_pattern, reason, source, enabled)
-VALUES ($1, $2, $3, $4, $5)
+INSERT INTO parsing_blacklist (host_pattern, path_pattern, reason, source, mode, enabled)
+VALUES ($1, $2, $3, $4, $5, $6)
 RETURNING id, created_at, updated_at
 `
 
@@ -51,8 +51,11 @@ func (r *pgBlacklistRepository) Insert(ctx context.Context, rec *storage.Blackli
 	if rec.Source == "" {
 		rec.Source = storage.BlacklistSourceManual
 	}
+	if rec.Mode == "" {
+		rec.Mode = storage.BlacklistModeDrop
+	}
 	row := r.pool.QueryRow(ctx, sqlInsertBlacklist,
-		rec.HostPattern, rec.PathPattern, rec.Reason, string(rec.Source), rec.Enabled,
+		rec.HostPattern, rec.PathPattern, rec.Reason, string(rec.Source), string(rec.Mode), rec.Enabled,
 	)
 	if err := row.Scan(&rec.ID, &rec.CreatedAt, &rec.UpdatedAt); err != nil {
 		var pgErr *pgconn.PgError
@@ -66,16 +69,19 @@ func (r *pgBlacklistRepository) Insert(ctx context.Context, rec *storage.Blackli
 
 const sqlUpdateBlacklist = `
 UPDATE parsing_blacklist
-SET reason = $2, source = $3, enabled = $4, updated_at = NOW()
+SET reason = $2, source = $3, mode = $4, enabled = $5, updated_at = NOW()
 WHERE id = $1
 RETURNING updated_at
 `
 
-// Update 는 ID 로 row 의 mutable 필드 (reason / source / enabled) 만 갱신합니다.
+// Update 는 ID 로 row 의 mutable 필드 (reason / source / mode / enabled) 만 갱신합니다.
 // 자연키 (host_pattern, path_pattern) 는 변경 불가 — 의도가 다르면 Delete + Insert.
 func (r *pgBlacklistRepository) Update(ctx context.Context, rec *storage.BlacklistRecord) error {
+	if rec.Mode == "" {
+		rec.Mode = storage.BlacklistModeDrop
+	}
 	row := r.pool.QueryRow(ctx, sqlUpdateBlacklist,
-		rec.ID, rec.Reason, string(rec.Source), rec.Enabled,
+		rec.ID, rec.Reason, string(rec.Source), string(rec.Mode), rec.Enabled,
 	)
 	if err := row.Scan(&rec.UpdatedAt); err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
@@ -97,7 +103,7 @@ func (r *pgBlacklistRepository) Delete(ctx context.Context, id int64) error {
 }
 
 const sqlGetBlacklistByID = `
-SELECT id, host_pattern, path_pattern, reason, source, enabled, created_at, updated_at
+SELECT id, host_pattern, path_pattern, reason, source, mode, enabled, created_at, updated_at
 FROM parsing_blacklist
 WHERE id = $1
 `
@@ -116,7 +122,7 @@ func (r *pgBlacklistRepository) GetByID(ctx context.Context, id int64) (*storage
 }
 
 const sqlFindEnabledBlacklistByHost = `
-SELECT id, host_pattern, path_pattern, reason, source, enabled, created_at, updated_at
+SELECT id, host_pattern, path_pattern, reason, source, mode, enabled, created_at, updated_at
 FROM parsing_blacklist
 WHERE host_pattern = $1 AND enabled = TRUE
 ORDER BY LENGTH(path_pattern) DESC, id DESC
@@ -157,7 +163,7 @@ func (r *pgBlacklistRepository) List(ctx context.Context, f storage.BlacklistFil
 		limit = 50
 	}
 	q := `
-SELECT id, host_pattern, path_pattern, reason, source, enabled, created_at, updated_at
+SELECT id, host_pattern, path_pattern, reason, source, mode, enabled, created_at, updated_at
 FROM parsing_blacklist
 WHERE ($1 = '' OR host_pattern = $1)
   AND ($2 = '' OR source = $2)
@@ -196,13 +202,14 @@ type rowScanner interface {
 
 func scanBlacklist(s rowScanner) (*storage.BlacklistRecord, error) {
 	rec := &storage.BlacklistRecord{}
-	var source string
+	var source, mode string
 	if err := s.Scan(
 		&rec.ID,
 		&rec.HostPattern,
 		&rec.PathPattern,
 		&rec.Reason,
 		&source,
+		&mode,
 		&rec.Enabled,
 		&rec.CreatedAt,
 		&rec.UpdatedAt,
@@ -210,6 +217,7 @@ func scanBlacklist(s rowScanner) (*storage.BlacklistRecord, error) {
 		return nil, err
 	}
 	rec.Source = storage.BlacklistSource(source)
+	rec.Mode = storage.BlacklistMode(mode)
 	return rec, nil
 }
 

--- a/migrations/down/017_parsing_blacklist_mode.sql
+++ b/migrations/down/017_parsing_blacklist_mode.sql
@@ -1,0 +1,3 @@
+-- 017_parsing_blacklist_mode (down): mode 컬럼 제거 (이슈 #297 롤백).
+
+ALTER TABLE parsing_blacklist DROP COLUMN IF EXISTS mode;

--- a/migrations/up/017_parsing_blacklist_mode.sql
+++ b/migrations/up/017_parsing_blacklist_mode.sql
@@ -1,0 +1,16 @@
+-- 017_parsing_blacklist_mode: parsing_blacklist 에 mode 컬럼 추가 (이슈 #297)
+--
+-- 배경:
+--   #295 (머지됨, 'drop' 단일 정책) 의 후속 — 분류 대상별 적합도 차이 cover.
+--   광고/sponsored 는 그 안의 링크도 광고일 가능성 ↑ → 'drop' 적합.
+--   비-article 영역 (about/login/sitemap/menu) 은 그 안에 정상 article 링크 다수 →
+--   'extract_links_only' 모드로 list 강제 발행 → ParseLinks 만 진행, ParsePage skip.
+--
+-- 운영자가 row 단위로 mode 선택 가능. 기존 row 는 default 'drop' — 후방 호환.
+
+ALTER TABLE parsing_blacklist
+  ADD COLUMN IF NOT EXISTS mode TEXT NOT NULL DEFAULT 'drop'
+  CHECK (mode IN ('drop', 'extract_links_only'));
+
+COMMENT ON COLUMN parsing_blacklist.mode IS
+  'drop: URL 자체 drop (default) / extract_links_only: list 로 강제 발행 → ParseLinks 만 진행, ParsePage skip. 이슈 #297.';

--- a/test/internal/processor/parser/rule/blacklist_matcher_test.go
+++ b/test/internal/processor/parser/rule/blacklist_matcher_test.go
@@ -3,6 +3,7 @@ package rule_test
 import (
 	"context"
 	"errors"
+	"sort"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -89,6 +90,13 @@ func (r *fakeBlacklistRepo) FindEnabledByHost(_ context.Context, host string) ([
 			out = append(out, existing)
 		}
 	}
+	// postgres ORDER BY LENGTH(path_pattern) DESC, id DESC 시뮬레이션 — 더 구체적 path 우선.
+	sort.SliceStable(out, func(i, j int) bool {
+		if len(out[i].PathPattern) != len(out[j].PathPattern) {
+			return len(out[i].PathPattern) > len(out[j].PathPattern)
+		}
+		return out[i].ID > out[j].ID
+	})
 	return out, nil
 }
 
@@ -403,6 +411,89 @@ func TestInvalidatingBlacklistRepo_NilInvalidator_NoOp(t *testing.T) {
 func TestBlacklistMatcher_NewWithNilRepo_Errors(t *testing.T) {
 	_, err := rule.NewBlacklistMatcher(nil)
 	require.Error(t, err)
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Classify (이슈 #297) — mode 별 분류
+// ─────────────────────────────────────────────────────────────────────────────
+
+func TestBlacklistMatcher_Classify_DropMatch_ExcludedFromAllSlices(t *testing.T) {
+	repo := &fakeBlacklistRepo{rows: []*storage.BlacklistRecord{
+		{ID: 1, HostPattern: "ads.example.com", PathPattern: "", Mode: storage.BlacklistModeDrop, Enabled: true},
+	}}
+	m, _ := rule.NewBlacklistMatcher(repo)
+
+	in := []string{
+		"https://news.example.com/article/1",
+		"https://ads.example.com/banner",
+	}
+	d := m.Classify(context.Background(), in)
+	assert.Equal(t, []string{"https://news.example.com/article/1"}, d.Allowed)
+	assert.Empty(t, d.ExtractLinksOnly, "drop 매칭은 ExtractLinksOnly 에 들어가지 않음")
+}
+
+func TestBlacklistMatcher_Classify_ExtractLinksOnly_RoutedToOwnSlice(t *testing.T) {
+	repo := &fakeBlacklistRepo{rows: []*storage.BlacklistRecord{
+		{ID: 1, HostPattern: "sitemap.example.com", PathPattern: "", Mode: storage.BlacklistModeExtractLinksOnly, Enabled: true},
+	}}
+	m, _ := rule.NewBlacklistMatcher(repo)
+
+	in := []string{
+		"https://news.example.com/article/1",
+		"https://sitemap.example.com/index",
+	}
+	d := m.Classify(context.Background(), in)
+	assert.Equal(t, []string{"https://news.example.com/article/1"}, d.Allowed)
+	assert.Equal(t, []string{"https://sitemap.example.com/index"}, d.ExtractLinksOnly,
+		"extract_links_only 매칭은 별도 슬라이스로 라우팅")
+}
+
+func TestBlacklistMatcher_Classify_MixedModes(t *testing.T) {
+	repo := &fakeBlacklistRepo{rows: []*storage.BlacklistRecord{
+		{ID: 1, HostPattern: "ads.example.com", PathPattern: "", Mode: storage.BlacklistModeDrop, Enabled: true},
+		{ID: 2, HostPattern: "sitemap.example.com", PathPattern: "", Mode: storage.BlacklistModeExtractLinksOnly, Enabled: true},
+	}}
+	m, _ := rule.NewBlacklistMatcher(repo)
+
+	in := []string{
+		"https://news.example.com/a",
+		"https://ads.example.com/banner",
+		"https://sitemap.example.com/i",
+		"https://news.example.com/b",
+	}
+	d := m.Classify(context.Background(), in)
+	assert.Equal(t, []string{"https://news.example.com/a", "https://news.example.com/b"}, d.Allowed)
+	assert.Equal(t, []string{"https://sitemap.example.com/i"}, d.ExtractLinksOnly)
+}
+
+func TestBlacklistMatcher_Classify_LookupError_FallbackToAllowed(t *testing.T) {
+	repo := &fakeBlacklistRepo{findErr: errors.New("db down")}
+	m, _ := rule.NewBlacklistMatcher(repo)
+
+	in := []string{"https://news.example.com/x"}
+	d := m.Classify(context.Background(), in)
+	assert.Equal(t, in, d.Allowed, "lookup 에러는 best-effort — Allowed 통과")
+	assert.Empty(t, d.ExtractLinksOnly)
+}
+
+// 같은 host 에 path 다른 두 row — LENGTH(path_pattern) DESC 정렬상 더 구체적 path 의 mode 채택.
+func TestBlacklistMatcher_Classify_LongerPathPatternModeWins(t *testing.T) {
+	repo := &fakeBlacklistRepo{rows: []*storage.BlacklistRecord{
+		// catch-all (path="") — 'extract_links_only'
+		{ID: 1, HostPattern: "site.example.com", PathPattern: "", Mode: storage.BlacklistModeExtractLinksOnly, Enabled: true},
+		// 정밀 path — 'drop'
+		{ID: 2, HostPattern: "site.example.com", PathPattern: `^/promotion/.*$`, Mode: storage.BlacklistModeDrop, Enabled: true},
+	}}
+	m, _ := rule.NewBlacklistMatcher(repo)
+
+	in := []string{
+		"https://site.example.com/promotion/123", // 정밀 매칭 → drop
+		"https://site.example.com/about/team",    // 미매칭 → catch-all → extract_links_only
+	}
+	d := m.Classify(context.Background(), in)
+	assert.Empty(t, d.Allowed, "둘 다 blacklist 어딘가 매칭")
+	assert.Equal(t, []string{"https://site.example.com/about/team"}, d.ExtractLinksOnly,
+		"정밀 path 미매칭 시 catch-all 의 mode (extract_links_only) 채택")
 }
 
 // 이슈 #295: Cache TTL 짧게 설정 후 만료 후 재fetch 검증.


### PR DESCRIPTION
## 연관 이슈
- Closes #297

## 구현 내용

#295 (머지된 PR #296) 의 후속 — 단일 'drop' 정책에 'extract_links_only' 모드 추가하여 row 단위 정책 선택 가능. 비-article 영역 (about/login/sitemap/menu) 의 cascade 보존 cover.

### 동작

| mode | parser_worker 동작 |
|---|---|
| `drop` (default) | URL 자체 drop — fetch / parse / 링크추출 모두 안 함 |
| `extract_links_only` | TargetTypeCategory 로 publish → 다음 cycle 에서 fetch + ParseLinks 만 진행, ParsePage skip |

### 5개 commit (논리 단위 분할)

1. \`[FEAT]: migration 017 — parsing_blacklist 에 mode 컬럼 추가\`
   - mode TEXT NOT NULL DEFAULT 'drop' CHECK (mode IN ('drop', 'extract_links_only'))
   - 기존 row 후방 호환
2. \`[FEAT]: BlacklistMode 타입 + Record.Mode 필드 + postgres CRUD 반영\`
   - Insert/Update/SELECT/Scan 모두 mode 컬럼 포함
3. \`[FEAT]: BlacklistMatcher.Classify — mode 별 URL 분류\`
   - BlacklistDecision { Allowed, ExtractLinksOnly }
   - LENGTH(path_pattern) DESC 정렬상 첫 매칭 row 의 mode 채택
   - Filter 메소드는 Deprecated 처리 (호환성 유지)
4. \`[FEAT]: parser_worker — Classify 결과 두 publish 분기\`
   - Allowed → TargetTypeArticle, ExtractLinksOnly → TargetTypeCategory
5. \`[FEAT]: BlacklistMatcher.Classify 단위 테스트 + fakeRepo 정렬 시뮬레이션\`

## CI / 머지 게이트 점검

### 변경 영향 범위
- 영향 패키지/모듈:
  - migrations (017 신규)
  - internal/storage (BlacklistMode + Record.Mode 필드)
  - internal/storage/postgres (CRUD mode 반영)
  - internal/processor/parser/rule/blacklist_matcher (Classify + Decision)
  - internal/processor/parser/worker (publish 분기 변경)
- 위험도: \`Low\` — 신규 기능. 기존 row 는 default 'drop' 으로 자동 마이그레이션 → 기존 동작 그대로.

### Required Status Checks
- 통과 확인 대상 (PR Checks 탭에서 확인):
  - [ ] \`Commit Lint\`
  - [ ] \`PR Title Lint\`
  - [ ] \`Linked Issue Check\`
  - [ ] \`Format Check\`
  - [ ] \`Build\`
  - [ ] \`Test\`
  - [ ] \`Lint\`

### 롤백 계획

운영자가 mode='extract_links_only' row 를 enabled=false 토글 → 다시 모두 'drop' 또는 정상 article 로 통과.
긴급 롤백: PR revert + migration 017 down. 'extract_links_only' 마킹된 row 는 mode 컬럼 제거되며 'drop' 동작으로 환원.

## 운영 가이드 (mode 선택 기준)

- 광고 / sponsored / redirect → \`'drop'\` (default) — 그 안의 링크도 가치 없음
- 비-article 영역 (about / login / sitemap / 카테고리 외 hub 페이지) → \`'extract_links_only'\` — 메뉴/사이드바에 정상 article 링크 cascade 보존

## TODO
- 라이브 검증 — sitemap host 등록 후 ParseLinks 실행 확인 + 그 안의 링크 cascade
- 후속 이슈로 분리: 자동 색출 (semantic reject 시그널 → mode 자동 분류)
- 후속 이슈로 분리: 운영 CLI

🤖 Generated with [Claude Code](https://claude.com/claude-code)