### PR TITLE
[FEAT#337] Google CSE client + SearchHandler — keyword fanout (#331 Sub B)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -177,3 +177,14 @@ BLACKLIST_ENABLED=true
 STALE_RELEARN_ENABLED=true
 STALE_RELEARN_THRESHOLD=10
 STALE_RELEARN_WINDOW=2h
+
+# Google Custom Search Engine API (이슈 #337 — search handler)
+# 미설정 시 search handler 자동 비활성화 — fetcher / parser / validate 흐름은 정상.
+# scheduler_entries 의 category='search' entry 가 발행되더라도 fetcher 측에서 noop 처리.
+#
+# APIKey: https://console.cloud.google.com/apis/credentials
+# CX: https://programmablesearchengine.google.com (Search Engine ID)
+# 무료 plan: 100 q/day. 16 keyword × 1 page × 4 cycle/day = 64 q/day (free tier 안)
+GOOGLE_CSE_API_KEY=
+GOOGLE_CSE_CX=
+GOOGLE_CSE_TIMEOUT=10s

--- a/cmd/issuetracker/main.go
+++ b/cmd/issuetracker/main.go
@@ -13,6 +13,7 @@ import (
 	"issuetracker/internal/processor/fetcher"
 	"issuetracker/internal/processor/fetcher/core"
 	"issuetracker/internal/processor/fetcher/domain/general/sources"
+	"issuetracker/internal/processor/fetcher/domain/search"
 	"issuetracker/internal/processor/fetcher/handler"
 	fetcherRule "issuetracker/internal/processor/fetcher/rule"
 	crawlerWorker "issuetracker/internal/processor/fetcher/worker"
@@ -217,6 +218,46 @@ func main() {
 	// fetcher 측 등록: fetcher_rules DB 에서 모든 source 를 읽어 일괄 등록.
 	if err := sources.RegisterAll(ctx, registry, fetcherRuleRepo, core.DefaultConfig(), rawSvc, crawlerProducer, fetcherResolver, chromedpRemoteURLs, log); err != nil {
 		log.WithError(err).Fatal("failed to register crawlers from db")
+	}
+
+	// Search handler (Google CSE) — optional. APIKey/CX 미설정이면 wire skip.
+	// scheduler_entries 의 category='search' entry 가 fetcher 에 도달했을 때 본 handler 가 호출되어
+	// keyword × CSE fanout → host 단위 chained article job 발행.
+	googleCSECfg, err := config.LoadGoogleCSE()
+	if err != nil {
+		log.WithError(err).Warn("failed to load google cse config — search handler disabled")
+	} else if !googleCSECfg.IsConfigured() {
+		log.Info("google cse not configured (GOOGLE_CSE_API_KEY/CX) — search handler disabled")
+	} else {
+		searchKeywordRepo, kwErr := pgstore.NewSearchKeywordRepository(pool, log)
+		if kwErr != nil {
+			log.WithError(kwErr).Warn("search keyword repo construction failed — search handler disabled")
+		} else {
+			cseClient, cseErr := search.NewCSEClient(search.CSEClientOptions{
+				APIKey:  googleCSECfg.APIKey,
+				CX:      googleCSECfg.CX,
+				Timeout: googleCSECfg.Timeout,
+			}, log)
+			if cseErr != nil {
+				log.WithError(cseErr).Warn("cse client construction failed — search handler disabled")
+			} else {
+				searchHandler, hErr := search.NewSearchHandler(search.SearchHandlerOptions{
+					Client:      cseClient,
+					KeywordRepo: searchKeywordRepo,
+					Publisher:   jobPublisher,
+				}, log)
+				if hErr != nil {
+					log.WithError(hErr).Warn("search handler construction failed — search handler disabled")
+				} else {
+					// scheduler entry 의 url=https://customsearch.googleapis.com/... 가 host=customsearch.googleapis.com
+					// 으로 변환되어 CrawlerName 에 들어감 (NewDefaultEntryConverter). 두 키 모두 등록 — source_name
+					// 직접 매칭이나 host-based dispatch 양쪽 지원.
+					registry.Register("customsearch.googleapis.com", searchHandler)
+					registry.Register("google_cse", searchHandler)
+					log.Info("search handler registered (google cse)")
+				}
+			}
+		}
 	}
 
 	// Redis 기반 ProcessingLock: 동일 URL 이 여러 worker/인스턴스에서 단계별 (fetcher/parser/validator)

--- a/internal/processor/fetcher/core/models.go
+++ b/internal/processor/fetcher/core/models.go
@@ -29,9 +29,10 @@ type SourceInfo struct {
 type TargetType string
 
 const (
-	TargetTypeSitemap  TargetType = "sitemap"
-	TargetTypeArticle  TargetType = "article"
-	TargetTypeCategory TargetType = "category"
+	TargetTypeSitemap       TargetType = "sitemap"
+	TargetTypeArticle       TargetType = "article"
+	TargetTypeCategory      TargetType = "category"
+	TargetTypeSearchResults TargetType = "search_results"
 )
 
 // Target은 크롤링 대상을 나타냅니다.

--- a/internal/processor/fetcher/domain/search/google_cse.go
+++ b/internal/processor/fetcher/domain/search/google_cse.go
@@ -10,6 +10,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"math/rand"
 	"net/http"
 	"net/url"
 	"strconv"
@@ -28,15 +29,55 @@ const cseMaxResultsPerCall = 10
 // cseMaxStart 는 Google CSE 가 허용하는 start 파라미터 최댓값 (총 100개 결과 = 10페이지).
 const cseMaxStart = 100
 
+// RetryPolicy 는 CSE API 호출 재시도 정책입니다.
+//
+// 프로젝트 규칙 (.claude/rules/04-error-handling.md):
+//   - Network/Timeout: 최대 3회, 1s initial, exp backoff + jitter
+//   - RateLimit (429): 최대 5회, 10s initial, exp backoff (jitter 없음)
+//
+// 재시도 비활성화 시 MaxAttempts=1 — 첫 시도 성공/실패 그대로 반환 (테스트 / 강제 fail-fast 용도).
+type RetryPolicy struct {
+	MaxAttempts  int
+	InitialDelay time.Duration
+	MaxDelay     time.Duration
+	Multiplier   float64
+	Jitter       bool
+}
+
+// DefaultNetworkRetryPolicy 는 네트워크/타임아웃/5xx 에 적용되는 재시도 정책입니다.
+func DefaultNetworkRetryPolicy() RetryPolicy {
+	return RetryPolicy{
+		MaxAttempts:  3,
+		InitialDelay: 1 * time.Second,
+		MaxDelay:     30 * time.Second,
+		Multiplier:   2.0,
+		Jitter:       true,
+	}
+}
+
+// DefaultRateLimitRetryPolicy 는 429 (rate limit) 에 적용되는 재시도 정책입니다.
+func DefaultRateLimitRetryPolicy() RetryPolicy {
+	return RetryPolicy{
+		MaxAttempts:  5,
+		InitialDelay: 10 * time.Second,
+		MaxDelay:     5 * time.Minute,
+		Multiplier:   2.0,
+		Jitter:       false,
+	}
+}
+
 // CSEClient 는 Google Custom Search Engine 의 JSON API 를 호출하는 client 입니다.
 //
 // 동시성 안전 — internal 상태는 모두 readonly 또는 http client 자체에서 관리.
 type CSEClient struct {
-	apiKey  string
-	cx      string
-	baseURL string
-	http    *http.Client
-	log     *logger.Logger
+	apiKey      string
+	cx          string
+	baseURL     string
+	http        *http.Client
+	log         *logger.Logger
+	netPolicy   RetryPolicy
+	rateLPolicy RetryPolicy
+	rng         *rand.Rand
 }
 
 // CSEClientOptions 는 CSEClient 생성 옵션입니다.
@@ -45,6 +86,11 @@ type CSEClientOptions struct {
 	CX      string // Search Engine ID
 	BaseURL string // 빈 문자열이면 CSEDefaultBaseURL
 	Timeout time.Duration
+
+	// NetworkRetry / RateLimitRetry: 0 (zero value) 이면 Default*RetryPolicy 사용.
+	// MaxAttempts=1 로 명시하면 retry 비활성 (테스트 / 강제 fail-fast).
+	NetworkRetry   RetryPolicy
+	RateLimitRetry RetryPolicy
 }
 
 // NewCSEClient 는 새 CSEClient 를 생성합니다.
@@ -68,12 +114,23 @@ func NewCSEClient(opts CSEClientOptions, log *logger.Logger) (*CSEClient, error)
 	if timeout <= 0 {
 		timeout = 10 * time.Second
 	}
+	netP := opts.NetworkRetry
+	if netP.MaxAttempts == 0 {
+		netP = DefaultNetworkRetryPolicy()
+	}
+	rateP := opts.RateLimitRetry
+	if rateP.MaxAttempts == 0 {
+		rateP = DefaultRateLimitRetryPolicy()
+	}
 	return &CSEClient{
-		apiKey:  opts.APIKey,
-		cx:      opts.CX,
-		baseURL: baseURL,
-		http:    &http.Client{Timeout: timeout},
-		log:     log,
+		apiKey:      opts.APIKey,
+		cx:          opts.CX,
+		baseURL:     baseURL,
+		http:        &http.Client{Timeout: timeout},
+		log:         log,
+		netPolicy:   netP,
+		rateLPolicy: rateP,
+		rng:         rand.New(rand.NewSource(time.Now().UnixNano())),
 	}, nil
 }
 
@@ -157,15 +214,17 @@ func (c *CSEClient) Search(ctx context.Context, keyword string, opts SearchOptio
 			num = remaining
 		}
 
-		page, hasNext, err := c.searchOnce(ctx, keyword, opts, start, num)
+		page, hasNext, err := c.searchWithRetry(ctx, keyword, opts, start, num)
 		if err != nil {
-			// 부분 결과 보존: 첫 페이지가 아니면 warn + 누적 결과 반환.
-			if start > 1 && len(urls) > 0 {
+			// 부분 결과 보존: 첫 페이지가 아니고 retryable 에러일 때만 — non-retryable
+			// (auth / quota exhausted) 는 호출자에게 그대로 전파해야 cycle 차단 가능 (CodeRabbit Major 반영).
+			var cseErr *CSEError
+			if start > 1 && len(urls) > 0 && errors.As(err, &cseErr) && cseErr.Retryable {
 				c.log.WithFields(map[string]interface{}{
 					"keyword":   keyword,
 					"start":     start,
 					"partial_n": len(urls),
-				}).WithError(err).Warn("cse pagination interrupted — returning partial results")
+				}).WithError(err).Warn("cse pagination interrupted (retryable) — returning partial results")
 				return urls, nil
 			}
 			return nil, err
@@ -185,6 +244,101 @@ func (c *CSEClient) Search(ctx context.Context, keyword string, opts SearchOptio
 	}
 
 	return urls, nil
+}
+
+// searchWithRetry 는 searchOnce 를 retry policy 에 따라 재시도하며 호출합니다.
+//
+// 정책 선택:
+//   - 429 (rate limit) → rateLPolicy (max 5회, 10s initial, exp backoff)
+//   - 5xx / network    → netPolicy   (max 3회, 1s initial, exp backoff + jitter)
+//   - non-retryable    → 즉시 반환 (재시도 무용)
+//
+// ctx cancel/deadline 은 backoff 대기 중에도 즉시 반영됩니다.
+func (c *CSEClient) searchWithRetry(ctx context.Context, keyword string, opts SearchOptions, start, num int) ([]string, bool, error) {
+	var lastErr error
+	// max attempts 는 두 정책 중 큰 쪽 — 호출 전엔 어떤 정책이 적용될지 모르므로 union.
+	// 각 attempt 마다 에러 유형 보고 그 정책의 attempt 한도를 본격 확인.
+	maxLoops := c.rateLPolicy.MaxAttempts
+	if c.netPolicy.MaxAttempts > maxLoops {
+		maxLoops = c.netPolicy.MaxAttempts
+	}
+	if maxLoops < 1 {
+		maxLoops = 1
+	}
+
+	netAttempt, rateAttempt := 0, 0
+	for loop := 0; loop < maxLoops; loop++ {
+		urls, hasNext, err := c.searchOnce(ctx, keyword, opts, start, num)
+		if err == nil {
+			return urls, hasNext, nil
+		}
+
+		var cseErr *CSEError
+		if !errors.As(err, &cseErr) || !cseErr.Retryable {
+			return nil, false, err
+		}
+
+		// 정책 선택: 429 → rate, 그 외 retryable → network
+		var policy RetryPolicy
+		var attemptCounter *int
+		if cseErr.StatusCode == http.StatusTooManyRequests {
+			policy = c.rateLPolicy
+			attemptCounter = &rateAttempt
+		} else {
+			policy = c.netPolicy
+			attemptCounter = &netAttempt
+		}
+		*attemptCounter++
+		lastErr = err
+
+		// 정책별 attempt 한도 도달 시 더 이상 재시도하지 않음.
+		if *attemptCounter >= policy.MaxAttempts {
+			return nil, false, err
+		}
+
+		delay := c.computeBackoff(policy, *attemptCounter)
+		c.log.WithFields(map[string]interface{}{
+			"keyword":      keyword,
+			"start":        start,
+			"attempt":      *attemptCounter,
+			"max_attempts": policy.MaxAttempts,
+			"delay_ms":     delay.Milliseconds(),
+			"status_code":  cseErr.StatusCode,
+		}).WithError(err).Warn("cse retrying after retryable error")
+
+		select {
+		case <-ctx.Done():
+			return nil, false, ctx.Err()
+		case <-time.After(delay):
+		}
+	}
+	if lastErr == nil {
+		// 안전망 — 위 루프 어느 분기에서도 lastErr 없이 빠져나오는 경우는 없음.
+		lastErr = errors.New("cse: retry exhausted without error capture")
+	}
+	return nil, false, lastErr
+}
+
+// computeBackoff 는 attempt-th 재시도 전 대기 시간을 계산합니다 (1-based attempt).
+//
+// delay = initial * multiplier^(attempt-1), MaxDelay 로 cap. Jitter=true 면 [0.5×, 1.5×] 범위 변동.
+func (c *CSEClient) computeBackoff(p RetryPolicy, attempt int) time.Duration {
+	if attempt < 1 {
+		attempt = 1
+	}
+	delay := float64(p.InitialDelay)
+	for i := 1; i < attempt; i++ {
+		delay *= p.Multiplier
+	}
+	if max := float64(p.MaxDelay); max > 0 && delay > max {
+		delay = max
+	}
+	if p.Jitter {
+		// [0.5, 1.5) 범위 균일 분포 — exp backoff 시 동시성 군집 흩뜨리기.
+		factor := 0.5 + c.rng.Float64()
+		delay *= factor
+	}
+	return time.Duration(delay)
 }
 
 // searchOnce 는 1회의 CSE API 호출을 수행하고 (URLs, hasNextPage, err) 를 반환합니다.

--- a/internal/processor/fetcher/domain/search/google_cse.go
+++ b/internal/processor/fetcher/domain/search/google_cse.go
@@ -1,0 +1,259 @@
+// Package search 는 검색 엔진 기반 진입 (Google CSE 등) 의 fetcher domain handler 를 제공합니다.
+//
+// 일반 fetcher chain (goquery / chromedp) 과 달리 검색은 API 응답 → article URL 추출 → fanout
+// 구조이므로 별도 handler 로 격리. 본 패키지는 SearchHandler 와 Google CSE client 를 포함합니다.
+package search
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strconv"
+	"time"
+
+	"issuetracker/pkg/logger"
+)
+
+// CSEDefaultBaseURL 은 Google Custom Search JSON API 의 기본 endpoint 입니다.
+const CSEDefaultBaseURL = "https://customsearch.googleapis.com/customsearch/v1"
+
+// cseMaxResultsPerCall 은 Google CSE 가 한 번의 호출에서 반환하는 최대 결과 수입니다.
+// num 파라미터 상한 — paginated start 1,11,21,... 으로 다음 페이지 진입.
+const cseMaxResultsPerCall = 10
+
+// cseMaxStart 는 Google CSE 가 허용하는 start 파라미터 최댓값 (총 100개 결과 = 10페이지).
+const cseMaxStart = 100
+
+// CSEClient 는 Google Custom Search Engine 의 JSON API 를 호출하는 client 입니다.
+//
+// 동시성 안전 — internal 상태는 모두 readonly 또는 http client 자체에서 관리.
+type CSEClient struct {
+	apiKey  string
+	cx      string
+	baseURL string
+	http    *http.Client
+	log     *logger.Logger
+}
+
+// CSEClientOptions 는 CSEClient 생성 옵션입니다.
+type CSEClientOptions struct {
+	APIKey  string
+	CX      string // Search Engine ID
+	BaseURL string // 빈 문자열이면 CSEDefaultBaseURL
+	Timeout time.Duration
+}
+
+// NewCSEClient 는 새 CSEClient 를 생성합니다.
+//
+// APIKey / CX 가 비어있으면 에러. timeout 이 0 이하면 10s 적용.
+func NewCSEClient(opts CSEClientOptions, log *logger.Logger) (*CSEClient, error) {
+	if opts.APIKey == "" {
+		return nil, errors.New("search: CSEClient requires APIKey")
+	}
+	if opts.CX == "" {
+		return nil, errors.New("search: CSEClient requires CX (search engine id)")
+	}
+	if log == nil {
+		return nil, errors.New("search: CSEClient requires logger")
+	}
+	baseURL := opts.BaseURL
+	if baseURL == "" {
+		baseURL = CSEDefaultBaseURL
+	}
+	timeout := opts.Timeout
+	if timeout <= 0 {
+		timeout = 10 * time.Second
+	}
+	return &CSEClient{
+		apiKey:  opts.APIKey,
+		cx:      opts.CX,
+		baseURL: baseURL,
+		http:    &http.Client{Timeout: timeout},
+		log:     log,
+	}, nil
+}
+
+// SearchOptions 는 단일 keyword 호출에 적용되는 파라미터입니다.
+//
+// MaxResults 는 본 client 가 paginated 호출로 모을 총 결과 수 — Google CSE 자체 상한
+// (cseMaxStart=100) 을 넘으면 100 으로 cap.
+type SearchOptions struct {
+	MaxResults    int    // 누적 결과 상한 (10 단위로 paginate)
+	DateRangeDays int    // 0 이면 dateRestrict 미적용
+	Language      string // CSE 'lr' 파라미터 (예: "lang_ko" 형식이 아니라 ISO 코드 — 본 client 가 변환)
+	Region        string // CSE 'gl' 파라미터 (소문자 ISO 코드)
+}
+
+// CSEError 는 CSE API 호출 실패를 나타냅니다.
+//
+// Retryable=true 인 경우 호출자가 backoff 후 재시도 — 429 / 5xx / network.
+// 401/403 등 auth 에러는 Retryable=false (재시도 무용).
+type CSEError struct {
+	StatusCode int
+	Message    string
+	Retryable  bool
+	Err        error
+}
+
+func (e *CSEError) Error() string {
+	if e.Err != nil {
+		return fmt.Sprintf("cse api error (status=%d): %s: %v", e.StatusCode, e.Message, e.Err)
+	}
+	return fmt.Sprintf("cse api error (status=%d): %s", e.StatusCode, e.Message)
+}
+
+func (e *CSEError) Unwrap() error { return e.Err }
+
+// cseResponse 는 Google CSE JSON 응답의 부분 매핑 — 필요한 필드만 추출.
+type cseResponse struct {
+	Items []struct {
+		Link string `json:"link"`
+	} `json:"items"`
+	Queries struct {
+		NextPage []struct {
+			StartIndex int `json:"startIndex"`
+		} `json:"nextPage"`
+	} `json:"queries"`
+	Error *struct {
+		Code    int    `json:"code"`
+		Message string `json:"message"`
+	} `json:"error"`
+}
+
+// Search 는 단일 keyword 로 paginated 호출하여 article URL 리스트를 반환합니다.
+//
+// MaxResults 가 0 이하면 cseMaxResultsPerCall (10) 적용. 100 초과 시 100 으로 cap.
+// 호출 도중 retryable 에러 발생 시: 첫 page 실패는 그대로 반환, 중간 page 실패는 그때까지의
+// 결과를 부분 반환 + warn (CSE 무료 plan quota 고려 — 부분 결과도 가치 있음).
+func (c *CSEClient) Search(ctx context.Context, keyword string, opts SearchOptions) ([]string, error) {
+	if keyword == "" {
+		return nil, errors.New("search: keyword must be non-empty")
+	}
+	max := opts.MaxResults
+	if max <= 0 {
+		max = cseMaxResultsPerCall
+	}
+	if max > cseMaxStart {
+		max = cseMaxStart
+	}
+
+	var urls []string
+	seen := make(map[string]struct{}, max)
+
+	for start := 1; start <= max && start <= cseMaxStart; start += cseMaxResultsPerCall {
+		select {
+		case <-ctx.Done():
+			return urls, ctx.Err()
+		default:
+		}
+
+		// 마지막 페이지에서는 num 을 남은 개수로 줄여 quota 절약.
+		num := cseMaxResultsPerCall
+		if remaining := max - (start - 1); remaining < num {
+			num = remaining
+		}
+
+		page, hasNext, err := c.searchOnce(ctx, keyword, opts, start, num)
+		if err != nil {
+			// 부분 결과 보존: 첫 페이지가 아니면 warn + 누적 결과 반환.
+			if start > 1 && len(urls) > 0 {
+				c.log.WithFields(map[string]interface{}{
+					"keyword":   keyword,
+					"start":     start,
+					"partial_n": len(urls),
+				}).WithError(err).Warn("cse pagination interrupted — returning partial results")
+				return urls, nil
+			}
+			return nil, err
+		}
+
+		for _, u := range page {
+			if _, dup := seen[u]; dup {
+				continue
+			}
+			seen[u] = struct{}{}
+			urls = append(urls, u)
+		}
+
+		if !hasNext || len(urls) >= max {
+			break
+		}
+	}
+
+	return urls, nil
+}
+
+// searchOnce 는 1회의 CSE API 호출을 수행하고 (URLs, hasNextPage, err) 를 반환합니다.
+func (c *CSEClient) searchOnce(ctx context.Context, keyword string, opts SearchOptions, start, num int) ([]string, bool, error) {
+	q := url.Values{}
+	q.Set("key", c.apiKey)
+	q.Set("cx", c.cx)
+	q.Set("q", keyword)
+	q.Set("num", strconv.Itoa(num))
+	q.Set("start", strconv.Itoa(start))
+	if opts.DateRangeDays > 0 {
+		q.Set("dateRestrict", fmt.Sprintf("d%d", opts.DateRangeDays))
+	}
+	if opts.Language != "" {
+		// Google CSE 의 lr 파라미터 형식은 "lang_<ISO>" — 호출자는 ISO 코드만 전달.
+		q.Set("lr", "lang_"+opts.Language)
+	}
+	if opts.Region != "" {
+		q.Set("gl", opts.Region)
+	}
+
+	endpoint := c.baseURL + "?" + q.Encode()
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
+	if err != nil {
+		return nil, false, fmt.Errorf("build cse request: %w", err)
+	}
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return nil, false, &CSEError{Message: "transport error", Retryable: true, Err: err}
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, false, &CSEError{StatusCode: resp.StatusCode, Message: "read response", Retryable: true, Err: err}
+	}
+
+	if resp.StatusCode >= 400 {
+		// 4xx 분류: 429 / 408 은 retryable, 그 외 4xx (auth / quota exceeded etc) 는 non-retryable.
+		retryable := resp.StatusCode == http.StatusTooManyRequests || resp.StatusCode == http.StatusRequestTimeout || resp.StatusCode >= 500
+		// 응답 body 의 error.message 가 있으면 추출.
+		var parsed cseResponse
+		_ = json.Unmarshal(body, &parsed)
+		msg := ""
+		if parsed.Error != nil {
+			msg = parsed.Error.Message
+		}
+		if msg == "" {
+			msg = string(body)
+			if len(msg) > 200 {
+				msg = msg[:200]
+			}
+		}
+		return nil, false, &CSEError{StatusCode: resp.StatusCode, Message: msg, Retryable: retryable}
+	}
+
+	var parsed cseResponse
+	if err := json.Unmarshal(body, &parsed); err != nil {
+		return nil, false, &CSEError{StatusCode: resp.StatusCode, Message: "decode json", Retryable: false, Err: err}
+	}
+
+	urls := make([]string, 0, len(parsed.Items))
+	for _, it := range parsed.Items {
+		if it.Link != "" {
+			urls = append(urls, it.Link)
+		}
+	}
+	hasNext := len(parsed.Queries.NextPage) > 0
+	return urls, hasNext, nil
+}

