### PR TITLE
[REFAC#303] GoDoc 정합성 보강 — exported 식별자 docstring 첫 단어 식별자명 일치

### DIFF
--- a/internal/processor/fetcher/domain/general/fetcher/browser.go
+++ b/internal/processor/fetcher/domain/general/fetcher/browser.go
@@ -23,6 +23,8 @@ type BrowserFetcher struct {
 	initialized bool
 }
 
+// NewBrowserFetcher 는 chromedp 기반 BrowserFetcher 를 생성합니다.
+// 첫 Fetch 호출 시점에 lazy initialize — 사용 안 되는 instance 의 Chrome 자원 점유 회피.
 func NewBrowserFetcher(crawler *cdp.ChromedpCrawler, config core.Config) *BrowserFetcher {
 	return &BrowserFetcher{crawler: crawler, config: config}
 }

--- a/internal/processor/fetcher/domain/general/fetcher/goquery.go
+++ b/internal/processor/fetcher/domain/general/fetcher/goquery.go
@@ -16,6 +16,7 @@ type GoqueryFetcher struct {
 	crawler *goquery.GoqueryCrawler
 }
 
+// NewGoqueryFetcher 는 GoqueryCrawler 를 wrap 한 GoqueryFetcher 를 생성합니다.
 func NewGoqueryFetcher(crawler *goquery.GoqueryCrawler) *GoqueryFetcher {
 	return &GoqueryFetcher{crawler: crawler}
 }

--- a/internal/processor/fetcher/domain/general/handler.go
+++ b/internal/processor/fetcher/domain/general/handler.go
@@ -48,8 +48,8 @@ type GoQueryFetchHandler struct {
 	lazyKeywords []string
 }
 
-// NewGoQueryFetchHandler 는 정적 HTML 만 처리하는 1차 fetch handler 를 생성합니다.
-// lazyKeywords 가 HTML 에 매칭되면 chromedp 로 escalate 신호 (ErrLazyContentNeedsBrowser) 반환.
+// NewGoQueryFetchHandler 는 정적 HTML 처리를 담당하는 fetch handler 를 생성합니다.
+// lazyKeywords 가 HTML 에 매칭되면 chromedp 로의 escalate 신호 (ErrLazyContentNeedsBrowser) 를 반환합니다.
 func NewGoQueryFetchHandler(fetcher Fetcher, log *logger.Logger, lazyKeywords ...string) *GoQueryFetchHandler {
 	return &GoQueryFetchHandler{
 		baseHandler:  baseHandler{log: log},
@@ -113,7 +113,7 @@ type BrowserFetchHandler struct {
 }
 
 // NewBrowserFetchHandler 는 chromedp 헤드리스 브라우저 기반 fetch handler 를 생성합니다.
-// chain 의 마지막 link — 여기서 실패하면 job 자체 실패.
+// 브라우저 렌더 실패 시 chain 위임 없이 job 실패로 종결합니다.
 func NewBrowserFetchHandler(fetcher Fetcher, log *logger.Logger) *BrowserFetchHandler {
 	return &BrowserFetchHandler{baseHandler: baseHandler{log: log}, fetcher: fetcher}
 }

--- a/internal/processor/fetcher/domain/general/handler.go
+++ b/internal/processor/fetcher/domain/general/handler.go
@@ -48,6 +48,8 @@ type GoQueryFetchHandler struct {
 	lazyKeywords []string
 }
 
+// NewGoQueryFetchHandler 는 정적 HTML 만 처리하는 1차 fetch handler 를 생성합니다.
+// lazyKeywords 가 HTML 에 매칭되면 chromedp 로 escalate 신호 (ErrLazyContentNeedsBrowser) 반환.
 func NewGoQueryFetchHandler(fetcher Fetcher, log *logger.Logger, lazyKeywords ...string) *GoQueryFetchHandler {
 	return &GoQueryFetchHandler{
 		baseHandler:  baseHandler{log: log},
@@ -110,6 +112,8 @@ type BrowserFetchHandler struct {
 	fetcher Fetcher
 }
 
+// NewBrowserFetchHandler 는 chromedp 헤드리스 브라우저 기반 fetch handler 를 생성합니다.
+// chain 의 마지막 link — 여기서 실패하면 job 자체 실패.
 func NewBrowserFetchHandler(fetcher Fetcher, log *logger.Logger) *BrowserFetchHandler {
 	return &BrowserFetchHandler{baseHandler: baseHandler{log: log}, fetcher: fetcher}
 }

--- a/internal/storage/parsing_rule.go
+++ b/internal/storage/parsing_rule.go
@@ -18,7 +18,8 @@ const (
 	TargetTypeList TargetType = "list"
 )
 
-// 호환성 — 기존 TargetTypeArticle 명칭이 코드/DB 에 잔존할 수 있어 별칭 유지.
+// TargetTypeArticle 은 TargetTypePage 의 호환 별칭입니다 — 기존 코드/DB 에 잔존할 수 있어 유지.
+//
 // Deprecated: TargetTypePage 사용 권장 (도메인 일반화).
 const TargetTypeArticle = TargetTypePage
 


### PR DESCRIPTION
## 연관 이슈
- Closes #303

## 구현 내용

[#301](https://github.com/EinSofINTEREST/IssueTracker/issues/301) (PR [#302](https://github.com/EinSofINTEREST/IssueTracker/pull/302)) 의 후속. godoc 컨벤션 위반 검출 + 정정.

### 검출 결과

awk 스크립트로 \`internal/\`, \`pkg/\`, \`cmd/\` 의 exported func/type/const/var 직전 godoc 검사:

| 항목 | 카운트 |
|---|---|
| MISMATCH (첫 단어가 식별자명 아님) | 1건 |
| MISSING (godoc 부재) | 16건 |
| 본 PR 처리 대상 | **5건** |
| 처리 제외 (\`internal/classifier/grpc/pb/*.pb.go\` generated code) | 12건 |

### 정정 5건

1. \`internal/storage/parsing_rule.go:23\` MISMATCH \`TargetTypeArticle\`
   - 첫 단어 \"호환성\" → \"TargetTypeArticle 은 ...\" 으로 정정 (Deprecated 마커 보존)
2. \`internal/processor/fetcher/domain/general/handler.go:51\` MISSING \`NewGoQueryFetchHandler\`
3. \`internal/processor/fetcher/domain/general/handler.go:113\` MISSING \`NewBrowserFetchHandler\`
4. \`internal/processor/fetcher/domain/general/fetcher/browser.go:26\` MISSING \`NewBrowserFetcher\`
5. \`internal/processor/fetcher/domain/general/fetcher/goquery.go:19\` MISSING \`NewGoqueryFetcher\`

### Generated code 12건 제외 사유

- \`internal/classifier/grpc/pb/classifier.pb.go\` / \`classifier_grpc.pb.go\` — protoc 가 자동 생성
- 직접 godoc 추가 시 다음 \`protoc\` 호출에 사라짐
- golangci-lint 도 보통 generated code 제외 (\`//nolint\` 또는 \`exclude-files\`)

## CI / 머지 게이트 점검

### 변경 영향 범위
- 영향: 4개 \`.go\` 파일의 godoc only — 기능적 변경 0
- 위험도: \`Low\`

### Required Status Checks
- 통과 확인 대상:
  - [ ] \`Commit Lint\`
  - [ ] \`PR Title Lint\`
  - [ ] \`Linked Issue Check\`
  - [ ] \`Format Check\`
  - [ ] \`Build\`
  - [ ] \`Test\`
  - [ ] \`Lint\`

### 로컬 검증 통과
- \`go build\` 통과
- \`go test ./...\` 통과 (35 패키지)
- \`go vet\` 통과
- \`gofmt\` 적용
- 검출 스크립트 재실행 → 0 violation (generated code 제외)

### 롤백 계획
PR revert — 기능 변경 0 이라 영향 없음.

## TODO (후속 권장)
- \`test/\` 디렉토리 godoc 검토 — 본 PR scope 외
- \`internal/classifier/grpc/pb/*.pb.go\` 의 godoc 은 \`.proto\` 파일에 도입 (protoc-gen-go-doc 활용) 또는 protobuf 파일 자체에 docstring 작성

🤖 Generated with [Claude Code](https://claude.com/claude-code)