### PR TITLE
[FEAT#330] community 진입점 6개 사이트 seed — theqoo/clien/fmkorea/dcinside/reddit/hackernews

### DIFF
--- a/migrations/down/021_community_sources_seed.sql
+++ b/migrations/down/021_community_sources_seed.sql
@@ -1,0 +1,16 @@
+-- 021 DOWN: community 진입점 제거.
+--
+-- scheduler_entries 의 community 카테고리 row + fetcher_rules 의 source_type='community'
+-- row 를 일괄 삭제. 운영자 manual 등록 row 도 삭제될 수 있어 보수적으로 source 명단으로
+-- 한정.
+--
+-- parsing_rules 의 LLM 자동 학습 결과 (host 별 row) 는 본 DOWN 에서 건드리지 않음 —
+-- 운영자가 별도로 정리.
+
+DELETE FROM scheduler_entries
+WHERE category = 'community'
+  AND source_name IN ('theqoo', 'clien', 'fmkorea', 'dcinside', 'reddit', 'hackernews');
+
+DELETE FROM fetcher_rules
+WHERE source_type = 'community'
+  AND source_name IN ('theqoo', 'clien', 'fmkorea', 'dcinside', 'reddit', 'hackernews');

--- a/migrations/down/021_community_sources_seed.sql
+++ b/migrations/down/021_community_sources_seed.sql
@@ -1,16 +1,37 @@
--- 021 DOWN: community 진입점 제거.
+-- 021 DOWN: community 진입점 제거 — 본 마이그레이션이 INSERT 한 정확한 row 만 삭제.
 --
--- scheduler_entries 의 community 카테고리 row + fetcher_rules 의 source_type='community'
--- row 를 일괄 삭제. 운영자 manual 등록 row 도 삭제될 수 있어 보수적으로 source 명단으로
--- 한정.
+-- source_name 만으로 매칭하면 운영자 manual 추가한 같은 source_name row 까지 삭제될 위험
+-- (CodeRabbit Major 반영). 정확한 (host_pattern) / (category, source_name, url) set 으로 한정.
 --
 -- parsing_rules 의 LLM 자동 학습 결과 (host 별 row) 는 본 DOWN 에서 건드리지 않음 —
 -- 운영자가 별도로 정리.
 
+-- scheduler_entries: 정확한 url set
 DELETE FROM scheduler_entries
 WHERE category = 'community'
-  AND source_name IN ('theqoo', 'clien', 'fmkorea', 'dcinside', 'reddit', 'hackernews');
+  AND (source_name, url) IN (
+    ('theqoo',     'https://theqoo.net/hot'),
+    ('clien',      'https://www.clien.net/service/board/park'),
+    ('fmkorea',    'https://www.fmkorea.com/best'),
+    ('fmkorea',    'https://www.fmkorea.com/index.php?mid=politics'),
+    ('dcinside',   'https://gall.dcinside.com/board/lists/?id=politics'),
+    ('dcinside',   'https://gall.dcinside.com/board/lists/?id=baseball_new11'),
+    ('reddit',     'https://www.reddit.com/r/news'),
+    ('reddit',     'https://www.reddit.com/r/worldnews'),
+    ('reddit',     'https://www.reddit.com/r/politics'),
+    ('hackernews', 'https://news.ycombinator.com/news'),
+    ('hackernews', 'https://news.ycombinator.com/best')
+  );
 
+-- fetcher_rules: 정확한 host_pattern set
 DELETE FROM fetcher_rules
-WHERE source_type = 'community'
-  AND source_name IN ('theqoo', 'clien', 'fmkorea', 'dcinside', 'reddit', 'hackernews');
+WHERE host_pattern IN (
+  'theqoo.net',
+  'www.clien.net',
+  'www.fmkorea.com',
+  'gall.dcinside.com',
+  'gallery.dcinside.com',
+  'www.reddit.com',
+  'old.reddit.com',
+  'news.ycombinator.com'
+);

--- a/migrations/up/021_community_sources_seed.sql
+++ b/migrations/up/021_community_sources_seed.sql
@@ -1,0 +1,82 @@
+-- 021_community_sources_seed: Community 카테고리 진입점 등록 (이슈 #330, #328 sub B)
+--
+-- 배경:
+--   기존 4 source 는 모두 source_type='news' 로 뉴스 보도 위주. 이슈 #328 의 3 카테고리
+--   설계에 따라 실시간 여론 파악을 위한 community 진입점을 별도 등록 — interval 10m,
+--   anti-bot 대응 chromedp 우선.
+--
+-- 등록 대상 (1차 6개 사이트):
+--   국내 4: theqoo / clien / fmkorea / dcinside (주요 한국 인기 커뮤니티)
+--   해외 2: reddit / hackernews (국제 community + tech 커뮤니티)
+--
+-- 정책:
+--   - fetcher='chromedp' — 대부분 SPA / anti-bot 으로 raw HTTP 의존 회피 (HN 만 정적 HTML 이라
+--     goquery 가능하지만 일관성 위해 chromedp 통일)
+--   - requests_per_hour 보수 (100~200) — IP 단위 token bucket 으로 throttle (#323)
+--   - parsing_rules 는 LLM 자동 학습 (#326 claudegen multi-step) 에 위임 — 본 마이그레이션은
+--     fetcher_rules + scheduler_entries 만 seed
+--   - scheduler_entries.interval_seconds = 600 (10m) — 실시간 여론 빈도
+
+-- ============================================================================
+-- Step 1: fetcher_rules (host_pattern 단위 source 등록)
+-- ============================================================================
+
+INSERT INTO fetcher_rules (host_pattern, fetcher, reason, source_name, source_type, country, language, base_url, requests_per_hour)
+VALUES
+  -- TheQoo (KR community — 실시간 인기글)
+  ('theqoo.net', 'chromedp', 'initial seed from migration 021', 'theqoo', 'community', 'KR', 'ko',
+    'https://theqoo.net', 100),
+
+  -- Clien (KR community — 모두의공원 / 새로운 소식)
+  ('www.clien.net', 'chromedp', 'initial seed from migration 021', 'clien', 'community', 'KR', 'ko',
+    'https://www.clien.net', 100),
+
+  -- FMKorea (KR community — 포텐 / 정치 베스트)
+  ('www.fmkorea.com', 'chromedp', 'initial seed from migration 021', 'fmkorea', 'community', 'KR', 'ko',
+    'https://www.fmkorea.com', 100),
+
+  -- DCInside (KR community — 갤러리)
+  ('gallery.dcinside.com', 'chromedp', 'initial seed from migration 021', 'dcinside', 'community', 'KR', 'ko',
+    'https://gallery.dcinside.com', 100),
+
+  -- Reddit (국제 community)
+  ('www.reddit.com', 'chromedp', 'initial seed from migration 021', 'reddit', 'community', 'US', 'en',
+    'https://www.reddit.com', 200),
+  ('old.reddit.com', 'chromedp', 'initial seed from migration 021 — old reddit fallback', 'reddit', 'community', 'US', 'en',
+    'https://www.reddit.com', 200),
+
+  -- Hacker News (국제 community)
+  ('news.ycombinator.com', 'chromedp', 'initial seed from migration 021', 'hackernews', 'community', 'US', 'en',
+    'https://news.ycombinator.com', 200)
+ON CONFLICT (host_pattern) DO NOTHING;
+
+-- ============================================================================
+-- Step 2: scheduler_entries (진입 URL — interval 10m)
+-- ============================================================================
+--   각 사이트의 메인 인기 / 정치 / 뉴스 카테고리 페이지를 1~3개씩 등록.
+
+INSERT INTO scheduler_entries (category, source_name, url, target_type, interval_seconds, priority, enabled, notes)
+VALUES
+  -- theqoo (1)
+  ('community', 'theqoo', 'https://theqoo.net/hot', 'category', 600, 2, TRUE, 'realtime hot'),
+
+  -- clien (1)
+  ('community', 'clien', 'https://www.clien.net/service/board/park', 'category', 600, 2, TRUE, '모두의공원'),
+
+  -- fmkorea (2)
+  ('community', 'fmkorea', 'https://www.fmkorea.com/best', 'category', 600, 2, TRUE, 'best'),
+  ('community', 'fmkorea', 'https://www.fmkorea.com/index.php?mid=politics', 'category', 600, 2, TRUE, 'politics'),
+
+  -- dcinside (2)
+  ('community', 'dcinside', 'https://gallery.dcinside.com/board/lists/?id=politics', 'category', 600, 2, TRUE, 'politics gallery'),
+  ('community', 'dcinside', 'https://gallery.dcinside.com/board/lists/?id=baseball_new11', 'category', 600, 2, TRUE, 'baseball gallery'),
+
+  -- reddit (3)
+  ('community', 'reddit', 'https://www.reddit.com/r/news', 'category', 600, 2, TRUE, 'r/news'),
+  ('community', 'reddit', 'https://www.reddit.com/r/worldnews', 'category', 600, 2, TRUE, 'r/worldnews'),
+  ('community', 'reddit', 'https://www.reddit.com/r/politics', 'category', 600, 2, TRUE, 'r/politics'),
+
+  -- hackernews (2)
+  ('community', 'hackernews', 'https://news.ycombinator.com/news', 'category', 600, 2, TRUE, 'top'),
+  ('community', 'hackernews', 'https://news.ycombinator.com/best', 'category', 600, 2, TRUE, 'best')
+ON CONFLICT (category, source_name, url) DO NOTHING;

--- a/migrations/up/021_community_sources_seed.sql
+++ b/migrations/up/021_community_sources_seed.sql
@@ -36,14 +36,18 @@ VALUES
     'https://www.fmkorea.com', 100),
 
   -- DCInside (KR community — 갤러리)
-  ('gallery.dcinside.com', 'chromedp', 'initial seed from migration 021', 'dcinside', 'community', 'KR', 'ko',
+  -- 정치 / 국내야구 등 메이저 갤러리는 gall.dcinside.com (gallery 는 마이너 갤러리 도메인 — gemini High 반영).
+  ('gall.dcinside.com', 'chromedp', 'initial seed from migration 021 — major galleries', 'dcinside', 'community', 'KR', 'ko',
+    'https://gall.dcinside.com', 100),
+  ('gallery.dcinside.com', 'chromedp', 'initial seed from migration 021 — minor galleries fallback', 'dcinside', 'community', 'KR', 'ko',
     'https://gallery.dcinside.com', 100),
 
   -- Reddit (국제 community)
   ('www.reddit.com', 'chromedp', 'initial seed from migration 021', 'reddit', 'community', 'US', 'en',
     'https://www.reddit.com', 200),
+  -- old.reddit.com 은 파싱 친화적 fallback. base_url 도 old 로 두어야 상대 경로가 new UI 로 ricochet 안 됨 (gemini Medium 반영).
   ('old.reddit.com', 'chromedp', 'initial seed from migration 021 — old reddit fallback', 'reddit', 'community', 'US', 'en',
-    'https://www.reddit.com', 200),
+    'https://old.reddit.com', 200),
 
   -- Hacker News (국제 community)
   ('news.ycombinator.com', 'chromedp', 'initial seed from migration 021', 'hackernews', 'community', 'US', 'en',
@@ -67,9 +71,9 @@ VALUES
   ('community', 'fmkorea', 'https://www.fmkorea.com/best', 'category', 600, 2, TRUE, 'best'),
   ('community', 'fmkorea', 'https://www.fmkorea.com/index.php?mid=politics', 'category', 600, 2, TRUE, 'politics'),
 
-  -- dcinside (2)
-  ('community', 'dcinside', 'https://gallery.dcinside.com/board/lists/?id=politics', 'category', 600, 2, TRUE, 'politics gallery'),
-  ('community', 'dcinside', 'https://gallery.dcinside.com/board/lists/?id=baseball_new11', 'category', 600, 2, TRUE, 'baseball gallery'),
+  -- dcinside (2) — 정치 / 국내야구 메이저 갤러리는 gall.dcinside.com (gemini High 반영).
+  ('community', 'dcinside', 'https://gall.dcinside.com/board/lists/?id=politics', 'category', 600, 2, TRUE, 'politics gallery (major)'),
+  ('community', 'dcinside', 'https://gall.dcinside.com/board/lists/?id=baseball_new11', 'category', 600, 2, TRUE, 'baseball gallery (major)'),
 
   -- reddit (3)
   ('community', 'reddit', 'https://www.reddit.com/r/news', 'category', 600, 2, TRUE, 'r/news'),


### PR DESCRIPTION
## 연관 이슈

Closes #330 (#328 sub B)

## 구현 내용

\`scheduler_entries\` (#328 인프라) 에 community 카테고리 진입점 등록 — 실시간 여론 파악을 위한 짧은 interval (10m) 의 1차 6개 사이트.

### 대상 사이트

**국내 (4)**
- TheQoo — \`theqoo.net/hot\` (실시간 인기글)
- Clien — \`www.clien.net/service/board/park\` (모두의공원)
- FMKorea — \`www.fmkorea.com/best\` + \`/index.php?mid=politics\` (베스트 / 정치)
- DCInside — \`gallery.dcinside.com/board/lists/?id=politics\` + \`/?id=baseball_new11\` (정치 / 야구 갤러리)

**해외 (2)**
- Reddit — \`r/news\` + \`r/worldnews\` + \`r/politics\`
- Hacker News — \`/news\` + \`/best\`

### Migration 021

- \`fetcher_rules\` 7 row 추가:
  - \`fetcher='chromedp'\` 통일 (anti-bot 대응)
  - \`requests_per_hour\` 보수 (KR 100 / international 200) — IPRateLimiterRegistry (#323) 가 IP 단위 token bucket 으로 throttle
  - reddit 은 \`www.reddit.com\` + \`old.reddit.com\` 양쪽 등록 (old 가 fallback parsing 친화)
- \`scheduler_entries\` 11 row 추가:
  - \`category='community'\`, \`interval_seconds=600\` (10m) — 실시간 여론 빈도
  - target_type='category', priority=2 (normal)

### parsing_rules

본 PR 에는 포함 안 됨 — \`#326\` claudegen multi-step extraction 이 LLM 자동 학습. 라이브 1 사이클 후 \`SELECT host_pattern, page_type FROM parsing_rules WHERE source_name='llm-auto'\` 으로 분류 분포 확인.

## 동작 흐름

1. migration 021 적용 → DB 에 7 fetcher_rules + 11 scheduler_entries
2. \`StartRefreshLoop\` (30s ticker) 가 신규 community entries 를 자동 pickup → spawn
3. 매 10m 마다 entry URL fetch (chromedp) → category page parse → article URL 추출
4. parser worker 가 host 별 ErrNoRule → \`Generator.EnqueueStale/Enqueue\` → claudegen LLM 자동 학습
5. \`page_type='community'\` 자동 분류 → 정보 신뢰도 시스템 (후속 이슈) 의 메타데이터

## 위험 / 영향

- **IP 차단 위험**: 빈번 fetch + chromedp 노출 — RPH 보수 + chromedp 의 자연스러운 navigation 으로 완화. 라이브 모니터링 후 RPH 조정 가능
- **LLM 자동 학습 실패**: 일부 사이트 (특히 dcinside / dynamic SPA) 는 selectors 불안정 — 운영 1 사이클 후 \`SELECT host_pattern FROM parsing_blacklist WHERE source='auto'\` 로 자동 차단 케이스 확인
- **콘텐츠 모더레이션**: 일부 사이트는 욕설 다수 — VAL_006 spam_punct 가 일부 cover, 추가 ban-word filter 는 별도 후속 이슈 후보
- **대부분 backward-compat**: 기존 news source 영향 없음 (다른 카테고리). DB 마이그레이션만 적용

## CI / 머지 게이트

- [x] migration 021 적용 + 검증 (\`SELECT category, source_name, COUNT(*) FROM scheduler_entries\`, \`fetcher_rules WHERE source_type='community'\`)
- [x] \`go build ./...\` 통과
- [x] \`go test -race ./...\` 통과
- [x] \`gofmt\` / \`go vet\` 깨끗

## 후속

- 라이브 1 사이클 후 \`page_type\` 분포 / blacklist 자동 등록 / RPH 도달 빈도 모니터링
- LLM 학습 실패 사이트는 운영자 manual parsing rule seed (별도 이슈)
- 추가 사이트 (Naver Cafe / Ruliweb / MLBPark / 4chan 등) 는 운영자 INSERT 또는 별도 migration

## 롤백

\`migrate-down 021\` — 해당 source 의 fetcher_rules + scheduler_entries 일괄 삭제 (parsing_rules 자동 학습 결과는 운영자 수동 정리).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enabled scheduled fetching from six community sources: TheQoo, Clien, FMKorea, DCInside, Reddit, and Hacker News.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/EinSofINTEREST/IssueTracker/pull/334)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->