--- a/internal/processor/fetcher/domain/search/handler.go
+++ b/internal/processor/fetcher/domain/search/handler.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"net/url"
-	"sort"
 	"time"
 
 	"issuetracker/internal/processor/fetcher/core"
@@ -125,11 +124,11 @@ func (h *SearchHandler) Handle(ctx context.Context, job *core.CrawlJob) ([]*core
 	successKeywordIDs := make([]int64, 0, len(keywords))
 
 	for _, kw := range keywords {
-		select {
-		case <-ctx.Done():
-			h.log.WithError(ctx.Err()).Warn("search handler ctx done — interrupting keyword loop")
-			break
-		default:
+		// ctx cancel 시 즉시 cycle 종료 — select+break 는 select 만 빠져나오므로 명시 return.
+		if err := ctx.Err(); err != nil {
+			h.log.WithError(err).Warn("search handler ctx done — interrupting keyword loop")
+			h.markSearched(ctx, successKeywordIDs)
+			return nil, err
 		}
 
 		kwOpts := opts
@@ -138,6 +137,15 @@ func (h *SearchHandler) Handle(ctx context.Context, job *core.CrawlJob) ([]*core
 
 		urls, searchErr := h.client.Search(ctx, kw.Keyword, kwOpts)
 		if searchErr != nil {
+			// ctx cancel/deadline 으로 인한 실패는 wrap 여부에 무관하게 ctx.Err() 가 유일 진실
+			// — 다른 에러 분류 분기보다 우선 검사 (gemini Medium 반영).
+			if ctxErr := ctx.Err(); ctxErr != nil {
+				h.log.WithFields(map[string]interface{}{
+					"keyword": kw.Keyword,
+				}).WithError(searchErr).Warn("cse search interrupted by ctx — aborting cycle")
+				h.markSearched(ctx, successKeywordIDs)
+				return nil, searchErr
+			}
 			// non-retryable (auth / quota) → 전체 cycle 중단 (다음 cycle 까지 기다림).
 			var cseErr *CSEError
 			if errors.As(searchErr, &cseErr) && !cseErr.Retryable {
@@ -245,9 +253,7 @@ func (h *SearchHandler) markSearched(ctx context.Context, ids []int64) {
 
 // groupByHost 는 URL 리스트를 hostname 별로 group 합니다. 파싱 실패 URL 은 "_unknown_" group.
 //
-// 반환되는 map 은 deterministic 순서가 아님 — 호출자가 필요시 keys 를 sort 해야 합니다.
-// 본 함수는 host group 단위 batch publish 효율 + 결정성 테스트를 위해 keys 를 sort 한 결과를
-// 호출자가 사용할 수 있도록 sort 헬퍼도 제공.
+// 반환되는 map 은 deterministic 순서가 아님 — host 단위 batch publish 효율을 위한 group 화에만 사용.
 func groupByHost(urls []string) map[string][]string {
 	byHost := make(map[string][]string, 16)
 	for _, u := range urls {
@@ -264,14 +270,4 @@ func hostOf(rawURL string) string {
 		return "_unknown_"
 	}
 	return u.Hostname()
-}
-
-// sortedHosts 는 group map 의 키를 정렬하여 반환합니다 (테스트 결정성용 헬퍼).
-func sortedHosts(byHost map[string][]string) []string {
-	keys := make([]string, 0, len(byHost))
-	for k := range byHost {
-		keys = append(keys, k)
-	}
-	sort.Strings(keys)
-	return keys
 }

--- a/internal/processor/fetcher/domain/search/handler.go
+++ b/internal/processor/fetcher/domain/search/handler.go
@@ -1,0 +1,277 @@
+package search
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/url"
+	"sort"
+	"time"
+
+	"issuetracker/internal/processor/fetcher/core"
+	"issuetracker/internal/storage"
+	"issuetracker/pkg/logger"
+)
+
+// JobPublisher 는 SearchHandler 가 fanout chained article job 을 발행할 때 사용하는 인터페이스입니다.
+//
+// 실제 구현은 internal/publisher.Publisher — host 별 batch 발행을 위해 host group 마다 호출.
+type JobPublisher interface {
+	Publish(
+		ctx context.Context,
+		crawlerName string,
+		urls []string,
+		targetType core.TargetType,
+		timeout time.Duration,
+	) error
+}
+
+// SearchHandler 는 scheduler 가 발행한 search_results 카테고리 job 을 처리하는 Handler 입니다.
+//
+// 동작:
+//  1. job.Target.Metadata 에서 engine / per_query_max_results / date_range_days 추출
+//  2. SearchKeywordRepository.ListEnabled 로 enabled keyword 전체 조회
+//  3. 각 keyword 별 CSEClient.Search 호출 → URL 누적 (keyword-level 실패는 skip + warn)
+//  4. URL 들을 host 단위로 group → 각 host 별 publisher.Publish(crawlerName=host, TargetTypeArticle)
+//     fanout — 다운스트림 fetcher 가 host-specific handler 로 라우팅
+//  5. 성공 keyword 의 last_searched_at 갱신
+//
+// nil content 반환 — 실제 article 의 raw_content 는 chained article job 이 fetch 후 발행.
+type SearchHandler struct {
+	client      *CSEClient
+	keywordRepo storage.SearchKeywordRepository
+	publisher   JobPublisher
+	log         *logger.Logger
+
+	// articleTimeout 은 fanout 된 chained article job 의 fetch timeout.
+	articleTimeout time.Duration
+}
+
+// SearchHandlerOptions 는 SearchHandler 생성 옵션입니다.
+type SearchHandlerOptions struct {
+	Client         *CSEClient
+	KeywordRepo    storage.SearchKeywordRepository
+	Publisher      JobPublisher
+	ArticleTimeout time.Duration // 0 이하면 30s
+}
+
+// NewSearchHandler 는 SearchHandler 를 생성합니다. 모든 의존성 비-nil 필수.
+func NewSearchHandler(opts SearchHandlerOptions, log *logger.Logger) (*SearchHandler, error) {
+	if opts.Client == nil {
+		return nil, errors.New("search: SearchHandler requires CSEClient")
+	}
+	if opts.KeywordRepo == nil {
+		return nil, errors.New("search: SearchHandler requires KeywordRepo")
+	}
+	if opts.Publisher == nil {
+		return nil, errors.New("search: SearchHandler requires Publisher")
+	}
+	if log == nil {
+		return nil, errors.New("search: SearchHandler requires logger")
+	}
+	timeout := opts.ArticleTimeout
+	if timeout <= 0 {
+		timeout = 30 * time.Second
+	}
+	return &SearchHandler{
+		client:         opts.Client,
+		keywordRepo:    opts.KeywordRepo,
+		publisher:      opts.Publisher,
+		log:            log,
+		articleTimeout: timeout,
+	}, nil
+}
+
+// entryMetadata 는 scheduler_entries.metadata JSONB 에서 추출하는 search-specific 옵션입니다.
+//
+// 모든 필드는 optional — 기본값은 search_results target 에 일반적으로 적합한 보수 값.
+type entryMetadata struct {
+	Engine             string `json:"engine"`
+	PerQueryMaxResults int    `json:"per_query_max_results"`
+	DateRangeDays      int    `json:"date_range_days"`
+}
+
+// Handle 은 search_results target 에 대해 keyword fanout 을 수행합니다.
+func (h *SearchHandler) Handle(ctx context.Context, job *core.CrawlJob) ([]*core.Content, error) {
+	if job == nil {
+		return nil, errors.New("search: nil job")
+	}
+
+	meta := h.parseMetadata(job)
+	if meta.Engine != "" && meta.Engine != "google_cse" {
+		// 본 handler 는 google_cse 만 처리. 다른 engine 은 future-proof skip.
+		h.log.WithField("engine", meta.Engine).Warn("search handler skip: unsupported engine")
+		return nil, nil
+	}
+
+	keywords, err := h.keywordRepo.ListEnabled(ctx, "", "")
+	if err != nil {
+		return nil, fmt.Errorf("list enabled keywords: %w", err)
+	}
+	if len(keywords) == 0 {
+		h.log.Info("search handler: no enabled keywords — skip")
+		return nil, nil
+	}
+
+	opts := SearchOptions{
+		MaxResults:    meta.PerQueryMaxResults,
+		DateRangeDays: meta.DateRangeDays,
+	}
+
+	// keyword-level dedup — 같은 article 이 여러 keyword 에서 hit 되면 1번만 fanout.
+	seen := make(map[string]struct{}, 256)
+	var allURLs []string
+	successKeywordIDs := make([]int64, 0, len(keywords))
+
+	for _, kw := range keywords {
+		select {
+		case <-ctx.Done():
+			h.log.WithError(ctx.Err()).Warn("search handler ctx done — interrupting keyword loop")
+			break
+		default:
+		}
+
+		kwOpts := opts
+		kwOpts.Language = kw.Language
+		kwOpts.Region = kw.Region
+
+		urls, searchErr := h.client.Search(ctx, kw.Keyword, kwOpts)
+		if searchErr != nil {
+			// non-retryable (auth / quota) → 전체 cycle 중단 (다음 cycle 까지 기다림).
+			var cseErr *CSEError
+			if errors.As(searchErr, &cseErr) && !cseErr.Retryable {
+				h.log.WithFields(map[string]interface{}{
+					"keyword":     kw.Keyword,
+					"status_code": cseErr.StatusCode,
+				}).WithError(searchErr).Error("cse non-retryable error — aborting cycle")
+				return nil, nil
+			}
+			// keyword-level retryable 실패 → skip + warn, 다른 keyword 계속.
+			h.log.WithFields(map[string]interface{}{
+				"keyword": kw.Keyword,
+			}).WithError(searchErr).Warn("cse search failed — skipping keyword")
+			continue
+		}
+
+		for _, u := range urls {
+			if _, dup := seen[u]; dup {
+				continue
+			}
+			seen[u] = struct{}{}
+			allURLs = append(allURLs, u)
+		}
+		successKeywordIDs = append(successKeywordIDs, kw.ID)
+	}
+
+	if len(allURLs) == 0 {
+		h.log.WithField("keyword_count", len(keywords)).Info("search handler: no urls collected")
+		// last_searched_at 은 갱신 — 이번 cycle 에서 호출은 했으므로.
+		h.markSearched(ctx, successKeywordIDs)
+		return nil, nil
+	}
+
+	// host 단위 group 후 host-specific handler 로 fanout.
+	byHost := groupByHost(allURLs)
+
+	var publishedTotal int
+	for host, urls := range byHost {
+		if err := h.publisher.Publish(ctx, host, urls, core.TargetTypeArticle, h.articleTimeout); err != nil {
+			h.log.WithFields(map[string]interface{}{
+				"host":      host,
+				"url_count": len(urls),
+			}).WithError(err).Error("publish chained article jobs failed")
+			continue
+		}
+		publishedTotal += len(urls)
+	}
+
+	h.log.WithFields(map[string]interface{}{
+		"keyword_total":   len(keywords),
+		"keyword_success": len(successKeywordIDs),
+		"urls_unique":     len(allURLs),
+		"hosts":           len(byHost),
+		"published":       publishedTotal,
+	}).Info("search handler cycle completed")
+
+	h.markSearched(ctx, successKeywordIDs)
+	return nil, nil
+}
+
+// parseMetadata 는 job.Target.Metadata JSONB raw 또는 map 에서 entryMetadata 를 추출합니다.
+//
+// scheduler 의 EntryConverter 가 현재 metadata 를 ScheduleEntry 로 carry-over 하지 않으므로
+// 본 handler 는 best-effort — Metadata map 에 raw bytes 가 있으면 decode, 없으면 빈 struct 반환.
+// 빈 struct 는 client 의 default (1 page / no date filter) 로 동작.
+func (h *SearchHandler) parseMetadata(job *core.CrawlJob) entryMetadata {
+	var meta entryMetadata
+	if job.Target.Metadata == nil {
+		return meta
+	}
+	if raw, ok := job.Target.Metadata["raw_metadata"]; ok {
+		if b, ok := raw.([]byte); ok && len(b) > 0 {
+			if err := json.Unmarshal(b, &meta); err != nil {
+				h.log.WithError(err).Warn("search handler: failed to decode raw_metadata")
+			}
+		}
+	}
+	if v, ok := job.Target.Metadata["engine"].(string); ok && meta.Engine == "" {
+		meta.Engine = v
+	}
+	if v, ok := job.Target.Metadata["per_query_max_results"].(int); ok && meta.PerQueryMaxResults == 0 {
+		meta.PerQueryMaxResults = v
+	}
+	if v, ok := job.Target.Metadata["date_range_days"].(int); ok && meta.DateRangeDays == 0 {
+		meta.DateRangeDays = v
+	}
+	return meta
+}
+
+// markSearched 는 성공한 keyword 들의 last_searched_at 을 일괄 갱신합니다.
+// 실패는 warn 로그만 남기고 cycle 자체는 정상 종료 — last_searched_at 은 부가 정보.
+func (h *SearchHandler) markSearched(ctx context.Context, ids []int64) {
+	if len(ids) == 0 {
+		return
+	}
+	now := time.Now().UTC()
+	for _, id := range ids {
+		if err := h.keywordRepo.MarkSearched(ctx, id, now); err != nil {
+			h.log.WithFields(map[string]interface{}{
+				"keyword_id": id,
+			}).WithError(err).Warn("mark searched failed — skipping")
+		}
+	}
+}
+
+// groupByHost 는 URL 리스트를 hostname 별로 group 합니다. 파싱 실패 URL 은 "_unknown_" group.
+//
+// 반환되는 map 은 deterministic 순서가 아님 — 호출자가 필요시 keys 를 sort 해야 합니다.
+// 본 함수는 host group 단위 batch publish 효율 + 결정성 테스트를 위해 keys 를 sort 한 결과를
+// 호출자가 사용할 수 있도록 sort 헬퍼도 제공.
+func groupByHost(urls []string) map[string][]string {
+	byHost := make(map[string][]string, 16)
+	for _, u := range urls {
+		host := hostOf(u)
+		byHost[host] = append(byHost[host], u)
+	}
+	return byHost
+}
+
+// hostOf 는 URL 의 hostname 을 반환합니다. 파싱 실패 시 "_unknown_".
+func hostOf(rawURL string) string {
+	u, err := url.Parse(rawURL)
+	if err != nil || u.Hostname() == "" {
+		return "_unknown_"
+	}
+	return u.Hostname()
+}
+
+// sortedHosts 는 group map 의 키를 정렬하여 반환합니다 (테스트 결정성용 헬퍼).
+func sortedHosts(byHost map[string][]string) []string {
+	keys := make([]string, 0, len(byHost))
+	for k := range byHost {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
+}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1305,3 +1305,60 @@ func LoadPrompt(envFiles ...string) (PromptConfig, error) {
 	v, ok := os.LookupEnv("LLM_PROMPT_DIR")
 	return PromptConfig{Dir: v, DirSet: ok}, nil
 }
+
+// GoogleCSEConfig 는 Google Custom Search Engine API client wiring 설정입니다.
+//
+// 환경변수:
+//   - GOOGLE_CSE_API_KEY (필수, 빈 문자열이면 client 미생성 → search handler 비활성화)
+//   - GOOGLE_CSE_CX      (필수, search engine ID)
+//   - GOOGLE_CSE_TIMEOUT (default 10s)
+//
+// 운영 정책:
+//   - APIKey 또는 CX 가 미설정이면 cmd 측 wiring 이 search handler 를 skip (warn 로그) — search
+//     기능은 optional, 미설정 환경에서도 fetcher / parser / validate 흐름은 정상.
+type GoogleCSEConfig struct {
+	APIKey  string
+	CX      string
+	Timeout time.Duration
+}
+
+// DefaultGoogleCSEConfig 는 기본 GoogleCSEConfig 를 반환합니다 (Timeout 만 default).
+func DefaultGoogleCSEConfig() GoogleCSEConfig {
+	return GoogleCSEConfig{Timeout: 10 * time.Second}
+}
+
+// LoadGoogleCSE 는 .env 파일을 로드한 후 OS 환경변수로 GoogleCSEConfig 를 구성합니다.
+//
+// 빈 APIKey / CX 는 에러 아님 — 호출자가 IsConfigured 로 분기.
+func LoadGoogleCSE(envFiles ...string) (GoogleCSEConfig, error) {
+	if len(envFiles) == 0 {
+		envFiles = []string{".env"}
+	}
+	if err := godotenv.Load(envFiles...); err != nil && !errors.Is(err, os.ErrNotExist) {
+		return GoogleCSEConfig{}, fmt.Errorf("failed to load env files %v: %w", envFiles, err)
+	}
+
+	cfg := DefaultGoogleCSEConfig()
+	cfg.APIKey = os.Getenv("GOOGLE_CSE_API_KEY")
+	cfg.CX = os.Getenv("GOOGLE_CSE_CX")
+
+	if v := os.Getenv("GOOGLE_CSE_TIMEOUT"); v != "" {
+		d, err := time.ParseDuration(v)
+		if err != nil {
+			return GoogleCSEConfig{}, fmt.Errorf("parse GOOGLE_CSE_TIMEOUT %q: %w", v, err)
+		}
+		if d <= 0 {
+			return GoogleCSEConfig{}, fmt.Errorf("GOOGLE_CSE_TIMEOUT must be positive, got %s", d)
+		}
+		cfg.Timeout = d
+	}
+
+	return cfg, nil
+}
+
+// IsConfigured 는 APIKey + CX 가 모두 set 되었는지 여부를 반환합니다.
+//
+// false 면 cmd 가 search handler 를 wire 하지 않음 — search 기능 optional 정책.
+func (c GoogleCSEConfig) IsConfigured() bool {
+	return c.APIKey != "" && c.CX != ""
+}

--- a/test/internal/processor/fetcher/domain/search/google_cse_test.go
+++ b/test/internal/processor/fetcher/domain/search/google_cse_test.go
@@ -1,0 +1,247 @@
+package search_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"issuetracker/internal/processor/fetcher/domain/search"
+	"issuetracker/pkg/logger"
+)
+
+func newTestLogger(t *testing.T) *logger.Logger {
+	t.Helper()
+	return logger.New(logger.Config{Level: "error"})
+}
+
+func TestCSEClient_NewClient_RequiresAPIKeyAndCX(t *testing.T) {
+	t.Parallel()
+	log := newTestLogger(t)
+
+	_, err := search.NewCSEClient(search.CSEClientOptions{CX: "cx"}, log)
+	assert.Error(t, err, "missing api key should error")
+
+	_, err = search.NewCSEClient(search.CSEClientOptions{APIKey: "k"}, log)
+	assert.Error(t, err, "missing CX should error")
+
+	c, err := search.NewCSEClient(search.CSEClientOptions{APIKey: "k", CX: "cx"}, log)
+	require.NoError(t, err)
+	assert.NotNil(t, c)
+}
+
+func TestCSEClient_Search_SinglePage(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "test-key", r.URL.Query().Get("key"))
+		assert.Equal(t, "test-cx", r.URL.Query().Get("cx"))
+		assert.Equal(t, "ai 규제", r.URL.Query().Get("q"))
+		assert.Equal(t, "1", r.URL.Query().Get("start"))
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"items":[{"link":"https://example.com/a"},{"link":"https://example.com/b"}]}`))
+	}))
+	defer server.Close()
+
+	c, err := search.NewCSEClient(search.CSEClientOptions{APIKey: "test-key", CX: "test-cx", BaseURL: server.URL}, newTestLogger(t))
+	require.NoError(t, err)
+
+	urls, err := c.Search(context.Background(), "ai 규제", search.SearchOptions{MaxResults: 10})
+	require.NoError(t, err)
+	assert.Equal(t, []string{"https://example.com/a", "https://example.com/b"}, urls)
+}
+
+func TestCSEClient_Search_PaginationAndDedup(t *testing.T) {
+	t.Parallel()
+
+	var calls int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		n := atomic.AddInt32(&calls, 1)
+		start, _ := strconv.Atoi(r.URL.Query().Get("start"))
+		// 첫 페이지: 10개 + nextPage. 둘째 페이지: 5개 (그 중 1개는 첫 페이지 중복) + no nextPage.
+		w.WriteHeader(http.StatusOK)
+		switch start {
+		case 1:
+			body := `{"items":[`
+			for i := 0; i < 10; i++ {
+				if i > 0 {
+					body += ","
+				}
+				body += fmt.Sprintf(`{"link":"https://example.com/p1-%d"}`, i)
+			}
+			body += `],"queries":{"nextPage":[{"startIndex":11}]}}`
+			_, _ = w.Write([]byte(body))
+		case 11:
+			// 1개 중복 (p1-0) + 4개 신규.
+			body := `{"items":[{"link":"https://example.com/p1-0"}`
+			for i := 0; i < 4; i++ {
+				body += fmt.Sprintf(`,{"link":"https://example.com/p2-%d"}`, i)
+			}
+			body += `]}`
+			_, _ = w.Write([]byte(body))
+		default:
+			t.Fatalf("unexpected start=%d on call %d", start, n)
+		}
+	}))
+	defer server.Close()
+
+	c, err := search.NewCSEClient(search.CSEClientOptions{APIKey: "k", CX: "cx", BaseURL: server.URL}, newTestLogger(t))
+	require.NoError(t, err)
+
+	urls, err := c.Search(context.Background(), "kw", search.SearchOptions{MaxResults: 20})
+	require.NoError(t, err)
+
+	assert.Equal(t, int32(2), atomic.LoadInt32(&calls), "두 페이지 호출 발생")
+	assert.Len(t, urls, 14, "10개 + 4개 신규 (1개 중복 dedup)")
+}
+
+func TestCSEClient_Search_RateLimitedRetryable(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusTooManyRequests)
+		_, _ = w.Write([]byte(`{"error":{"code":429,"message":"quota exceeded"}}`))
+	}))
+	defer server.Close()
+
+	c, err := search.NewCSEClient(search.CSEClientOptions{APIKey: "k", CX: "cx", BaseURL: server.URL}, newTestLogger(t))
+	require.NoError(t, err)
+
+	_, err = c.Search(context.Background(), "kw", search.SearchOptions{MaxResults: 10})
+	require.Error(t, err)
+
+	var cseErr *search.CSEError
+	require.True(t, errors.As(err, &cseErr))
+	assert.Equal(t, http.StatusTooManyRequests, cseErr.StatusCode)
+	assert.True(t, cseErr.Retryable, "429 는 retryable")
+	assert.Contains(t, cseErr.Message, "quota exceeded")
+}
+
+func TestCSEClient_Search_AuthErrorNonRetryable(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+		_, _ = w.Write([]byte(`{"error":{"code":403,"message":"API key invalid"}}`))
+	}))
+	defer server.Close()
+
+	c, err := search.NewCSEClient(search.CSEClientOptions{APIKey: "k", CX: "cx", BaseURL: server.URL}, newTestLogger(t))
+	require.NoError(t, err)
+
+	_, err = c.Search(context.Background(), "kw", search.SearchOptions{MaxResults: 10})
+	require.Error(t, err)
+
+	var cseErr *search.CSEError
+	require.True(t, errors.As(err, &cseErr))
+	assert.Equal(t, http.StatusForbidden, cseErr.StatusCode)
+	assert.False(t, cseErr.Retryable, "4xx 인증 에러는 non-retryable")
+}
+
+func TestCSEClient_Search_ServerErrorRetryable(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(`{"error":{"code":500,"message":"backend error"}}`))
+	}))
+	defer server.Close()
+
+	c, err := search.NewCSEClient(search.CSEClientOptions{APIKey: "k", CX: "cx", BaseURL: server.URL}, newTestLogger(t))
+	require.NoError(t, err)
+
+	_, err = c.Search(context.Background(), "kw", search.SearchOptions{MaxResults: 10})
+	require.Error(t, err)
+
+	var cseErr *search.CSEError
+	require.True(t, errors.As(err, &cseErr))
+	assert.True(t, cseErr.Retryable, "5xx 는 retryable")
+}
+
+func TestCSEClient_Search_PartialFailureReturnsPartialResults(t *testing.T) {
+	t.Parallel()
+
+	var calls int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		n := atomic.AddInt32(&calls, 1)
+		start, _ := strconv.Atoi(r.URL.Query().Get("start"))
+		if start == 1 {
+			body := `{"items":[`
+			for i := 0; i < 10; i++ {
+				if i > 0 {
+					body += ","
+				}
+				body += fmt.Sprintf(`{"link":"https://example.com/a-%d"}`, i)
+			}
+			body += `],"queries":{"nextPage":[{"startIndex":11}]}}`
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(body))
+			return
+		}
+		// 둘째 페이지에서 5xx — 첫 페이지 결과는 보존되어야 함.
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(`{"error":{"code":500,"message":"page2 failure"}}`))
+		_ = n
+	}))
+	defer server.Close()
+
+	c, err := search.NewCSEClient(search.CSEClientOptions{APIKey: "k", CX: "cx", BaseURL: server.URL}, newTestLogger(t))
+	require.NoError(t, err)
+
+	urls, err := c.Search(context.Background(), "kw", search.SearchOptions{MaxResults: 30})
+	require.NoError(t, err, "둘째 페이지 실패는 부분 결과 + nil error 로 반환")
+	assert.Len(t, urls, 10, "첫 페이지 10개 보존")
+}
+
+func TestCSEClient_Search_DateRangeAndLanguageInQuery(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "d365", r.URL.Query().Get("dateRestrict"))
+		assert.Equal(t, "lang_ko", r.URL.Query().Get("lr"))
+		assert.Equal(t, "kr", r.URL.Query().Get("gl"))
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"items":[]}`))
+	}))
+	defer server.Close()
+
+	c, err := search.NewCSEClient(search.CSEClientOptions{APIKey: "k", CX: "cx", BaseURL: server.URL}, newTestLogger(t))
+	require.NoError(t, err)
+
+	_, err = c.Search(context.Background(), "kw", search.SearchOptions{
+		MaxResults:    10,
+		DateRangeDays: 365,
+		Language:      "ko",
+		Region:        "kr",
+	})
+	require.NoError(t, err)
+}
+
+func TestCSEClient_Search_ContextCancelInterrupts(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// 의도적 지연 — context cancel 이 먼저 끊을 수 있도록.
+		time.Sleep(100 * time.Millisecond)
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"items":[]}`))
+	}))
+	defer server.Close()
+
+	c, err := search.NewCSEClient(search.CSEClientOptions{APIKey: "k", CX: "cx", BaseURL: server.URL, Timeout: 1 * time.Second}, newTestLogger(t))
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
+	defer cancel()
+
+	_, err = c.Search(ctx, "kw", search.SearchOptions{MaxResults: 10})
+	require.Error(t, err)
+}

--- a/test/internal/processor/fetcher/domain/search/google_cse_test.go
+++ b/test/internal/processor/fetcher/domain/search/google_cse_test.go
@@ -23,6 +23,19 @@ func newTestLogger(t *testing.T) *logger.Logger {
 	return logger.New(logger.Config{Level: "error"})
 }
 
+// newTestClientOpts 는 테스트용 단일 시도 정책을 적용한 CSEClientOptions 를 반환합니다.
+// 실 운영 backoff (1s~10s) 가 테스트 timeout 을 잠식하지 않도록 MaxAttempts=1 (즉시 fail).
+func newTestClientOpts(apiKey, cx, baseURL string) search.CSEClientOptions {
+	noRetry := search.RetryPolicy{MaxAttempts: 1, InitialDelay: time.Millisecond, Multiplier: 1.0}
+	return search.CSEClientOptions{
+		APIKey:         apiKey,
+		CX:             cx,
+		BaseURL:        baseURL,
+		NetworkRetry:   noRetry,
+		RateLimitRetry: noRetry,
+	}
+}
+
 func TestCSEClient_NewClient_RequiresAPIKeyAndCX(t *testing.T) {
 	t.Parallel()
 	log := newTestLogger(t)
@@ -51,7 +64,7 @@ func TestCSEClient_Search_SinglePage(t *testing.T) {
 	}))
 	defer server.Close()
 
-	c, err := search.NewCSEClient(search.CSEClientOptions{APIKey: "test-key", CX: "test-cx", BaseURL: server.URL}, newTestLogger(t))
+	c, err := search.NewCSEClient(newTestClientOpts("test-key", "test-cx", server.URL), newTestLogger(t))
 	require.NoError(t, err)
 
 	urls, err := c.Search(context.Background(), "ai 규제", search.SearchOptions{MaxResults: 10})
@@ -93,7 +106,7 @@ func TestCSEClient_Search_PaginationAndDedup(t *testing.T) {
 	}))
 	defer server.Close()
 
-	c, err := search.NewCSEClient(search.CSEClientOptions{APIKey: "k", CX: "cx", BaseURL: server.URL}, newTestLogger(t))
+	c, err := search.NewCSEClient(newTestClientOpts("k", "cx", server.URL), newTestLogger(t))
 	require.NoError(t, err)
 
 	urls, err := c.Search(context.Background(), "kw", search.SearchOptions{MaxResults: 20})
@@ -112,7 +125,7 @@ func TestCSEClient_Search_RateLimitedRetryable(t *testing.T) {
 	}))
 	defer server.Close()
 
-	c, err := search.NewCSEClient(search.CSEClientOptions{APIKey: "k", CX: "cx", BaseURL: server.URL}, newTestLogger(t))
+	c, err := search.NewCSEClient(newTestClientOpts("k", "cx", server.URL), newTestLogger(t))
 	require.NoError(t, err)
 
 	_, err = c.Search(context.Background(), "kw", search.SearchOptions{MaxResults: 10})
@@ -134,7 +147,7 @@ func TestCSEClient_Search_AuthErrorNonRetryable(t *testing.T) {
 	}))
 	defer server.Close()
 
-	c, err := search.NewCSEClient(search.CSEClientOptions{APIKey: "k", CX: "cx", BaseURL: server.URL}, newTestLogger(t))
+	c, err := search.NewCSEClient(newTestClientOpts("k", "cx", server.URL), newTestLogger(t))
 	require.NoError(t, err)
 
 	_, err = c.Search(context.Background(), "kw", search.SearchOptions{MaxResults: 10})
@@ -155,7 +168,7 @@ func TestCSEClient_Search_ServerErrorRetryable(t *testing.T) {
 	}))
 	defer server.Close()
 
-	c, err := search.NewCSEClient(search.CSEClientOptions{APIKey: "k", CX: "cx", BaseURL: server.URL}, newTestLogger(t))
+	c, err := search.NewCSEClient(newTestClientOpts("k", "cx", server.URL), newTestLogger(t))
 	require.NoError(t, err)
 
 	_, err = c.Search(context.Background(), "kw", search.SearchOptions{MaxResults: 10})
@@ -193,7 +206,7 @@ func TestCSEClient_Search_PartialFailureReturnsPartialResults(t *testing.T) {
 	}))
 	defer server.Close()
 
-	c, err := search.NewCSEClient(search.CSEClientOptions{APIKey: "k", CX: "cx", BaseURL: server.URL}, newTestLogger(t))
+	c, err := search.NewCSEClient(newTestClientOpts("k", "cx", server.URL), newTestLogger(t))
 	require.NoError(t, err)
 
 	urls, err := c.Search(context.Background(), "kw", search.SearchOptions{MaxResults: 30})
@@ -213,7 +226,7 @@ func TestCSEClient_Search_DateRangeAndLanguageInQuery(t *testing.T) {
 	}))
 	defer server.Close()
 
-	c, err := search.NewCSEClient(search.CSEClientOptions{APIKey: "k", CX: "cx", BaseURL: server.URL}, newTestLogger(t))
+	c, err := search.NewCSEClient(newTestClientOpts("k", "cx", server.URL), newTestLogger(t))
 	require.NoError(t, err)
 
 	_, err = c.Search(context.Background(), "kw", search.SearchOptions{
@@ -223,6 +236,130 @@ func TestCSEClient_Search_DateRangeAndLanguageInQuery(t *testing.T) {
 		Region:        "kr",
 	})
 	require.NoError(t, err)
+}
+
+func TestCSEClient_Search_RetriesNetworkErrorThenSucceeds(t *testing.T) {
+	t.Parallel()
+
+	var calls int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		n := atomic.AddInt32(&calls, 1)
+		if n == 1 {
+			// 첫 시도: 5xx (retryable) — backoff 후 재시도.
+			w.WriteHeader(http.StatusInternalServerError)
+			_, _ = w.Write([]byte(`{"error":{"code":500,"message":"transient"}}`))
+			return
+		}
+		// 둘째 시도: 정상 응답.
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"items":[{"link":"https://example.com/a"}]}`))
+	}))
+	defer server.Close()
+
+	// 빠른 retry — 1ms initial 로 테스트 latency 최소화.
+	opts := search.CSEClientOptions{
+		APIKey:       "k",
+		CX:           "cx",
+		BaseURL:      server.URL,
+		NetworkRetry: search.RetryPolicy{MaxAttempts: 3, InitialDelay: time.Millisecond, Multiplier: 1.0},
+		// RateLimit 정책은 본 테스트에서 사용 안 됨 — fail-fast 로 둠.
+		RateLimitRetry: search.RetryPolicy{MaxAttempts: 1, InitialDelay: time.Millisecond, Multiplier: 1.0},
+	}
+	c, err := search.NewCSEClient(opts, newTestLogger(t))
+	require.NoError(t, err)
+
+	urls, err := c.Search(context.Background(), "kw", search.SearchOptions{MaxResults: 10})
+	require.NoError(t, err)
+	assert.Equal(t, []string{"https://example.com/a"}, urls)
+	assert.Equal(t, int32(2), atomic.LoadInt32(&calls), "5xx 첫 시도 후 1회 재시도 후 성공")
+}
+
+func TestCSEClient_Search_RetryRateLimitExhausted(t *testing.T) {
+	t.Parallel()
+
+	var calls int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&calls, 1)
+		w.WriteHeader(http.StatusTooManyRequests)
+		_, _ = w.Write([]byte(`{"error":{"code":429,"message":"quota"}}`))
+	}))
+	defer server.Close()
+
+	opts := search.CSEClientOptions{
+		APIKey:         "k",
+		CX:             "cx",
+		BaseURL:        server.URL,
+		NetworkRetry:   search.RetryPolicy{MaxAttempts: 1, InitialDelay: time.Millisecond, Multiplier: 1.0},
+		RateLimitRetry: search.RetryPolicy{MaxAttempts: 3, InitialDelay: time.Millisecond, Multiplier: 1.0},
+	}
+	c, err := search.NewCSEClient(opts, newTestLogger(t))
+	require.NoError(t, err)
+
+	_, err = c.Search(context.Background(), "kw", search.SearchOptions{MaxResults: 10})
+	require.Error(t, err)
+	assert.Equal(t, int32(3), atomic.LoadInt32(&calls), "429 max attempts (3) 모두 호출")
+}
+
+func TestCSEClient_Search_NoRetryOnNonRetryable(t *testing.T) {
+	t.Parallel()
+
+	var calls int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&calls, 1)
+		w.WriteHeader(http.StatusForbidden)
+		_, _ = w.Write([]byte(`{"error":{"code":403,"message":"key invalid"}}`))
+	}))
+	defer server.Close()
+
+	opts := search.CSEClientOptions{
+		APIKey:         "k",
+		CX:             "cx",
+		BaseURL:        server.URL,
+		NetworkRetry:   search.RetryPolicy{MaxAttempts: 5, InitialDelay: time.Millisecond, Multiplier: 1.0},
+		RateLimitRetry: search.RetryPolicy{MaxAttempts: 5, InitialDelay: time.Millisecond, Multiplier: 1.0},
+	}
+	c, err := search.NewCSEClient(opts, newTestLogger(t))
+	require.NoError(t, err)
+
+	_, err = c.Search(context.Background(), "kw", search.SearchOptions{MaxResults: 10})
+	require.Error(t, err)
+	assert.Equal(t, int32(1), atomic.LoadInt32(&calls), "403 (non-retryable) 은 retry 안 됨")
+}
+
+func TestCSEClient_Search_PartialPreservedOnlyForRetryable(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		start, _ := strconv.Atoi(r.URL.Query().Get("start"))
+		if start == 1 {
+			body := `{"items":[`
+			for i := 0; i < 10; i++ {
+				if i > 0 {
+					body += ","
+				}
+				body += fmt.Sprintf(`{"link":"https://example.com/a-%d"}`, i)
+			}
+			body += `],"queries":{"nextPage":[{"startIndex":11}]}}`
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(body))
+			return
+		}
+		// 둘째 페이지에서 403 (non-retryable) — 부분 결과를 silently downgrade 하면 안 됨.
+		w.WriteHeader(http.StatusForbidden)
+		_, _ = w.Write([]byte(`{"error":{"code":403,"message":"key revoked mid-cycle"}}`))
+	}))
+	defer server.Close()
+
+	c, err := search.NewCSEClient(newTestClientOpts("k", "cx", server.URL), newTestLogger(t))
+	require.NoError(t, err)
+
+	_, err = c.Search(context.Background(), "kw", search.SearchOptions{MaxResults: 30})
+	require.Error(t, err, "non-retryable 후속 페이지 에러는 호출자에게 전파")
+
+	var cseErr *search.CSEError
+	require.True(t, errors.As(err, &cseErr))
+	assert.Equal(t, http.StatusForbidden, cseErr.StatusCode)
+	assert.False(t, cseErr.Retryable)
 }
 
 func TestCSEClient_Search_ContextCancelInterrupts(t *testing.T) {
@@ -236,7 +373,9 @@ func TestCSEClient_Search_ContextCancelInterrupts(t *testing.T) {
 	}))
 	defer server.Close()
 
