### PR TITLE
[FEAT#330] community 진입점 8개 사이트 추가 — ruliweb/mlbpark/inven/bobaedream/pgr21/slashdot/lemmy/tildes

### DIFF
--- a/migrations/down/022_community_sources_more.sql
+++ b/migrations/down/022_community_sources_more.sql
@@ -26,7 +26,7 @@ WHERE category = 'community'
     ('tildes',     'https://tildes.net/~news')
   );
 
--- fetcher_rules: 정확한 host_pattern set
+-- fetcher_rules: 정확한 host_pattern set + reason 매칭 — 동일 host_pattern 의 운영자 manual row 보호
 DELETE FROM fetcher_rules
 WHERE host_pattern IN (
   'bbs.ruliweb.com',
@@ -38,4 +38,5 @@ WHERE host_pattern IN (
   'news.slashdot.org',
   'lemmy.world',
   'tildes.net'
-);
+)
+  AND reason = 'initial seed from migration 022';

--- a/migrations/down/022_community_sources_more.sql
+++ b/migrations/down/022_community_sources_more.sql
@@ -1,0 +1,41 @@
+-- 022 DOWN: community 추가 진입점 (8 사이트) 제거 — 본 마이그레이션이 INSERT 한 정확한 row 만 삭제.
+--
+-- (host_pattern) / (category, source_name, url) set 으로 한정 — source_name 만으로 매칭하면
+-- 운영자 manual 추가한 같은 source_name row 까지 삭제될 위험 (021 의 CodeRabbit Major 패턴 반영).
+--
+-- parsing_rules 의 LLM 자동 학습 결과 (host 별 row) 는 본 DOWN 에서 건드리지 않음 —
+-- 운영자가 별도로 정리.
+
+-- scheduler_entries: 정확한 url set
+DELETE FROM scheduler_entries
+WHERE category = 'community'
+  AND (source_name, url) IN (
+    ('ruliweb',    'https://bbs.ruliweb.com/best/humor'),
+    ('ruliweb',    'https://bbs.ruliweb.com/community'),
+    ('mlbpark',    'https://mlbpark.donga.com/mp/?b=bullpen'),
+    ('mlbpark',    'https://mlbpark.donga.com/mp/?b=political'),
+    ('inven',      'https://www.inven.co.kr/board/it'),
+    ('inven',      'https://www.inven.co.kr/board/webzine'),
+    ('bobaedream', 'https://www.bobaedream.co.kr/list?code=best'),
+    ('pgr21',      'https://www.pgr21.com/freedom'),
+    ('slashdot',   'https://slashdot.org/'),
+    ('slashdot',   'https://news.slashdot.org/'),
+    ('lemmy',      'https://lemmy.world/c/news'),
+    ('lemmy',      'https://lemmy.world/c/worldnews'),
+    ('tildes',     'https://tildes.net/'),
+    ('tildes',     'https://tildes.net/~news')
+  );
+
+-- fetcher_rules: 정확한 host_pattern set
+DELETE FROM fetcher_rules
+WHERE host_pattern IN (
+  'bbs.ruliweb.com',
+  'mlbpark.donga.com',
+  'www.inven.co.kr',
+  'www.bobaedream.co.kr',
+  'www.pgr21.com',
+  'slashdot.org',
+  'news.slashdot.org',
+  'lemmy.world',
+  'tildes.net'
+);

