### PR TITLE
[FIX#323] fetcher rate limit 미강제 — production goquery/chromedp wiring 채움

### DIFF
--- a/internal/processor/fetcher/domain/general/sources/registry.go
+++ b/internal/processor/fetcher/domain/general/sources/registry.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"fmt"
 	"net/url"
+	"time"
 
 	"issuetracker/internal/processor/fetcher/core"
 	"issuetracker/internal/processor/fetcher/domain/general"
@@ -15,12 +16,23 @@ import (
 	"issuetracker/internal/processor/fetcher/handler"
 	cdp "issuetracker/internal/processor/fetcher/implementation/chromedp"
 	"issuetracker/internal/processor/fetcher/implementation/goquery"
+	"issuetracker/internal/processor/fetcher/rate_limiter"
 	"issuetracker/internal/processor/fetcher/rule"
 	"issuetracker/internal/storage"
 	"issuetracker/internal/storage/service"
 	"issuetracker/pkg/logger"
 	"issuetracker/pkg/queue"
 )
+
+// dnsCacheTTL 는 fetcher rate limiter 가 사용하는 DNS resolver 의 entry TTL.
+// IP 변경 빈도와 DNS lookup 비용 trade-off — 5분이 일반.
+const dnsCacheTTL = 5 * time.Minute
+
+// defaultRateLimitBurst 는 IPRateLimiterRegistry 생성 시 burst 기본값.
+//
+// fetcher_rules 테이블에 burst 컬럼은 아직 없음 — RPH 기반 단일 정책. 향후 컬럼 추가 시
+// per-source 동적 값으로 대체.
+const defaultRateLimitBurst = 10
 
 // defaultLazyKeywords 는 대부분 뉴스 사이트가 사용하는 lazy-load 감지 attr 목록입니다.
 // chromedp 가 활성화된 경우에만 BuildChain 에 전달합니다 — pool 이 꺼진 환경에서
@@ -88,11 +100,15 @@ func RegisterAll(
 		return fmt.Errorf("no sources found in fetcher_rules; apply migration 014 seed data")
 	}
 
+	// 사이트별 rate limiter 의 IP 해석에 사용할 공유 DNS resolver — 모든 source 공유.
+	// 캐시 TTL 안에서 동일 host 의 반복 lookup 비용을 흡수.
+	dnsResolver := rate_limiter.NewDNSIPResolver(dnsCacheTTL)
+
 	// source_name 별로 handler 를 빌드한 뒤, source_name 과 각 host_pattern 양쪽으로 등록.
 	// CrawlerName 이 host 기반으로 통일 (#248) — source_name 키는 하위 호환 유지.
 	for sourceName, entry := range bySource {
 		h, err := buildHandler(sourceName, entry.rec,
-			baseConfig, rawSvc, producer, resolver, chromedpRemoteURLs, log)
+			baseConfig, rawSvc, producer, resolver, chromedpRemoteURLs, dnsResolver, log)
 		if err != nil {
 			return err
 		}
@@ -100,10 +116,16 @@ func RegisterAll(
 		for _, host := range hostsBySource[sourceName] {
 			registry.Register(host, h)
 		}
+		rateLimitMode := "unlimited"
+		if entry.rec.RequestsPerHour > 0 {
+			rateLimitMode = "enforced"
+		}
 		log.WithFields(map[string]interface{}{
 			"source":            sourceName,
 			"hosts":             hostsBySource[sourceName],
 			"requests_per_hour": entry.rec.RequestsPerHour,
+			"burst":             defaultRateLimitBurst,
+			"rate_limit":        rateLimitMode,
 		}).Info("crawler registered from db")
 	}
 	return nil
@@ -111,6 +133,10 @@ func RegisterAll(
 
 // buildHandler 는 source 의 ChainHandler 를 빌드하여 반환합니다.
 // 등록(registry.Register)은 호출자가 직접 수행 — source_name 과 host_pattern 양쪽 등록 지원.
+//
+// dnsResolver 는 모든 source 가 공유 — 사이트별 IPRateLimiterRegistry 가 IP 해석에 사용.
+// rec.RequestsPerHour 가 0 이면 IPRateLimiterRegistry 내부 NewRateLimiter 가 noop 으로
+// 분기 — 즉 limiter 객체는 유지하되 Wait 가 즉시 통과.
 func buildHandler(
 	sourceName string,
 	rec *storage.FetcherRuleRecord,
@@ -119,6 +145,7 @@ func buildHandler(
 	producer queue.Producer,
 	resolver rule.Resolver,
 	chromedpRemoteURLs []string,
+	dnsResolver core.IPResolver,
 	log *logger.Logger,
 ) (handler.Handler, error) {
 	sourceInfo := core.SourceInfo{
@@ -134,7 +161,11 @@ func buildHandler(
 	// DB 값을 그대로 반영 — 0 은 스키마 상 "제한 없음" 이므로 > 0 조건 없이 항상 적용 (CodeRabbit Major 반영).
 	cfg.RequestsPerHour = rec.RequestsPerHour
 
-	gqCrawler := goquery.NewGoqueryCrawler(sourceName+"-goquery", sourceInfo, cfg)
+	// 사이트별 IPRateLimiterRegistry — 동일 source 의 모든 host (goquery + chromedp) 가 공유.
+	// IP 단위 token bucket 이므로 host 가 같은 IP 면 limiter 도 공유.
+	rateLimiter := rate_limiter.NewIPRateLimiterRegistry(dnsResolver, rec.RequestsPerHour, defaultRateLimitBurst)
+
+	gqCrawler := goquery.NewGoqueryCrawlerWithRateLimiter(sourceName+"-goquery", sourceInfo, cfg, rateLimiter)
 	gqFetcher := fetcher.NewGoqueryFetcher(gqCrawler)
 
 	crawler := general.NewGenericCrawler(sourceName, sourceInfo, gqFetcher, rec.BaseURL, cfg)
@@ -150,7 +181,7 @@ func buildHandler(
 		return nil, fmt.Errorf("%s default chain wiring: %w", sourceName, err)
 	}
 
-	chromedpChains, err := buildChromedpChains(sourceName, sourceInfo, cfg, chromedpRemoteURLs, log)
+	chromedpChains, err := buildChromedpChains(sourceName, sourceInfo, cfg, chromedpRemoteURLs, rateLimiter, log)
 	if err != nil {
 		return nil, err
 	}
@@ -173,11 +204,16 @@ func isCanonicalHost(r *storage.FetcherRuleRecord) bool {
 
 // buildChromedpChains 는 source 의 chromedp chain 을 worker_id 별 N 개 build 합니다.
 // remoteURLs 가 empty 이면 nil 반환 (chromedp 미사용).
+//
+// rateLimiter 는 buildHandler 가 생성한 source 단위 IPRateLimiterRegistry — 동일 source 의
+// goquery / chromedp 가 같은 limiter 공유하여 IP 단위 token bucket 정책이 fetcher 종류와
+// 무관하게 일관 적용.
 func buildChromedpChains(
 	sourceName string,
 	sourceInfo core.SourceInfo,
 	cfg core.Config,
 	remoteURLs []string,
+	rateLimiter core.URLRateLimiter,
 	log *logger.Logger,
 ) ([]general.Handler, error) {
 	if len(remoteURLs) == 0 {
@@ -187,8 +223,8 @@ func buildChromedpChains(
 	for i, remoteURL := range remoteURLs {
 		opts := cdp.DefaultRemoteOptions()
 		opts.RemoteURL = remoteURL
-		cdpCrawler := cdp.NewChromedpCrawlerWithOptions(
-			fmt.Sprintf("%s-browser-%d", sourceName, i), sourceInfo, cfg, opts,
+		cdpCrawler := cdp.NewChromedpCrawlerWithRateLimiter(
+			fmt.Sprintf("%s-browser-%d", sourceName, i), sourceInfo, cfg, opts, rateLimiter,
 		)
 		brFetcher := fetcher.NewBrowserFetcher(cdpCrawler, cfg)
 		chain, err := general.BuildChain(nil, brFetcher, log)

--- a/internal/processor/fetcher/domain/general/sources/registry.go
+++ b/internal/processor/fetcher/domain/general/sources/registry.go
@@ -163,7 +163,14 @@ func buildHandler(
 
 	// 사이트별 IPRateLimiterRegistry — 동일 source 의 모든 host (goquery + chromedp) 가 공유.
 	// IP 단위 token bucket 이므로 host 가 같은 IP 면 limiter 도 공유.
-	rateLimiter := rate_limiter.NewIPRateLimiterRegistry(dnsResolver, rec.RequestsPerHour, defaultRateLimitBurst)
+	//
+	// RPH=0 (제한 없음) 인 source 는 nil 주입 — IPRateLimiterRegistry.Wait 가 항상 DNS lookup 을
+	// 수행하므로 의미 없는 네트워크 비용 + 잠재 에러 포인트 회피. crawler 가 nil limiter 를 graceful
+	// bypass 하는 분기는 이미 구현되어 있어 동작 안전.
+	var rateLimiter core.URLRateLimiter
+	if rec.RequestsPerHour > 0 {
+		rateLimiter = rate_limiter.NewIPRateLimiterRegistry(dnsResolver, rec.RequestsPerHour, defaultRateLimitBurst)
+	}
 
 	gqCrawler := goquery.NewGoqueryCrawlerWithRateLimiter(sourceName+"-goquery", sourceInfo, cfg, rateLimiter)
 	gqFetcher := fetcher.NewGoqueryFetcher(gqCrawler)

--- a/internal/processor/fetcher/implementation/chromedp/crawler.go
+++ b/internal/processor/fetcher/implementation/chromedp/crawler.go
@@ -9,7 +9,10 @@ import (
 	"issuetracker/pkg/logger"
 )
 
-// NewChromedpCrawler: 새로운 ChromedpCrawler 인스턴스 생성
+// NewChromedpCrawler: 새로운 ChromedpCrawler 인스턴스 생성 (rate limiter 없음).
+//
+// production wiring 은 NewChromedpCrawlerWithRateLimiter 를 사용. 본 생성자는 example /
+// test 환경용.
 func NewChromedpCrawler(name string, source core.SourceInfo, config core.Config) *ChromedpCrawler {
 	return &ChromedpCrawler{
 		name:       name,
@@ -19,13 +22,22 @@ func NewChromedpCrawler(name string, source core.SourceInfo, config core.Config)
 	}
 }
 
-// NewChromedpCrawlerWithOptions: 옵션을 지정하여 인스턴스 생성
+// NewChromedpCrawlerWithOptions: 옵션을 지정하여 인스턴스 생성 (rate limiter 없음).
 func NewChromedpCrawlerWithOptions(name string, source core.SourceInfo, config core.Config, opts ChromedpOptions) *ChromedpCrawler {
+	return NewChromedpCrawlerWithRateLimiter(name, source, config, opts, nil)
+}
+
+// NewChromedpCrawlerWithRateLimiter: rate limiter 가 주입된 ChromedpCrawler 를 생성합니다.
+//
+// chromedp 는 raw http.Client 를 거치지 않으므로 Fetch entry 에서 직접 Wait 를 호출해
+// RPH 정책을 강제합니다. rateLimiter 가 nil 이면 NewChromedpCrawlerWithOptions 와 동일.
+func NewChromedpCrawlerWithRateLimiter(name string, source core.SourceInfo, config core.Config, opts ChromedpOptions, rateLimiter core.URLRateLimiter) *ChromedpCrawler {
 	return &ChromedpCrawler{
-		name:       name,
-		sourceInfo: source,
-		config:     config,
-		opts:       opts,
+		name:           name,
+		sourceInfo:     source,
+		config:         config,
+		opts:           opts,
+		urlRateLimiter: rateLimiter,
 	}
 }
 

--- a/internal/processor/fetcher/implementation/chromedp/fetch.go
+++ b/internal/processor/fetcher/implementation/chromedp/fetch.go
@@ -34,6 +34,22 @@ func (c *ChromedpCrawler) Fetch(ctx context.Context, target core.Target) (*core.
 		}
 	}
 
+	// 사이트별 rate limiting: chromedp 는 raw http.Client 를 거치지 않으므로 Fetch entry 에서
+	// 직접 Wait. limiter 가 nil 이면 즉시 진행.
+	if c.urlRateLimiter != nil {
+		if err := c.urlRateLimiter.Wait(ctx, target.URL); err != nil {
+			return nil, &core.CrawlerError{
+				Category:  core.ErrCategoryRateLimit,
+				Code:      "RATE_001",
+				Message:   "rate limit wait failed",
+				Source:    c.name,
+				URL:       target.URL,
+				Retryable: true,
+				Err:       err,
+			}
+		}
+	}
+
 	// 탭 생성 (요청별 격리)
 	// browserCtx는 timeout이 적용되지 않은 tab context로, graceful capture 시 재사용된다.
 	browserCtx, browserCancel := chromedp.NewContext(c.allocCtx)

--- a/internal/processor/fetcher/implementation/chromedp/types.go
+++ b/internal/processor/fetcher/implementation/chromedp/types.go
@@ -9,6 +9,9 @@ import (
 
 // ChromedpCrawler: 헤드리스 브라우저 기반 동적 크롤러
 // JavaScript 렌더링이 필요한 SPA, 커뮤니티 등 동적 페이지 크롤링에 사용
+//
+// urlRateLimiter 가 nil 이 아니면 매 Fetch 진입 직전 Wait 를 호출해 RPH 정책 강제.
+// chromedp 는 raw http.Client 를 사용하지 않으므로 entry-level 에서 직접 limiter 호출.
 type ChromedpCrawler struct {
 	name       string
 	sourceInfo core.SourceInfo
@@ -20,6 +23,9 @@ type ChromedpCrawler struct {
 
 	// 옵션
 	opts ChromedpOptions
+
+	// rate limiter (nil 허용)
+	urlRateLimiter core.URLRateLimiter
 }
 
 // ChromedpOptions: chromedp 크롤러 추가 옵션

--- a/internal/processor/fetcher/implementation/goquery/crawler.go
+++ b/internal/processor/fetcher/implementation/goquery/crawler.go
@@ -9,8 +9,19 @@ import (
 	"issuetracker/pkg/logger"
 )
 
-// NewGoqueryCrawler: 새로운 GoqueryCrawler 인스턴스 생성
+// NewGoqueryCrawler: 새로운 GoqueryCrawler 인스턴스 생성 (rate limiter 없음).
+//
+// production wiring 은 NewGoqueryCrawlerWithRateLimiter 를 사용하여 사이트별 RPH 정책을
+// 강제. 본 생성자는 example / test / 테스트 환경에서 사용.
 func NewGoqueryCrawler(name string, source core.SourceInfo, config core.Config) *GoqueryCrawler {
+	return NewGoqueryCrawlerWithRateLimiter(name, source, config, nil)
+}
+
+// NewGoqueryCrawlerWithRateLimiter: rate limiter 가 주입된 GoqueryCrawler 를 생성합니다.
+//
+// rateLimiter 가 nil 이면 NewGoqueryCrawler 와 동일 (제한 없음). 비-nil 이면 매 fetch 직전
+// rateLimiter.Wait(ctx, url) 호출하여 RPH 정책 강제. ctx cancel 또는 timeout 시 에러 반환.
+func NewGoqueryCrawlerWithRateLimiter(name string, source core.SourceInfo, config core.Config, rateLimiter core.URLRateLimiter) *GoqueryCrawler {
 	return &GoqueryCrawler{
 		name:       name,
 		sourceInfo: source,
@@ -18,6 +29,7 @@ func NewGoqueryCrawler(name string, source core.SourceInfo, config core.Config) 
 		httpClient: &http.Client{
 			Timeout: config.Timeout,
 		},
+		urlRateLimiter: rateLimiter,
 	}
 }
 

--- a/internal/processor/fetcher/implementation/goquery/fetch.go
+++ b/internal/processor/fetcher/implementation/goquery/fetch.go
@@ -13,9 +13,28 @@ import (
 	"issuetracker/pkg/logger"
 )
 
-// Fetch: URL에서 컨텐츠 가져오기
+// Fetch: URL에서 컨텐츠 가져오기.
+//
+// 매 호출 직전 urlRateLimiter.Wait 호출 (limiter 가 주입된 경우) — 사이트별 RPH 정책 강제.
+// limiter 가 nil 이면 즉시 진행 (제한 없음).
 func (c *GoqueryCrawler) Fetch(ctx context.Context, target core.Target) (*core.RawContent, error) {
 	log := logger.FromContext(ctx)
+
+	// 사이트별 rate limiting: 비-nil limiter 만 강제. ctx cancel 시 즉시 에러 전파.
+	// limiter 가 IP 해석 실패 시 graceful degradation (limiter 자체 정책) — 본 호출자는 그냥 전달받음.
+	if c.urlRateLimiter != nil {
+		if err := c.urlRateLimiter.Wait(ctx, target.URL); err != nil {
+			return nil, &core.CrawlerError{
+				Category:  core.ErrCategoryRateLimit,
+				Code:      "RATE_001",
+				Message:   "rate limit wait failed",
+				Source:    c.name,
+				URL:       target.URL,
+				Retryable: true,
+				Err:       err,
+			}
+		}
+	}
 
 	// HTTP 요청
 	req, err := http.NewRequestWithContext(ctx, "GET", target.URL, nil)

--- a/internal/processor/fetcher/implementation/goquery/parse.go
+++ b/internal/processor/fetcher/implementation/goquery/parse.go
@@ -23,7 +23,15 @@ func (c *GoqueryCrawler) FetchAndParse(ctx context.Context, target core.Target, 
 
 	if c.urlRateLimiter != nil {
 		if err := c.urlRateLimiter.Wait(ctx, target.URL); err != nil {
-			return nil, fmt.Errorf("rate limit wait for %s: %w", target.URL, err)
+			return nil, &core.CrawlerError{
+				Category:  core.ErrCategoryRateLimit,
+				Code:      "RATE_001",
+				Message:   "rate limit wait failed",
+				Source:    c.name,
+				URL:       target.URL,
+				Retryable: true,
+				Err:       err,
+			}
 		}
 	}
 

--- a/internal/processor/fetcher/implementation/goquery/parse.go
+++ b/internal/processor/fetcher/implementation/goquery/parse.go
@@ -17,9 +17,15 @@ import (
 )
 
 // FetchAndParse: URL에서 컨텐츠를 가져와서 바로 파싱
-// goquery의 장점을 활용하여 한 번에 처리
+// goquery의 장점을 활용하여 한 번에 처리. Fetch 와 동일하게 limiter 가 주입된 경우 RPH 강제.
 func (c *GoqueryCrawler) FetchAndParse(ctx context.Context, target core.Target, selectors map[string]string) (*core.Content, error) {
 	log := logger.FromContext(ctx)
+
+	if c.urlRateLimiter != nil {
+		if err := c.urlRateLimiter.Wait(ctx, target.URL); err != nil {
+			return nil, fmt.Errorf("rate limit wait for %s: %w", target.URL, err)
+		}
+	}
 
 	// HTTP 요청
 	req, err := http.NewRequestWithContext(ctx, "GET", target.URL, nil)

--- a/internal/processor/fetcher/implementation/goquery/types.go
+++ b/internal/processor/fetcher/implementation/goquery/types.go
@@ -8,9 +8,14 @@ import (
 
 // GoqueryCrawler: goquery 라이브러리 기반 크롤러
 // goquery를 사용하여 HTML 파싱과 크롤링을 동시에 처리
+//
+// urlRateLimiter 가 nil 이 아니면 매 fetch 직전 Wait 를 호출해 사이트별 RPH 정책을 강제합니다.
+// nil 이면 기존 동작과 동일 (제한 없음) — 호출자 (sources/registry) 가 fetcher_rules 의
+// requests_per_hour 가 0 이거나 wiring 단계에서 limiter 없는 환경에 대해 nil 을 주입.
 type GoqueryCrawler struct {
-	name       string
-	sourceInfo core.SourceInfo
-	config     core.Config
-	httpClient *http.Client
+	name           string
+	sourceInfo     core.SourceInfo
+	config         core.Config
+	httpClient     *http.Client
+	urlRateLimiter core.URLRateLimiter
 }

--- a/test/internal/processor/fetcher/implementation/goquery/rate_limit_test.go
+++ b/test/internal/processor/fetcher/implementation/goquery/rate_limit_test.go
@@ -1,0 +1,94 @@
+package goquery_test
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"issuetracker/internal/processor/fetcher/core"
+	gqimpl "issuetracker/internal/processor/fetcher/implementation/goquery"
+)
+
+// recordingLimiter 는 Wait 호출을 카운트하고 선택적으로 에러를 주입하는 테스트 stub.
+// 실 limiter 는 IP 해석 + token bucket 까지 포함하지만, 본 테스트는 fetcher 가 limiter 를
+// 호출하는지 (RPH 미강제 회귀 방지) 만 검증.
+type recordingLimiter struct {
+	calls atomic.Int64
+	err   error
+}
+
+func (r *recordingLimiter) Wait(_ context.Context, _ string) error {
+	r.calls.Add(1)
+	return r.err
+}
+
+// TestFetch_RateLimiterCalled 는 GoqueryCrawler 가 fetch 직전 limiter.Wait 를 호출하는지
+// 검증합니다 — 이슈 #323 회귀 방지 (production wiring 누락 시 silent 우회).
+func TestFetch_RateLimiterCalled(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`<html><body>ok</body></html>`))
+	}))
+	defer srv.Close()
+
+	limiter := &recordingLimiter{}
+	cfg := core.DefaultConfig()
+	cfg.UserAgent = "test-agent"
+	info := core.SourceInfo{Name: "test", Country: "KR", Language: "ko"}
+	crawler := gqimpl.NewGoqueryCrawlerWithRateLimiter("test", info, cfg, limiter)
+
+	_, err := crawler.Fetch(t.Context(), core.Target{URL: srv.URL, Type: core.TargetTypeArticle})
+	require.NoError(t, err)
+
+	assert.Equal(t, int64(1), limiter.calls.Load(), "limiter.Wait 가 정확히 1회 호출되어야 함")
+}
+
+// TestFetch_RateLimiterError_PropagatesAsRateLimitError 는 limiter.Wait 실패 시 fetch 가
+// rate_limit 카테고리 CrawlerError 로 즉시 전파되는지 검증합니다.
+func TestFetch_RateLimiterError_PropagatesAsRateLimitError(t *testing.T) {
+	// 핸들러가 절대 호출되면 안 됨 — limiter 거부 시점에 fetch 가 차단되어야 함.
+	var serverHits atomic.Int64
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		serverHits.Add(1)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	wantErr := errors.New("rate limit refused")
+	limiter := &recordingLimiter{err: wantErr}
+	cfg := core.DefaultConfig()
+	info := core.SourceInfo{Name: "test", Country: "KR", Language: "ko"}
+	crawler := gqimpl.NewGoqueryCrawlerWithRateLimiter("test", info, cfg, limiter)
+
+	_, err := crawler.Fetch(t.Context(), core.Target{URL: srv.URL, Type: core.TargetTypeArticle})
+	require.Error(t, err)
+
+	var ce *core.CrawlerError
+	require.ErrorAs(t, err, &ce, "limiter 에러는 CrawlerError 로 wrap")
+	assert.Equal(t, core.ErrCategoryRateLimit, ce.Category)
+	assert.True(t, errors.Is(err, wantErr), "원본 limiter 에러가 chain 에 보존")
+	assert.Equal(t, int64(0), serverHits.Load(), "limiter 거부 시 실제 HTTP 호출 발생 X")
+}
+
+// TestFetch_NilRateLimiter_BypassesGracefully 는 limiter 가 nil 이면 기존 동작과 동일하게
+// 진행되는지 검증합니다 — example / test 환경 호환성.
+func TestFetch_NilRateLimiter_BypassesGracefully(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`<html><body>ok</body></html>`))
+	}))
+	defer srv.Close()
+
+	cfg := core.DefaultConfig()
+	info := core.SourceInfo{Name: "test", Country: "KR", Language: "ko"}
+	crawler := gqimpl.NewGoqueryCrawler("test", info, cfg) // nil limiter
+
+	_, err := crawler.Fetch(t.Context(), core.Target{URL: srv.URL, Type: core.TargetTypeArticle})
+	require.NoError(t, err)
+}


### PR DESCRIPTION
## 연관 이슈

Closes #323

선행 이슈로서 #322 (dynamic RPH) 도 본 PR 머지 후 재개 가능.

## 구현 내용

라이브 운영 점검 (#322 작업 진입 전 사전 검증) 중 발견된 사전 문제 — \`fetcher_rules.requests_per_hour\` 가 production fetch path 에서 enforce 되지 않는 상태 — 를 해소.

### 1. goquery / chromedp crawler 가 URLRateLimiter 주입 받음 (1번 commit)
- 양쪽 모두 \`urlRateLimiter core.URLRateLimiter\` 필드 + nil 허용
- \`NewGoqueryCrawlerWithRateLimiter\`, \`NewChromedpCrawlerWithRateLimiter\` 생성자 신규
- 기존 \`NewGoqueryCrawler\`, \`NewChromedpCrawlerWithOptions\` 는 nil limiter 로 wrap (backward compat)
- \`Fetch\` / \`FetchAndParse\` 가 limiter.Wait 호출 후 진행
- Wait 실패 시 \`ErrCategoryRateLimit\` CrawlerError 로 wrap (Retryable=true)

### 2. RegisterAll 이 source 별 IPRateLimiterRegistry 생성 + 주입 (2번 commit)
- 공유 \`DNSIPResolver\` (5분 TTL) 1개 — 모든 source 공유
- 각 source 마다 \`IPRateLimiterRegistry\` 생성 (RPH = rec.RequestsPerHour, burst 10 고정)
- \`buildHandler\` 가 동일 limiter 인스턴스를 goquery / chromedp 양쪽에 주입 → 동일 source 의 두 fetcher 가 같은 IP 단위 token bucket 공유
- crawler 등록 로그에 \`burst\` / \`rate_limit (enforced|unlimited)\` 필드 추가

### 3. 회귀 방지 테스트 (3번 commit)
- recordingLimiter stub 으로 fetch 직전 Wait 호출 검증
- 3 케이스: 정상 호출 / 거부 시 차단 + RateLimit 에러 wrap / nil bypass

## 검증

- [x] \`grep -rn 'NewIPRateLimiterRegistry'\` production 호출 1건 추가 (이전 0건 → registry.go:166)
- [x] \`go build ./...\` 통과
- [x] \`go test ./...\` 통과 — 기존 모든 테스트 + 신규 3 케이스 green
- [x] \`go vet\` / \`gofmt\` 깨끗

## 영향 / 위험

**Severity**: Bug fix — 운영 정책 (anti-bot 회피, IP 차단 방어) 가 실제 작동하기 시작.

**위험**:
- **fetch 처리 지연 ↑** (의도된 효과). 라이브 시 burst 10 / RPH 100~200 환경에서 backlog 증가 가능 — 운영 metric (\`rate limit reached, waiting for token\` debug 로그) 으로 모니터링 필요
- **DNS 미해석 fallback**: \`IPRateLimiterRegistry.Wait\` 가 DNS 실패 시 \"proceeding without rate limiting\" warn 로그 남기고 진행 — graceful degradation 이미 구현됨
- **테스트 환경 영향 없음**: 기존 \`NewGoqueryCrawler\` / \`NewChromedpCrawlerWithOptions\` 는 nil limiter 로 wrap — example / test 코드 변경 불필요

## 후속

- #322 (dynamic RPH 반영) — 본 PR 머지 후 재개. SourceConfigResolver + IPRateLimiterRegistry 가 resolver 주입받도록 수정.
- burst 컬럼 동적화는 별도 이슈 후보.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added per-source IP rate limiting across all crawlers to enforce consistent request-per-hour policies
  * Implemented DNS resolver caching for improved performance
  * Enhanced logging to display rate limit enforcement mode and burst configuration values

* **Tests**
  * Added comprehensive test coverage for rate limiting behavior and error handling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->