### PR TITLE
[FEAT#326] claudegen multi-step extraction — 페이지 유효성 / 타입 분류 / 셀렉터 자가 검증

### DIFF
--- a/cmd/issuetracker/main.go
+++ b/cmd/issuetracker/main.go
@@ -143,17 +143,18 @@ func main() {
 	if err != nil {
 		log.WithError(err).Fatal("failed to load blacklist config")
 	}
-	var blacklistMatcher *rule.BlacklistMatcher
+	var (
+		blacklistMatcher *rule.BlacklistMatcher
+		blacklistRepo    storage.BlacklistRepository // llmGen.SetBlacklistRepo 에 전달 (#326).
+	)
 	if blacklistCfg.Enabled {
-		blacklistRepo := pgstore.NewBlacklistRepository(pool, log)
-		bm, bmErr := rule.NewBlacklistMatcher(blacklistRepo)
+		repo := pgstore.NewBlacklistRepository(pool, log)
+		bm, bmErr := rule.NewBlacklistMatcher(repo)
 		if bmErr != nil {
 			log.WithError(bmErr).Fatal("failed to construct blacklist matcher")
 		}
-		// invalidatingBlacklistRepo decorator 는 현재 wiring 하지 않음.
-		// read-only 경로 (Matcher.Filter) 만 사용 — application 측 mutation 경로 부재.
-		// 운영 CLI / 자동 색출 후속 이슈에서 decorator 도입 + 변수 재할당으로 invalidate 결합.
-		// (decorator 코드 자체는 blacklist_matcher.go 에 보존, unit test 로 검증.)
+		// invalidatingBlacklistRepo decorator: claudegen 자동 INSERT (#326) 시 Matcher cache flush.
+		blacklistRepo = storage.WrapBlacklistWithInvalidator(repo, bm)
 		blacklistMatcher = bm
 		log.Info("page-parse blacklist enabled (parsing_blacklist DB-backed)")
 	} else {
@@ -585,6 +586,14 @@ func main() {
 			claudegenWorker = worker
 			log.Info("llmgen: Claude Code 웜 컨테이너 추출기 활성화")
 		}
+	}
+
+	// claudegen 의 EnrichedExtractor 분기에서 페이지를 blacklist 로 판정 시 자동 등록할
+	// repository 주입 (#326). blacklistRepo 가 nil (BLACKLIST_ENABLED=false) 이면
+	// Generator 내부 분기가 셀렉터 INSERT skip 만 보장.
+	if blacklistRepo != nil && llmGen != nil {
+		llmGen.SetBlacklistRepo(blacklistRepo)
+		log.Info("llmgen: 자동 blacklist 등록 활성화 (claudegen multi-step extraction)")
 	}
 
 	// ── Refiner ──────────────────────────────────────────

--- a/internal/processor/parser/rule/claudegen/worker.go
+++ b/internal/processor/parser/rule/claudegen/worker.go
@@ -31,9 +31,11 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync"
 	"time"
 
+	"issuetracker/internal/processor/parser/rule/llmgen"
 	"issuetracker/internal/storage"
 	"issuetracker/pkg/llm/prompt"
 	"issuetracker/pkg/logger"
@@ -308,13 +310,35 @@ func (w *ClaudeWorker) Stop(ctx context.Context) error {
 
 // Extract 는 실행 중인 컨테이너에 새 세션을 생성해 CSS 셀렉터를 추출합니다.
 //
+// 본 메소드는 SelectorExtractor 인터페이스 호환성을 위한 thin wrapper —
+// 내부적으로 ExtractEnriched 를 호출하고 Selectors 만 반환합니다.
+// Blacklist 결정은 무시 (호출자가 ExtractEnriched 직접 호출하도록 권장).
+//
+// llmgen.Generator 는 EnrichedExtractor 인터페이스 type assertion 으로 자동 분기 —
+// claudegen.ClaudeWorker 는 두 인터페이스 모두 구현.
+func (w *ClaudeWorker) Extract(ctx context.Context, host string, targetType storage.TargetType, html string) (storage.SelectorMap, error) {
+	res, err := w.ExtractEnriched(ctx, host, targetType, html)
+	if err != nil {
+		return storage.SelectorMap{}, err
+	}
+	if res.Blacklist != nil {
+		return storage.SelectorMap{}, fmt.Errorf("page blacklisted: %s", res.Blacklist.Reason)
+	}
+	return res.Selectors, nil
+}
+
+// ExtractEnriched 는 multi-step 추출을 수행합니다 — 페이지 유효성 / 타입 / 셀렉터 + 자가 검증.
+//
 // 실행 흐름:
 //  1. 세션 고유 디렉토리 생성 (workDir/<sessionID>/)
 //  2. page.html 기록
 //  3. docker exec <containerID> claude --model ... -p <prompt>
-//  4. stdout JSON 파싱 → SelectorMap 반환
+//  4. stdout JSON 파싱 → ExtractResult (validity / page_type / selectors / self_check)
 //  5. 세션 디렉토리 정리 (defer)
-func (w *ClaudeWorker) Extract(ctx context.Context, host string, targetType storage.TargetType, html string) (storage.SelectorMap, error) {
+//
+// validity == "blacklist" 면 ExtractResult.Blacklist 비-nil — 호출자가 셀렉터 INSERT skip
+// + parsing_blacklist Upsert 분기. Selectors / PageType 은 의미 없음.
+func (w *ClaudeWorker) ExtractEnriched(ctx context.Context, host string, targetType storage.TargetType, html string) (*llmgen.ExtractResult, error) {
 	// wg.Add 를 락 획득보다 먼저 수행 — Stop() 의 wg.Wait() 이 이 Extract 호출을 놓치지 않도록 함.
 	w.wg.Add(1)
 	defer w.wg.Done()
@@ -325,22 +349,22 @@ func (w *ClaudeWorker) Extract(ctx context.Context, host string, targetType stor
 	w.mu.RUnlock()
 
 	if containerID == "" {
-		return storage.SelectorMap{}, errors.New("claudegen: worker not started — call Start() first")
+		return nil, errors.New("claudegen: worker not started — call Start() first")
 	}
 
 	sessionID, err := newSessionID()
 	if err != nil {
-		return storage.SelectorMap{}, fmt.Errorf("generate session id: %w", err)
+		return nil, fmt.Errorf("generate session id: %w", err)
 	}
 
 	sessionHostDir := filepath.Join(workDir, sessionID)
 	if err := os.MkdirAll(sessionHostDir, 0o755); err != nil {
-		return storage.SelectorMap{}, fmt.Errorf("create session dir: %w", err)
+		return nil, fmt.Errorf("create session dir: %w", err)
 	}
 	defer os.RemoveAll(sessionHostDir)
 
 	if err := os.WriteFile(filepath.Join(sessionHostDir, "page.html"), []byte(html), 0o644); err != nil {
-		return storage.SelectorMap{}, fmt.Errorf("write html: %w", err)
+		return nil, fmt.Errorf("write html: %w", err)
 	}
 
 	sessionContainerPath := "/workspace/" + sessionID
@@ -350,7 +374,7 @@ func (w *ClaudeWorker) Extract(ctx context.Context, host string, targetType stor
 
 	promptText, err := buildPrompt(w.loader, host, targetType, sessionContainerPath)
 	if err != nil {
-		return storage.SelectorMap{}, fmt.Errorf("build claudegen prompt: %w", err)
+		return nil, fmt.Errorf("build claudegen prompt: %w", err)
 	}
 	args := []string{
 		"claude",
@@ -369,29 +393,40 @@ func (w *ClaudeWorker) Extract(ctx context.Context, host string, targetType stor
 
 	stdout, stderr, err := w.runner.ExecSession(runCtx, containerID, args)
 	if err != nil {
-		return storage.SelectorMap{}, fmt.Errorf("claude code exec session: %w (stderr: %s)",
+		return nil, fmt.Errorf("claude code exec session: %w (stderr: %s)",
 			err, truncate(stderr, truncateStderrLen))
 	}
 
-	sm, err := parseSelectorOutput(stdout)
+	res, err := parseEnrichedOutput(stdout)
 	if err != nil {
 		w.log.WithFields(map[string]interface{}{
 			"host":        host,
 			"target_type": string(targetType),
 			"raw_output":  truncate(stdout, truncateStdoutLen),
 		}).Debug("claude code session output parse failed")
-		return storage.SelectorMap{}, fmt.Errorf("parse claude output: %w", err)
+		return nil, fmt.Errorf("parse claude output: %w", err)
 	}
 
-	w.log.WithFields(map[string]interface{}{
+	logFields := map[string]interface{}{
 		"host":        host,
 		"target_type": string(targetType),
-	}).Info("claude code session extraction succeeded")
+	}
+	if res.Blacklist != nil {
+		logFields["blacklist_reason"] = res.Blacklist.Reason
+		w.log.WithFields(logFields).Info("claude code session marked page as blacklist")
+	} else {
+		logFields["page_type"] = string(res.PageType)
+		logFields["page_type_confidence"] = res.PageTypeConfidence
+		w.log.WithFields(logFields).Info("claude code session extraction succeeded")
+	}
 
-	return sm, nil
+	return res, nil
 }
 
 // parseSelectorOutput 은 Claude Code 출력에서 JSON 블록을 추출하고 SelectorMap 으로 파싱합니다.
+//
+// Deprecated: 새 prompt schema 는 enriched output 을 사용합니다 — parseEnrichedOutput 사용.
+// 본 함수는 ExtractEnriched 가 unmarshal 실패 시 SelectorMap-only legacy fallback 으로 사용.
 func parseSelectorOutput(output string) (storage.SelectorMap, error) {
 	jsonStr := extractJSON(output)
 	if jsonStr == "" {
@@ -402,6 +437,65 @@ func parseSelectorOutput(output string) (storage.SelectorMap, error) {
 		return storage.SelectorMap{}, fmt.Errorf("unmarshal selector map: %w", err)
 	}
 	return sm, nil
+}
+
+// enrichedOutput 은 새 prompt schema 의 응답 구조 (claudegen multi-step extraction).
+//
+// validity == "blacklist" 일 때 selectors / self_check 는 비어있을 수 있음 — Generator 의
+// 호출자가 Blacklist 분기로 즉시 진입하므로 의미 없음.
+type enrichedOutput struct {
+	Validity           string              `json:"validity"`
+	BlacklistReason    string              `json:"blacklist_reason"`
+	PageType           string              `json:"page_type"`
+	PageTypeConfidence float64             `json:"page_type_confidence"`
+	Selectors          storage.SelectorMap `json:"selectors"`
+	// SelfCheck 는 운영 진단용 — 본 worker 는 currently 무시 (호출자가 metrics / 로그에 활용 가능).
+	// 향후 self_check.warnings 가 있으면 LLM 재시도 trigger 로 사용 가능.
+	SelfCheck json.RawMessage `json:"self_check,omitempty"`
+}
+
+// parseEnrichedOutput 은 새 schema 응답을 ExtractResult 로 변환합니다.
+//
+// validity == "blacklist" → ExtractResult.Blacklist 비-nil, 다른 필드는 의미 없음.
+// validity == "ok" → Selectors / PageType 정상 채움. Blacklist == nil.
+// validity 가 빈 문자열 / 미인식 값 → legacy SelectorMap-only output 으로 간주하고 재파싱.
+func parseEnrichedOutput(output string) (*llmgen.ExtractResult, error) {
+	jsonStr := extractJSON(output)
+	if jsonStr == "" {
+		return nil, fmt.Errorf("no JSON object found in output")
+	}
+
+	var eo enrichedOutput
+	if err := json.Unmarshal([]byte(jsonStr), &eo); err != nil {
+		return nil, fmt.Errorf("unmarshal enriched output: %w", err)
+	}
+
+	switch eo.Validity {
+	case "blacklist":
+		reason := strings.TrimSpace(eo.BlacklistReason)
+		if reason == "" {
+			reason = "(no reason provided)"
+		}
+		return &llmgen.ExtractResult{
+			Blacklist: &llmgen.BlacklistDecision{Reason: reason},
+		}, nil
+	case "ok":
+		return &llmgen.ExtractResult{
+			Selectors:          eo.Selectors,
+			PageType:           llmgen.PageType(eo.PageType),
+			PageTypeConfidence: eo.PageTypeConfidence,
+		}, nil
+	case "":
+		// Schema 가 채워지지 않았거나 LLM 이 여전히 legacy SelectorMap-only 를 반환한 경우.
+		// 같은 JSON 을 SelectorMap 으로 재파싱 시도 — backward compat fallback.
+		var sm storage.SelectorMap
+		if err := json.Unmarshal([]byte(jsonStr), &sm); err != nil {
+			return nil, fmt.Errorf("validity field missing and not a legacy selector map: %w", err)
+		}
+		return &llmgen.ExtractResult{Selectors: sm}, nil
+	default:
+		return nil, fmt.Errorf("unrecognized validity %q (expected ok|blacklist)", eo.Validity)
+	}
 }
 
 // extractJSON 은 출력 텍스트에서 첫 번째 유효한 {...} JSON 블록을 추출합니다.

--- a/internal/processor/parser/rule/claudegen/worker.go
+++ b/internal/processor/parser/rule/claudegen/worker.go
@@ -466,7 +466,7 @@ func parseEnrichedOutput(output string) (*llmgen.ExtractResult, error) {
 	case "ok":
 		return &llmgen.ExtractResult{
 			Selectors:          eo.Selectors,
-			PageType:           llmgen.PageType(eo.PageType),
+			PageType:           normalizePageType(eo.PageType),
 			PageTypeConfidence: eo.PageTypeConfidence,
 		}, nil
 	case "":
@@ -551,4 +551,39 @@ func truncate(s string, n int) string {
 		count++
 	}
 	return s
+}
+
+// knownPageTypes 는 prompt schema 에 명시된 valid page_type 집합입니다 (CodeRabbit Major 반영).
+//
+// LLM 응답이 prompt 명세를 벗어나면 (예: "News" 대문자, "news_article" 등 변종) silent 하게
+// parsing_rules.page_type 에 들어가 분류 통계가 오염될 수 있어 정규화 + 허용 set 검증.
+//
+// 동의어 매핑: 잘 알려진 변종은 표준 PageType 으로 매핑. 모르는 값은 빈 문자열 (Unspecified)
+// 로 fall-back — rule INSERT 자체는 막지 않음 (selector 가 정상이면 분류만 미상태로 저장).
+var knownPageTypes = map[string]llmgen.PageType{
+	"news":         llmgen.PageTypeNews,
+	"news_article": llmgen.PageTypeNews,
+	"article":      llmgen.PageTypeNews,
+	"community":    llmgen.PageTypeCommunity,
+	"forum":        llmgen.PageTypeCommunity,
+	"info":         llmgen.PageTypeInfo,
+	"information":  llmgen.PageTypeInfo,
+	"wiki":         llmgen.PageTypeInfo,
+	"commercial":   llmgen.PageTypeCommercial,
+	"shopping":     llmgen.PageTypeCommercial,
+	"product":      llmgen.PageTypeCommercial,
+	"paper":        llmgen.PageTypePaper,
+	"academic":     llmgen.PageTypePaper,
+	"research":     llmgen.PageTypePaper,
+	"other":        llmgen.PageTypeOther,
+}
+
+// normalizePageType 은 LLM 응답의 page_type 문자열을 prompt schema 의 valid set 으로
+// 정규화합니다. 동의어 / 대소문자 변종 흡수, 미인식 값은 PageTypeUnspecified.
+func normalizePageType(raw string) llmgen.PageType {
+	key := strings.ToLower(strings.TrimSpace(raw))
+	if pt, ok := knownPageTypes[key]; ok {
+		return pt
+	}
+	return llmgen.PageTypeUnspecified
 }

--- a/internal/processor/parser/rule/claudegen/worker.go
+++ b/internal/processor/parser/rule/claudegen/worker.go
@@ -423,22 +423,6 @@ func (w *ClaudeWorker) ExtractEnriched(ctx context.Context, host string, targetT
 	return res, nil
 }
 
-// parseSelectorOutput 은 Claude Code 출력에서 JSON 블록을 추출하고 SelectorMap 으로 파싱합니다.
-//
-// Deprecated: 새 prompt schema 는 enriched output 을 사용합니다 — parseEnrichedOutput 사용.
-// 본 함수는 ExtractEnriched 가 unmarshal 실패 시 SelectorMap-only legacy fallback 으로 사용.
-func parseSelectorOutput(output string) (storage.SelectorMap, error) {
-	jsonStr := extractJSON(output)
-	if jsonStr == "" {
-		return storage.SelectorMap{}, fmt.Errorf("no JSON object found in output")
-	}
-	var sm storage.SelectorMap
-	if err := json.Unmarshal([]byte(jsonStr), &sm); err != nil {
-		return storage.SelectorMap{}, fmt.Errorf("unmarshal selector map: %w", err)
-	}
-	return sm, nil
-}
-
 // enrichedOutput 은 새 prompt schema 의 응답 구조 (claudegen multi-step extraction).
 //
 // validity == "blacklist" 일 때 selectors / self_check 는 비어있을 수 있음 — Generator 의

--- a/internal/processor/parser/rule/llmgen/extractor.go
+++ b/internal/processor/parser/rule/llmgen/extractor.go
@@ -1,0 +1,71 @@
+package llmgen
+
+import (
+	"context"
+
+	"issuetracker/internal/storage"
+)
+
+// PageType 은 LLM 이 추출한 페이지의 도메인 분류입니다.
+//
+// 본 분류는 정보 신뢰도 시스템 (별도 후속 이슈) 의 1차 입력으로 사용됩니다 —
+// news / paper 는 높은 신뢰도, commercial 은 낮은 신뢰도 weight 등으로 매핑.
+//
+// 새 분류는 추가될 수 있는 확장 지점 — 본 패키지는 string 으로 받아 storage 에 그대로 저장,
+// 검증은 application 측 (운영자가 잘못된 분류를 후처리로 정정 가능).
+type PageType string
+
+const (
+	PageTypeNews        PageType = "news"       // 보도/저널리즘
+	PageTypeCommunity   PageType = "community"  // 게시판/포럼
+	PageTypeInfo        PageType = "info"       // 위키/공식 가이드/문서
+	PageTypeCommercial  PageType = "commercial" // 쇼핑/홍보
+	PageTypePaper       PageType = "paper"      // 학술/논문
+	PageTypeOther       PageType = "other"      // 기타
+	PageTypeUnspecified PageType = ""           // 미분류 (legacy / Extract 경로)
+)
+
+// BlacklistDecision 은 LLM 이 페이지를 \"파싱에 부적합\" 으로 판단했을 때의 결정입니다.
+//
+// 호출자 (Generator) 가 본 결정을 받으면 셀렉터 INSERT 를 skip 하고 parsing_blacklist 에
+// source='auto' 로 등록 — 동일 host+path 가 다음 사이클에서 fetch / parse 되지 않음.
+type BlacklistDecision struct {
+	// Reason 은 운영자가 사후 분류 / 검증할 수 있도록 한국어로 작성된 사유.
+	// parsing_blacklist.reason 컬럼에 그대로 저장.
+	Reason string
+}
+
+// ExtractResult 는 EnrichedExtractor 의 다단계 추출 결과입니다.
+//
+// Blacklist != nil 인 경우 Selectors / PageType 은 의미 없음 — 호출자는 Blacklist 분기로
+// 즉시 넘어가야 함. Blacklist == nil 이면 Selectors 가 정상 추출 결과 + PageType 메타데이터.
+type ExtractResult struct {
+	// Selectors: target_type 별 추출된 CSS 셀렉터 맵. Blacklist != nil 이면 비어있을 수 있음.
+	Selectors storage.SelectorMap
+
+	// PageType: 페이지 도메인 분류. 빈 문자열이면 미분류. Blacklist != nil 이면 의미 없음.
+	PageType PageType
+
+	// PageTypeConfidence: 0.0 ~ 1.0 — LLM 의 자기 보고 신뢰도. 운영자가 낮은 confidence 를
+	// 사후 검토 trigger 로 사용 가능.
+	PageTypeConfidence float64
+
+	// Blacklist: 페이지가 파싱 부적합 (광고 / interstitial / 빈 페이지 등) 일 때 비-nil.
+	// nil 이면 정상 추출 결과로 분기.
+	Blacklist *BlacklistDecision
+}
+
+// EnrichedExtractor 는 SelectorExtractor 의 multi-step 확장 인터페이스입니다.
+//
+// SelectorExtractor 는 셀렉터만 반환하는 단일 분기였으나, 본 인터페이스는 다음 3가지 단계를
+// 통합:
+//  1. 페이지 유효성 판정 (광고 / 빈 페이지 등 → blacklist)
+//  2. 페이지 타입 분류 (news / community / ...)
+//  3. 셀렉터 추출 (기존 동작)
+//
+// claudegen 등 multi-turn agent 능력이 풍부한 backend 가 본 인터페이스를 구현. Gemini Flash
+// 등 단순 provider 는 SelectorExtractor 만 구현 — Generator 가 인터페이스 type assertion 으로
+// 자동 분기.
+type EnrichedExtractor interface {
+	ExtractEnriched(ctx context.Context, host string, targetType storage.TargetType, html string) (*ExtractResult, error)
+}

--- a/internal/processor/parser/rule/llmgen/generator.go
+++ b/internal/processor/parser/rule/llmgen/generator.go
@@ -26,6 +26,8 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"net/url"
+	"regexp"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -120,12 +122,13 @@ type Generator struct {
 	// nil 이면 호출 안 함.
 	validateFailureHandler func(context.Context, core.RawContentRef, int, storage.TargetType, string)
 
-	locker       storage.InflightLocker // 기본: memInflightLocker, Redis 활성 시: RedisInflightLocker
-	pendingQueue storage.PendingQueue   // nil 이면 pending URL 보존 비활성
-	requeueFn    RequeueFunc            // nil 이면 재투입 비활성
-	semValidator SelectorValidator      // nil 이면 의미 검증 건너뜀
-	wg           sync.WaitGroup
-	stopped      atomic.Bool
+	locker        storage.InflightLocker      // 기본: memInflightLocker, Redis 활성 시: RedisInflightLocker
+	pendingQueue  storage.PendingQueue        // nil 이면 pending URL 보존 비활성
+	requeueFn     RequeueFunc                 // nil 이면 재투입 비활성
+	semValidator  SelectorValidator           // nil 이면 의미 검증 건너뜀
+	blacklistRepo storage.BlacklistRepository // nil 이면 자동 blacklist 등록 skip (#326)
+	wg            sync.WaitGroup
+	stopped       atomic.Bool
 }
 
 // SetValidateFailureHandler 는 selector 검증 실패 시 호출할 콜백을 등록합니다.
@@ -165,6 +168,15 @@ func (g *Generator) SetSelectorValidator(v SelectorValidator) {
 // Stop 전에 설정해야 하며, goroutine-safe 하지 않으므로 초기화 시 1회만 호출합니다.
 func (g *Generator) SetExtractor(e SelectorExtractor) {
 	g.extractor = e
+}
+
+// SetBlacklistRepo 는 EnrichedExtractor 가 페이지를 blacklist 로 판정했을 때 등록할
+// repository 를 등록합니다 (#326). nil 이면 blacklist 자동 등록 skip — Generator 는 셀렉터
+// INSERT 만 skip 하고 다음 흐름 진행 (LLM retry 가능).
+//
+// Stop 전에 설정해야 하며, goroutine-safe 하지 않으므로 초기화 시 1회만 호출합니다.
+func (g *Generator) SetBlacklistRepo(r storage.BlacklistRepository) {
+	g.blacklistRepo = r
 }
 
 // New 는 Generator 를 생성합니다.
@@ -477,20 +489,40 @@ func (g *Generator) runOnce(ctx context.Context, host string, targetType storage
 	var (
 		selectors storage.SelectorMap
 		modelName string
+		pageType  string // EnrichedExtractor 모드에서 채워짐. legacy 경로는 "" (미분류).
 	)
 
 	if g.extractor != nil {
-		// Claude Code 웜 컨테이너 추출 경로
-		sm, err := g.extractor.Extract(ctx, host, targetType, html)
-		if err != nil {
-			return fmt.Errorf("claude code extractor: %w", err)
-		}
-		selectors = sm
-		// 추출기가 ModelName() 을 구현하면 실제 모델 ID 를 사용, 없으면 fallback.
-		if mn, ok := g.extractor.(modelNamer); ok {
-			modelName = mn.ModelName()
+		// EnrichedExtractor (claudegen multi-step) 우선 — type assertion 으로 자동 분기.
+		if enriched, ok := g.extractor.(EnrichedExtractor); ok {
+			res, err := enriched.ExtractEnriched(ctx, host, targetType, html)
+			if err != nil {
+				return fmt.Errorf("claude code extractor: %w", err)
+			}
+			// validity == "blacklist" 분기 — 셀렉터 INSERT skip + 자동 blacklist 등록.
+			if res.Blacklist != nil {
+				g.handleBlacklistDecision(ctx, host, sampleURL, targetType, res.Blacklist)
+				return nil
+			}
+			selectors = res.Selectors
+			pageType = string(res.PageType)
+			if mn, ok := g.extractor.(modelNamer); ok {
+				modelName = mn.ModelName()
+			} else {
+				modelName = "claude-code"
+			}
 		} else {
-			modelName = "claude-code"
+			// legacy SelectorExtractor — Blacklist 분기 없음, page_type 도 빈 문자열.
+			sm, err := g.extractor.Extract(ctx, host, targetType, html)
+			if err != nil {
+				return fmt.Errorf("claude code extractor: %w", err)
+			}
+			selectors = sm
+			if mn, ok := g.extractor.(modelNamer); ok {
+				modelName = mn.ModelName()
+			} else {
+				modelName = "claude-code"
+			}
 		}
 	} else {
 		// 기존 LLM provider 경로 (Gemini Flash 등)
@@ -553,6 +585,7 @@ func (g *Generator) runOnce(ctx context.Context, host string, targetType storage
 		Selectors:   selectors,
 		Confidence:  confidence,
 		Description: fmt.Sprintf("%s (sample url: %s, model: %s)", llmAutoDescription, sampleURL, modelName),
+		PageType:    pageType, // EnrichedExtractor 모드에서만 채워짐 — legacy 경로는 "" (미분류, #326).
 	}
 	var insertErr error
 	if stale {
@@ -654,4 +687,60 @@ func selectorMatches(doc *goquery.Document, fs *storage.FieldSelector) bool {
 		return false
 	}
 	return doc.Find(fs.CSS).Length() > 0
+}
+
+// handleBlacklistDecision 은 EnrichedExtractor 가 페이지를 blacklist 로 판정했을 때 호출됩니다.
+//
+// blacklistRepo 가 비-nil 이면 sampleURL 의 path 를 정확 일치 regex (escape + ^/$ anchor) 로
+// parsing_blacklist 에 INSERT — 동일 URL 만 차단, 같은 host 의 다른 path 는 영향 없음.
+// 운영자가 후속으로 host-level catch-all 등 정책 widening 가능.
+//
+// 모든 실패 (blacklistRepo nil / Insert 에러 / ErrDuplicate) 는 non-fatal — 호출자는
+// 셀렉터 INSERT skip 만 보장하고 다음 흐름 진행. ErrDuplicate 는 같은 URL 이 이미 등록됨 — 정상.
+func (g *Generator) handleBlacklistDecision(ctx context.Context, host, sampleURL string, targetType storage.TargetType, decision *BlacklistDecision) {
+	logFields := map[string]interface{}{
+		"host":             host,
+		"sample_url":       sampleURL,
+		"target_type":      string(targetType),
+		"blacklist_reason": decision.Reason,
+	}
+
+	if g.blacklistRepo == nil {
+		g.log.WithFields(logFields).Info("page judged as blacklist by LLM but blacklistRepo not wired — selector insert skipped only")
+		return
+	}
+
+	pathPattern := pathPatternFromURL(sampleURL)
+	rec := &storage.BlacklistRecord{
+		HostPattern: host,
+		PathPattern: pathPattern,
+		Reason:      decision.Reason,
+		Source:      storage.BlacklistSourceAuto,
+		Mode:        storage.BlacklistModeDrop,
+		Enabled:     true,
+	}
+	if err := g.blacklistRepo.Insert(ctx, rec); err != nil {
+		if errors.Is(err, storage.ErrDuplicate) {
+			g.log.WithFields(logFields).Info("page already in blacklist — selector insert skipped")
+			return
+		}
+		// Insert 실패는 non-fatal — 셀렉터 INSERT 는 어쨌든 skip.
+		g.log.WithFields(logFields).WithError(err).Warn("blacklist insert failed (non-fatal — selector insert still skipped)")
+		return
+	}
+	logFields["blacklist_id"] = rec.ID
+	g.log.WithFields(logFields).Info("page auto-blacklisted by LLM, selector insert skipped")
+}
+
+// pathPatternFromURL 은 sampleURL 의 path 부분을 RE2 regex 로 escape 한 anchor pattern 을
+// 반환합니다. parsing_blacklist 의 path_pattern 컬럼에 사용 — 정확히 동일한 URL 만 매칭.
+//
+// URL parse 실패 시 빈 문자열 반환 — host-level catch-all 효과 (host 단위 차단). 보수적으로
+// 의도된 fallback (LLM 이 이 호스트의 페이지를 bad 로 판정했으므로 host 전체 차단도 합리).
+func pathPatternFromURL(sampleURL string) string {
+	u, err := url.Parse(sampleURL)
+	if err != nil || u.Path == "" {
+		return ""
+	}
+	return "^" + regexp.QuoteMeta(u.Path) + "$"
 }

--- a/internal/processor/parser/rule/llmgen/generator.go
+++ b/internal/processor/parser/rule/llmgen/generator.go
@@ -97,6 +97,17 @@ func (e *selectorValidationError) Error() string {
 }
 func (e *selectorValidationError) Unwrap() error { return e.cause }
 
+// errBlacklistedNoRule 는 EnrichedExtractor 가 페이지를 blacklist 로 판정해 셀렉터 INSERT 를
+// skip 한 경우 runOnce 가 반환하는 sentinel error 입니다 (CodeRabbit Major 반영).
+//
+// 본 에러는 Enqueue goroutine 에서 정상 분기 (룰 생성 성공 → pendingQueue.Flush) 와 구분
+// 하기 위한 전용 신호. blacklist 로 판정된 host 는 새 룰이 없으므로 pending 큐에 쌓인 URL
+// 들도 fetch 시 ErrNoRule 로 다시 LLM 호출 → 또 blacklist → 무한 루프 발생을 방지하기 위해
+// pendingQueue flush 를 skip.
+//
+// 호출자는 errors.Is 로 식별 — 다른 에러 (LLM API 실패, JSON 파싱 등) 와 분리.
+var errBlacklistedNoRule = errors.New("llmgen: page blacklisted, no rule generated")
+
 // Generator 는 host 별 parsing rule 을 LLM 으로 자동 생성합니다.
 //
 // goroutine-safe — provider / repo / resolver 가 자체 thread-safety 를 가짐.
@@ -338,6 +349,16 @@ func (g *Generator) enqueueImpl(ctx context.Context, host string, targetType sto
 
 		err := g.runOnce(bgCtx, host, targetType, urlSnapshot, htmlSnapshot, stale)
 		if err != nil {
+			// blacklist sentinel 은 normal completion — pending flush skip 만 하고 logging 도 별도.
+			if errors.Is(err, errBlacklistedNoRule) {
+				logger.FromContext(bgCtx).WithFields(map[string]interface{}{
+					"host":        host,
+					"target_type": string(targetType),
+					"url":         urlSnapshot,
+				}).Info("llmgen page blacklisted, pending flush skipped")
+				return
+			}
+
 			logger.FromContext(bgCtx).WithFields(map[string]interface{}{
 				"host":        host,
 				"target_type": string(targetType),
@@ -500,9 +521,11 @@ func (g *Generator) runOnce(ctx context.Context, host string, targetType storage
 				return fmt.Errorf("claude code extractor: %w", err)
 			}
 			// validity == "blacklist" 분기 — 셀렉터 INSERT skip + 자동 blacklist 등록.
+			// errBlacklistedNoRule sentinel 반환 — 정상 룰 생성 분기와 구분되어 호출자가
+			// pendingQueue flush 를 skip (무한 루프 방지).
 			if res.Blacklist != nil {
 				g.handleBlacklistDecision(ctx, host, sampleURL, targetType, res.Blacklist)
-				return nil
+				return errBlacklistedNoRule
 			}
 			selectors = res.Selectors
 			pageType = string(res.PageType)
@@ -711,6 +734,13 @@ func (g *Generator) handleBlacklistDecision(ctx context.Context, host, sampleURL
 	}
 
 	pathPattern := pathPatternFromURL(sampleURL)
+	if pathPattern == "" {
+		// URL parse 실패 — host-wide catch-all 회피 (CodeRabbit Major 반영).
+		// 빈 path_pattern 은 host 전체 차단 효과인데, 단일 malformed URL 만 보고 host 전체를
+		// 차단하는 건 over-reach. 운영자 manual 등록 경로로 위임.
+		g.log.WithFields(logFields).Warn("blacklist insert skipped — sample URL parse failed (host-wide catch-all 회피)")
+		return
+	}
 	rec := &storage.BlacklistRecord{
 		HostPattern: host,
 		PathPattern: pathPattern,
@@ -735,12 +765,20 @@ func (g *Generator) handleBlacklistDecision(ctx context.Context, host, sampleURL
 // pathPatternFromURL 은 sampleURL 의 path 부분을 RE2 regex 로 escape 한 anchor pattern 을
 // 반환합니다. parsing_blacklist 의 path_pattern 컬럼에 사용 — 정확히 동일한 URL 만 매칭.
 //
-// URL parse 실패 시 빈 문자열 반환 — host-level catch-all 효과 (host 단위 차단). 보수적으로
-// 의도된 fallback (LLM 이 이 호스트의 페이지를 bad 로 판정했으므로 host 전체 차단도 합리).
+// 정책 (CodeRabbit Major 반영):
+//   - URL parse 실패 → "" 반환 (호출자가 insert skip)
+//   - 정상 parse + 빈 path (예: https://example.com) → "/" 로 normalize → "^/$" pattern
+//     (이전: "" 반환으로 host-wide catch-all 이 되어 단일 root URL blacklist 가 host 전체
+//     차단 — 의도되지 않은 over-reach)
+//   - 정상 parse + non-empty path → "^<escaped>$"
 func pathPatternFromURL(sampleURL string) string {
 	u, err := url.Parse(sampleURL)
-	if err != nil || u.Path == "" {
+	if err != nil {
 		return ""
 	}
-	return "^" + regexp.QuoteMeta(u.Path) + "$"
+	path := u.Path
+	if path == "" {
+		path = "/"
+	}
+	return "^" + regexp.QuoteMeta(path) + "$"
 }

--- a/internal/storage/parsing_rule.go
+++ b/internal/storage/parsing_rule.go
@@ -148,8 +148,16 @@ type ParsingRuleRecord struct {
 	// validator 는 보수적 default 정책 (모든 필드 reliable 가정) 적용.
 	Confidence  map[string]FieldConfidence
 	Description string
-	CreatedAt   time.Time
-	UpdatedAt   time.Time
+
+	// PageType 은 페이지 도메인 분류입니다 (news/community/info/commercial/paper/other).
+	//
+	// claudegen multi-step extraction 이 LLM 응답에서 추출 (이슈 #326). 빈 문자열은 미분류 —
+	// non-claudegen 경로 (Gemini Flash 등) 또는 운영자 manual 등록 룰. 정보 신뢰도 시스템
+	// (별도 후속 이슈) 의 1차 입력.
+	PageType string
+
+	CreatedAt time.Time
+	UpdatedAt time.Time
 }
 
 // FieldConfidence 는 단일 필드의 추출 신뢰도.

--- a/internal/storage/postgres/parsing_rule.go
+++ b/internal/storage/postgres/parsing_rule.go
@@ -34,9 +34,9 @@ func NewParsingRuleRepository(pool *pgxpool.Pool, log *logger.Logger) storage.Pa
 
 const sqlInsertParsingRule = `
 INSERT INTO parsing_rules (
-  source_name, host_pattern, path_pattern, target_type, version, enabled, selectors, confidence, description
+  source_name, host_pattern, path_pattern, target_type, version, enabled, selectors, confidence, description, page_type
 ) VALUES (
-  $1, $2, $3, $4, $5, $6, $7, $8, $9
+  $1, $2, $3, $4, $5, $6, $7, $8, $9, $10
 )
 RETURNING id, created_at, updated_at
 `
@@ -68,7 +68,7 @@ func (r *pgParsingRuleRepository) Insert(ctx context.Context, rec *storage.Parsi
 	}
 	row := r.pool.QueryRow(ctx, sqlInsertParsingRule,
 		rec.SourceName, rec.HostPattern, rec.PathPattern, string(rec.TargetType), rec.Version,
-		rec.Enabled, selectors, confidence, rec.Description,
+		rec.Enabled, selectors, confidence, rec.Description, rec.PageType,
 	)
 	if err := row.Scan(&rec.ID, &rec.CreatedAt, &rec.UpdatedAt); err != nil {
 		var pgErr *pgconn.PgError
@@ -151,7 +151,7 @@ func (r *pgParsingRuleRepository) UpdatePathPattern(ctx context.Context, id int6
 }
 
 const sqlGetParsingRuleByID = `
-SELECT id, source_name, host_pattern, path_pattern, target_type, version, enabled, selectors, confidence, description, created_at, updated_at
+SELECT id, source_name, host_pattern, path_pattern, target_type, version, enabled, selectors, confidence, description, page_type, created_at, updated_at
 FROM parsing_rules
 WHERE id = $1
 `
@@ -170,7 +170,7 @@ func (r *pgParsingRuleRepository) GetByID(ctx context.Context, id int64) (*stora
 }
 
 const sqlFindParsingRuleByNaturalKey = `
-SELECT id, source_name, host_pattern, path_pattern, target_type, version, enabled, selectors, confidence, description, created_at, updated_at
+SELECT id, source_name, host_pattern, path_pattern, target_type, version, enabled, selectors, confidence, description, page_type, created_at, updated_at
 FROM parsing_rules
 WHERE source_name  = $1
   AND host_pattern = $2
@@ -261,7 +261,7 @@ func (r *pgParsingRuleRepository) HasAnyRule(ctx context.Context, hostPattern st
 //   - LENGTH(path_pattern) DESC : 더 구체적인 (긴) regex 패턴 우선 (path_pattern=” 은 길이 0 으로 마지막)
 //   - version DESC             : 같은 패턴 안에서 최신 버전 우선
 const sqlFindActiveCandidates = `
-SELECT id, source_name, host_pattern, path_pattern, target_type, version, enabled, selectors, confidence, description, created_at, updated_at
+SELECT id, source_name, host_pattern, path_pattern, target_type, version, enabled, selectors, confidence, description, page_type, created_at, updated_at
 FROM parsing_rules
 WHERE host_pattern = $1
   AND target_type  = $2
@@ -318,7 +318,7 @@ func (r *pgParsingRuleRepository) List(ctx context.Context, f storage.ParsingRul
 	}
 
 	query := `
-SELECT id, source_name, host_pattern, path_pattern, target_type, version, enabled, selectors, confidence, description, created_at, updated_at
+SELECT id, source_name, host_pattern, path_pattern, target_type, version, enabled, selectors, confidence, description, page_type, created_at, updated_at
 FROM parsing_rules
 WHERE 1=1`
 	args := make([]any, 0, 4)
@@ -384,7 +384,8 @@ func scanParsingRule(s scanner) (*storage.ParsingRuleRecord, error) {
 	var targetType string
 	if err := s.Scan(
 		&rec.ID, &rec.SourceName, &rec.HostPattern, &rec.PathPattern, &targetType, &rec.Version,
-		&rec.Enabled, &selectorsRaw, &confidenceRaw, &rec.Description, &rec.CreatedAt, &rec.UpdatedAt,
+		&rec.Enabled, &selectorsRaw, &confidenceRaw, &rec.Description, &rec.PageType,
+		&rec.CreatedAt, &rec.UpdatedAt,
 	); err != nil {
 		return nil, err
 	}

--- a/migrations/down/018_parsing_rules_page_type.sql
+++ b/migrations/down/018_parsing_rules_page_type.sql
@@ -1,0 +1,4 @@
+-- 018_parsing_rules_page_type DOWN: page_type 컬럼 제거.
+
+ALTER TABLE parsing_rules
+  DROP COLUMN IF EXISTS page_type;

--- a/migrations/up/018_parsing_rules_page_type.sql
+++ b/migrations/up/018_parsing_rules_page_type.sql
@@ -1,0 +1,20 @@
+-- 018_parsing_rules_page_type: parsing_rules 에 page_type 메타데이터 컬럼 추가 (이슈 #326)
+--
+-- 배경:
+--   claudegen multi-step extraction 이 LLM 응답에서 페이지 도메인 분류
+--   (news / community / info / commercial / paper / other) 을 함께 추출. 이는 추후
+--   정보 신뢰도 시스템 (별도 후속 이슈) 의 1차 입력으로 사용 — news / paper 는 높은
+--   신뢰도 weight, commercial 은 낮은 weight 등.
+--
+-- 스키마:
+--   - page_type: TEXT — '' (빈 문자열) = 미분류 (기존 row + non-claudegen 경로)
+--   - 도메인 분류는 application 측 검증 — DB CHECK 제약은 두지 않음 (확장 친화적):
+--     새 분류 추가 시 application struct 만 갱신, migration 불필요
+--
+-- 진화 친화적 — page_type_confidence 등 추가 메타데이터는 향후 동일 패턴으로 컬럼 추가.
+
+ALTER TABLE parsing_rules
+  ADD COLUMN IF NOT EXISTS page_type TEXT NOT NULL DEFAULT '';
+
+COMMENT ON COLUMN parsing_rules.page_type IS
+  '페이지 도메인 분류 (news/community/info/commercial/paper/other). claudegen multi-step extraction 이 추출. 빈 문자열은 미분류. 이슈 #326.';

--- a/pkg/llm/prompt/assets/claudegen/list.user.txt
+++ b/pkg/llm/prompt/assets/claudegen/list.user.txt
@@ -1,22 +1,57 @@
 Read the HTML file at {{SESSION_PATH}}/page.html from the {{HOST}} website.
 
-Your task: extract CSS selectors for the fields below and return them as a single JSON object only — no explanation, no markdown, no code blocks.
+Your task: analyze the page and return a single JSON object with the following structure — no explanation, no markdown, no code blocks.
 
 Target page type: {{TARGET_TYPE}}
 
-Required fields:
+Output schema:
 {
-  "item_container": {"css": "<selector for each list item root>"},
-  "item_link":      {"css": "<selector inside item for the article link>", "attribute": "href"},
-  "item_title":     {"css": "<selector inside item for the title text>"},
-  "item_snippet":   {"css": "<selector inside item for the short summary>"}
+  "validity": "ok" or "blacklist",
+  "blacklist_reason": "<korean reason if validity=blacklist, else null>",
+  "page_type": "news" | "community" | "info" | "commercial" | "paper" | "other",
+  "page_type_confidence": <float 0.0 to 1.0>,
+  "selectors": {
+    "item_container": {"css": "<selector for each list item root>"},
+    "item_link":      {"css": "<selector inside item for the article link>", "attribute": "href"},
+    "item_title":     {"css": "<selector inside item for the title text>"},
+    "item_snippet":   {"css": "<selector inside item for the short summary>"}
+  },
+  "self_check": {
+    "item_count_estimate": <integer>,
+    "first_item_title_sample": "<actual text of the first item title>",
+    "warnings": ["<short korean warning if any>", ...]
+  }
 }
 
-Rules:
+Validity decision rules:
+- "blacklist" if the page is one of:
+  * Advertisement / interstitial / paywall / login wall
+  * Empty page or "page not found" / "service unavailable" message
+  * Captcha / bot-detection page
+  * URL shortener / redirect landing
+  * Page with no parseable list of articles (just a single large component, embed widget, etc.)
+- "ok" otherwise. If "ok", you MUST fill `selectors` and `self_check` based on the actual HTML.
+- If "blacklist", `selectors` and `self_check` may be empty objects (`{}`), and `blacklist_reason` MUST be a short Korean explanation (e.g., "광고 페이지", "리스트 없음").
+
+Page type classification:
+- "news"       — news aggregator / category page with editorial article links
+- "community"  — forum / bulletin board / user-posted content listing
+- "info"       — wiki / documentation index / TOC page
+- "commercial" — product catalog / shopping listing
+- "paper"      — academic publication index / search results
+- "other"      — anything not fitting above
+- `page_type_confidence` is your self-assessed certainty (0.0 ~ 1.0).
+
+Selector rules (when validity="ok"):
 1. Use only selectors that actually appear in the HTML — do not invent.
 2. Prefer stable selectors (semantic tags, ARIA roles, id/class with meaningful names) over brittle ones (auto-generated hashes, nth-child indices).
 3. "css" must be a valid goquery/CSS selector. "attribute" must be empty for text content, or the HTML attribute name (e.g. "href", "datetime", "content").
 4. "multi": true when the selector matches multiple elements (lists, paragraphs).
 5. Omit fields you cannot find a reliable selector for.
+
+Self-check rules:
+- `item_count_estimate`: how many items the item_container selector would yield
+- `first_item_title_sample`: actual title text of the first matched item (truncate to 200 chars)
+- `warnings`: list any concerns (e.g., "리스트 항목 0개", "광고가 다수 섞임")
 
 Return ONLY the JSON object.

--- a/pkg/llm/prompt/assets/claudegen/page.user.txt
+++ b/pkg/llm/prompt/assets/claudegen/page.user.txt
@@ -1,26 +1,61 @@
 Read the HTML file at {{SESSION_PATH}}/page.html from the {{HOST}} website.
 
-Your task: extract CSS selectors for the fields below and return them as a single JSON object only — no explanation, no markdown, no code blocks.
+Your task: analyze the page and return a single JSON object with the following structure — no explanation, no markdown, no code blocks.
 
 Target page type: {{TARGET_TYPE}}
 
-Required fields:
+Output schema:
 {
-  "title":        {"css": "<selector for page title>"},
-  "main_content": {"css": "<selector for primary article body>", "multi": true},
-  "summary":      {"css": "<selector for description/summary, often meta>", "attribute": "content"},
-  "author":       {"css": "<selector for author name>"},
-  "published_at": {"css": "<selector for publish datetime>", "attribute": "datetime"},
-  "category":     {"css": "<selector for section/category>"},
-  "tags":         {"css": "<selector for tag links>", "multi": true},
-  "images":       {"css": "<selector for content images>", "attribute": "src", "multi": true}
+  "validity": "ok" or "blacklist",
+  "blacklist_reason": "<korean reason if validity=blacklist, else null>",
+  "page_type": "news" | "community" | "info" | "commercial" | "paper" | "other",
+  "page_type_confidence": <float 0.0 to 1.0>,
+  "selectors": {
+    "title":        {"css": "<selector for page title>"},
+    "main_content": {"css": "<selector for primary article body>", "multi": true},
+    "summary":      {"css": "<selector for description/summary, often meta>", "attribute": "content"},
+    "author":       {"css": "<selector for author name>"},
+    "published_at": {"css": "<selector for publish datetime>", "attribute": "datetime"},
+    "category":     {"css": "<selector for section/category>"},
+    "tags":         {"css": "<selector for tag links>", "multi": true},
+    "images":       {"css": "<selector for content images>", "attribute": "src", "multi": true}
+  },
+  "self_check": {
+    "title_sample": "<actual text the title selector would extract>",
+    "body_word_count_estimate": <integer>,
+    "warnings": ["<short korean warning if any>", ...]
+  }
 }
 
-Rules:
+Validity decision rules:
+- "blacklist" if the page is one of:
+  * Advertisement / interstitial / paywall / login wall (no real content visible)
+  * Empty page or "page not found" / "service unavailable" message
+  * Pure navigation page with no article-like content
+  * Captcha / bot-detection page
+  * URL shortener / redirect landing
+- "ok" otherwise. If "ok", you MUST fill `selectors` and `self_check` based on the actual HTML.
+- If "blacklist", `selectors` and `self_check` may be empty objects (`{}`), and `blacklist_reason` MUST be a short Korean explanation (e.g., "광고 페이지", "로그인 요구", "빈 페이지").
+
+Page type classification:
+- "news"       — journalistic article (newspaper, broadcaster, news aggregator with editorial content)
+- "community"  — forum / bulletin board / user-posted content (Reddit-like, cafe, gallery)
+- "info"       — wiki / official documentation / how-to guide / reference page
+- "commercial" — product listing / shopping / promotional landing page
+- "paper"      — academic article / research paper / preprint
+- "other"      — anything not fitting above (catch-all)
+- `page_type_confidence` is your self-assessed certainty (0.0 ~ 1.0). Lower it for ambiguous cases.
+
+Selector rules (when validity="ok"):
 1. Use only selectors that actually appear in the HTML — do not invent.
 2. Prefer stable selectors (semantic tags, ARIA roles, id/class with meaningful names) over brittle ones (auto-generated hashes, nth-child indices).
 3. "css" must be a valid goquery/CSS selector. "attribute" must be empty for text content, or the HTML attribute name (e.g. "href", "datetime", "content").
 4. "multi": true when the selector matches multiple elements (lists, paragraphs).
 5. Omit fields you cannot find a reliable selector for.
+
+Self-check rules:
+- `title_sample`: extract the actual text your title selector would return (truncate to 200 chars if longer)
+- `body_word_count_estimate`: rough word count of what your main_content selector would extract
+- `warnings`: list any concerns (e.g., "셀렉터 매칭 0건", "본문이 너무 짧음", "광고로 보이는 부분 다수")
 
 Return ONLY the JSON object.

--- a/test/internal/processor/parser/rule/claudegen/parse_enriched_output_test.go
+++ b/test/internal/processor/parser/rule/claudegen/parse_enriched_output_test.go
@@ -1,0 +1,54 @@
+package claudegen_test
+
+// parseEnrichedOutput 은 claudegen 패키지의 unexported 헬퍼라 동일 구조의 동작은 통합 테스트
+// (worker_test.go 의 ExtractEnriched flow) 로 검증됩니다. 본 파일은 ExtractResult 의 schema
+// 호환성 — JSON unmarshal contract — 를 별도로 고정하여 향후 schema drift 회귀를 방지합니다.
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"issuetracker/internal/processor/parser/rule/llmgen"
+)
+
+// TestExtractResult_BlacklistDecision_JSONShape 은 BlacklistDecision 이 운영자 manual review
+// 시 사용 가능한 형태로 JSON 직렬화되는지 검증합니다 (운영 dashboard / DB INSERT 전 dry-run).
+func TestExtractResult_BlacklistDecision_JSONShape(t *testing.T) {
+	res := llmgen.ExtractResult{
+		Blacklist: &llmgen.BlacklistDecision{Reason: "광고 페이지"},
+	}
+
+	data, err := json.Marshal(res)
+	require.NoError(t, err)
+
+	// JSON 키가 의도된 camelCase / snake_case 정책에 따라 직렬화되는지는 application
+	// 측 검증 — 현재 ExtractResult 는 Go default tag 없는 PascalCase exported 필드.
+	var unmarshalled struct {
+		Blacklist *struct {
+			Reason string `json:"Reason"`
+		} `json:"Blacklist"`
+	}
+	require.NoError(t, json.Unmarshal(data, &unmarshalled))
+	require.NotNil(t, unmarshalled.Blacklist)
+	assert.Equal(t, "광고 페이지", unmarshalled.Blacklist.Reason)
+}
+
+// TestPageType_Constants 는 claudegen prompt 와 storage layer 사이의 분류 string 계약이
+// 깨지지 않도록 상수 값을 고정합니다.
+func TestPageType_Constants(t *testing.T) {
+	cases := map[llmgen.PageType]string{
+		llmgen.PageTypeNews:        "news",
+		llmgen.PageTypeCommunity:   "community",
+		llmgen.PageTypeInfo:        "info",
+		llmgen.PageTypeCommercial:  "commercial",
+		llmgen.PageTypePaper:       "paper",
+		llmgen.PageTypeOther:       "other",
+		llmgen.PageTypeUnspecified: "",
+	}
+	for pt, want := range cases {
+		assert.Equal(t, want, string(pt))
+	}
+}

--- a/test/internal/processor/parser/rule/llmgen/enriched_extractor_test.go
+++ b/test/internal/processor/parser/rule/llmgen/enriched_extractor_test.go
@@ -1,0 +1,185 @@
+package llmgen_test
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"issuetracker/internal/processor/fetcher/core"
+	"issuetracker/internal/processor/parser/rule/llmgen"
+	"issuetracker/internal/storage"
+)
+
+// fakeEnrichedExtractor 는 ExtractEnriched 결과를 프로그래매틱하게 제어하는 stub.
+// SelectorExtractor 와 EnrichedExtractor 인터페이스 모두 구현 — Generator 의 type assertion 분기 검증.
+type fakeEnrichedExtractor struct {
+	mu     sync.Mutex
+	calls  int
+	result *llmgen.ExtractResult
+	err    error
+}
+
+func (e *fakeEnrichedExtractor) Extract(ctx context.Context, host string, t storage.TargetType, html string) (storage.SelectorMap, error) {
+	res, err := e.ExtractEnriched(ctx, host, t, html)
+	if err != nil {
+		return storage.SelectorMap{}, err
+	}
+	if res.Blacklist != nil {
+		// legacy 인터페이스 호환 — Generator 는 EnrichedExtractor 분기를 우선하므로 본 경로는 실제 미사용.
+		return storage.SelectorMap{}, nil
+	}
+	return res.Selectors, nil
+}
+
+func (e *fakeEnrichedExtractor) ExtractEnriched(_ context.Context, _ string, _ storage.TargetType, _ string) (*llmgen.ExtractResult, error) {
+	e.mu.Lock()
+	e.calls++
+	e.mu.Unlock()
+	return e.result, e.err
+}
+
+func (e *fakeEnrichedExtractor) callCount() int {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	return e.calls
+}
+
+// recordingBlacklistRepo 는 Insert 호출을 기록하는 BlacklistRepository stub.
+type recordingBlacklistRepo struct {
+	mu       sync.Mutex
+	inserts  []*storage.BlacklistRecord
+	insertOK bool // false 면 ErrDuplicate 반환 (멱등성 검증)
+}
+
+func (r *recordingBlacklistRepo) Insert(_ context.Context, rec *storage.BlacklistRecord) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.inserts = append(r.inserts, rec)
+	if !r.insertOK {
+		return storage.ErrDuplicate
+	}
+	return nil
+}
+
+func (r *recordingBlacklistRepo) Update(_ context.Context, _ *storage.BlacklistRecord) error {
+	return nil
+}
+func (r *recordingBlacklistRepo) Delete(_ context.Context, _ int64) error { return nil }
+func (r *recordingBlacklistRepo) GetByID(_ context.Context, _ int64) (*storage.BlacklistRecord, error) {
+	return nil, storage.ErrNotFound
+}
+func (r *recordingBlacklistRepo) FindEnabledByHost(_ context.Context, _ string) ([]*storage.BlacklistRecord, error) {
+	return nil, nil
+}
+func (r *recordingBlacklistRepo) List(_ context.Context, _ storage.BlacklistFilter) ([]*storage.BlacklistRecord, error) {
+	return nil, nil
+}
+
+func (r *recordingBlacklistRepo) callCount() int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return len(r.inserts)
+}
+
+// TestGenerator_EnrichedExtractor_BlacklistBranch 는 EnrichedExtractor 가 페이지를 blacklist 로
+// 판정하면:
+//  1. 셀렉터 INSERT 가 skip 되어야 함
+//  2. blacklistRepo.Insert 가 정확히 1회 호출되어야 함 (host_pattern + path regex + reason)
+func TestGenerator_EnrichedExtractor_BlacklistBranch(t *testing.T) {
+	provider := &fakeProvider{name: "gemini-flash", response: "{}"}
+	repo := &recordingRepo{}
+	g, _ := newGenerator(t, provider, repo)
+
+	extractor := &fakeEnrichedExtractor{
+		result: &llmgen.ExtractResult{
+			Blacklist: &llmgen.BlacklistDecision{Reason: "광고 페이지"},
+		},
+	}
+	g.SetExtractor(extractor)
+
+	blRepo := &recordingBlacklistRepo{insertOK: true}
+	g.SetBlacklistRepo(blRepo)
+
+	g.Enqueue(context.Background(), "ads.example.com", storage.TargetTypePage, &core.RawContent{
+		URL: "https://ads.example.com/promo/123", HTML: samplePageHTML,
+	}, 0, "", 0)
+
+	stopCtx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	g.Stop(stopCtx)
+
+	// 셀렉터 INSERT skip 검증.
+	assert.Empty(t, repo.inserts(), "blacklist 분기 시 ParsingRuleRepository.Insert 발생 X")
+	assert.Equal(t, 1, extractor.callCount(), "ExtractEnriched 1회 호출")
+
+	// Blacklist Insert 1회 검증 + 페이로드 확인.
+	require.Equal(t, 1, blRepo.callCount(), "BlacklistRepository.Insert 정확히 1회")
+	rec := blRepo.inserts[0]
+	assert.Equal(t, "ads.example.com", rec.HostPattern)
+	assert.Equal(t, storage.BlacklistSourceAuto, rec.Source)
+	assert.Equal(t, storage.BlacklistModeDrop, rec.Mode)
+	assert.True(t, rec.Enabled)
+	assert.Equal(t, "광고 페이지", rec.Reason)
+	// path_pattern 은 ^/promo/123$ 형태로 escape + anchor.
+	assert.Contains(t, rec.PathPattern, "/promo/123")
+}
+
+// TestGenerator_EnrichedExtractor_Ok_PageTypeStored 는 validity=ok 분기에서 PageType 이
+// 정상으로 ParsingRuleRecord 에 저장되는지 검증합니다.
+func TestGenerator_EnrichedExtractor_Ok_PageTypeStored(t *testing.T) {
+	provider := &fakeProvider{name: "gemini-flash", response: "{}"}
+	repo := &recordingRepo{}
+	g, _ := newGenerator(t, provider, repo)
+
+	extractor := &fakeEnrichedExtractor{
+		result: &llmgen.ExtractResult{
+			Selectors: storage.SelectorMap{
+				Title:       &storage.FieldSelector{CSS: "h1.article-title"},
+				MainContent: &storage.FieldSelector{CSS: "article p", Multi: true},
+			},
+			PageType:           llmgen.PageTypeNews,
+			PageTypeConfidence: 0.95,
+		},
+	}
+	g.SetExtractor(extractor)
+
+	g.Enqueue(context.Background(), "example.com", storage.TargetTypePage, &core.RawContent{
+		URL: "https://example.com/article/1", HTML: samplePageHTML,
+	}, 0, "", 0)
+
+	waitForInserts(t, repo, 1, 2*time.Second)
+
+	recs := repo.inserts()
+	require.Len(t, recs, 1)
+	assert.Equal(t, "news", recs[0].PageType, "ExtractResult.PageType 가 ParsingRuleRecord.PageType 에 저장")
+}
+
+// TestGenerator_EnrichedExtractor_BlacklistRepoNil_StillSkipsInsert 는 blacklistRepo 가
+// 미설정 (nil) 일 때도 셀렉터 INSERT 만 skip 되고 panic / 에러 없이 graceful 진행하는지 검증.
+func TestGenerator_EnrichedExtractor_BlacklistRepoNil_StillSkipsInsert(t *testing.T) {
+	provider := &fakeProvider{name: "gemini-flash", response: "{}"}
+	repo := &recordingRepo{}
+	g, _ := newGenerator(t, provider, repo)
+
+	extractor := &fakeEnrichedExtractor{
+		result: &llmgen.ExtractResult{
+			Blacklist: &llmgen.BlacklistDecision{Reason: "로그인 요구"},
+		},
+	}
+	g.SetExtractor(extractor)
+	// SetBlacklistRepo 미호출 — nil 상태.
+
+	g.Enqueue(context.Background(), "loginwall.example.com", storage.TargetTypePage, &core.RawContent{
+		URL: "https://loginwall.example.com/secure", HTML: samplePageHTML,
+	}, 0, "", 0)
+
+	stopCtx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	g.Stop(stopCtx)
+
+	assert.Empty(t, repo.inserts(), "blacklist 분기에서 셀렉터 INSERT skip")
+}


### PR DESCRIPTION
## 연관 이슈

Closes #326

## 구현 내용

claudegen 의 single-shot 셀렉터 추출 prompt 를 enriched JSON schema 로 확장 — 페이지 유효성 / 타입 분류 / 자가 검증을 single response 에 통합.

### 1. Prompt + 타입 (1번 commit)
- \`pkg/llm/prompt/assets/claudegen/{page,list}.user.txt\` 갱신: validity / page_type / selectors / self_check schema
- \`internal/processor/parser/rule/llmgen/extractor.go\` 신규:
  - \`PageType\` enum (news / community / info / commercial / paper / other)
  - \`BlacklistDecision\`, \`ExtractResult\`, \`EnrichedExtractor\` 인터페이스
- multi-turn agent 의 stateful interaction 대신 single Claude exec 응답에 multi-phase 결과를 enriched JSON 으로 담는 방식 — 기존 docker exec 비용 (~10s) 재사용

### 2. claudegen worker (2번 commit)
- \`ExtractEnriched\` 신규 — docker exec 결과를 ExtractResult 로 파싱
- \`parseEnrichedOutput\`: validity 분기 + legacy SelectorMap-only 응답 후방 호환 fallback
- 기존 \`Extract\` 는 thin wrapper (Selector 만 반환, Blacklist 시 명시적 에러)

### 3. Migration + storage (3번 commit)
- \`migrations/{up,down}/018_parsing_rules_page_type.sql\` — TEXT NOT NULL DEFAULT ''
- \`ParsingRuleRecord.PageType\` 필드
- 12개 SQL statement 갱신 (INSERT / SELECT)

### 4. Generator wiring + 테스트 (4번 commit)
- \`Generator.SetBlacklistRepo\` setter
- \`Generator.runOnce\`: extractor type assertion 으로 EnrichedExtractor 자동 분기
- \`handleBlacklistDecision\`: parsing_blacklist INSERT (source='auto', mode='drop', path = exact regex)
- 정상 분기는 \`ExtractResult.PageType\` 을 ParsingRuleRecord 에 저장
- \`cmd/issuetracker/main.go\`: blacklistRepo 를 invalidatingBlacklistRepo decorator 로 wrap (자동 INSERT 시 Matcher cache flush)
- 테스트: Blacklist 분기 / PageType 저장 / blacklistRepo nil graceful + PageType 상수 contract + ExtractResult JSON shape

## 운영 효과

```sql
-- 라이브 1 사이클 후 분류 분포 확인
SELECT host_pattern, page_type, COUNT(*)
FROM parsing_rules
WHERE source_name='llm-auto'
GROUP BY host_pattern, page_type
ORDER BY host_pattern;

-- 자동 등록된 blacklist
SELECT host_pattern, path_pattern, reason, created_at
FROM parsing_blacklist
WHERE source='auto'
ORDER BY created_at DESC;
```

LLM 이 페이지를 광고 / interstitial / 빈 페이지로 판정하면:
1. 셀렉터 INSERT 가 skip 되어 무의미한 \`parsing_rules\` row 가 생기지 않음
2. \`parsing_blacklist\` 에 자동 등록 — 같은 URL 이 다음 사이클에서 fetch / parse 안 됨
3. 정상 페이지는 page_type 메타데이터가 함께 저장되어 정보 신뢰도 시스템 (후속 이슈) 의 1차 입력 마련

## CI / 머지 게이트

- [x] migration 018 적용 + 컬럼 검증 (\`PGPASSWORD=postgres psql -c '\d parsing_rules'\`)
- [x] \`go build ./...\` 통과
- [x] \`go test ./...\` 통과 — 신규 5 케이스 + 기존 회귀 green
- [x] \`gofmt -l\` / \`go vet\` 깨끗

## 변경 영향 / 위험

- **Backward-compat**: \`SelectorExtractor\` (legacy) 인터페이스 그대로 유지. \`Extract\` 메소드 시그니처 변경 없음. claudegen 외 LLM provider (Gemini Flash 등) 경로는 EnrichedExtractor 미구현 → page_type 빈 문자열로 저장
- **Schema migration**: \`parsing_rules.page_type\` 추가 — 기존 row 는 default '' (NOT NULL) 이므로 backward-compat
- **위험**: claudegen 응답이 enriched schema 를 따르지 않을 가능성 — \`parseEnrichedOutput\` 의 \`validity\`==\"\" 분기에서 legacy SelectorMap 으로 재파싱하는 graceful fallback 으로 흡수
- **운영**: blacklistRepo 가 wiring 되어 있어야 자동 등록 실효 — BLACKLIST_ENABLED=false 환경에서는 셀렉터 INSERT skip 만 동작 (Info 로그)

## 후속 이슈 후보 (별도)

- 정보 신뢰도 시스템 설계 — page_type 을 1차 입력으로 받아 trust score 산출
- Gemini 등 다른 LLM provider 도 EnrichedExtractor 구현 — ports & adapters 로 \`PageAnalyzer\` 인터페이스 추출
- self_check.warnings 기반 LLM 재시도 (현재는 unmarshal 만 하고 무시)
- path 단위 page_type 세분화 (현재는 rule 단위)

## 롤백

\`git revert <merge-commit>\` — 4개 commit 단일 머지 commit 으로 통합 revert. migration down 으로 page_type 컬럼 제거.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added page type classification system that categorizes extracted pages into types (news, community, info, commercial, paper, other) with confidence scores.
  * Implemented blacklist mechanism to exclude specific pages from selector extraction with customizable reasoning.

* **Tests**
  * Added tests validating enriched extraction, blacklist handling, and page type persistence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->