--- a/migrations/up/022_community_sources_more.sql
+++ b/migrations/up/022_community_sources_more.sql
@@ -44,7 +44,7 @@ VALUES
   ('slashdot.org', 'chromedp', 'initial seed from migration 022', 'slashdot', 'community', 'US', 'en',
     'https://slashdot.org', 200),
   ('news.slashdot.org', 'chromedp', 'initial seed from migration 022', 'slashdot', 'community', 'US', 'en',
-    'https://slashdot.org', 200),
+    'https://news.slashdot.org', 200),
 
   -- Lemmy.world (decentralized reddit alternative)
   ('lemmy.world', 'chromedp', 'initial seed from migration 022', 'lemmy', 'community', 'US', 'en',

--- a/migrations/up/022_community_sources_more.sql
+++ b/migrations/up/022_community_sources_more.sql
@@ -1,0 +1,93 @@
+-- 022_community_sources_more: Community 진입점 추가 등록 — 8 사이트 (이슈 #330 후속)
+--
+-- 배경:
+--   migration 021 의 6 사이트 (theqoo / clien / fmkorea / dcinside / reddit / hackernews)
+--   이후 사용자 요청으로 더 다양한 커뮤니티 cover. 본 마이그레이션은 국내 5 + 해외 3 추가.
+--
+-- 신규 대상 (8 사이트):
+--   국내 5: ruliweb / mlbpark / inven / bobaedream / pgr21 (gaming / sports / general)
+--   해외 3: slashdot / lemmy.world / tildes (tech / decentralized / curated)
+--
+-- 정책 (021 과 동일):
+--   - fetcher='chromedp' 통일 — anti-bot 대응
+--   - requests_per_hour 보수 (KR 100 / international 200)
+--   - parsing_rules 는 LLM 자동 학습 (#326) 에 위임
+--   - scheduler_entries.interval_seconds = 600 (10m)
+
+-- ============================================================================
+-- Step 1: fetcher_rules
+-- ============================================================================
+
+INSERT INTO fetcher_rules (host_pattern, fetcher, reason, source_name, source_type, country, language, base_url, requests_per_hour)
+VALUES
+  -- Ruliweb (KR — 유머 / 베스트 게시판)
+  ('bbs.ruliweb.com', 'chromedp', 'initial seed from migration 022', 'ruliweb', 'community', 'KR', 'ko',
+    'https://bbs.ruliweb.com', 100),
+
+  -- MLBPark (KR — 불펜 / 베스트 / 야구)
+  ('mlbpark.donga.com', 'chromedp', 'initial seed from migration 022', 'mlbpark', 'community', 'KR', 'ko',
+    'https://mlbpark.donga.com', 100),
+
+  -- Inven (KR — 게임 커뮤니티)
+  ('www.inven.co.kr', 'chromedp', 'initial seed from migration 022', 'inven', 'community', 'KR', 'ko',
+    'https://www.inven.co.kr', 100),
+
+  -- Bobaedream (KR — 자동차 / 베스트)
+  ('www.bobaedream.co.kr', 'chromedp', 'initial seed from migration 022', 'bobaedream', 'community', 'KR', 'ko',
+    'https://www.bobaedream.co.kr', 100),
+
+  -- PGR21 (KR — e스포츠 / 자유게시판)
+  ('www.pgr21.com', 'chromedp', 'initial seed from migration 022', 'pgr21', 'community', 'KR', 'ko',
+    'https://www.pgr21.com', 100),
+
+  -- Slashdot (US — tech news community)
+  ('slashdot.org', 'chromedp', 'initial seed from migration 022', 'slashdot', 'community', 'US', 'en',
+    'https://slashdot.org', 200),
+  ('news.slashdot.org', 'chromedp', 'initial seed from migration 022', 'slashdot', 'community', 'US', 'en',
+    'https://slashdot.org', 200),
+
+  -- Lemmy.world (decentralized reddit alternative)
+  ('lemmy.world', 'chromedp', 'initial seed from migration 022', 'lemmy', 'community', 'US', 'en',
+    'https://lemmy.world', 200),
+
+  -- Tildes (curated discussion)
+  ('tildes.net', 'chromedp', 'initial seed from migration 022', 'tildes', 'community', 'US', 'en',
+    'https://tildes.net', 200)
+ON CONFLICT (host_pattern) DO NOTHING;
+
+-- ============================================================================
+-- Step 2: scheduler_entries — interval 10m
+-- ============================================================================
+
+INSERT INTO scheduler_entries (category, source_name, url, target_type, interval_seconds, priority, enabled, notes)
+VALUES
+  -- ruliweb (2)
+  ('community', 'ruliweb',    'https://bbs.ruliweb.com/best/humor',                                 'category', 600, 2, TRUE, 'humor best'),
+  ('community', 'ruliweb',    'https://bbs.ruliweb.com/community',                                  'category', 600, 2, TRUE, 'community'),
+
+  -- mlbpark (2)
+  ('community', 'mlbpark',    'https://mlbpark.donga.com/mp/?b=bullpen',                            'category', 600, 2, TRUE, 'bullpen'),
+  ('community', 'mlbpark',    'https://mlbpark.donga.com/mp/?b=political',                          'category', 600, 2, TRUE, 'political'),
+
+  -- inven (2)
+  ('community', 'inven',      'https://www.inven.co.kr/board/it',                                   'category', 600, 2, TRUE, 'IT 게시판'),
+  ('community', 'inven',      'https://www.inven.co.kr/board/webzine',                              'category', 600, 2, TRUE, 'webzine'),
+
+  -- bobaedream (1)
+  ('community', 'bobaedream', 'https://www.bobaedream.co.kr/list?code=best',                        'category', 600, 2, TRUE, 'best 게시판'),
+
+  -- pgr21 (1)
+  ('community', 'pgr21',      'https://www.pgr21.com/freedom',                                      'category', 600, 2, TRUE, '자유게시판'),
+
+  -- slashdot (2)
+  ('community', 'slashdot',   'https://slashdot.org/',                                              'category', 600, 2, TRUE, 'main top'),
+  ('community', 'slashdot',   'https://news.slashdot.org/',                                         'category', 600, 2, TRUE, 'news'),
+
+  -- lemmy (2)
+  ('community', 'lemmy',      'https://lemmy.world/c/news',                                         'category', 600, 2, TRUE, 'c/news'),
+  ('community', 'lemmy',      'https://lemmy.world/c/worldnews',                                    'category', 600, 2, TRUE, 'c/worldnews'),
+
+  -- tildes (2)
+  ('community', 'tildes',     'https://tildes.net/',                                                'category', 600, 2, TRUE, 'front page'),
+  ('community', 'tildes',     'https://tildes.net/~news',                                           'category', 600, 2, TRUE, '~news')
+ON CONFLICT (category, source_name, url) DO NOTHING;


### PR DESCRIPTION
## 연관 이슈
Closes #330 의 community 카테고리 후속 — 메인 #330 은 sub-issue #331 (search) 까지 완료 후 close 예정.

migration 021 (PR #334) 의 6 사이트 이후 사용자 요청 \"더 많은 양의 사이트를 추가해줘\" 반영.

## 구현 내용

### 신규 등록 (8 사이트)

**국내 5 (KR / RPH=100):**
- ruliweb — `bbs.ruliweb.com` — humor best / community
- mlbpark — `mlbpark.donga.com` — bullpen / political
- inven — `www.inven.co.kr` — IT 게시판 / webzine
- bobaedream — `www.bobaedream.co.kr` — best 게시판
- pgr21 — `www.pgr21.com` — 자유게시판

**해외 3 (international / RPH=200):**
- slashdot — `slashdot.org` + `news.slashdot.org` — main top / news
- lemmy.world — c/news / c/worldnews
- tildes.net — front page / ~news

### 정책 (021 과 동일)
- `fetcher='chromedp'` 통일 — anti-bot 대응
- `requests_per_hour` 보수 (KR 100 / international 200)
- `parsing_rules` 는 LLM 자동 학습 (#326 claudegen multi-step) 에 위임
- `scheduler_entries.interval_seconds = 600` (10m) — community 카테고리 빈번 갱신
- `priority=2` (news 보다 한 단계 낮음)

### Migration 변경
- `migrations/up/022_community_sources_more.sql` — fetcher_rules 9건 + scheduler_entries 14건 (ON CONFLICT DO NOTHING)
- `migrations/down/022_community_sources_more.sql` — (category, source_name, url) tuple set + host_pattern set 정확 매칭 (021 의 CodeRabbit Major 패턴 반영)

## CI / 머지 게이트 점검
- [x] `go build ./...` 통과
- [x] `go test -race -count=1 ./test/...` 전부 ok
- [x] 로컬 DB 적용 검증 — fetcher_rules 9건 + scheduler_entries 14건 INSERT 확인
- [x] commit / branch / PR 컨벤션 준수

## 변경 영향 범위 + 위험도
- **영향**: 다음 Scheduler.Refresh tick (30s) 부터 본 14개 URL 대상 fetch 시작
- **위험도**: 낮음 — chromedp + RPH 정책으로 source 부담 cap, IPRateLimiterRegistry (#323) 가 IP 단위 throttle, parsing_rules 는 LLM 학습 도중 partial 결과여도 pipeline guard 가 흡수
- pipeline guard (Article 24h / Category 1m TTL) 가 중복 fetch 차단

## 롤백 계획
1. `migrate-down` 으로 022 down 적용 — INSERT 한 정확한 row 만 삭제
2. parsing_rules 의 LLM 학습 결과는 down 에서 건드리지 않음 — 운영자가 별도로 정리

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added eight new community sources for content scraping, including popular Korean and international platforms
  * Configured automated content collection with optimized scheduling intervals

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/EinSofINTEREST/IssueTracker/pull/335)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->