### PR TITLE
[FEAT#313] pkg/llm/prompt 인프라 + llmgen 마이그레이션

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -79,6 +79,12 @@ LLM_API_KEY=
 # LLM prompt 디렉토리 override (default: scripts/prompts)
 # ISSUETRACKER_PROMPTS_DIR=scripts/prompts
 
+# LLM prompt 외부 파일 디렉토리 (이슈 #313)
+# 모든 LLM prompt (llmgen / pathinfer / validator / claudegen) 가 본 디렉토리의
+# 파일에서 로드됩니다. 디렉토리 또는 필수 파일 부재 시 boot 단계에서 fail-fast.
+# 운영자가 prompt 갱신 원하면 파일 수정 후 프로세스 재기동.
+LLM_PROMPT_DIR=scripts/prompts
+
 # 셀렉터 추출기 선택 (이슈 #267)
 # - "" 또는 "gemini" (기본): buildLLMGenerator 가 설정한 LLM provider (Gemini Flash 등) 추출
 # - "claude-code": Claude Code 웜 컨테이너 (sonnet) 추출 — 사전에 make claudegen-build + claude CLI 로그인 필요

--- a/cmd/issuetracker/main.go
+++ b/cmd/issuetracker/main.go
@@ -349,18 +349,22 @@ func main() {
 	// 동일 provider 를 refiner 와 공유 — 환경변수 1세트로 동시 제어.
 	llmProvider := llmwiring.BuildProvider(log)
 
-	// LLM prompt loader — 외부 파일 (LLM_PROMPT_DIR, default scripts/prompts) 에서 로드.
-	// 디렉토리 / 필수 파일 부재 시 Generator 가 첫 LLM 호출에서 fail. deployment 에 본 디렉토리
-	// 포함 보장이 운영자 책임 (이슈 #313 — embed fallback 은 후속 sub-issue).
-	promptDir := os.Getenv("LLM_PROMPT_DIR")
-	if promptDir == "" {
-		promptDir = "scripts/prompts"
+	// LLM prompt loader — provider 가 nil (LLM_ENABLED=false 또는 API key 부재) 이면
+	// promptLoader 도 미생성. wiring.Build 가 provider==nil 시 short-circuit 하므로
+	// LLM 비활성 환경에서 prompt 디렉토리 부재로 인한 boot 실패 회피.
+	var promptLoader prompt.Loader
+	if llmProvider != nil {
+		promptDir := os.Getenv("LLM_PROMPT_DIR")
+		if promptDir == "" {
+			promptDir = "scripts/prompts"
+		}
+		fl, plErr := prompt.NewFileLoader(promptDir)
+		if plErr != nil {
+			log.WithError(plErr).Fatal("failed to construct prompt loader")
+		}
+		promptLoader = fl
+		log.WithFields(map[string]interface{}{"prompt_dir": promptDir}).Info("LLM prompt loader enabled")
 	}
-	promptLoader, err := prompt.NewFileLoader(promptDir)
-	if err != nil {
-		log.WithError(err).Fatal("failed to construct prompt loader")
-	}
-	log.WithFields(map[string]interface{}{"prompt_dir": promptDir}).Info("LLM prompt loader enabled")
 
 	llmGen, err := llmgenwiring.Build(llmProvider, parsingRuleRepo, ruleResolver, promptLoader, redisClientShared, log)
 	if err != nil {

--- a/cmd/issuetracker/main.go
+++ b/cmd/issuetracker/main.go
@@ -31,6 +31,7 @@ import (
 	"issuetracker/internal/storage/service"
 	"issuetracker/pkg/config"
 	"issuetracker/pkg/links"
+	"issuetracker/pkg/llm/prompt"
 	llmwiring "issuetracker/pkg/llm/wiring"
 	"issuetracker/pkg/logger"
 	"issuetracker/pkg/metrics"
@@ -347,7 +348,21 @@ func main() {
 	//
 	// 동일 provider 를 refiner 와 공유 — 환경변수 1세트로 동시 제어.
 	llmProvider := llmwiring.BuildProvider(log)
-	llmGen, err := llmgenwiring.Build(llmProvider, parsingRuleRepo, ruleResolver, redisClientShared, log)
+
+	// LLM prompt loader — 외부 파일 (LLM_PROMPT_DIR, default scripts/prompts) 에서 로드.
+	// 디렉토리 / 필수 파일 부재 시 Generator 가 첫 LLM 호출에서 fail. deployment 에 본 디렉토리
+	// 포함 보장이 운영자 책임 (이슈 #313 — embed fallback 은 후속 sub-issue).
+	promptDir := os.Getenv("LLM_PROMPT_DIR")
+	if promptDir == "" {
+		promptDir = "scripts/prompts"
+	}
+	promptLoader, err := prompt.NewFileLoader(promptDir)
+	if err != nil {
+		log.WithError(err).Fatal("failed to construct prompt loader")
+	}
+	log.WithFields(map[string]interface{}{"prompt_dir": promptDir}).Info("LLM prompt loader enabled")
+
+	llmGen, err := llmgenwiring.Build(llmProvider, parsingRuleRepo, ruleResolver, promptLoader, redisClientShared, log)
 	if err != nil {
 		log.WithError(err).Fatal("failed to build llmgen generator")
 	}

--- a/internal/processor/parser/rule/llmgen/generator.go
+++ b/internal/processor/parser/rule/llmgen/generator.go
@@ -37,6 +37,7 @@ import (
 	"issuetracker/internal/processor/parser/rule"
 	"issuetracker/internal/storage"
 	"issuetracker/pkg/llm"
+	"issuetracker/pkg/llm/prompt"
 	"issuetracker/pkg/logger"
 )
 
@@ -104,11 +105,12 @@ func (e *selectorValidationError) Unwrap() error { return e.cause }
 //   - Stop(ctx) 호출 시 새 Enqueue 차단 + 진행 중 goroutine 의 완료 대기 (graceful shutdown)
 //   - Stop 후 Enqueue 는 noop (race 안전)
 type Generator struct {
-	provider  llm.Provider
-	extractor SelectorExtractor // nil 이면 provider 로 fallback
-	repo      storage.ParsingRuleRepository
-	resolver  *rule.Resolver
-	log       *logger.Logger
+	provider     llm.Provider
+	extractor    SelectorExtractor // nil 이면 provider 로 fallback
+	repo         storage.ParsingRuleRepository
+	resolver     *rule.Resolver
+	promptLoader prompt.Loader
+	log          *logger.Logger
 
 	// validateFailureHandler 는 selector 검증 실패 시 호출되는 콜백입니다.
 	// 인자: (ctx, ref, llmRetryCount, targetType, crawlerName).
@@ -167,9 +169,9 @@ func (g *Generator) SetExtractor(e SelectorExtractor) {
 
 // New 는 Generator 를 생성합니다.
 //
-// provider / repo / resolver / log 모두 비-nil 필수. 하나라도 nil 이면 error —
+// provider / repo / resolver / promptLoader / log 모두 비-nil 필수. 하나라도 nil 이면 error —
 // 호출자 (cmd/main) 가 boot fatal 처리.
-func New(provider llm.Provider, repo storage.ParsingRuleRepository, resolver *rule.Resolver, log *logger.Logger) (*Generator, error) {
+func New(provider llm.Provider, repo storage.ParsingRuleRepository, resolver *rule.Resolver, promptLoader prompt.Loader, log *logger.Logger) (*Generator, error) {
 	if provider == nil {
 		return nil, errors.New("llmgen: New requires non-nil provider")
 	}
@@ -179,15 +181,19 @@ func New(provider llm.Provider, repo storage.ParsingRuleRepository, resolver *ru
 	if resolver == nil {
 		return nil, errors.New("llmgen: New requires non-nil resolver")
 	}
+	if promptLoader == nil {
+		return nil, errors.New("llmgen: New requires non-nil promptLoader")
+	}
 	if log == nil {
 		return nil, errors.New("llmgen: New requires non-nil log")
 	}
 	return &Generator{
-		provider: provider,
-		repo:     repo,
-		resolver: resolver,
-		log:      log,
-		locker:   storage.NewMemInflightLocker(),
+		provider:     provider,
+		repo:         repo,
+		resolver:     resolver,
+		promptLoader: promptLoader,
+		log:          log,
+		locker:       storage.NewMemInflightLocker(),
 	}, nil
 }
 
@@ -488,7 +494,10 @@ func (g *Generator) runOnce(ctx context.Context, host string, targetType storage
 		}
 	} else {
 		// 기존 LLM provider 경로 (Gemini Flash 등)
-		system, user := BuildPrompt(host, targetType, html)
+		system, user, bpErr := BuildPrompt(g.promptLoader, host, targetType, html)
+		if bpErr != nil {
+			return fmt.Errorf("build llmgen prompt: %w", bpErr)
+		}
 		resp, err := g.provider.Generate(ctx, llm.Request{
 			Messages: []llm.Message{
 				{Role: llm.RoleSystem, Content: system},

--- a/internal/processor/parser/rule/llmgen/prompt.go
+++ b/internal/processor/parser/rule/llmgen/prompt.go
@@ -2,9 +2,11 @@ package llmgen
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
 
 	"issuetracker/internal/storage"
+	"issuetracker/pkg/llm/prompt"
 )
 
 // promptMaxHTMLBytes 는 프롬프트에 첨부할 HTML 의 최대 바이트 수입니다.
@@ -20,64 +22,30 @@ const promptMaxHTMLBytes = 32 * 1024
 // LLM 응답 형식 강제 — 반드시 단일 JSON 객체로 응답하도록 지시.
 // JSON 구조는 storage.SelectorMap 의 JSON tag 와 1:1 매핑되어 그대로 unmarshal 가능.
 //
+// loader 는 외부 파일 (scripts/prompts/llmgen/...) 에서 prompt 본문을 로드.
 // 반환값: (system, user) — Provider 호출 시 RoleSystem + RoleUser 메시지로 분리 전달.
-func BuildPrompt(host string, targetType storage.TargetType, html string) (system, user string) {
-	system = systemPrompt
-	user = buildUserPrompt(host, targetType, truncateHTML(html))
-	return system, user
-}
-
-const systemPrompt = `You are an expert web scraper. Given an HTML sample of a webpage, extract CSS selectors for the most important fields and return them as a single JSON object.
-
-Strict rules:
-1. Respond ONLY with a single JSON object — no prose, no markdown fences, no comments.
-2. Use only selectors that actually appear in the provided HTML — do not invent.
-3. Prefer stable selectors (semantic tags, ARIA roles, id/class with meaningful names) over brittle ones (auto-generated hashes, nth-child indices).
-4. If a field cannot be confidently identified, omit it (do not guess).
-5. The "css" value must be a valid goquery selector. The "attribute" value must be empty for text content, or the HTML attribute name (e.g. "href", "src", "datetime", "content").
-6. Use "multi": true only when the field contains multiple distinct values (tags, image lists, paragraph blocks).`
-
-// buildUserPrompt 는 target_type 별로 요청 필드를 다르게 안내합니다.
-func buildUserPrompt(host string, targetType storage.TargetType, html string) string {
-	var fieldsGuide string
-	switch targetType {
-	case storage.TargetTypeList:
-		fieldsGuide = `Required JSON shape (omit fields you cannot identify):
-{
-  "item_container": {"css": "<selector for each list item root>"},
-  "item_link":      {"css": "<selector inside item for the article link>", "attribute": "href"},
-  "item_title":     {"css": "<selector inside item for the title text>"},
-  "item_snippet":   {"css": "<selector inside item for the short summary>"}
-}
-
-Goal: extract a list of article links from a hub/category page.`
-	default: // TargetTypePage and unknown — default to single-page extraction.
-		fieldsGuide = `Required JSON shape (omit fields you cannot identify):
-{
-  "title":        {"css": "<selector for page title>"},
-  "main_content": {"css": "<selector for primary article body>", "multi": true},
-  "summary":      {"css": "<selector for description/summary, often meta>", "attribute": "content"},
-  "author":       {"css": "<selector for author name>"},
-  "published_at": {"css": "<selector for publish datetime>", "attribute": "datetime"},
-  "category":     {"css": "<selector for section/category>"},
-  "tags":         {"css": "<selector for tag links>", "multi": true},
-  "images":       {"css": "<selector for content images>", "attribute": "src", "multi": true}
-}
-
-Goal: extract a single content page (article / blog post / document).`
+func BuildPrompt(loader prompt.Loader, host string, targetType storage.TargetType, html string) (system, user string, err error) {
+	system, err = loader.Load("llmgen/system")
+	if err != nil {
+		return "", "", fmt.Errorf("load llmgen system prompt: %w", err)
 	}
 
-	return fmt.Sprintf(`Host: %s
-Target type: %s
+	userPromptName := "llmgen/page.user"
+	if targetType == storage.TargetTypeList {
+		userPromptName = "llmgen/list.user"
+	}
+	template, err := loader.Load(userPromptName)
+	if err != nil {
+		return "", "", fmt.Errorf("load %s prompt: %w", userPromptName, err)
+	}
 
-%s
-
-HTML sample (truncated to %d bytes if longer):
----
-%s
----
-
-Return ONLY the JSON object.`, host, string(targetType), fieldsGuide, promptMaxHTMLBytes, html)
+	user = prompt.Render(template,
+		"{{HOST}}", host,
+		"{{TARGET_TYPE}}", string(targetType),
+		"{{MAX_HTML_BYTES}}", strconv.Itoa(promptMaxHTMLBytes),
+		"{{HTML}}", truncateHTML(html),
+	)
+	return system, user, nil
 }
 
 // truncateHTML 은 HTML 을 promptMaxHTMLBytes 까지 잘라냅니다 (UTF-8 경계 안전).

--- a/internal/processor/parser/rule/llmgen/wiring/wiring.go
+++ b/internal/processor/parser/rule/llmgen/wiring/wiring.go
@@ -13,21 +13,22 @@ import (
 	"issuetracker/internal/storage"
 	redisstore "issuetracker/internal/storage/redis"
 	"issuetracker/pkg/llm"
+	"issuetracker/pkg/llm/prompt"
 	"issuetracker/pkg/logger"
 	"issuetracker/pkg/redis"
 )
 
-// Build 는 LLM provider + repository + resolver 로 llmgen.Generator 를 구성합니다.
+// Build 는 LLM provider + repository + resolver + prompt loader 로 llmgen.Generator 를 구성합니다.
 //
 // provider 는 호출자가 직접 주입 — 일반적으로 pkg/llm/wiring.BuildProvider 결과를 그대로 전달.
 // provider 가 nil (LLM 비활성) 이면 (nil, nil) 반환 — parser worker 는 ErrNoRule 시 raw 만 잔존.
 // llmgen.New 자체 실패는 wiring 버그 — 호출자 (main) 에서 Fatal 결정.
 // redisClient 가 nil 이면 in-process memInflightLocker 로 graceful degrade.
-func Build(provider llm.Provider, repo storage.ParsingRuleRepository, resolver *rule.Resolver, redisClient *redis.Client, log *logger.Logger) (*llmgen.Generator, error) {
+func Build(provider llm.Provider, repo storage.ParsingRuleRepository, resolver *rule.Resolver, promptLoader prompt.Loader, redisClient *redis.Client, log *logger.Logger) (*llmgen.Generator, error) {
 	if provider == nil {
 		return nil, nil
 	}
-	gen, err := llmgen.New(provider, repo, resolver, log)
+	gen, err := llmgen.New(provider, repo, resolver, promptLoader, log)
 	if err != nil {
 		return nil, fmt.Errorf("construct llmgen generator: %w", err)
 	}

--- a/pkg/llm/prompt/loader.go
+++ b/pkg/llm/prompt/loader.go
@@ -1,0 +1,120 @@
+// Package prompt 는 LLM 프롬프트를 외부 파일에서 로드하는 공통 인프라를 제공합니다.
+//
+// 의도: prompt 가 LLM 응답 품질의 가장 큰 lever 라 운영자가 빈번히 튜닝하는데, Go const 로
+// hardcode 되어 있으면 한 줄 수정도 코드 변경 → PR → 재빌드 → 재배포 cycle 을 강제. 외부
+// 파일 + 환경변수 (LLM_PROMPT_DIR) 로 분리하여 파일 수정 + 프로세스 재기동만으로 갱신 가능.
+//
+// 4개 호출자 (llmgen / pathinfer / validator / claudegen) 가 동일 Loader 인터페이스를 공유해
+// 중복 코드 회피.
+package prompt
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+)
+
+// Loader 는 prompt name (예: "llmgen/system") 으로 prompt 본문을 반환하는 인터페이스입니다.
+//
+// name 은 디렉토리 separator 로 sub-package 와 prompt 파일을 구분 — FileLoader 는 자동으로
+// ".txt" suffix 를 붙여 디스크에서 로드합니다 (예: "llmgen/system" → "<dir>/llmgen/system.txt").
+type Loader interface {
+	Load(name string) (string, error)
+}
+
+// FileLoader 는 외부 디렉토리의 .txt 파일을 첫 호출 시 lazy load 후 in-memory cache 합니다.
+//
+// 동시 호출 안전 — sync.RWMutex 로 보호. cache miss 시 file read + 캐싱.
+// 프로세스 재기동 전까지 cache 유지 — 운영자가 파일 수정 후 reload 원하면 재기동 필요.
+type FileLoader struct {
+	dir   string
+	mu    sync.RWMutex
+	cache map[string]string
+}
+
+// NewFileLoader 는 dir 디렉토리를 root 로 하는 FileLoader 를 생성합니다.
+//
+// dir 이 비어있거나 디렉토리가 아니면 error — 운영 deployment 누락을 fail-fast 로 가시화.
+func NewFileLoader(dir string) (*FileLoader, error) {
+	if dir == "" {
+		return nil, errors.New("prompt: NewFileLoader requires non-empty directory path")
+	}
+	info, err := os.Stat(dir)
+	if err != nil {
+		return nil, fmt.Errorf("prompt: stat %q: %w", dir, err)
+	}
+	if !info.IsDir() {
+		return nil, fmt.Errorf("prompt: %q is not a directory", dir)
+	}
+	return &FileLoader{
+		dir:   dir,
+		cache: make(map[string]string),
+	}, nil
+}
+
+// Load 는 name 에 해당하는 prompt 본문을 반환합니다.
+//
+// name 은 sub-package 와 prompt 식별자를 "/" 로 구분 (예: "llmgen/system", "pathinfer/user").
+// 파일 경로는 "<dir>/<name>.txt" 로 해석되며 파일 부재 / read 실패 시 error.
+// cache hit 시 disk I/O 없이 즉시 반환.
+func (l *FileLoader) Load(name string) (string, error) {
+	if name == "" {
+		return "", errors.New("prompt: Load requires non-empty name")
+	}
+
+	l.mu.RLock()
+	if v, ok := l.cache[name]; ok {
+		l.mu.RUnlock()
+		return v, nil
+	}
+	l.mu.RUnlock()
+
+	path := filepath.Join(l.dir, name+".txt")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return "", fmt.Errorf("prompt: read %q: %w", path, err)
+	}
+	body := string(data)
+	if strings.TrimSpace(body) == "" {
+		return "", fmt.Errorf("prompt: %q is empty", path)
+	}
+
+	l.mu.Lock()
+	l.cache[name] = body
+	l.mu.Unlock()
+	return body, nil
+}
+
+// MapLoader 는 테스트 / dev 환경용 in-memory Loader 입니다.
+//
+// key 는 Load 의 name 인자와 동일 (예: "llmgen/system"). value 는 prompt 본문.
+// 부재 key 는 error 반환.
+type MapLoader map[string]string
+
+// Load 는 m 에서 name 에 해당하는 prompt 를 반환합니다.
+func (m MapLoader) Load(name string) (string, error) {
+	v, ok := m[name]
+	if !ok {
+		return "", fmt.Errorf("prompt: %q not in MapLoader", name)
+	}
+	if strings.TrimSpace(v) == "" {
+		return "", fmt.Errorf("prompt: %q is empty in MapLoader", name)
+	}
+	return v, nil
+}
+
+// Render 는 template 의 placeholder 를 replacements 로 치환한 결과를 반환합니다.
+//
+// replacements 는 ("{{KEY}}", value) 의 짝수 슬라이스 — strings.NewReplacer 와 동일 인자 형식.
+// template 안에 정의되지 않은 placeholder 는 그대로 잔존 — 호출자가 필요한 경우 별도 검증.
+//
+// Go text/template 의 의존성 회피 — 운영자가 Go template 문법 몰라도 단순 {{KEY}} 치환만 가능.
+func Render(template string, replacements ...string) string {
+	if len(replacements) == 0 {
+		return template
+	}
+	return strings.NewReplacer(replacements...).Replace(template)
+}

--- a/pkg/llm/prompt/loader.go
+++ b/pkg/llm/prompt/loader.go
@@ -111,10 +111,16 @@ func (m MapLoader) Load(name string) (string, error) {
 // replacements 는 ("{{KEY}}", value) 의 짝수 슬라이스 — strings.NewReplacer 와 동일 인자 형식.
 // template 안에 정의되지 않은 placeholder 는 그대로 잔존 — 호출자가 필요한 경우 별도 검증.
 //
+// 홀수 인자 시 panic — strings.NewReplacer 의 panic 보다 본 패키지 컨텍스트가 명확하도록
+// 우선 검증 후 호출자 실수를 즉시 가시화.
+//
 // Go text/template 의 의존성 회피 — 운영자가 Go template 문법 몰라도 단순 {{KEY}} 치환만 가능.
 func Render(template string, replacements ...string) string {
 	if len(replacements) == 0 {
 		return template
+	}
+	if len(replacements)%2 != 0 {
+		panic(fmt.Sprintf("prompt: Render requires even number of replacements (got %d): %v", len(replacements), replacements))
 	}
 	return strings.NewReplacer(replacements...).Replace(template)
 }

--- a/scripts/prompts/llmgen/list.user.txt
+++ b/scripts/prompts/llmgen/list.user.txt
@@ -1,0 +1,19 @@
+Host: {{HOST}}
+Target type: {{TARGET_TYPE}}
+
+Required JSON shape (omit fields you cannot identify):
+{
+  "item_container": {"css": "<selector for each list item root>"},
+  "item_link":      {"css": "<selector inside item for the article link>", "attribute": "href"},
+  "item_title":     {"css": "<selector inside item for the title text>"},
+  "item_snippet":   {"css": "<selector inside item for the short summary>"}
+}
+
+Goal: extract a list of article links from a hub/category page.
+
+HTML sample (truncated to {{MAX_HTML_BYTES}} bytes if longer):
+---
+{{HTML}}
+---
+
+Return ONLY the JSON object.

--- a/scripts/prompts/llmgen/page.user.txt
+++ b/scripts/prompts/llmgen/page.user.txt
@@ -1,0 +1,23 @@
+Host: {{HOST}}
+Target type: {{TARGET_TYPE}}
+
+Required JSON shape (omit fields you cannot identify):
+{
+  "title":        {"css": "<selector for page title>"},
+  "main_content": {"css": "<selector for primary article body>", "multi": true},
+  "summary":      {"css": "<selector for description/summary, often meta>", "attribute": "content"},
+  "author":       {"css": "<selector for author name>"},
+  "published_at": {"css": "<selector for publish datetime>", "attribute": "datetime"},
+  "category":     {"css": "<selector for section/category>"},
+  "tags":         {"css": "<selector for tag links>", "multi": true},
+  "images":       {"css": "<selector for content images>", "attribute": "src", "multi": true}
+}
+
+Goal: extract a single content page (article / blog post / document).
+
+HTML sample (truncated to {{MAX_HTML_BYTES}} bytes if longer):
+---
+{{HTML}}
+---
+
+Return ONLY the JSON object.

--- a/scripts/prompts/llmgen/system.txt
+++ b/scripts/prompts/llmgen/system.txt
@@ -1,0 +1,9 @@
+You are an expert web scraper. Given an HTML sample of a webpage, extract CSS selectors for the most important fields and return them as a single JSON object.
+
+Strict rules:
+1. Respond ONLY with a single JSON object — no prose, no markdown fences, no comments.
+2. Use only selectors that actually appear in the provided HTML — do not invent.
+3. Prefer stable selectors (semantic tags, ARIA roles, id/class with meaningful names) over brittle ones (auto-generated hashes, nth-child indices).
+4. If a field cannot be confidently identified, omit it (do not guess).
+5. The "css" value must be a valid goquery selector. The "attribute" value must be empty for text content, or the HTML attribute name (e.g. "href", "src", "datetime", "content").
+6. Use "multi": true only when the field contains multiple distinct values (tags, image lists, paragraph blocks).

--- a/test/internal/processor/parser/rule/llmgen/generator_test.go
+++ b/test/internal/processor/parser/rule/llmgen/generator_test.go
@@ -16,6 +16,7 @@ import (
 	"issuetracker/internal/processor/parser/rule/llmgen"
 	"issuetracker/internal/storage"
 	"issuetracker/pkg/llm"
+	"issuetracker/pkg/llm/prompt"
 	"issuetracker/pkg/logger"
 )
 
@@ -155,10 +156,19 @@ const sampleListHTML = `<!DOCTYPE html><html><body>
 </ul>
 </body></html>`
 
+// testPromptLoader 는 단위 테스트용 in-memory prompt loader 입니다.
+// llmgen 의 system / user prompt 를 최소 형태로 stub — placeholder 가 그대로 잔존해도 테스트
+// 단위 (provider 가 fakeProvider 라 실제 LLM 호출 없음) 에선 의미 없음.
+var testPromptLoader = prompt.MapLoader{
+	"llmgen/system":    "test system prompt",
+	"llmgen/page.user": "host={{HOST}} type={{TARGET_TYPE}} html={{HTML}}",
+	"llmgen/list.user": "host={{HOST}} type={{TARGET_TYPE}} html={{HTML}}",
+}
+
 func newGenerator(t *testing.T, provider llm.Provider, repo storage.ParsingRuleRepository) (*llmgen.Generator, *rule.Resolver) {
 	t.Helper()
 	resolver, _ := rule.NewResolver(&noopFindRepo{}, rule.WithCacheTTL(time.Minute))
-	g, err := llmgen.New(provider, repo, resolver, logger.New(logger.DefaultConfig()))
+	g, err := llmgen.New(provider, repo, resolver, testPromptLoader, logger.New(logger.DefaultConfig()))
 	require.NoError(t, err)
 	return g, resolver
 }

--- a/test/pkg/llm/prompt/loader_test.go
+++ b/test/pkg/llm/prompt/loader_test.go
@@ -129,3 +129,9 @@ func TestRender_UnknownPlaceholder_LeftUntouched(t *testing.T) {
 	out := prompt.Render("Hello {{NAME}} and {{UNKNOWN}}", "{{NAME}}", "World")
 	assert.Equal(t, "Hello World and {{UNKNOWN}}", out)
 }
+
+func TestRender_OddLengthReplacements_Panics(t *testing.T) {
+	assert.Panics(t, func() {
+		prompt.Render("template", "{{KEY}}", "value", "{{ORPHAN}}")
+	}, "Render 가 odd-length 인자에 명시적 panic")
+}

--- a/test/pkg/llm/prompt/loader_test.go
+++ b/test/pkg/llm/prompt/loader_test.go
@@ -1,0 +1,131 @@
+package prompt_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"issuetracker/pkg/llm/prompt"
+)
+
+func TestNewFileLoader_NonExistentDir_ReturnsError(t *testing.T) {
+	_, err := prompt.NewFileLoader("/nonexistent/path/should/not/exist")
+	require.Error(t, err)
+}
+
+func TestNewFileLoader_NotADirectory_ReturnsError(t *testing.T) {
+	tmp := filepath.Join(t.TempDir(), "file.txt")
+	require.NoError(t, os.WriteFile(tmp, []byte("x"), 0o600))
+
+	_, err := prompt.NewFileLoader(tmp)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not a directory")
+}
+
+func TestNewFileLoader_EmptyDir_ReturnsError(t *testing.T) {
+	_, err := prompt.NewFileLoader("")
+	require.Error(t, err)
+}
+
+func TestFileLoader_Load_Success(t *testing.T) {
+	dir := t.TempDir()
+	subdir := filepath.Join(dir, "llmgen")
+	require.NoError(t, os.MkdirAll(subdir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(subdir, "system.txt"), []byte("hello world"), 0o600))
+
+	l, err := prompt.NewFileLoader(dir)
+	require.NoError(t, err)
+
+	body, err := l.Load("llmgen/system")
+	require.NoError(t, err)
+	assert.Equal(t, "hello world", body)
+}
+
+func TestFileLoader_Load_FileMissing_ReturnsError(t *testing.T) {
+	l, err := prompt.NewFileLoader(t.TempDir())
+	require.NoError(t, err)
+
+	_, err = l.Load("llmgen/missing")
+	require.Error(t, err)
+}
+
+func TestFileLoader_Load_EmptyFile_ReturnsError(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "empty.txt"), []byte("   \n\t"), 0o600))
+
+	l, err := prompt.NewFileLoader(dir)
+	require.NoError(t, err)
+
+	_, err = l.Load("empty")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "empty")
+}
+
+func TestFileLoader_Load_EmptyName_ReturnsError(t *testing.T) {
+	l, err := prompt.NewFileLoader(t.TempDir())
+	require.NoError(t, err)
+
+	_, err = l.Load("")
+	require.Error(t, err)
+}
+
+func TestFileLoader_Load_CacheHit_NoSecondReadEvenAfterFileDelete(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "x.txt")
+	require.NoError(t, os.WriteFile(path, []byte("first"), 0o600))
+
+	l, err := prompt.NewFileLoader(dir)
+	require.NoError(t, err)
+
+	body1, err := l.Load("x")
+	require.NoError(t, err)
+	require.Equal(t, "first", body1)
+
+	// 캐시 동작 검증 — 파일을 삭제해도 cache hit 으로 동일 결과 반환.
+	require.NoError(t, os.Remove(path))
+
+	body2, err := l.Load("x")
+	require.NoError(t, err)
+	assert.Equal(t, "first", body2, "cache 가 사용되어 disk read skip")
+}
+
+func TestMapLoader_Load_KnownKey(t *testing.T) {
+	m := prompt.MapLoader{"a/b": "value"}
+	body, err := m.Load("a/b")
+	require.NoError(t, err)
+	assert.Equal(t, "value", body)
+}
+
+func TestMapLoader_Load_UnknownKey_Errors(t *testing.T) {
+	m := prompt.MapLoader{}
+	_, err := m.Load("missing")
+	require.Error(t, err)
+}
+
+func TestMapLoader_Load_EmptyValue_Errors(t *testing.T) {
+	m := prompt.MapLoader{"empty": "  "}
+	_, err := m.Load("empty")
+	require.Error(t, err)
+}
+
+func TestRender_PlaceholderReplacement(t *testing.T) {
+	out := prompt.Render(
+		"Hello {{NAME}}, you have {{COUNT}} messages.",
+		"{{NAME}}", "Alice",
+		"{{COUNT}}", "3",
+	)
+	assert.Equal(t, "Hello Alice, you have 3 messages.", out)
+}
+
+func TestRender_NoReplacements_ReturnsTemplate(t *testing.T) {
+	out := prompt.Render("unchanged template")
+	assert.Equal(t, "unchanged template", out)
+}
+
+func TestRender_UnknownPlaceholder_LeftUntouched(t *testing.T) {
+	out := prompt.Render("Hello {{NAME}} and {{UNKNOWN}}", "{{NAME}}", "World")
+	assert.Equal(t, "Hello World and {{UNKNOWN}}", out)
+}


### PR DESCRIPTION
## 연관 이슈
- Closes #313
- Parent: #312
- Sibling sub-issue: #314 (pathinfer / validator / claudegen 마이그레이션 — 본 PR 머지 후 진행)

## 구현 내용

[#312](https://github.com/EinSofINTEREST/IssueTracker/issues/312) 의 sub-A — 모든 LLM prompt 를 외부 파일로 이전하기 위한 공유 인프라 + 첫 패키지 (llmgen) 마이그레이션.

### 1. \`pkg/llm/prompt/\` 신규 패키지

| 항목 | 책임 |
|---|---|
| \`Loader\` interface | \`Load(name) (string, error)\` — 호출자가 \"llmgen/system\" 같은 이름으로 lookup |
| \`FileLoader\` | \`<dir>/<name>.txt\` 외부 파일 lazy load + in-memory cache (sync.RWMutex) |
| \`MapLoader\` | 테스트 / dev 친화 in-memory loader |
| \`Render\` | \`strings.NewReplacer\` 기반 placeholder 치환 — Go template 의존성 회피, 운영자가 \`{{KEY}}\` 만 알면 됨 |

### 2. llmgen 마이그레이션

- \`llmgen/prompt.go\`: \`const systemPrompt\` + \`buildUserPrompt\` 함수 제거 → Loader 의존성
- \`BuildPrompt\` 시그니처: \`(loader prompt.Loader, host, targetType, html) (system, user, error)\`
- \`Generator.New\` 에 \`promptLoader prompt.Loader\` 필수 인자 추가 — boot fail-fast
- \`llmgenwiring.Build\` 시그니처에 \`promptLoader\` 추가
- 외부 파일 3건 추가:
  - \`scripts/prompts/llmgen/system.txt\`
  - \`scripts/prompts/llmgen/page.user.txt\`
  - \`scripts/prompts/llmgen/list.user.txt\`
- placeholder: \`{{HOST}}\`, \`{{TARGET_TYPE}}\`, \`{{HTML}}\`, \`{{MAX_HTML_BYTES}}\`

### 3. wiring (\`cmd/issuetracker/main.go\`)

- \`LLM_PROMPT_DIR\` 환경변수 (default \`scripts/prompts\`) → \`prompt.NewFileLoader\`
- 디렉토리 / 필수 파일 부재 시 boot 단계 \`Fatal\` — deployment 누락 가시화
- 생성된 loader 를 \`llmgenwiring.Build\` 에 주입

### 4. 테스트

- \`test/pkg/llm/prompt/loader_test.go\` — 11 케이스 (정상 / 부재 / 빈 / cache hit / Render)
- 기존 llmgen 테스트의 \`newGenerator\` helper 가 \`MapLoader\` 사용 — 통합 시나리오에서 fakeProvider 와 함께 정상 동작

## scope 외 (후속 권장)

- **Embed fallback**: Go embed 는 모듈 root 트릭 (root 패키지 또는 별도 디렉토리 + 중복 관리) 이 필요해 본 PR scope 외. 별도 sub-issue 분리 권장 — 운영 안전성 강화 (deployment 의 prompt 디렉토리 누락 시에도 binary embed 로 fallback)
- sub-B (#314): pathinfer / validator / claudegen 마이그레이션 — 본 PR 머지 후 동일 인프라 활용

## CI / 머지 게이트 점검

### 변경 영향 범위
- 11 파일 / +383 / -72 line
- 신규: \`pkg/llm/prompt/\` (loader.go) + \`scripts/prompts/llmgen/*.txt\` 3 + 단위 테스트
- 위험도: \`Medium\` — Generator.New 시그니처 변경 + boot 단계 fail-fast (deployment 의 prompt 디렉토리 부재 시 시작 실패)

### Required Status Checks
- 통과 확인 대상:
  - [ ] \`Commit Lint\`
  - [ ] \`PR Title Lint\`
  - [ ] \`Linked Issue Check\`
  - [ ] \`Format Check\`
  - [ ] \`Build\`
  - [ ] \`Test\`
  - [ ] \`Lint\`

### 로컬 검증 통과
- \`go build ./...\` 통과
- \`go test -race ./...\` 통과 (36 패키지)
- \`gofmt\` 적용

### 롤백 계획
- PR revert: 인프라 + llmgen 모두 환원
- 부분 롤백 어려움 — 인프라 / 마이그레이션 atomic 변경

## TODO
- 운영 deployment 에 \`scripts/prompts/\` 디렉토리 포함 보장 확인
- 후속 sub-issue (embed fallback) 검토

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * LLM prompts can now be externalized and configured via the `LLM_PROMPT_DIR` environment variable, allowing operators to customize and update prompts without code deployment.
  
* **Chores**
  * Added fail-fast validation for required prompt files during startup; process restart is required when prompts are updated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->