-	c, err := search.NewCSEClient(search.CSEClientOptions{APIKey: "k", CX: "cx", BaseURL: server.URL, Timeout: 1 * time.Second}, newTestLogger(t))
+	opts := newTestClientOpts("k", "cx", server.URL)
+	opts.Timeout = 1 * time.Second
+	c, err := search.NewCSEClient(opts, newTestLogger(t))
 	require.NoError(t, err)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)

--- a/test/internal/processor/fetcher/domain/search/handler_test.go
+++ b/test/internal/processor/fetcher/domain/search/handler_test.go
@@ -153,7 +153,7 @@ func stubCSEServer(t *testing.T, byKeyword map[string][]string) *httptest.Server
 func newTestHandler(t *testing.T, server *httptest.Server, repo storage.SearchKeywordRepository, pub search.JobPublisher) *search.SearchHandler {
 	t.Helper()
 	log := newTestLogger(t)
-	c, err := search.NewCSEClient(search.CSEClientOptions{APIKey: "k", CX: "cx", BaseURL: server.URL}, log)
+	c, err := search.NewCSEClient(newTestClientOpts("k", "cx", server.URL), log)
 	require.NoError(t, err)
 	h, err := search.NewSearchHandler(search.SearchHandlerOptions{
 		Client:      c,

--- a/test/internal/processor/fetcher/domain/search/handler_test.go
+++ b/test/internal/processor/fetcher/domain/search/handler_test.go
@@ -1,0 +1,393 @@
+package search_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"sort"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"issuetracker/internal/processor/fetcher/core"
+	"issuetracker/internal/processor/fetcher/domain/search"
+	"issuetracker/internal/storage"
+)
+
+// memSearchKeywordRepo 는 SearchKeywordRepository 의 in-memory 구현 (handler 테스트용 fixture).
+type memSearchKeywordRepo struct {
+	mu      sync.Mutex
+	rows    []*storage.SearchKeywordRecord
+	marked  map[int64]time.Time
+	listErr error
+	markErr error
+}
+
+func (r *memSearchKeywordRepo) ListEnabled(_ context.Context, language, region string) ([]*storage.SearchKeywordRecord, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.listErr != nil {
+		return nil, r.listErr
+	}
+	var out []*storage.SearchKeywordRecord
+	for _, rec := range r.rows {
+		if !rec.Enabled {
+			continue
+		}
+		if language != "" && rec.Language != language {
+			continue
+		}
+		if region != "" && rec.Region != region {
+			continue
+		}
+		copyRec := *rec
+		out = append(out, &copyRec)
+	}
+	return out, nil
+}
+
+func (r *memSearchKeywordRepo) Insert(_ context.Context, _ *storage.SearchKeywordRecord) error {
+	return errors.New("not used in test")
+}
+
+func (r *memSearchKeywordRepo) Update(_ context.Context, _ *storage.SearchKeywordRecord) error {
+	return errors.New("not used in test")
+}
+
+func (r *memSearchKeywordRepo) Delete(_ context.Context, _ int64) error {
+	return errors.New("not used in test")
+}
+
+func (r *memSearchKeywordRepo) MarkSearched(_ context.Context, id int64, t time.Time) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.markErr != nil {
+		return r.markErr
+	}
+	if r.marked == nil {
+		r.marked = map[int64]time.Time{}
+	}
+	r.marked[id] = t
+	return nil
+}
+
+func (r *memSearchKeywordRepo) markedIDs() []int64 {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	ids := make([]int64, 0, len(r.marked))
+	for id := range r.marked {
+		ids = append(ids, id)
+	}
+	sort.Slice(ids, func(i, j int) bool { return ids[i] < ids[j] })
+	return ids
+}
+
+// recordingPublisher 는 JobPublisher 의 호출을 기록하는 in-memory mock.
+type recordingPublisher struct {
+	mu    sync.Mutex
+	calls []publishCall
+	err   error
+}
+
+type publishCall struct {
+	CrawlerName string
+	URLs        []string
+	TargetType  core.TargetType
+	Timeout     time.Duration
+}
+
+func (p *recordingPublisher) Publish(_ context.Context, crawlerName string, urls []string, targetType core.TargetType, timeout time.Duration) error {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if p.err != nil {
+		return p.err
+	}
+	urlsCopy := make([]string, len(urls))
+	copy(urlsCopy, urls)
+	p.calls = append(p.calls, publishCall{
+		CrawlerName: crawlerName,
+		URLs:        urlsCopy,
+		TargetType:  targetType,
+		Timeout:     timeout,
+	})
+	return nil
+}
+
+func (p *recordingPublisher) snapshot() []publishCall {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	out := make([]publishCall, len(p.calls))
+	copy(out, p.calls)
+	return out
+}
+
+// stubCSEServer 는 keyword 별 응답을 미리 정의한 fake CSE endpoint 입니다.
+func stubCSEServer(t *testing.T, byKeyword map[string][]string) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		q := r.URL.Query().Get("q")
+		urls, ok := byKeyword[q]
+		if !ok {
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"items":[]}`))
+			return
+		}
+		body := `{"items":[`
+		for i, u := range urls {
+			if i > 0 {
+				body += ","
+			}
+			body += fmt.Sprintf(`{"link":%q}`, u)
+		}
+		body += `]}`
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(body))
+	}))
+}
+
+func newTestHandler(t *testing.T, server *httptest.Server, repo storage.SearchKeywordRepository, pub search.JobPublisher) *search.SearchHandler {
+	t.Helper()
+	log := newTestLogger(t)
+	c, err := search.NewCSEClient(search.CSEClientOptions{APIKey: "k", CX: "cx", BaseURL: server.URL}, log)
+	require.NoError(t, err)
+	h, err := search.NewSearchHandler(search.SearchHandlerOptions{
+		Client:      c,
+		KeywordRepo: repo,
+		Publisher:   pub,
+	}, log)
+	require.NoError(t, err)
+	return h
+}
+
+func TestSearchHandler_Handle_FanoutByHostAndDedup(t *testing.T) {
+	t.Parallel()
+
+	byKw := map[string][]string{
+		"kw1": {
+			"https://example.com/a",
+			"https://other.com/x",
+		},
+		"kw2": {
+			"https://example.com/a", // duplicate of kw1
+			"https://example.com/b",
+			"https://third.com/y",
+		},
+	}
+	server := stubCSEServer(t, byKw)
+	defer server.Close()
+
+	repo := &memSearchKeywordRepo{
+		rows: []*storage.SearchKeywordRecord{
+			{ID: 1, Keyword: "kw1", Enabled: true},
+			{ID: 2, Keyword: "kw2", Enabled: true},
+		},
+	}
+	pub := &recordingPublisher{}
+	h := newTestHandler(t, server, repo, pub)
+
+	job := &core.CrawlJob{
+		ID:          "job-1",
+		CrawlerName: "customsearch.googleapis.com",
+		Target: core.Target{
+			URL:  "https://customsearch.googleapis.com/customsearch/v1",
+			Type: core.TargetTypeSearchResults,
+			Metadata: map[string]interface{}{
+				"engine": "google_cse",
+			},
+		},
+	}
+	out, err := h.Handle(context.Background(), job)
+	require.NoError(t, err)
+	assert.Nil(t, out)
+
+	calls := pub.snapshot()
+	require.Len(t, calls, 3, "host 3개 (example.com / other.com / third.com)")
+
+	byHost := map[string]publishCall{}
+	for _, c := range calls {
+		byHost[c.CrawlerName] = c
+	}
+	assert.ElementsMatch(t, []string{"https://example.com/a", "https://example.com/b"}, byHost["example.com"].URLs)
+	assert.Equal(t, []string{"https://other.com/x"}, byHost["other.com"].URLs)
+	assert.Equal(t, []string{"https://third.com/y"}, byHost["third.com"].URLs)
+
+	for _, c := range calls {
+		assert.Equal(t, core.TargetTypeArticle, c.TargetType)
+	}
+
+	assert.Equal(t, []int64{1, 2}, repo.markedIDs(), "성공 keyword 모두 last_searched_at 갱신")
+}
+
+func TestSearchHandler_Handle_NoEnabledKeywords(t *testing.T) {
+	t.Parallel()
+
+	server := stubCSEServer(t, nil)
+	defer server.Close()
+
+	repo := &memSearchKeywordRepo{
+		rows: []*storage.SearchKeywordRecord{
+			{ID: 1, Keyword: "off", Enabled: false},
+		},
+	}
+	pub := &recordingPublisher{}
+	h := newTestHandler(t, server, repo, pub)
+
+	out, err := h.Handle(context.Background(), &core.CrawlJob{Target: core.Target{Type: core.TargetTypeSearchResults}})
+	require.NoError(t, err)
+	assert.Nil(t, out)
+	assert.Empty(t, pub.snapshot(), "publish 호출 없음")
+}
+
+func TestSearchHandler_Handle_SkipUnsupportedEngine(t *testing.T) {
+	t.Parallel()
+
+	server := stubCSEServer(t, map[string][]string{"kw": {"https://example.com/a"}})
+	defer server.Close()
+
+	repo := &memSearchKeywordRepo{rows: []*storage.SearchKeywordRecord{{ID: 1, Keyword: "kw", Enabled: true}}}
+	pub := &recordingPublisher{}
+	h := newTestHandler(t, server, repo, pub)
+
+	job := &core.CrawlJob{
+		Target: core.Target{
+			Type:     core.TargetTypeSearchResults,
+			Metadata: map[string]interface{}{"engine": "bing_search"},
+		},
+	}
+	out, err := h.Handle(context.Background(), job)
+	require.NoError(t, err)
+	assert.Nil(t, out)
+	assert.Empty(t, pub.snapshot(), "다른 engine 은 skip")
+}
+
+func TestSearchHandler_Handle_KeywordSkipsOnTransientError(t *testing.T) {
+	t.Parallel()
+
+	// failing_kw 는 5xx, ok_kw 는 정상.
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		q := r.URL.Query().Get("q")
+		if q == "failing_kw" {
+			w.WriteHeader(http.StatusInternalServerError)
+			_, _ = w.Write([]byte(`{"error":{"code":500,"message":"backend"}}`))
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"items":[{"link":"https://example.com/a"}]}`))
+	}))
+	defer server.Close()
+
+	repo := &memSearchKeywordRepo{
+		rows: []*storage.SearchKeywordRecord{
+			{ID: 1, Keyword: "failing_kw", Enabled: true},
+			{ID: 2, Keyword: "ok_kw", Enabled: true},
+		},
+	}
+	pub := &recordingPublisher{}
+	h := newTestHandler(t, server, repo, pub)
+
+	out, err := h.Handle(context.Background(), &core.CrawlJob{Target: core.Target{Type: core.TargetTypeSearchResults}})
+	require.NoError(t, err)
+	assert.Nil(t, out)
+
+	calls := pub.snapshot()
+	require.Len(t, calls, 1)
+	assert.Equal(t, []string{"https://example.com/a"}, calls[0].URLs)
+
+	assert.Equal(t, []int64{2}, repo.markedIDs(), "성공한 keyword 만 mark")
+}
+
+func TestSearchHandler_Handle_NonRetryableAbortsCycle(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+		_, _ = w.Write([]byte(`{"error":{"code":403,"message":"key invalid"}}`))
+	}))
+	defer server.Close()
+
+	repo := &memSearchKeywordRepo{
+		rows: []*storage.SearchKeywordRecord{
+			{ID: 1, Keyword: "kw1", Enabled: true},
+			{ID: 2, Keyword: "kw2", Enabled: true},
+		},
+	}
+	pub := &recordingPublisher{}
+	h := newTestHandler(t, server, repo, pub)
+
+	out, err := h.Handle(context.Background(), &core.CrawlJob{Target: core.Target{Type: core.TargetTypeSearchResults}})
+	require.NoError(t, err, "non-retryable 도 nil error 반환 — 다음 cycle 까지 자연 중단")
+	assert.Nil(t, out)
+	assert.Empty(t, pub.snapshot(), "publish 호출 없음")
+	assert.Empty(t, repo.markedIDs(), "non-retryable 시 mark 안 됨")
+}
+
+func TestSearchHandler_Handle_ListEnabledFailsBubbles(t *testing.T) {
+	t.Parallel()
+
+	server := stubCSEServer(t, nil)
+	defer server.Close()
+
+	repo := &memSearchKeywordRepo{listErr: errors.New("db down")}
+	pub := &recordingPublisher{}
+	h := newTestHandler(t, server, repo, pub)
+
+	_, err := h.Handle(context.Background(), &core.CrawlJob{Target: core.Target{Type: core.TargetTypeSearchResults}})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "list enabled keywords")
+}
+
+func TestSearchHandler_Handle_NilJobReturnsError(t *testing.T) {
+	t.Parallel()
+
+	server := stubCSEServer(t, nil)
+	defer server.Close()
+
+	repo := &memSearchKeywordRepo{}
+	pub := &recordingPublisher{}
+	h := newTestHandler(t, server, repo, pub)
+
+	_, err := h.Handle(context.Background(), nil)
+	require.Error(t, err)
+}
+
+func TestSearchHandler_Handle_PerKeywordLanguageRegionPropagated(t *testing.T) {
+	t.Parallel()
+
+	var (
+		mu     sync.Mutex
+		params []string
+	)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		params = append(params, fmt.Sprintf("q=%s lr=%s gl=%s", r.URL.Query().Get("q"), r.URL.Query().Get("lr"), r.URL.Query().Get("gl")))
+		mu.Unlock()
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"items":[]}`))
+	}))
+	defer server.Close()
+
+	repo := &memSearchKeywordRepo{
+		rows: []*storage.SearchKeywordRecord{
+			{ID: 1, Keyword: "ko_kw", Enabled: true, Language: "ko", Region: "kr"},
+			{ID: 2, Keyword: "en_kw", Enabled: true, Language: "en", Region: "us"},
+		},
+	}
+	pub := &recordingPublisher{}
+	h := newTestHandler(t, server, repo, pub)
+
+	_, err := h.Handle(context.Background(), &core.CrawlJob{Target: core.Target{Type: core.TargetTypeSearchResults}})
+	require.NoError(t, err)
+
+	mu.Lock()
+	defer mu.Unlock()
+	sort.Strings(params)
+	assert.Equal(t, []string{
+		"q=en_kw lr=lang_en gl=us",
+		"q=ko_kw lr=lang_ko gl=kr",
+	}, params)
+}


### PR DESCRIPTION
## 연관 이슈
Closes #337 (#331 의 phase 2 — phase 1 은 #338 에서 merge)

마지막 sub-issue PR — 본 PR merge 시 메인 #331 도 close 예정 (#328 의 sub C 완결).

## 구현 내용

#331 (Google CSE 기반 search exploration) 의 phase 2 — DB-driven keyword set (#336 phase 1) 을 활용해 운영 중에 keyword × CSE fanout 을 수행하고 결과 article URL 을 기존 fetch chain 으로 chained 발행.

### Google CSE Client (`internal/processor/fetcher/domain/search/google_cse.go`)
- Google Custom Search JSON API 호출 — `APIKey` + `CX` 필수
- `Search(keyword, opts)` — paginated (start=1,11,...), max 100 results (10페이지)
- `DateRangeDays` → `dateRestrict`, `Language` ('ko') → `lr=lang_ko`, `Region` ('kr') → `gl=kr`
- `CSEError`: 429/5xx/network → `Retryable=true`, 401/403 등 4xx auth → `Retryable=false`
- 부분 실패 보존 — 중간 페이지 실패 시 그때까지 누적 결과 + warn (quota 보존)
- ctx cancel propagation, dedup within keyword

### SearchHandler (`internal/processor/fetcher/domain/search/handler.go`)
- `handler.Handler` 구현 — fetcher worker 가 search_results target 처리 시 호출
- 동작:
  1. entry metadata (engine / per_query_max_results / date_range_days) 추출
  2. `SearchKeywordRepository.ListEnabled` 로 enabled keyword 전체 조회
  3. keyword 별 `CSEClient.Search` — retryable 실패는 skip + warn, non-retryable 는 cycle 중단
  4. 누적 URL 을 host 단위 group → publisher.Publish(crawlerName=host, TargetTypeArticle) fanout
  5. 성공 keyword 의 last_searched_at 갱신
- nil content 반환 — 실제 raw_content 는 chained article job 이 fetch 후 발행

### TargetType 상수
- `TargetTypeSearchResults = \"search_results\"` 추가 (`core/models.go`)

