### PR TITLE
[FEAT#311] pathinfer broadness 휴리스틱 — too-broad 패턴 거부

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -188,3 +188,9 @@ STALE_RELEARN_WINDOW=2h
 GOOGLE_CSE_API_KEY=
 GOOGLE_CSE_CX=
 GOOGLE_CSE_TIMEOUT=10s
+
+# pathinfer broadness 휴리스틱 토글 (이슈 #311)
+# false / 0 / no → 비활성. 미설정 / 그 외 값 → 활성 (default).
+# LLM 정밀화 결과가 너무 broad 한 패턴 (예: ^/.+/\d+$) 도 거부하는 sample-driven 검증.
+# 정상 정밀화도 거부될 때 fail-safe off — 코드 변경 / 재배포 없이 환경변수만 갱신.
+PATHINFER_BROADNESS_CHECK=true

--- a/internal/processor/parser/rule/pathinfer/broadness.go
+++ b/internal/processor/parser/rule/pathinfer/broadness.go
@@ -1,0 +1,181 @@
+package pathinfer
+
+import (
+	"os"
+	"regexp"
+	"strings"
+)
+
+// broadnessCheckEnvVar 는 broadness 휴리스틱의 fail-safe off 토글입니다 (이슈 #311).
+//
+// 운영 정책:
+//   - 미설정 / 빈 값 / 그 외   → enabled (default true)
+//   - "false" / "0" / "no"     → disabled
+//
+// case-insensitive. 정상 정밀화가 broadness 휴리스틱에 의해 거부될 때 운영자가 빠르게 차단 해제
+// 가능 — 코드 변경 / 재배포 없이 환경변수만 갱신.
+const broadnessCheckEnvVar = "PATHINFER_BROADNESS_CHECK"
+
+// broadnessCheckEnabled 는 PATHINFER_BROADNESS_CHECK 환경변수를 기준으로 휴리스틱 활성 여부를 반환합니다.
+func broadnessCheckEnabled() bool {
+	v := strings.ToLower(strings.TrimSpace(os.Getenv(broadnessCheckEnvVar)))
+	switch v {
+	case "false", "0", "no":
+		return false
+	default:
+		return true
+	}
+}
+
+// validateBroadness 는 sample-driven 휴리스틱으로 pattern 의 구체성 (specificity) 을 검증합니다 (이슈 #311).
+//
+// triviallyBroad 화이트리스트 12 케이스 외에 "약간만 좁은" broad 패턴 (예: ^/.+/\d+$, ^/[^/]+/\d+$)
+// 도 거부하기 위한 추가 안전망. positive samples 의 구조적 특성을 기반으로 합성 negative path 를
+// 만들어 pattern 이 그것까지 매칭하면 broad 로 판정.
+//
+// 검증 단계:
+//  1. Segment 수 일치 — positive 가 모두 K segment 면, K±1 segment path 도 매칭하면 거부
+//  2. Literal segment 보존 — positive 모두에 동일한 segment value 가 있으면, 그 자리에 임의 token
+//     을 넣은 path 가 매칭되면 거부 (예: 모든 positive 가 /article/ 시작이면 /broadnesstoken/X 거부)
+//
+// 두 단계 모두 sample-driven — positive 가 적거나 segment 수가 들쑥날쑥하면 fail-open (true 반환).
+//
+// re 가 nil 이면 panic — 호출자가 RE2 컴파일 후 전달.
+func validateBroadness(re *regexp.Regexp, samples LLMSamples) bool {
+	if re == nil {
+		panic("pathinfer: validateBroadness called with nil regexp")
+	}
+	if len(samples.Articles) == 0 {
+		return true
+	}
+
+	// positives 를 segment array 로 normalize.
+	positives := make([][]string, 0, len(samples.Articles))
+	for _, a := range samples.Articles {
+		positives = append(positives, splitPathSegments(a))
+	}
+
+	if !validateSegmentCount(re, positives) {
+		return false
+	}
+	if !validateLiteralSegments(re, positives) {
+		return false
+	}
+	return true
+}
+
+// splitPathSegments 는 path 를 정규화 (앞뒤 / 제거) 후 / 로 split 한 segment 슬라이스를 반환합니다.
+// 빈 path / "/" 는 빈 슬라이스 반환.
+func splitPathSegments(path string) []string {
+	trimmed := strings.Trim(path, "/")
+	if trimmed == "" {
+		return nil
+	}
+	return strings.Split(trimmed, "/")
+}
+
+// validateSegmentCount 는 positive 가 모두 동일 segment 수 K 인 경우, pattern 이 K-1 / K+1
+// segment path 도 매칭하면 false 반환 (broad).
+//
+// positive 가 들쑥날쑥하면 (예: 2 + 3 segments) skip — 정확성 보장 못해 fail-open.
+func validateSegmentCount(re *regexp.Regexp, positives [][]string) bool {
+	if len(positives) == 0 {
+		return true
+	}
+	k := len(positives[0])
+	for _, p := range positives[1:] {
+		if len(p) != k {
+			return true // 들쑥날쑥 — skip
+		}
+	}
+	if k == 0 {
+		return true // 모두 root path
+	}
+
+	base := positives[0]
+
+	// K+1 segment 변형 (prepend): pattern 이 "/" 시작이 아닌 token 으로 확장된 path 도 허용하면 broad.
+	longerPrepend := "/broadnesstoken/" + strings.Join(base, "/")
+	if re.MatchString(longerPrepend) {
+		return false
+	}
+
+	// K+1 segment 변형 (append): 끝 segment 추가. ^/article/\d+(/.+)?$ 같은 trailing-optional
+	// 패턴이 K+1 까지 허용하는 케이스를 거부.
+	longerAppend := "/" + strings.Join(base, "/") + "/broadnesstoken"
+	if re.MatchString(longerAppend) {
+		return false
+	}
+
+	// K-1 segment 변형: 마지막 segment drop. K=1 이면 "/" 가 되므로 의미 없는 경우 skip.
+	if k >= 2 {
+		shorter := "/" + strings.Join(base[:k-1], "/")
+		if re.MatchString(shorter) {
+			return false
+		}
+	}
+
+	return true
+}
+
+// validateLiteralSegments 는 positive 들이 같은 자리에 같은 값을 가지는 (constant) segment 가 있을 때,
+// 그 자리에 임의 token 을 넣은 path 가 매칭되면 false 반환 (broad).
+//
+// positive 가 1개만 있으면 모든 segment 가 "constant" 처럼 보이므로 검증 skip — 정상 capture
+// (예: \d+) 까지 거부할 위험.
+//
+// segment 수가 들쑥날쑥해도 정확한 비교 불가 — skip.
+func validateLiteralSegments(re *regexp.Regexp, positives [][]string) bool {
+	if len(positives) < 2 {
+		return true
+	}
+	k := len(positives[0])
+	for _, p := range positives[1:] {
+		if len(p) != k {
+			return true
+		}
+	}
+	if k == 0 {
+		return true
+	}
+
+	// 모든 positive 가 동일 값을 갖는 segment 인덱스 찾기.
+	constantIdx := make([]int, 0, k)
+	for i := 0; i < k; i++ {
+		v := positives[0][i]
+		constant := true
+		for _, p := range positives[1:] {
+			if p[i] != v {
+				constant = false
+				break
+			}
+		}
+		if constant {
+			constantIdx = append(constantIdx, i)
+		}
+	}
+
+	if len(constantIdx) == 0 {
+		return true // literal 신호 없음
+	}
+
+	// constant segment 자리에 임의 token 을 넣어 변형 path 생성. pattern 이 매칭하면 broad.
+	// 다양한 token 으로 character class 변형도 흡수 — 숫자 only 인 [0-9]+ 같은 좁은 capture 는
+	// alphanumeric token 에서 매칭 안 되어 정상 통과.
+	tokens := []string{"broadnesstoken", "ZZZZZZZZZ", "different-host"}
+	base := make([]string, k)
+	copy(base, positives[0])
+	for _, idx := range constantIdx {
+		for _, tok := range tokens {
+			variant := make([]string, k)
+			copy(variant, base)
+			variant[idx] = tok
+			test := "/" + strings.Join(variant, "/")
+			if re.MatchString(test) {
+				return false
+			}
+		}
+	}
+
+	return true
+}

--- a/internal/processor/parser/rule/pathinfer/broadness.go
+++ b/internal/processor/parser/rule/pathinfer/broadness.go
@@ -49,10 +49,10 @@ func validateBroadness(re *regexp.Regexp, samples LLMSamples) bool {
 		return true
 	}
 
-	// positives 를 segment array 로 normalize.
+	// positives 를 segment array 로 normalize. pathinfer.go 의 splitSegments 재사용.
 	positives := make([][]string, 0, len(samples.Articles))
 	for _, a := range samples.Articles {
-		positives = append(positives, splitPathSegments(a))
+		positives = append(positives, splitSegments(a))
 	}
 
 	if !validateSegmentCount(re, positives) {
@@ -62,16 +62,6 @@ func validateBroadness(re *regexp.Regexp, samples LLMSamples) bool {
 		return false
 	}
 	return true
-}
-
-// splitPathSegments 는 path 를 정규화 (앞뒤 / 제거) 후 / 로 split 한 segment 슬라이스를 반환합니다.
-// 빈 path / "/" 는 빈 슬라이스 반환.
-func splitPathSegments(path string) []string {
-	trimmed := strings.Trim(path, "/")
-	if trimmed == "" {
-		return nil
-	}
-	return strings.Split(trimmed, "/")
 }
 
 // validateSegmentCount 는 positive 가 모두 동일 segment 수 K 인 경우, pattern 이 K-1 / K+1
@@ -107,10 +97,16 @@ func validateSegmentCount(re *regexp.Regexp, positives [][]string) bool {
 		return false
 	}
 
-	// K-1 segment 변형: 마지막 segment drop. K=1 이면 "/" 가 되므로 의미 없는 경우 skip.
+	// K-1 segment 변형: 앞 / 뒤 양쪽에서 한 segment drop (CodeRabbit Major 반영).
+	// optional leading group (예: ^(/lang)?/article/\d+$) 같은 패턴이 K-1 으로 통과하는 케이스도 거부.
+	// K=1 이면 "/" 가 되므로 의미 없는 경우 skip.
 	if k >= 2 {
-		shorter := "/" + strings.Join(base[:k-1], "/")
-		if re.MatchString(shorter) {
+		shorterFront := "/" + strings.Join(base[1:], "/")
+		if re.MatchString(shorterFront) {
+			return false
+		}
+		shorterBack := "/" + strings.Join(base[:k-1], "/")
+		if re.MatchString(shorterBack) {
 			return false
 		}
 	}
@@ -167,6 +163,11 @@ func validateLiteralSegments(re *regexp.Regexp, positives [][]string) bool {
 	copy(base, positives[0])
 	for _, idx := range constantIdx {
 		for _, tok := range tokens {
+			// constant value 와 동일한 token 은 substitution 효과 없음 → false rejection 회피
+			// (CodeRabbit Minor 반영).
+			if tok == base[idx] {
+				continue
+			}
 			variant := make([]string, k)
 			copy(variant, base)
 			variant[idx] = tok

--- a/internal/processor/parser/rule/pathinfer/llm.go
+++ b/internal/processor/parser/rule/pathinfer/llm.go
@@ -172,6 +172,7 @@ func extractPattern(resp string) string {
 //  2. positive (samples.Articles) 100% 매칭
 //  3. negative (samples.NonArticles) 0% 매칭
 //  4. trivially broad 거부 (isTriviallyBroad)
+//  5. broadness 휴리스틱 (이슈 #311) — broadnessCheckEnabled() 가 true 일 때만
 //
 // 모든 단계 통과 시 true, 1단계라도 실패 시 false.
 func validateLLMResult(pattern string, samples LLMSamples) bool {
@@ -193,6 +194,11 @@ func validateLLMResult(pattern string, samples LLMSamples) bool {
 		if re.MatchString("/" + strings.Trim(p, "/")) {
 			return false
 		}
+	}
+	// broadness 휴리스틱 (이슈 #311) — sample-driven 으로 segment 수 / literal segment 보존 검증.
+	// PATHINFER_BROADNESS_CHECK=false 면 skip — 정상 정밀화도 거부될 때 fail-safe off.
+	if broadnessCheckEnabled() && !validateBroadness(re, samples) {
+		return false
 	}
 	return true
 }

--- a/test/internal/processor/parser/rule/pathinfer/broadness_test.go
+++ b/test/internal/processor/parser/rule/pathinfer/broadness_test.go
@@ -1,0 +1,191 @@
+package pathinfer_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"issuetracker/internal/processor/parser/rule/pathinfer"
+)
+
+// validateBroadness 는 unexported 이지만 InferLLM 의 마지막 검증 단계로 entry — 본 테스트는
+// InferLLM 을 호출하여 (LLM 응답 = pattern) end-to-end 로 broadness 검증 동작을 확인합니다.
+//
+// 모든 테스트는 PATHINFER_BROADNESS_CHECK 미설정 (default true) 가정 — t.Setenv 로 회피.
+
+func newBroadnessLLM(pattern string) *fakeLLM {
+	return &fakeLLM{resp: pattern}
+}
+
+func TestBroadness_AcceptsSpecificPattern(t *testing.T) {
+	t.Setenv("PATHINFER_BROADNESS_CHECK", "")
+	samples := pathinfer.LLMSamples{
+		Articles: []string{"/article/1", "/article/200", "/article/9999"},
+	}
+	llm := newBroadnessLLM(`^/article/\d+$`)
+	pattern, ok, err := pathinfer.InferLLM(context.Background(), samples, llm, testLoader)
+	require.NoError(t, err)
+	assert.True(t, ok, "리터럴 + 좁은 capture — 통과")
+	assert.Equal(t, `^/article/\d+$`, pattern)
+}
+
+func TestBroadness_RejectsBroadFirstSegment(t *testing.T) {
+	t.Setenv("PATHINFER_BROADNESS_CHECK", "")
+	samples := pathinfer.LLMSamples{
+		Articles: []string{"/article/1", "/article/200", "/article/9999"},
+	}
+	llm := newBroadnessLLM(`^/.+/\d+$`)
+	_, ok, err := pathinfer.InferLLM(context.Background(), samples, llm, testLoader)
+	require.NoError(t, err)
+	assert.False(t, ok, "첫 segment .+ 로 broad — 거부")
+}
+
+func TestBroadness_RejectsBracketBroadSegment(t *testing.T) {
+	t.Setenv("PATHINFER_BROADNESS_CHECK", "")
+	samples := pathinfer.LLMSamples{
+		Articles: []string{"/article/1", "/article/200", "/article/9999"},
+	}
+	llm := newBroadnessLLM(`^/[^/]+/\d+$`)
+	_, ok, err := pathinfer.InferLLM(context.Background(), samples, llm, testLoader)
+	require.NoError(t, err)
+	assert.False(t, ok, "첫 segment [^/]+ — broadnesstoken 매칭 → 거부")
+}
+
+func TestBroadness_RejectsLowercaseBroadSegment(t *testing.T) {
+	t.Setenv("PATHINFER_BROADNESS_CHECK", "")
+	samples := pathinfer.LLMSamples{
+		Articles: []string{"/article/1", "/article/200", "/article/9999"},
+	}
+	// [a-z]+ 는 broadnesstoken (모두 소문자) 도 매칭 → broad 판정.
+	llm := newBroadnessLLM(`^/[a-z]+/\d+$`)
+	_, ok, err := pathinfer.InferLLM(context.Background(), samples, llm, testLoader)
+	require.NoError(t, err)
+	assert.False(t, ok, "literal 자리에 [a-z]+ — token 매칭 → 거부")
+}
+
+func TestBroadness_AcceptsVariedFirstSegment(t *testing.T) {
+	t.Setenv("PATHINFER_BROADNESS_CHECK", "")
+	// positive 가 다양한 첫 segment 를 가지면 그 자리는 constant 가 아니므로 [a-z]+ 통과.
+	samples := pathinfer.LLMSamples{
+		Articles: []string{"/article/1", "/news/2", "/column/3"},
+	}
+	llm := newBroadnessLLM(`^/[a-z]+/\d+$`)
+	pattern, ok, err := pathinfer.InferLLM(context.Background(), samples, llm, testLoader)
+	require.NoError(t, err)
+	assert.True(t, ok, "다양한 첫 segment — broadness 검증 skip")
+	assert.Equal(t, `^/[a-z]+/\d+$`, pattern)
+}
+
+func TestBroadness_RejectsTooManySegments(t *testing.T) {
+	t.Setenv("PATHINFER_BROADNESS_CHECK", "")
+	samples := pathinfer.LLMSamples{
+		Articles: []string{"/article/1", "/article/200", "/article/9999"},
+	}
+	// 3 segment 까지 허용하는 pattern — positive 는 모두 2 segment 인데 K+1 매칭 → broad.
+	llm := newBroadnessLLM(`^/article/\d+(/.+)?$`)
+	_, ok, err := pathinfer.InferLLM(context.Background(), samples, llm, testLoader)
+	require.NoError(t, err)
+	assert.False(t, ok, "K+1 segment 매칭 → 거부")
+}
+
+func TestBroadness_AcceptsMatchingSegmentCount(t *testing.T) {
+	t.Setenv("PATHINFER_BROADNESS_CHECK", "")
+	samples := pathinfer.LLMSamples{
+		Articles: []string{"/news/100", "/news/200", "/news/300"},
+	}
+	llm := newBroadnessLLM(`^/news/\d+$`)
+	pattern, ok, err := pathinfer.InferLLM(context.Background(), samples, llm, testLoader)
+	require.NoError(t, err)
+	assert.True(t, ok)
+	assert.Equal(t, `^/news/\d+$`, pattern)
+}
+
+func TestBroadness_EnvToggleDisables(t *testing.T) {
+	t.Setenv("PATHINFER_BROADNESS_CHECK", "false")
+	samples := pathinfer.LLMSamples{
+		Articles: []string{"/article/1", "/article/200", "/article/9999"},
+	}
+	// 정상 정밀화도 거부될 수 있는 broad 패턴 — toggle off 상태에서는 통과.
+	llm := newBroadnessLLM(`^/[^/]+/\d+$`)
+	pattern, ok, err := pathinfer.InferLLM(context.Background(), samples, llm, testLoader)
+	require.NoError(t, err)
+	assert.True(t, ok, "PATHINFER_BROADNESS_CHECK=false — 휴리스틱 skip")
+	assert.Equal(t, `^/[^/]+/\d+$`, pattern)
+}
+
+func TestBroadness_EnvToggleVariations(t *testing.T) {
+	cases := []struct {
+		env     string
+		enabled bool
+	}{
+		{"", true},        // 미설정 = default true
+		{"true", true},    // 명시 true
+		{"1", true},       // 1 도 true 로 취급
+		{"yes", true},     //
+		{"false", false},  //
+		{"FALSE", false},  // case-insensitive
+		{"0", false},      //
+		{"no", false},     //
+		{"  no  ", false}, // trim
+	}
+	for _, c := range cases {
+		c := c
+		t.Run(c.env, func(t *testing.T) {
+			t.Setenv("PATHINFER_BROADNESS_CHECK", c.env)
+			samples := pathinfer.LLMSamples{
+				Articles: []string{"/article/1", "/article/200", "/article/9999"},
+			}
+			llm := newBroadnessLLM(`^/[^/]+/\d+$`)
+			_, ok, err := pathinfer.InferLLM(context.Background(), samples, llm, testLoader)
+			require.NoError(t, err)
+			if c.enabled {
+				assert.False(t, ok, "broadness 활성 — broad 패턴 거부")
+			} else {
+				assert.True(t, ok, "broadness 비활성 — broad 패턴 통과")
+			}
+		})
+	}
+}
+
+func TestBroadness_SinglePositiveSkipsLiteralCheck(t *testing.T) {
+	t.Setenv("PATHINFER_BROADNESS_CHECK", "")
+	// positive 가 1개면 literal segment check skip — 정상 capture (\d+) 도 거부될 위험 회피.
+	// 단 minSamples (3) 미만이면 InferLLM 자체가 일찍 반환 — 본 테스트는 minSamples=1 override.
+	samples := pathinfer.LLMSamples{
+		Articles: []string{"/article/1"},
+	}
+	llm := newBroadnessLLM(`^/article/\d+$`)
+	pattern, ok, err := pathinfer.InferLLM(context.Background(), samples, llm, testLoader, pathinfer.WithMinSamples(1))
+	require.NoError(t, err)
+	assert.True(t, ok)
+	assert.Equal(t, `^/article/\d+$`, pattern)
+}
+
+func TestBroadness_VariedSegmentCountsSkipsValidation(t *testing.T) {
+	t.Setenv("PATHINFER_BROADNESS_CHECK", "")
+	// segment 수가 들쑥날쑥 — broadness 검증 skip (fail-open).
+	samples := pathinfer.LLMSamples{
+		Articles: []string{"/article/1", "/article/sub/2", "/article/3"},
+	}
+	// catch-all 보다 약간만 좁은 패턴 — 정상이면 거부되겠지만 segment 수 mismatch 로 skip.
+	llm := newBroadnessLLM(`^/article(/.+)?$`)
+	pattern, ok, err := pathinfer.InferLLM(context.Background(), samples, llm, testLoader)
+	require.NoError(t, err)
+	assert.True(t, ok, "segment 수 들쑥날쑥 — fail-open")
+	assert.Equal(t, `^/article(/.+)?$`, pattern)
+}
+
+func TestBroadness_RejectsSinglePathFollowedByTrailingSlash(t *testing.T) {
+	t.Setenv("PATHINFER_BROADNESS_CHECK", "")
+	// K-1 변형: 마지막 segment 제거 후 매칭되면 broad.
+	samples := pathinfer.LLMSamples{
+		Articles: []string{"/article/1", "/article/2", "/article/3"},
+	}
+	// /article 도 매칭하는 패턴 — 1 segment 변형 매칭 → broad.
+	llm := newBroadnessLLM(`^/article(/\d+)?$`)
+	_, ok, err := pathinfer.InferLLM(context.Background(), samples, llm, testLoader)
+	require.NoError(t, err)
+	assert.False(t, ok, "K-1 변형 매칭 → 거부")
+}


### PR DESCRIPTION
## 연관 이슈
Closes #311

## 구현 내용

`pathinfer.validateLLMResult` 의 기존 검증 (RE2 컴파일 / positive / negative / triviallyBroad) 외에 sample-driven broadness 휴리스틱 추가. \"약간만 좁은\" broad 패턴 (예: `^/.+/\d+$`, `^/[^/]+/\d+$`, `^/[a-z]+/\d+$`) 거부.

### Heuristic 1: Segment 수 일치
positive 가 모두 K segment 인 경우, pattern 이 다음을 매칭하면 broad:
- **K+1 (prepend)**: `/broadnesstoken/<base>` — 첫 segment 자유 capture (`.+`, `[^/]+`) 거부
- **K+1 (append)**: `<base>/broadnesstoken` — trailing-optional (`^/article/\d+(/.+)?$`) 거부
- **K-1**: `<base>[:k-1]` — prefix-only catch-all 식 거부

### Heuristic 2: Literal segment 보존
positive 모두에 동일 segment value 가 있는 자리 (\"constant segment\") 에 임의 token 을 넣은 path 가 매칭되면 broad. 3가지 token (`broadnesstoken` / `ZZZZZZZZZ` / `different-host`) 으로 character class 변형도 흡수:
- `^/[^/]+/\d+$` — `/broadnesstoken/123` 매칭 → 거부
- `^/[a-z]+/\d+$` — `broadnesstoken` 모두 소문자 → 매칭 → 거부
- `^/\\d+/\\d+$` — `broadnesstoken` 숫자 아님 → 매칭 안 됨 → 통과 (정상 capture 보호)

### Fail-open 정책
- positive 1개만 → literal check skip (정상 `\d+` capture 도 거부될 위험)
- segment 수 들쑥날쑥 → 두 단계 모두 skip
- positive 빈 슬라이스 → skip

### 환경변수 토글: `PATHINFER_BROADNESS_CHECK`
- 미설정 / 빈 값 / 그 외 → **enabled (default true)**
- `false` / `0` / `no` (case-insensitive) → disabled
- 정상 정밀화가 broadness 휴리스틱에 의해 거부될 때 fail-safe off — 코드 변경 / 재배포 없이 환경변수만 갱신

### 통합 위치
`validateLLMResult` 의 마지막 단계 — RE2 컴파일 / positive / negative / triviallyBroad 통과 후 `broadnessCheckEnabled()` true 일 때만 실행.

## 테스트 (test/internal/processor/parser/rule/pathinfer/broadness_test.go) — 11건

- `AcceptsSpecificPattern` / `AcceptsMatchingSegmentCount` — 정상 패턴 통과
- `RejectsBroadFirstSegment` (`^/.+/\d+$`)
- `RejectsBracketBroadSegment` (`^/[^/]+/\d+$`)
- `RejectsLowercaseBroadSegment` (`^/[a-z]+/\d+$`)
- `RejectsTooManySegments` (`^/article/\d+(/.+)?$`)
- `RejectsSinglePathFollowedByTrailingSlash` (K-1 변형)
- `AcceptsVariedFirstSegment` — positive 다양하면 broadness skip
- `EnvToggleDisables` / `EnvToggleVariations` (9 env 값)
- `SinglePositiveSkipsLiteralCheck` / `VariedSegmentCountsSkipsValidation` — fail-open

## CI / 머지 게이트 점검
- [x] `go build ./...` 통과
- [x] `go test -race -count=1 ./test/...` 전부 ok
- [x] `go vet ./...` 깨끗
- [x] gofmt 정리

## 변경 영향 범위 + 위험도
- **영향**: pathinfer.InferLLM 의 검증 단계 강화 — 운영 LLM 응답 중 broad 한 패턴이 INSERT 되는 빈도 감소
- **위험도**: 낮음
  - 검증이 너무 엄격하면 정상적 정밀화도 거부 → sample 누적 + 다음 cycle 재시도 (LLM 비용 미미 증가)
  - `PATHINFER_BROADNESS_CHECK=false` 로 즉시 fail-safe off 가능
  - fail-open 정책 (positive 1개 / segment 수 들쑥날쑥) 으로 정상 케이스 보호

## 롤백 계획
1. `PATHINFER_BROADNESS_CHECK=false` 환경변수 — 휴리스틱 즉시 비활성
2. 코드 롤백: `git revert` — pathinfer 단일 패키지 변경

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `PATHINFER_BROADNESS_CHECK` environment variable to control pattern broadness validation (enabled by default).

* **Bug Fixes**
  * Enhanced pattern validation to reject excessively broad patterns that match too many path variations.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/EinSofINTEREST/IssueTracker/pull/341)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->