### PR TITLE
[FEAT#170] LLM wiring — MeasuredProvider 통합 + LLM_POLICY (chain/cheapest/latency/hybrid)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -194,3 +194,16 @@ GOOGLE_CSE_TIMEOUT=10s
 # LLM 정밀화 결과가 너무 broad 한 패턴 (예: ^/.+/\d+$) 도 거부하는 sample-driven 검증.
 # 정상 정밀화도 거부될 때 fail-safe off — 코드 변경 / 재배포 없이 환경변수만 갱신.
 PATHINFER_BROADNESS_CHECK=true
+
+# LLM routing policy (이슈 #170)
+# 다중 provider chain 의 후보 정렬 정책 — provider key 가 여러 개 설정된 경우에만 의미.
+# - chain (default): FixedOrder(gemini → openai → anthropic) — 정적 우선순위
+# - cheapest       : CheapestFirst — Capabilities.CostInputPer1M 오름차순
+# - latency        : LatencyWeighted — MeasuredProvider EMA latency 오름차순 (이력 없으면 baseline)
+# - hybrid         : Hybrid — cost + latency + failure_rate 가중 합산
+LLM_POLICY=chain
+
+# Hybrid 가중치 (LLM_POLICY=hybrid 일 때만 적용)
+# 형식: "cost,latency,failure_rate" — 음수 거부, 합이 1.0 일 필요 없음 (각 시그널 normalize 후 가중 합산)
+# default: 1.0,1.0,0.5 (Cost 와 Latency 동일, FailureRate 는 그 절반)
+LLM_HYBRID_WEIGHTS=1.0,1.0,0.5

--- a/cmd/issuetracker/main.go
+++ b/cmd/issuetracker/main.go
@@ -386,7 +386,9 @@ func main() {
 	// rule.ErrNoRule (host 매칭 활성 규칙 없음) fallback 으로 LLM 이 selector 를 자동 생성합니다.
 	// LLM_ENABLED=false 또는 API key 누락 시 nil — parser worker 는 ErrNoRule 시 raw 만 잔존.
 	//
-	// **현재 정책**: FixedOrder("gemini") 정책으로 Gemini 단일 provider 사용 (1000회/일 무료 한도 내 검증).
+	// **현재 정책**: LLM_POLICY 환경변수로 선택 (default "chain"):
+	//   - chain (default): FixedOrder(gemini → openai → anthropic) — 정적 순서
+	//   - cheapest / latency / hybrid: capability + MeasuredProvider 메트릭 기반 dynamic routing (이슈 #170)
 	// metricsRegistry 를 전달하여 각 provider 호출의 latency / failure 를 Prometheus 로 노출 +
 	// MeasuredProvider Stats 를 hybrid/latency 정책이 dynamic routing 에 활용 (이슈 #170).
 	//

--- a/cmd/issuetracker/main.go
+++ b/cmd/issuetracker/main.go
@@ -387,10 +387,13 @@ func main() {
 	// LLM_ENABLED=false 또는 API key 누락 시 nil — parser worker 는 ErrNoRule 시 raw 만 잔존.
 	//
 	// **현재 정책**: FixedOrder("gemini") 정책으로 Gemini 단일 provider 사용 (1000회/일 무료 한도 내 검증).
-	// 후속 PR (이슈 TBD) 에서 chain (gemini → openai → anthropic) 으로 정책 확장.
+	// metricsRegistry 를 전달하여 각 provider 호출의 latency / failure 를 Prometheus 로 노출 +
+	// MeasuredProvider Stats 를 hybrid/latency 정책이 dynamic routing 에 활용 (이슈 #170).
 	//
 	// 동일 provider 를 refiner 와 공유 — 환경변수 1세트로 동시 제어.
-	llmProvider := llmwiring.BuildProvider(log)
+	llmProvider := llmwiring.BuildProviderWithOptions(log, llmwiring.Options{
+		PrometheusRegistry: metricsRegistry,
+	})
 
 	// LLM prompt loader — provider 가 nil (LLM_ENABLED=false 또는 API key 부재) 이면
 	// promptLoader 도 미생성. wiring.Build 가 provider==nil 시 short-circuit 하므로

--- a/pkg/llm/wiring/wiring.go
+++ b/pkg/llm/wiring/wiring.go
@@ -161,13 +161,16 @@ func BuildProviderWithOptions(log *logger.Logger, opts Options) llm.Provider {
 	pol, polName := selectPolicy(log)
 	composed := chain.NewWithPolicy(pol, candidates, chain.WithPolicyLogger(log))
 
+	// first_in_candidates 는 정책 적용 전 후보 목록의 첫 항목 — FixedOrder 일 때만 실제 첫 시도 대상과
+	// 일치. 동적 정책 (cheapest / latency / hybrid) 은 매 호출마다 policy.Select 가 정렬을 변경하므로
+	// 실제 첫 시도는 chain Generate 시점 로그에 의존 (Copilot 피드백 #342).
 	log.WithFields(map[string]interface{}{
-		"chain":              activeNames,
-		"first_in_chain":     activeNames[0],
-		"configured_primary": primaryName,
-		"policy":             polName,
-		"timeout":            cfg.Timeout.String(),
-		"metrics_registered": opts.PrometheusRegistry != nil,
+		"chain":               activeNames,
+		"first_in_candidates": activeNames[0],
+		"configured_primary":  primaryName,
+		"policy":              polName,
+		"timeout":             cfg.Timeout.String(),
+		"metrics_registered":  opts.PrometheusRegistry != nil,
 	}).Info("LLM provider chain enabled")
 
 	return composed
@@ -209,15 +212,15 @@ func loadHybridWeights() (policy.HybridWeights, error) {
 	}
 	parts := strings.Split(v, ",")
 	if len(parts) != 3 {
-		return policy.HybridWeights{}, fmt.Errorf("LLM_HYBRID_WEIGHTS expects 3 comma-separated floats (cost,latency,failure_rate), got %q", v)
+		return policy.HybridWeights{}, fmt.Errorf("invalid LLM_HYBRID_WEIGHTS: expected 3 comma-separated floats (cost,latency,failure_rate), got %q", v)
 	}
 	parseFloat := func(s, label string) (float64, error) {
 		f, err := strconv.ParseFloat(strings.TrimSpace(s), 64)
 		if err != nil {
-			return 0, fmt.Errorf("parse %s weight %q: %w", label, s, err)
+			return 0, fmt.Errorf("invalid LLM_HYBRID_WEIGHTS: parse %s weight %q: %w", label, s, err)
 		}
 		if f < 0 {
-			return 0, fmt.Errorf("%s weight must be non-negative, got %v", label, f)
+			return 0, fmt.Errorf("invalid LLM_HYBRID_WEIGHTS: %s weight must be non-negative, got %v", label, f)
 		}
 		return f, nil
 	}

--- a/pkg/llm/wiring/wiring.go
+++ b/pkg/llm/wiring/wiring.go
@@ -6,6 +6,7 @@ package wiring
 
 import (
 	"fmt"
+	"math"
 	"os"
 	"strconv"
 	"strings"
@@ -218,6 +219,10 @@ func loadHybridWeights() (policy.HybridWeights, error) {
 		f, err := strconv.ParseFloat(strings.TrimSpace(s), 64)
 		if err != nil {
 			return 0, fmt.Errorf("invalid LLM_HYBRID_WEIGHTS: parse %s weight %q: %w", label, s, err)
+		}
+		// NaN / ±Inf 는 Hybrid 정책의 normalize 계산을 깨뜨림 (NaN 전파) — 명시 거부 (gemini Medium 반영).
+		if math.IsNaN(f) || math.IsInf(f, 0) {
+			return 0, fmt.Errorf("invalid LLM_HYBRID_WEIGHTS: %s weight must be a finite number, got %v", label, f)
 		}
 		if f < 0 {
 			return 0, fmt.Errorf("invalid LLM_HYBRID_WEIGHTS: %s weight must be non-negative, got %v", label, f)

--- a/pkg/llm/wiring/wiring.go
+++ b/pkg/llm/wiring/wiring.go
@@ -5,7 +5,12 @@
 package wiring
 
 import (
+	"fmt"
 	"os"
+	"strconv"
+	"strings"
+
+	"github.com/prometheus/client_golang/prometheus"
 
 	"issuetracker/pkg/config"
 	"issuetracker/pkg/llm"
@@ -46,34 +51,56 @@ func normalizePrimary(name string) string {
 // fallbackOrder 는 fixed-order fallback chain 의 시도 순서입니다.
 //
 // 현재는 gemini → openai → anthropic 으로 hardcoded — 비용 / 한도 / 가용성 우선순위 기준.
-// 향후 capability 기반 metric 정책 (cost / latency / 성공률) 도입 시 본 슬라이스 대신
-// pkg/llm/policy 의 dynamic policy (CheapestFirst / Latency / Hybrid 등) 로 NewFixedOrder 만 교체.
+// LLM_POLICY=chain (default) 일 때 적용. 다른 정책 (hybrid / latency / cheapest) 은 metric /
+// capability 기반으로 동적 정렬.
 var fallbackOrder = []string{"gemini", "openai", "anthropic"}
 
-// BuildProvider 는 LLMConfig (환경변수) 에 따라 fixed-order fallback chain 을 구성합니다.
+// metricsLabelPrefix 는 MeasuredFactory 가 collector 이름에 prepend 하는 prefix 입니다.
+// /metrics endpoint 에서 "issuetracker_llm_*" 메트릭으로 노출 — 다른 도메인 메트릭과 충돌 회피.
+const metricsLabelPrefix = "issuetracker_llm"
+
+// Options 는 BuildProviderWithOptions 의 선택 인자입니다.
 //
-// fallback 순서: gemini → openai → anthropic (hardcoded — 향후 metric 기반 정책으로 대체).
-// 각 provider 는 자신의 API key 가 환경변수에 설정된 경우에만 chain 후보에 포함:
-//   - GEMINI_API_KEY / OPENAI_API_KEY / ANTHROPIC_API_KEY 직접 lookup
+// 모든 필드 zero value 면 BuildProvider 의 default 동작과 동일.
+type Options struct {
+	// PrometheusRegistry: nil 이면 Prometheus collector 등록 skip — in-memory EMA / Stats 만 유지
+	// (LatencyWeighted / Hybrid 정책은 그대로 동작). cmd/* 가 metrics endpoint 를 노출하는 경우 전달.
+	PrometheusRegistry *prometheus.Registry
+}
+
+// BuildProvider 는 backward-compatible wrapper — Prometheus registry 없이 default option 으로 wiring 합니다.
 //
-// LLM_API_KEY 의 역할 (backward compat — primary 1건 한정):
-//   - primary (LLM_PROVIDER 가 가리키는 provider) 가 자신의 specific key 부재인 경우에만 LLM_API_KEY 적용.
-//   - 다른 provider 에는 cascade 되지 않음 — 잘못된 key 가 chain 에 채워져 auth 실패로 시간 낭비하는 부작용 회피.
+// 신규 wiring 은 BuildProviderWithOptions 를 직접 호출하여 metrics registry 를 전달.
+func BuildProvider(log *logger.Logger) llm.Provider {
+	return BuildProviderWithOptions(log, Options{})
+}
+
+// BuildProviderWithOptions 는 LLMConfig (환경변수) + opts 에 따라 multi-provider chain 을 구성합니다.
+//
+// 각 provider 는 inner → outer 순으로 다음 decorator 로 wrap 됩니다:
+//  1. RealProvider (gemini / openai / anthropic)
+//  2. RetryProvider — rate_limit / network 백오프 재시도 (이슈 #215)
+//  3. MeasuredProvider — per-call latency EMA + Prometheus 메트릭 + Stats (이슈 #170)
+//
+// candidates 가 *MeasuredProvider 이므로 정책 (LatencyWeighted / Hybrid) 의 type assertion 이 hit —
+// 동적 metric 기반 정렬 가능.
+//
+// LLM_API_KEY fallback 은 primary (cfg.Provider) 1건에만 적용 — backward compat.
+// LLM_PROVIDER 의 alias (claude → anthropic) 는 normalizePrimary 가 정규화.
+//
+// 정책 선택 (LLM_POLICY, 이슈 #170):
+//   - "chain" (default) : FixedOrder(fallbackOrder...) — gemini → openai → anthropic 정적 순서
+//   - "cheapest"        : CheapestFirst(caps) — Capabilities.CostInputPer1M 오름차순
+//   - "latency"         : LatencyWeighted(caps) — Stats.LatencyMs() EMA 오름차순 (이력 없으면 Capabilities baseline)
+//   - "hybrid"          : Hybrid(caps, weights) — cost + latency + failure_rate 가중 합산
+//     가중치는 LLM_HYBRID_WEIGHTS 환경변수로 override (default 1.0,1.0,0.5)
 //
 // 반환값 nil 은 LLM 비활성을 의미 — 호출자가 nil 허용 분기:
 //   - LLM_ENABLED=false → nil
 //   - 모든 provider 가 API key 부재 / 생성 실패 → nil + warn
 //
-// 정책 적용:
-//   - policy.NewFixedOrder(fallbackOrder...) 로 후보를 정해진 순서로 정렬
-//   - 향후 metric 기반 정책 도입 시 본 함수의 policy 객체만 교체하면 됨
-//
-// LLM_PROVIDER / LLM_MODEL 의 역할 (backward compat):
-//   - LLM_PROVIDER 와 일치하는 provider 에는 LLM_MODEL 이 적용됨 (claude alias 포함)
-//   - 그 외 provider 는 자체 default model 사용 (gemini-2.5-flash / gpt-4o-mini / claude-opus-4-7)
-//
 // llmgen 과 refiner 가 동일 provider 를 공유 — 환경변수 1세트 (LLM_*) 로 두 컴포넌트 동시 제어.
-func BuildProvider(log *logger.Logger) llm.Provider {
+func BuildProviderWithOptions(log *logger.Logger, opts Options) llm.Provider {
 	cfg, err := config.LoadLLM()
 	if err != nil {
 		log.WithError(err).Warn("failed to load LLM config, llm provider disabled")
@@ -84,16 +111,17 @@ func BuildProvider(log *logger.Logger) llm.Provider {
 		return nil
 	}
 
-	// LLM_PROVIDER alias (예: "claude" → "anthropic") 정규화 — fallbackOrder 의 정식 이름과 매칭하여
-	// LLM_API_KEY fallback / LLM_MODEL override 가 올바른 chain 항목에 적용되도록 보장.
 	primaryName := normalizePrimary(cfg.Provider)
+
+	// MeasuredFactory 는 모든 후보가 공유 — 단일 collector set 으로 등록.
+	// PrometheusRegistry 가 nil 이면 collector 등록 skip — in-memory EMA / Stats 는 그대로 동작.
+	measuredFactory := llm.NewMeasuredFactory(opts.PrometheusRegistry, metricsLabelPrefix)
 
 	candidates := make([]llm.Provider, 0, len(fallbackOrder))
 	activeNames := make([]string, 0, len(fallbackOrder))
 	for _, name := range fallbackOrder {
 		apiKey := lookupProviderAPIKey(name)
 		// LLM_API_KEY fallback 은 primary (LLM_PROVIDER) 에만 적용 — backward compat.
-		// 다른 provider 에 같은 key 를 cascade 하면 chain 이 잘못 채워져 auth 실패 후 다음 시도로 낭비.
 		if apiKey == "" && name == primaryName {
 			apiKey = cfg.APIKey
 		}
@@ -101,7 +129,6 @@ func BuildProvider(log *logger.Logger) llm.Provider {
 			log.WithField("provider", name).Debug("skipping provider — no API key configured")
 			continue
 		}
-		// 사용자가 LLM_PROVIDER 로 지정한 primary 에는 LLM_MODEL override 적용. 나머지는 provider default.
 		model := ""
 		if name == primaryName {
 			model = cfg.Model
@@ -116,11 +143,13 @@ func BuildProvider(log *logger.Logger) llm.Provider {
 			log.WithError(perr).WithField("provider", name).Warn("failed to construct LLM provider, skipping")
 			continue
 		}
-		// 각 provider 를 RetryProvider 로 감싸 — rate_limit / network 발생 시 chain fallback 전에
-		// 같은 provider 에서 backoff 재시도 (이슈 #215). chain 은 RetryProvider 가 모든 시도 소진
-		// 후에야 다음 provider 로 fallthrough — backoff 정책은 default (RateLimit 5회/10s + Network 3회/1s).
-		p = llm.NewRetryProvider(p, llm.RetryProviderOptions{})
-		candidates = append(candidates, p)
+		// RetryProvider — rate_limit / network 발생 시 chain fallback 전에 같은 provider 에서
+		// backoff 재시도 (이슈 #215). default 정책 (RateLimit 5회/10s + Network 3회/1s).
+		retryWrapped := llm.NewRetryProvider(p, llm.RetryProviderOptions{})
+		// MeasuredProvider — per-call latency EMA + Prometheus 메트릭 (이슈 #170).
+		// outer wrap 으로 retries 포함한 end-to-end 시간을 기록 — 정책이 보는 latency 는 실 사용자 경험.
+		measured := measuredFactory.Wrap(retryWrapped)
+		candidates = append(candidates, measured)
 		activeNames = append(activeNames, name)
 	}
 
@@ -129,22 +158,80 @@ func BuildProvider(log *logger.Logger) llm.Provider {
 		return nil
 	}
 
-	// FixedOrder 정책 — fallbackOrder 의 순서를 후보에 강제. 향후 metric 정책으로 교체 시 본 줄만 변경.
-	pol := policy.NewFixedOrder(fallbackOrder...)
+	pol, polName := selectPolicy(log)
 	composed := chain.NewWithPolicy(pol, candidates, chain.WithPolicyLogger(log))
 
-	// 로그 필드 의미:
-	//   - chain          : 실제 활성화되어 시도되는 provider 시퀀스 (정책 적용 전 후보 목록)
-	//   - first_in_chain : chain[0] — 매 호출의 첫 시도 대상 (디버깅용)
-	//   - configured_primary : LLM_PROVIDER 가 가리키는 사용자 의도 (alias 정규화 후)
-	//                          — first_in_chain 과 다를 수 있음 (key 부재 등으로 chain 에서 제외된 경우)
 	log.WithFields(map[string]interface{}{
 		"chain":              activeNames,
 		"first_in_chain":     activeNames[0],
 		"configured_primary": primaryName,
-		"policy":             "FixedOrder",
+		"policy":             polName,
 		"timeout":            cfg.Timeout.String(),
-	}).Info("LLM provider chain enabled (fixed order — gemini → openai → anthropic; metric policy 후속 PR)")
+		"metrics_registered": opts.PrometheusRegistry != nil,
+	}).Info("LLM provider chain enabled")
 
 	return composed
+}
+
+// selectPolicy 는 LLM_POLICY 환경변수에 따라 정책을 생성합니다 — invalid 값은 default 로 fallback.
+//
+// 반환: (Policy, name) — name 은 로그용 식별자.
+func selectPolicy(log *logger.Logger) (policy.Policy, string) {
+	raw := strings.ToLower(strings.TrimSpace(os.Getenv("LLM_POLICY")))
+	switch raw {
+	case "", "chain", "fixed":
+		// 기본값 — FixedOrder(fallbackOrder...) 로 gemini → openai → anthropic 정적 순서.
+		return policy.NewFixedOrder(fallbackOrder...), "FixedOrder"
+	case "cheapest":
+		return policy.NewCheapestFirst(llm.NewStaticCapabilitiesProvider()), "CheapestFirst"
+	case "latency":
+		return policy.NewLatencyWeighted(llm.NewStaticCapabilitiesProvider()), "LatencyWeighted"
+	case "hybrid":
+		weights, werr := loadHybridWeights()
+		if werr != nil {
+			log.WithError(werr).Warn("invalid LLM_HYBRID_WEIGHTS — falling back to default")
+			weights = policy.DefaultHybridWeights()
+		}
+		return policy.NewHybrid(llm.NewStaticCapabilitiesProvider(), weights), "Hybrid"
+	default:
+		log.WithField("requested", raw).Warn("unknown LLM_POLICY — falling back to chain (FixedOrder)")
+		return policy.NewFixedOrder(fallbackOrder...), "FixedOrder"
+	}
+}
+
+// loadHybridWeights 는 LLM_HYBRID_WEIGHTS 환경변수 (예: "1.0,1.0,0.5") 를 파싱합니다.
+//
+// 미설정 / 빈 값 이면 DefaultHybridWeights 반환. 형식 오류면 error + caller 가 default fallback.
+func loadHybridWeights() (policy.HybridWeights, error) {
+	v := strings.TrimSpace(os.Getenv("LLM_HYBRID_WEIGHTS"))
+	if v == "" {
+		return policy.DefaultHybridWeights(), nil
+	}
+	parts := strings.Split(v, ",")
+	if len(parts) != 3 {
+		return policy.HybridWeights{}, fmt.Errorf("LLM_HYBRID_WEIGHTS expects 3 comma-separated floats (cost,latency,failure_rate), got %q", v)
+	}
+	parseFloat := func(s, label string) (float64, error) {
+		f, err := strconv.ParseFloat(strings.TrimSpace(s), 64)
+		if err != nil {
+			return 0, fmt.Errorf("parse %s weight %q: %w", label, s, err)
+		}
+		if f < 0 {
+			return 0, fmt.Errorf("%s weight must be non-negative, got %v", label, f)
+		}
+		return f, nil
+	}
+	cost, err := parseFloat(parts[0], "cost")
+	if err != nil {
+		return policy.HybridWeights{}, err
+	}
+	latency, err := parseFloat(parts[1], "latency")
+	if err != nil {
+		return policy.HybridWeights{}, err
+	}
+	failure, err := parseFloat(parts[2], "failure_rate")
+	if err != nil {
+		return policy.HybridWeights{}, err
+	}
+	return policy.HybridWeights{Cost: cost, Latency: latency, FailureRate: failure}, nil
 }

--- a/test/pkg/llm/wiring/policy_test.go
+++ b/test/pkg/llm/wiring/policy_test.go
@@ -134,6 +134,28 @@ func TestBuildProvider_PolicyHybridWithWrongCount(t *testing.T) {
 	assert.Contains(t, buf.String(), "invalid LLM_HYBRID_WEIGHTS")
 }
 
+// TestBuildProvider_PolicyHybridNaNInfRejected 는 NaN / Inf 가중치를 invalid 로 거부함을 검증합니다.
+// Hybrid normalize 계산이 NaN 전파로 깨지는 것 방지 (gemini Medium 반영).
+func TestBuildProvider_PolicyHybridNaNInfRejected(t *testing.T) {
+	cases := []string{"NaN,1.0,0.5", "1.0,Inf,0.5", "1.0,1.0,-Inf"}
+	for _, weights := range cases {
+		weights := weights
+		t.Run(weights, func(t *testing.T) {
+			clearLLMEnv(t)
+			t.Setenv("LLM_ENABLED", "true")
+			t.Setenv("LLM_POLICY", "hybrid")
+			t.Setenv("LLM_HYBRID_WEIGHTS", weights)
+			t.Setenv("GEMINI_API_KEY", "fake-gemini-key")
+
+			log, buf := captureLog(t)
+			p := wiring.BuildProvider(log)
+			require.NotNil(t, p, "invalid weights → default fallback, provider 정상 생성")
+
+			assert.Contains(t, buf.String(), "invalid LLM_HYBRID_WEIGHTS")
+		})
+	}
+}
+
 // TestBuildProvider_PolicyHybridNegativeWeightRejected 는 음수 가중치를 invalid 로 거부함을 검증합니다.
 func TestBuildProvider_PolicyHybridNegativeWeightRejected(t *testing.T) {
 	clearLLMEnv(t)

--- a/test/pkg/llm/wiring/policy_test.go
+++ b/test/pkg/llm/wiring/policy_test.go
@@ -1,0 +1,204 @@
+package wiring_test
+
+import (
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"issuetracker/pkg/llm/wiring"
+)
+
+// TestBuildProvider_PolicyDefaultIsFixedOrder 는 LLM_POLICY 미설정 시 default 가 FixedOrder 임을 검증합니다.
+func TestBuildProvider_PolicyDefaultIsFixedOrder(t *testing.T) {
+	clearLLMEnv(t)
+	t.Setenv("LLM_ENABLED", "true")
+	t.Setenv("GEMINI_API_KEY", "fake-gemini-key")
+
+	log, buf := captureLog(t)
+	p := wiring.BuildProvider(log)
+	require.NotNil(t, p)
+
+	entry := findChainEnabledLog(t, buf)
+	assert.Equal(t, "FixedOrder", entry["policy"])
+}
+
+// TestBuildProvider_PolicyChainAlias 는 LLM_POLICY=chain 도 FixedOrder 로 매핑됨을 검증합니다.
+func TestBuildProvider_PolicyChainAlias(t *testing.T) {
+	clearLLMEnv(t)
+	t.Setenv("LLM_ENABLED", "true")
+	t.Setenv("LLM_POLICY", "chain")
+	t.Setenv("GEMINI_API_KEY", "fake-gemini-key")
+
+	log, buf := captureLog(t)
+	p := wiring.BuildProvider(log)
+	require.NotNil(t, p)
+
+	entry := findChainEnabledLog(t, buf)
+	assert.Equal(t, "FixedOrder", entry["policy"])
+}
+
+// TestBuildProvider_PolicyCheapest 는 LLM_POLICY=cheapest 시 CheapestFirst 정책이 선택됨을 검증합니다.
+func TestBuildProvider_PolicyCheapest(t *testing.T) {
+	clearLLMEnv(t)
+	t.Setenv("LLM_ENABLED", "true")
+	t.Setenv("LLM_POLICY", "cheapest")
+	t.Setenv("GEMINI_API_KEY", "fake-gemini-key")
+
+	log, buf := captureLog(t)
+	p := wiring.BuildProvider(log)
+	require.NotNil(t, p)
+
+	entry := findChainEnabledLog(t, buf)
+	assert.Equal(t, "CheapestFirst", entry["policy"])
+}
+
+// TestBuildProvider_PolicyLatency 는 LLM_POLICY=latency 시 LatencyWeighted 정책이 선택됨을 검증합니다.
+func TestBuildProvider_PolicyLatency(t *testing.T) {
+	clearLLMEnv(t)
+	t.Setenv("LLM_ENABLED", "true")
+	t.Setenv("LLM_POLICY", "latency")
+	t.Setenv("GEMINI_API_KEY", "fake-gemini-key")
+
+	log, buf := captureLog(t)
+	p := wiring.BuildProvider(log)
+	require.NotNil(t, p)
+
+	entry := findChainEnabledLog(t, buf)
+	assert.Equal(t, "LatencyWeighted", entry["policy"])
+}
+
+// TestBuildProvider_PolicyHybrid 는 LLM_POLICY=hybrid 시 Hybrid 정책이 선택됨을 검증합니다.
+func TestBuildProvider_PolicyHybrid(t *testing.T) {
+	clearLLMEnv(t)
+	t.Setenv("LLM_ENABLED", "true")
+	t.Setenv("LLM_POLICY", "hybrid")
+	t.Setenv("GEMINI_API_KEY", "fake-gemini-key")
+
+	log, buf := captureLog(t)
+	p := wiring.BuildProvider(log)
+	require.NotNil(t, p)
+
+	entry := findChainEnabledLog(t, buf)
+	assert.Equal(t, "Hybrid", entry["policy"])
+}
+
+// TestBuildProvider_PolicyHybridWithCustomWeights 는 LLM_HYBRID_WEIGHTS 가 valid 일 때 정상 통과를 검증합니다.
+func TestBuildProvider_PolicyHybridWithCustomWeights(t *testing.T) {
+	clearLLMEnv(t)
+	t.Setenv("LLM_ENABLED", "true")
+	t.Setenv("LLM_POLICY", "hybrid")
+	t.Setenv("LLM_HYBRID_WEIGHTS", "2.0,1.5,0.25")
+	t.Setenv("GEMINI_API_KEY", "fake-gemini-key")
+
+	log, buf := captureLog(t)
+	p := wiring.BuildProvider(log)
+	require.NotNil(t, p)
+
+	entry := findChainEnabledLog(t, buf)
+	assert.Equal(t, "Hybrid", entry["policy"])
+	// "invalid LLM_HYBRID_WEIGHTS" warn 로그가 없어야 함 — 출력 전체에서 substring 미발견 확인.
+	assert.NotContains(t, buf.String(), "invalid LLM_HYBRID_WEIGHTS")
+}
+
+// TestBuildProvider_PolicyHybridWithInvalidWeights 는 LLM_HYBRID_WEIGHTS 가 invalid 일 때 default 로 fallback 됨을 검증합니다.
+func TestBuildProvider_PolicyHybridWithInvalidWeights(t *testing.T) {
+	clearLLMEnv(t)
+	t.Setenv("LLM_ENABLED", "true")
+	t.Setenv("LLM_POLICY", "hybrid")
+	t.Setenv("LLM_HYBRID_WEIGHTS", "not,a,float")
+	t.Setenv("GEMINI_API_KEY", "fake-gemini-key")
+
+	log, buf := captureLog(t)
+	p := wiring.BuildProvider(log)
+	require.NotNil(t, p, "invalid weights → default fallback, provider 정상 생성")
+
+	entry := findChainEnabledLog(t, buf)
+	assert.Equal(t, "Hybrid", entry["policy"])
+	assert.Contains(t, buf.String(), "invalid LLM_HYBRID_WEIGHTS")
+}
+
+// TestBuildProvider_PolicyHybridWithWrongCount 는 LLM_HYBRID_WEIGHTS comma 개수가 잘못된 경우 default fallback 검증.
+func TestBuildProvider_PolicyHybridWithWrongCount(t *testing.T) {
+	clearLLMEnv(t)
+	t.Setenv("LLM_ENABLED", "true")
+	t.Setenv("LLM_POLICY", "hybrid")
+	t.Setenv("LLM_HYBRID_WEIGHTS", "1.0,2.0")
+	t.Setenv("GEMINI_API_KEY", "fake-gemini-key")
+
+	log, buf := captureLog(t)
+	p := wiring.BuildProvider(log)
+	require.NotNil(t, p)
+
+	assert.Contains(t, buf.String(), "invalid LLM_HYBRID_WEIGHTS")
+}
+
+// TestBuildProvider_PolicyHybridNegativeWeightRejected 는 음수 가중치를 invalid 로 거부함을 검증합니다.
+func TestBuildProvider_PolicyHybridNegativeWeightRejected(t *testing.T) {
+	clearLLMEnv(t)
+	t.Setenv("LLM_ENABLED", "true")
+	t.Setenv("LLM_POLICY", "hybrid")
+	t.Setenv("LLM_HYBRID_WEIGHTS", "1.0,-0.5,0.5")
+	t.Setenv("GEMINI_API_KEY", "fake-gemini-key")
+
+	log, buf := captureLog(t)
+	p := wiring.BuildProvider(log)
+	require.NotNil(t, p)
+
+	assert.Contains(t, buf.String(), "invalid LLM_HYBRID_WEIGHTS")
+}
+
+// TestBuildProvider_UnknownPolicyFallsBackToFixed 는 invalid LLM_POLICY 가 FixedOrder 로 fallback 됨을 검증합니다.
+func TestBuildProvider_UnknownPolicyFallsBackToFixed(t *testing.T) {
+	clearLLMEnv(t)
+	t.Setenv("LLM_ENABLED", "true")
+	t.Setenv("LLM_POLICY", "nonexistent-policy")
+	t.Setenv("GEMINI_API_KEY", "fake-gemini-key")
+
+	log, buf := captureLog(t)
+	p := wiring.BuildProvider(log)
+	require.NotNil(t, p)
+
+	entry := findChainEnabledLog(t, buf)
+	assert.Equal(t, "FixedOrder", entry["policy"])
+	assert.Contains(t, buf.String(), "unknown LLM_POLICY")
+}
+
+// TestBuildProviderWithOptions_PrometheusRegistryWired 는 registry 가 전달되면 collector 등록이
+// 실패 없이 진행되고 log 의 metrics_registered=true 가 기록됨을 검증합니다.
+func TestBuildProviderWithOptions_PrometheusRegistryWired(t *testing.T) {
+	clearLLMEnv(t)
+	t.Setenv("LLM_ENABLED", "true")
+	t.Setenv("GEMINI_API_KEY", "fake-gemini-key")
+
+	reg := prometheus.NewRegistry()
+	log, buf := captureLog(t)
+
+	p := wiring.BuildProviderWithOptions(log, wiring.Options{PrometheusRegistry: reg})
+	require.NotNil(t, p)
+
+	entry := findChainEnabledLog(t, buf)
+	assert.Equal(t, true, entry["metrics_registered"])
+
+	// 등록된 collector 가 동일 registry 에 두 번째 호출되어도 (idempotent) panic 안 함을 검증 —
+	// HistogramVec / CounterVec 은 observe 전엔 Gather() 가 빈 슬라이스 반환할 수 있어
+	// 등록 자체의 sanity 는 두번째 wiring 으로 확인.
+	assert.NotPanics(t, func() {
+		_ = wiring.BuildProviderWithOptions(log, wiring.Options{PrometheusRegistry: reg})
+	}, "동일 registry 재사용 시 panic 없음 (collector 중복 등록 보호)")
+}
+
+// TestBuildProviderWithOptions_NilRegistry 는 registry 가 nil 이어도 정상 wiring 됨을 검증합니다.
+func TestBuildProviderWithOptions_NilRegistry(t *testing.T) {
+	clearLLMEnv(t)
+	t.Setenv("LLM_ENABLED", "true")
+	t.Setenv("GEMINI_API_KEY", "fake-gemini-key")
+
+	log, buf := captureLog(t)
+	p := wiring.BuildProviderWithOptions(log, wiring.Options{PrometheusRegistry: nil})
+	require.NotNil(t, p)
+
+	entry := findChainEnabledLog(t, buf)
+	assert.Equal(t, false, entry["metrics_registered"])
+}

--- a/test/pkg/llm/wiring/wiring_test.go
+++ b/test/pkg/llm/wiring/wiring_test.go
@@ -14,8 +14,12 @@ import (
 )
 
 // llmEnvKeys 는 본 테스트가 격리해야 하는 LLM 관련 환경변수 키들입니다.
+//
+// LLM_POLICY / LLM_HYBRID_WEIGHTS 포함 — 로컬 운영자 .env 가 set 된 상태에서 hermetic 보장
+// (Copilot 피드백 #342).
 var llmEnvKeys = []string{
 	"LLM_ENABLED", "LLM_PROVIDER", "LLM_MODEL", "LLM_TIMEOUT", "LLM_API_KEY",
+	"LLM_POLICY", "LLM_HYBRID_WEIGHTS",
 	"GEMINI_API_KEY", "OPENAI_API_KEY", "ANTHROPIC_API_KEY",
 }
 
@@ -28,7 +32,7 @@ func clearLLMEnv(t *testing.T) {
 
 // captureLog 는 BuildProvider 의 로그 출력을 캡처할 (logger, *bytes.Buffer) 페어를 반환합니다.
 //
-// chain 구성 검증을 위해 "LLM provider chain enabled" info 로그의 chain / first_in_chain /
+// chain 구성 검증을 위해 "LLM provider chain enabled" info 로그의 chain / first_in_candidates /
 // configured_primary 필드 값을 assert (PR #280 Copilot 리뷰).
 func captureLog(t *testing.T) (*logger.Logger, *bytes.Buffer) {
 	t.Helper()
@@ -107,7 +111,7 @@ func TestBuildProvider_SingleKey_ChainHasOnlyThatProvider(t *testing.T) {
 
 	entry := findChainEnabledLog(t, buf)
 	assert.Equal(t, []string{"gemini"}, chainNames(t, entry), "단일 key 환경 — chain 1개")
-	assert.Equal(t, "gemini", entry["first_in_chain"])
+	assert.Equal(t, "gemini", entry["first_in_candidates"])
 }
 
 // TestBuildProvider_AllKeys_ChainHasAllInOrder 는 3개 key 모두 있을 때 fallbackOrder 순서대로 chain 구성됨을 검증합니다.
@@ -125,7 +129,7 @@ func TestBuildProvider_AllKeys_ChainHasAllInOrder(t *testing.T) {
 	entry := findChainEnabledLog(t, buf)
 	assert.Equal(t, []string{"gemini", "openai", "anthropic"}, chainNames(t, entry),
 		"3개 key 환경 — fallbackOrder 순서로 chain 구성")
-	assert.Equal(t, "gemini", entry["first_in_chain"])
+	assert.Equal(t, "gemini", entry["first_in_candidates"])
 }
 
 // TestBuildProvider_LLMAPIKeyFallback_OnlyPrimary 는 LLM_API_KEY fallback 이 primary (LLM_PROVIDER) 에만
@@ -167,10 +171,10 @@ func TestBuildProvider_LLMAPIKeyFallback_ClaudeAlias(t *testing.T) {
 }
 
 // TestBuildProvider_PrimaryDifferentFromFirstInChain 는 LLM_PROVIDER 가 chain 에 포함되지 않은 경우
-// configured_primary 와 first_in_chain 이 다르게 로깅되는지 검증합니다 (PR #280 Copilot).
+// configured_primary 와 first_in_candidates 이 다르게 로깅되는지 검증합니다 (PR #280 Copilot).
 //
 // 시나리오: LLM_PROVIDER=openai (primary 의도) 인데 OPENAI_API_KEY 부재, GEMINI_API_KEY 만 있음 →
-// chain=[gemini], first_in_chain=gemini, configured_primary=openai 으로 운영자가 의도 vs 실제 차이를 감지 가능.
+// chain=[gemini], first_in_candidates=gemini, configured_primary=openai 으로 운영자가 의도 vs 실제 차이를 감지 가능.
 func TestBuildProvider_PrimaryDifferentFromFirstInChain(t *testing.T) {
 	clearLLMEnv(t)
 	t.Setenv("LLM_ENABLED", "true")
@@ -183,7 +187,7 @@ func TestBuildProvider_PrimaryDifferentFromFirstInChain(t *testing.T) {
 
 	entry := findChainEnabledLog(t, buf)
 	assert.Equal(t, []string{"gemini"}, chainNames(t, entry))
-	assert.Equal(t, "gemini", entry["first_in_chain"])
+	assert.Equal(t, "gemini", entry["first_in_candidates"])
 	assert.Equal(t, "openai", entry["configured_primary"],
 		"운영자 의도 (openai) 와 실제 chain 첫 시도 (gemini) 가 다른 상황을 운영 로그로 식별 가능")
 }


### PR DESCRIPTION
## 연관 이슈
Closes #170

## 배경

사전 검증 결과 — **재료는 다 있고 조립만 남은 상태**:

**구현 완료 (이전 PR)**:
- `pkg/llm/measured.go` — `MeasuredProvider` (per-call latency EMA + Prometheus 메트릭 + Stats)
- `pkg/llm/policy/hybrid.go` — Hybrid (cost + latency + failure_rate 가중 합산, MeasuredProvider type assertion)
- `pkg/llm/policy/latency.go` — LatencyWeighted (EMA 기반 동적 정렬)
- `pkg/llm/policy/cheapest.go` — CheapestFirst (Capabilities cost 기반)
- `pkg/llm/capabilities.go` — 정적 baseline (cost / latency)

**누락 (본 PR scope)**:
- `pkg/llm/wiring/wiring.go` 가 candidates 를 `MeasuredProvider` 로 wrap 하지 않음 → policy 의 type assertion 실패 → metric 기반 정렬 불가
- `cmd/issuetracker/main.go` 가 Prometheus registry 를 전달하지 않음
- 정책을 환경변수로 선택할 수 없음 (FixedOrder 하드코딩)

## 구현 내용

### `pkg/llm/wiring/wiring.go`
- `BuildProvider(log)` → backward-compat wrapper 로 유지 (기존 test 변경 없음)
- `BuildProviderWithOptions(log, Options)` 신설 — `Options.PrometheusRegistry` 수용
- provider 후보를 **inner→outer**: Real → RetryProvider → MeasuredProvider 로 wrap
  - candidates 가 `*MeasuredProvider` 이므로 policy 의 `c.(*llm.MeasuredProvider)` 가 hit
  - outer wrap 으로 retries 포함 end-to-end latency 측정 — 정책이 보는 latency = 실 사용자 경험
- `MeasuredFactory` 단일 인스턴스 공유 — 모든 provider 가 동일 collector set 사용 (중복 등록 panic 회피)
- registry nil 이면 collector 등록 skip — in-memory EMA/Stats 만 동작 (테스트 / metrics 비활성 환경)

### 정책 선택 (`LLM_POLICY` 환경변수)
| 값 | 정책 | 동작 |
|---|---|---|
| `chain` (default) / `fixed` | FixedOrder(fallbackOrder...) | gemini → openai → anthropic 정적 순서 |
| `cheapest` | CheapestFirst(caps) | Capabilities.CostInputPer1M 오름차순 |
| `latency` | LatencyWeighted(caps) | EMA latency 오름차순 (이력 없으면 baseline) |
| `hybrid` | Hybrid(caps, weights) | cost + latency + failure_rate 가중 합산 |
| unknown | (warn + FixedOrder fallback) | 운영 안전망 |

### `LLM_HYBRID_WEIGHTS` (hybrid 정책 전용)
- 형식: `cost,latency,failure_rate` (예: `1.0,1.0,0.5`)
- 미설정 / 빈 값 → `DefaultHybridWeights()` (1.0, 1.0, 0.5)
- 음수 / non-float / 개수 오류 → default 로 fallback + warn 로그 (운영 안전망)

### `cmd/issuetracker/main.go`
- `BuildProvider(log)` → `BuildProviderWithOptions(log, Options{PrometheusRegistry: metricsRegistry})`
- 기존 `metrics.NewRegistry()` 인스턴스 공유 — /metrics endpoint 로 `issuetracker_llm_*` 메트릭 노출
- llmgen / refiner 가 공유하는 동일 provider 측정

### `.env.example`
- `LLM_POLICY` (default chain) — 4가지 옵션 설명
- `LLM_HYBRID_WEIGHTS` (default 1.0,1.0,0.5)

## 테스트 (test/pkg/llm/wiring/policy_test.go) — 11건
- 정책 default / chain alias / cheapest / latency / hybrid 각 선택 검증
- hybrid valid 가중치 통과
- hybrid invalid (non-float / 개수 오류 / 음수) → default fallback + warn
- unknown LLM_POLICY → FixedOrder fallback + warn
- PrometheusRegistry 전달 시 idempotent re-wiring (collector 중복 등록 보호)
- nil registry 시 metrics_registered=false 로 로그

## CI / 머지 게이트 점검
- [x] `go build ./...` 통과
- [x] `go test -race -count=1 ./test/...` 전부 ok
- [x] `go vet ./...` 깨끗
- [x] gofmt 정리
- [x] 기존 wiring_test.go 7건 + 신규 policy_test.go 11건 모두 통과

## 변경 영향 범위 + 위험도
- **영향**: LLM 호출 경로의 wrapping 1 layer 추가 (MeasuredProvider) — overhead 무시 가능 (timing 측정 + Stats atomic update)
- **위험도**: 낮음
  - default 동작 (chain / FixedOrder) 은 이전과 동일 — 기존 운영 환경 행동 변화 없음
  - metric 정책 (latency/hybrid) 은 운영자가 명시 선택 시에만 활성화
  - invalid 환경변수는 warn + default fallback — fail-safe
  - `MeasuredFactory` 의 idempotent registration 으로 collector 중복 panic 방지

## 롤백 계획
1. `LLM_POLICY=chain` (또는 unset) — 정책 변경만 되돌리기
2. 코드 롤백: `git revert` — wiring 단일 패키지 변경

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable LLM provider routing policies: fixed order, cheapest, latency-based, and hybrid strategies.
  * Introduced environment variables for policy selection (`LLM_POLICY`) and hybrid weight configuration (`LLM_HYBRID_WEIGHTS`).
  * Integrated performance metrics collection for provider analysis.

* **Tests**
  * Added comprehensive test coverage for policy selection and configuration validation.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/EinSofINTEREST/IssueTracker/pull/342)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->