### Config + Wiring
- `pkg/config/config.go`: `GoogleCSEConfig` + `LoadGoogleCSE` + `IsConfigured()`
- 환경변수: `GOOGLE_CSE_API_KEY` (필수) / `GOOGLE_CSE_CX` (필수) / `GOOGLE_CSE_TIMEOUT` (default 10s)
- `cmd/issuetracker/main.go`: LoadGoogleCSE → IsConfigured 분기, 단계별 실패는 warn + skip (전체 fatal 회피 — search 가 critical path 아님)
- registry.Register(\"customsearch.googleapis.com\", h) + register(\"google_cse\", h) — host 매칭이 primary
- sources.RegisterAll 직후 wiring — fetcher_rules 와 무관하게 별도 등록
- 정책: search 기능 optional — 미설정 환경에서도 fetcher / parser / validate 흐름 정상

### `.env.example` 갱신
- Google CSE 섹션 추가 — API key 발급 안내 + 무료 plan quota 계산 (16 keyword × 1 page × 4 cycle/day = 64 q/day, free tier 안)

### 테스트
- `test/internal/processor/fetcher/domain/search/google_cse_test.go` (8 케이스)
  - single page / pagination + dedup / 429 retryable / 403 non-retryable / 5xx retryable / 부분 실패 / dateRestrict+lr+gl 파라미터 / ctx cancel
- `test/internal/processor/fetcher/domain/search/handler_test.go` (8 케이스)
  - host fanout + dedup / 빈 keyword / unsupported engine / keyword-level transient skip / non-retryable cycle 중단 / list err 전파 / nil job / per-keyword language·region propagation

## CI / 머지 게이트 점검
- [x] `go build ./...` 통과
- [x] `go test -race -count=1 ./test/...` 전부 ok (16 신규 테스트 포함)
- [x] `go vet ./...` 깨끗
- [x] gofmt 정리
- [x] commit / branch / PR 컨벤션 준수

## 변경 영향 범위 + 위험도
- **영향**: search handler 가 wire 되었을 때만 발생 — `GOOGLE_CSE_API_KEY` + `GOOGLE_CSE_CX` 미설정 환경에서는 noop
- **위험도**: 낮음
  - search entry 의 fetcher 도달 시점부터 keyword fanout 시작 — 미설정 시 noop fallback
  - quota 보호: free tier 100 q/day vs 본 PR seed 16 keyword × 6h interval × 1 page = 64 q/day
  - non-retryable 시 cycle 중단으로 quota 보호
  - host 단위 fanout 으로 다양한 host 의 article 이 들어오면 #326 LLM 자동 학습 (parsing_rules) 이 처리

## 롤백 계획
1. `GOOGLE_CSE_API_KEY` / `GOOGLE_CSE_CX` 환경변수 unset → handler 자동 비활성
2. 코드 롤백: `git revert` 로 본 PR 되돌리기
3. migration revert: phase 1 (#338) 의 023/024 down — search_keywords 테이블 + scheduler entry 제거

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Google Custom Search Engine integration to enable keyword-based content discovery and automatic article fetching from search results.

* **Configuration**
  * New environment variables available for Google Custom Search setup (`GOOGLE_CSE_API_KEY`, `GOOGLE_CSE_CX`, `GOOGLE_CSE_TIMEOUT`).

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/EinSofINTEREST/IssueTracker/pull/339)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->