### PR TITLE
[FIX#299] RawIDTracker freshness 필터 — upgrader GetByID stale race 차단

### DIFF
--- a/cmd/issuetracker/main.go
+++ b/cmd/issuetracker/main.go
@@ -457,11 +457,17 @@ func main() {
 
 	// host 단위 실패 raw_id 추적기 — 단계 3 의 chromedp 자동 전환 trigger 가 republish 대상 수집에 사용.
 	// 카운터와 같은 lifecycle (window TTL 동기화) — Redis 미연결 시 Noop.
+	//
+	// freshness = parserWorker.DefaultStaleRawTTL (1h) — raw_contents cleanup 의 StaleTTL 과 동기화.
+	// ZSET key-level EXPIRE 는 Track 마다 refresh 되어 stale entry 가 살아남는 race 차단 (이슈 #299).
+	// raw_contents row 가 cleanup 으로 삭제된 직후 Upgrader 가 그 ID 로 GetByID 호출하여 ErrNotFound
+	// (STORAGE_001) 노이즈 발생하던 케이스 봉쇄.
 	var rawIDTracker storage.RawIDTracker = storage.NewNoopRawIDTracker()
 	if fetcherUpgradeCfg.Enabled && redisClientShared != nil {
-		t, tErr := redisstore.NewRawIDTracker(
+		t, tErr := redisstore.NewRawIDTrackerWithFreshness(
 			redisClientShared.Raw(),
 			fetcherUpgradeCfg.Window,
+			parserWorker.DefaultStaleRawTTL,
 			"", // default keyPrefix "fetcher:failed_raws"
 			log,
 		)
@@ -469,7 +475,8 @@ func main() {
 			log.WithError(tErr).Warn("failed to construct redis raw id tracker, falling back to noop")
 		} else {
 			rawIDTracker = t
-			log.Info("fetcher raw id tracker (redis set) enabled")
+			log.WithField("freshness", parserWorker.DefaultStaleRawTTL.String()).
+				Info("fetcher raw id tracker (redis zset) enabled with freshness filter")
 		}
 	}
 

--- a/internal/storage/redis/raw_id_tracker.go
+++ b/internal/storage/redis/raw_id_tracker.go
@@ -58,10 +58,10 @@ func NewRawIDTracker(client *goredis.Client, ttl time.Duration, keyPrefix string
 // freshness=0 또는 음수면 score 필터 비활성 — NewRawIDTracker 와 동일 동작.
 func NewRawIDTrackerWithFreshness(client *goredis.Client, ttl, freshness time.Duration, keyPrefix string, log *logger.Logger) (storage.RawIDTracker, error) {
 	if client == nil {
-		return nil, errors.New("redisstore: NewRawIDTracker requires non-nil redis client")
+		return nil, errors.New("redisstore: raw id tracker requires non-nil redis client")
 	}
 	if ttl <= 0 {
-		return nil, fmt.Errorf("redisstore: NewRawIDTracker requires positive ttl, got %s", ttl)
+		return nil, fmt.Errorf("redisstore: raw id tracker requires positive ttl, got %s", ttl)
 	}
 	if freshness < 0 {
 		freshness = 0

--- a/internal/storage/redis/raw_id_tracker.go
+++ b/internal/storage/redis/raw_id_tracker.go
@@ -108,45 +108,36 @@ func (r *rawIDTracker) PeekByHost(ctx context.Context, host string, limit int) (
 	}
 	key := r.keyFor(host)
 
-	// freshness=0 (back-compat) → 인덱스 기반 ZRANGE REV.
+	// ZRangeArgs 구성 일원화 — freshness 분기별 차이만 분리, 호출/에러 처리 공통화 (gemini Medium 반영).
+	args := goredis.ZRangeArgs{Key: key, Rev: true}
+	op := "ZREVRANGE"
+
 	if r.freshness <= 0 {
-		res, err := r.client.ZRangeArgs(ctx, goredis.ZRangeArgs{
-			Key:   key,
-			Start: 0,
-			Stop:  int64(limit - 1),
-			Rev:   true,
-		}).Result()
-		if err != nil {
-			if errors.Is(err, goredis.Nil) {
-				return nil, nil
-			}
-			return nil, fmt.Errorf("redis raw id tracker ZREVRANGE for host %s: %w", host, err)
+		// freshness=0 (back-compat) → 인덱스 기반 ZRANGE REV.
+		args.Start = 0
+		args.Stop = int64(limit - 1)
+	} else {
+		// freshness>0 → score 필터 (이슈 #299).
+		// Rev=true 이면 Start/Stop 의미가 뒤집힘 (Start=max, Stop=min).
+		// score (unix-nano) 가 (now - freshness) 이상인 member 만 반환.
+		now := time.Now()
+		if r.now != nil {
+			now = r.now()
 		}
-		return res, nil
+		minScore := now.Add(-r.freshness).UnixNano()
+		args.Start = "+inf"
+		args.Stop = strconv.FormatInt(minScore, 10)
+		args.ByScore = true
+		args.Count = int64(limit)
+		op = "ZRANGE BYSCORE"
 	}
 
-	// freshness>0 → score 필터 적용 (이슈 #299):
-	//   ZRANGE BYSCORE REV — Rev=true 이면 Start/Stop 의 의미가 뒤집힘: Start=max, Stop=min.
-	//   score (unix-nano) 가 (now - freshness) 이상인 member 만 반환.
-	now := time.Now()
-	if r.now != nil {
-		now = r.now()
-	}
-	minScore := now.Add(-r.freshness).UnixNano()
-
-	res, err := r.client.ZRangeArgs(ctx, goredis.ZRangeArgs{
-		Key:     key,
-		Start:   "+inf",
-		Stop:    strconv.FormatInt(minScore, 10),
-		ByScore: true,
-		Rev:     true,
-		Count:   int64(limit),
-	}).Result()
+	res, err := r.client.ZRangeArgs(ctx, args).Result()
 	if err != nil {
 		if errors.Is(err, goredis.Nil) {
 			return nil, nil
 		}
-		return nil, fmt.Errorf("redis raw id tracker ZRANGE BYSCORE for host %s: %w", host, err)
+		return nil, fmt.Errorf("redis raw id tracker %s for host %s: %w", op, host, err)
 	}
 	return res, nil
 }

--- a/internal/storage/redis/raw_id_tracker.go
+++ b/internal/storage/redis/raw_id_tracker.go
@@ -18,27 +18,53 @@ import (
 // 알고리즘:
 //
 //   - Track:        ZADD key={prefix}:{host}, score=now-unix-nano, member=rawID + EXPIRE ttl
-//   - PeekByHost:   ZREVRANGE key 0 limit-1 (score DESC = 최근 우선)
+//   - PeekByHost:   freshness>0 → ZRANGE BYSCORE REV (score >= now-freshness),
+//     freshness=0 → ZRANGE REV (back-compat)
 //   - RemoveByHost: ZREM key member1 member2 ...
+//
+// **이슈 #299 — freshness 의 역할**:
+//
+//	ZSET key-level EXPIRE 는 매 Track 마다 refresh 되어 활발한 host 의 오래된 entry 가 key 가
+//	살아있는 한 만료되지 않음. 한편 raw_contents 테이블은 별도 cleanup 이 StaleTTL (default 1h)
+//	기준 row 삭제 → ZSET 항목은 살아있으나 DB row 는 사라진 stale state 가 발생, Upgrader 가
+//	그 stale ID 로 GetByID 호출하여 ErrNotFound (STORAGE_001) 노이즈 유발.
+//	freshness 로 score-cutoff (member 별 age) 를 적용하여 read-side 에서 자동 제외.
 type rawIDTracker struct {
 	client    *goredis.Client
 	keyPrefix string
 	ttl       time.Duration
+	freshness time.Duration    // 0 = score 필터 없음 (back-compat)
 	now       func() time.Time // 테스트 주입용 — 일반 사용 시 nil → time.Now
 	log       *logger.Logger
 }
 
-// NewRawIDTracker 는 Redis ZSET 기반 RawIDTracker 를 생성합니다.
+// NewRawIDTracker 는 Redis ZSET 기반 RawIDTracker 를 생성합니다 (freshness=0 — score 필터 비활성).
 //
 // client 가 nil 이거나 ttl 이 비정상이면 error 반환.
 // keyPrefix 가 빈 문자열이면 "fetcher:failed_raws" 사용.
 // ttl 은 host 별 ZSET 의 자연 정리 시간 — FailureCounter 의 window 와 동기화 권장.
+//
+// 신규 wiring 은 NewRawIDTrackerWithFreshness 사용 권장 — freshness 적용으로 #299 race 차단.
 func NewRawIDTracker(client *goredis.Client, ttl time.Duration, keyPrefix string, log *logger.Logger) (storage.RawIDTracker, error) {
+	return NewRawIDTrackerWithFreshness(client, ttl, 0, keyPrefix, log)
+}
+
+// NewRawIDTrackerWithFreshness 는 read-side score 필터링이 적용된 RawIDTracker 를 생성합니다.
+//
+// freshness > 0 이면 PeekByHost 가 (now - freshness) 이상인 score 의 member 만 반환 — raw_contents
+// cleanup StaleTTL 과 동일/짧은 값으로 설정하여 stale ZSET 항목이 Upgrader 의 GetByID 호출로
+// 누설되는 것을 차단 (이슈 #299).
+//
+// freshness=0 또는 음수면 score 필터 비활성 — NewRawIDTracker 와 동일 동작.
+func NewRawIDTrackerWithFreshness(client *goredis.Client, ttl, freshness time.Duration, keyPrefix string, log *logger.Logger) (storage.RawIDTracker, error) {
 	if client == nil {
 		return nil, errors.New("redisstore: NewRawIDTracker requires non-nil redis client")
 	}
 	if ttl <= 0 {
 		return nil, fmt.Errorf("redisstore: NewRawIDTracker requires positive ttl, got %s", ttl)
+	}
+	if freshness < 0 {
+		freshness = 0
 	}
 	if keyPrefix == "" {
 		keyPrefix = "fetcher:failed_raws"
@@ -47,6 +73,7 @@ func NewRawIDTracker(client *goredis.Client, ttl time.Duration, keyPrefix string
 		client:    client,
 		keyPrefix: keyPrefix,
 		ttl:       ttl,
+		freshness: freshness,
 		log:       log,
 	}, nil
 }
@@ -80,19 +107,46 @@ func (r *rawIDTracker) PeekByHost(ctx context.Context, host string, limit int) (
 		return nil, nil
 	}
 	key := r.keyFor(host)
-	// ZRangeArgs with Rev — score DESC 순으로 N 개 (가장 최근 우선).
-	// ZRevRange 는 go-redis v9 에서 deprecated (Redis 6.2.0+ 권장 API).
+
+	// freshness=0 (back-compat) → 인덱스 기반 ZRANGE REV.
+	if r.freshness <= 0 {
+		res, err := r.client.ZRangeArgs(ctx, goredis.ZRangeArgs{
+			Key:   key,
+			Start: 0,
+			Stop:  int64(limit - 1),
+			Rev:   true,
+		}).Result()
+		if err != nil {
+			if errors.Is(err, goredis.Nil) {
+				return nil, nil
+			}
+			return nil, fmt.Errorf("redis raw id tracker ZREVRANGE for host %s: %w", host, err)
+		}
+		return res, nil
+	}
+
+	// freshness>0 → score 필터 적용 (이슈 #299):
+	//   ZRANGE BYSCORE REV — Rev=true 이면 Start/Stop 의 의미가 뒤집힘: Start=max, Stop=min.
+	//   score (unix-nano) 가 (now - freshness) 이상인 member 만 반환.
+	now := time.Now()
+	if r.now != nil {
+		now = r.now()
+	}
+	minScore := now.Add(-r.freshness).UnixNano()
+
 	res, err := r.client.ZRangeArgs(ctx, goredis.ZRangeArgs{
-		Key:   key,
-		Start: 0,
-		Stop:  int64(limit - 1),
-		Rev:   true,
+		Key:     key,
+		Start:   "+inf",
+		Stop:    strconv.FormatInt(minScore, 10),
+		ByScore: true,
+		Rev:     true,
+		Count:   int64(limit),
 	}).Result()
 	if err != nil {
 		if errors.Is(err, goredis.Nil) {
 			return nil, nil
 		}
-		return nil, fmt.Errorf("redis raw id tracker ZREVRANGE for host %s: %w", host, err)
+		return nil, fmt.Errorf("redis raw id tracker ZRANGE BYSCORE for host %s: %w", host, err)
 	}
 	return res, nil
 }

--- a/test/internal/storage/redis/raw_id_tracker_test.go
+++ b/test/internal/storage/redis/raw_id_tracker_test.go
@@ -5,12 +5,18 @@ import (
 	"testing"
 	"time"
 
+	goredis "github.com/redis/go-redis/v9"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"issuetracker/internal/storage"
 	redisstore "issuetracker/internal/storage/redis"
 )
+
+// redisZ 는 테스트에서 goredis.Z 를 간결하게 생성하기 위한 helper.
+func redisZ(member string, score float64) goredis.Z {
+	return goredis.Z{Score: score, Member: member}
+}
 
 // TestNewRedisRawIDTracker_NilClient_ReturnsError:
 // 이슈 #208 panic-on-nil → error 정책.
@@ -169,6 +175,91 @@ func TestRedisRawIDTracker_PeekByHost_NonexistentKey_ReturnsEmpty(t *testing.T) 
 	peeked, err := tr.PeekByHost(context.Background(), "no-such-host", 10)
 	require.NoError(t, err)
 	assert.Empty(t, peeked)
+}
+
+// TestRedisRawIDTracker_FreshnessFilter_ExcludesStaleEntries:
+// freshness>0 일 때 (now - freshness) 보다 오래된 entry 가 PeekByHost 결과에서 제외 (이슈 #299).
+//
+// 시나리오:
+//  1. 같은 host 에 3건 Track — 첫 2건은 freshness 임계 직전 시각, 마지막 1건은 그 이후
+//  2. Track 후 직접 ZADD 로 oldest entry 의 score 를 충분히 과거로 강제 변경 (cleanup 으로 raw_contents
+//     row 가 삭제된 상황 simulate)
+//  3. PeekByHost 결과에 oldest 가 포함되지 않음을 확인.
+func TestRedisRawIDTracker_FreshnessFilter_ExcludesStaleEntries(t *testing.T) {
+	client := newTestRedisClient(t)
+	prefix := uniqueKeyPrefix(t)
+	freshness := 500 * time.Millisecond
+	tr, err := redisstore.NewRawIDTrackerWithFreshness(client.Raw(), time.Hour, freshness, prefix, nil)
+	require.NoError(t, err)
+
+	host := "stale.example.com"
+	ctx := context.Background()
+
+	// stale entry: Track 후 score 를 과거로 직접 overwrite — cleanup 이 raw_contents 삭제한 상황 simulate.
+	require.NoError(t, tr.Track(ctx, host, "raw-stale"))
+	staleScore := float64(time.Now().Add(-2 * freshness).UnixNano())
+	key := prefix + ":" + host
+	require.NoError(t, client.Raw().ZAdd(ctx, key, redisZ("raw-stale", staleScore)).Err())
+
+	// fresh entry: 정상 Track — 현재 시각 score.
+	require.NoError(t, tr.Track(ctx, host, "raw-fresh"))
+
+	peeked, err := tr.PeekByHost(ctx, host, 10)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"raw-fresh"}, peeked, "freshness 보다 오래된 raw-stale 은 제외")
+}
+
+// TestRedisRawIDTracker_FreshnessFilter_ZeroDisablesFilter:
+// freshness=0 (또는 음수) 이면 기존 ZREVRANGE 동작 그대로 — 모든 entry 반환.
+func TestRedisRawIDTracker_FreshnessFilter_ZeroDisablesFilter(t *testing.T) {
+	client := newTestRedisClient(t)
+	prefix := uniqueKeyPrefix(t)
+	tr, err := redisstore.NewRawIDTrackerWithFreshness(client.Raw(), time.Hour, 0, prefix, nil)
+	require.NoError(t, err)
+
+	host := "all.example.com"
+	ctx := context.Background()
+
+	require.NoError(t, tr.Track(ctx, host, "raw-old"))
+	// 의도적으로 score 를 과거로 overwrite — freshness=0 이라 필터링 없음.
+	oldScore := float64(time.Now().Add(-24 * time.Hour).UnixNano())
+	key := prefix + ":" + host
+	require.NoError(t, client.Raw().ZAdd(ctx, key, redisZ("raw-old", oldScore)).Err())
+
+	time.Sleep(1 * time.Millisecond)
+	require.NoError(t, tr.Track(ctx, host, "raw-new"))
+
+	peeked, err := tr.PeekByHost(ctx, host, 10)
+	require.NoError(t, err)
+	assert.ElementsMatch(t, []string{"raw-old", "raw-new"}, peeked, "freshness=0 — 모든 entry 반환")
+}
+
+// TestRedisRawIDTracker_FreshnessFilter_RespectsLimit:
+// freshness 적용 시에도 limit 가 정상 동작 — count 옵션.
+func TestRedisRawIDTracker_FreshnessFilter_RespectsLimit(t *testing.T) {
+	client := newTestRedisClient(t)
+	prefix := uniqueKeyPrefix(t)
+	tr, err := redisstore.NewRawIDTrackerWithFreshness(client.Raw(), time.Hour, time.Hour, prefix, nil)
+	require.NoError(t, err)
+
+	host := "limit.example.com"
+	ctx := context.Background()
+	for i := 0; i < 5; i++ {
+		require.NoError(t, tr.Track(ctx, host, "raw-"+string(rune('a'+i))))
+		time.Sleep(1 * time.Millisecond)
+	}
+
+	peeked, err := tr.PeekByHost(ctx, host, 2)
+	require.NoError(t, err)
+	assert.Len(t, peeked, 2)
+}
+
+// TestNewRedisRawIDTracker_NegativeFreshnessNormalized:
+// freshness=-1 등 음수 입력은 0 으로 정규화 — error 아님 (back-compat).
+func TestNewRedisRawIDTracker_NegativeFreshnessNormalized(t *testing.T) {
+	client := newTestRedisClient(t)
+	_, err := redisstore.NewRawIDTrackerWithFreshness(client.Raw(), time.Hour, -1*time.Second, "", nil)
+	assert.NoError(t, err, "음수 freshness 는 0 으로 정규화 — 생성 성공")
 }
 
 // TestNoopRawIDTracker_AllNoop:

--- a/test/internal/storage/redis/raw_id_tracker_test.go
+++ b/test/internal/storage/redis/raw_id_tracker_test.go
@@ -194,6 +194,9 @@ func TestRedisRawIDTracker_FreshnessFilter_ExcludesStaleEntries(t *testing.T) {
 
 	host := "stale.example.com"
 	ctx := context.Background()
+	t.Cleanup(func() {
+		client.Raw().Del(context.Background(), prefix+":"+host)
+	})
 
 	// stale entry: Track 후 score 를 과거로 직접 overwrite — cleanup 이 raw_contents 삭제한 상황 simulate.
 	require.NoError(t, tr.Track(ctx, host, "raw-stale"))
@@ -219,6 +222,9 @@ func TestRedisRawIDTracker_FreshnessFilter_ZeroDisablesFilter(t *testing.T) {
 
 	host := "all.example.com"
 	ctx := context.Background()
+	t.Cleanup(func() {
+		client.Raw().Del(context.Background(), prefix+":"+host)
+	})
 
 	require.NoError(t, tr.Track(ctx, host, "raw-old"))
 	// 의도적으로 score 를 과거로 overwrite — freshness=0 이라 필터링 없음.
@@ -244,6 +250,9 @@ func TestRedisRawIDTracker_FreshnessFilter_RespectsLimit(t *testing.T) {
 
 	host := "limit.example.com"
 	ctx := context.Background()
+	t.Cleanup(func() {
+		client.Raw().Del(context.Background(), prefix+":"+host)
+	})
 	for i := 0; i < 5; i++ {
 		require.NoError(t, tr.Track(ctx, host, "raw-"+string(rune('a'+i))))
 		time.Sleep(1 * time.Millisecond)


### PR DESCRIPTION
## 연관 이슈
Closes #299

## 배경 — race 가설 확정 + 정교화

이슈 본문의 가설 (\"chromedp 전환 발화 시점 race\") 직접 검증 결과 **확정 + 한 단계 정교화**:

### 라이브 증상 (#299)
- 2026-05-07 18:36:29 동시 4건 `[storage:STORAGE_001] get raw content by id: record not found`
- 모두 `host=news.naver.com`, 모두 \`upgrader raw GetByID failed — marking stale\` 로그
- chromedp 자동 전환 (auto_upgrade_validation) 발화와 동일 시각

### 실제 race window (직접 코드 검증)
| 구성요소 | 값 | 위치 |
|---|---|---|
| `FETCHER_AUTO_UPGRADE_WINDOW` | default 1h | [config.go:582](pkg/config/config.go#L582) |
| `RawIDTracker` ttl | window 재사용 = 1h | [main.go:464](cmd/issuetracker/main.go#L464) |
| Cleanup `StaleTTL` | hardcoded 1h | [cleanup.go:23](internal/processor/parser/worker/cleanup.go#L23) |
| `PeekByHost` 알고리즘 | 기존: ZREVRANGE (score 무시) | [raw_id_tracker.go](internal/storage/redis/raw_id_tracker.go) |
| ZSET key EXPIRE | **매 Track 마다 refresh** | [raw_id_tracker.go:71](internal/storage/redis/raw_id_tracker.go#L71) |

**핵심 발견**: ZSET 의 `EXPIRE` 는 **key-level** — 활발한 host 는 Track 마다 TTL refresh 되어 1h 보다 오래된 ZSET entry 가 그대로 살아남음. 그러나 raw_contents 테이블은 별도 cleanup 이 1h 기준 row 삭제 → **ZSET 항목은 있으나 DB row 는 사라진 stale state** 발생. Upgrader 가 stale ID 로 `GetByID` 호출 → ErrNotFound.

```
T=0min   raw1 fetch + parse fail → Track(host, raw1), ZSET key TTL=1h
T=10min  raw2 fail → Track(raw2), TTL refreshed to 1h
T=20min  raw3 fail → Track(raw3), TTL refreshed
T=60min  cleanup runs → raw1 (>=1h) DELETED from raw_contents
T=70min  raw4 fail → Track(raw4), TTL refreshed. 그러나 raw1 은 ZSET 에 잔존
T=80min  raw5 fail → threshold 5 도달 → Upgrader.Trigger
         PeekByHost → [raw1, raw2, raw3, raw4, raw5] 반환
         GetByID(raw1) → ErrNotFound → \"marking stale\" 로그 노이즈
```

\"동시 4건\" 패턴 = burst 가 아니라 **누적 stale** — 단일 Trigger 가 직렬 GetByID 시도 중 4개 raw 가 cleanup 이후 stale.

## 구현 (Plan A — read-side score 필터)

### `internal/storage/redis/raw_id_tracker.go`
- `NewRawIDTrackerWithFreshness(client, ttl, freshness, prefix, log)` 신설
- `freshness > 0` → `PeekByHost` 가 `ZRANGE BYSCORE REV` 사용:
  ```
  ZRANGEBYSCORE key +inf (now - freshness) BYSCORE REV LIMIT 0 limit
  ```
  score (unix-nano) 가 `(now - freshness)` 이상인 member 만 반환
- `freshness <= 0` → 기존 `ZRANGE 0 limit-1 REV` (back-compat)
- 음수 freshness 는 0 으로 정규화 — error 아님
- `NewRawIDTracker` 는 backward-compat wrapper (freshness=0)

### `cmd/issuetracker/main.go`
- `NewRawIDTracker(...)` → `NewRawIDTrackerWithFreshness(..., parserWorker.DefaultStaleRawTTL, ...)`
- raw_contents cleanup 의 `StaleTTL` 과 동일 값 (1h) — 두 lifecycle 동기화
- 로그 필드 `freshness` 추가 — 운영자가 적용 값 확인 가능

### 효과
- ZSET 에 살아있어도 `(now - 1h)` 보다 오래된 entry 는 PeekByHost 결과에서 자동 제외
- cleanup 이 삭제한 raw 의 ID 가 Upgrader 의 GetByID 로 흘러가지 않음 → STORAGE_001 노이즈 0
- Track 측 변경 없음 — Redis 호출 횟수 / latency 영향 없음
- `RemoveByHost` 가 stale 항목을 정리 안 해도 OK — 다음 PeekByHost 가 알아서 필터

## 테스트 (test/internal/storage/redis/raw_id_tracker_test.go) — 4건 추가
- `FreshnessFilter_ExcludesStaleEntries` — stale + fresh 혼재 시 fresh 만 반환 (ZADD overwrite 로 stale score 강제)
- `FreshnessFilter_ZeroDisablesFilter` — freshness=0 시 stale 도 포함 (back-compat)
- `FreshnessFilter_RespectsLimit` — Count 적용 검증
- `NegativeFreshnessNormalized` — 음수 freshness 정규화

기존 8건 테스트는 모두 통과 (변경 없음 — `NewRawIDTracker` 가 freshness=0 으로 wrap).

## CI / 머지 게이트 점검
- [x] `go build ./...` 통과
- [x] `go test -race -count=1 ./test/...` 전부 ok
- [x] `go vet ./...` 깨끗
- [x] gofmt 정리

## 변경 영향 범위 + 위험도
- **영향**: Upgrader 의 PeekByHost 결과가 freshness 보다 오래된 ID 를 제외 — STORAGE_001 노이즈 차단
- **위험도**: 낮음
  - `NewRawIDTracker` 의 기존 시그니처 / 동작 보존 (back-compat)
  - freshness=0 명시 시 기존 동작 그대로 — fail-safe off 가능
  - 정상 운영에서는 freshness 보다 오래된 raw 도 cleanup 이미 삭제했을 것이므로 republish 후보 손실 없음
  - **잠재 부작용**: freshness 보다 오래된 raw 가 raw_contents 에 살아있는 비정상 케이스 (cleanup 지연) 에서는 republish 누락 — 그러나 다음 trigger 가 새 ID 누적되며 자연 진행, silent miss 아님

## 롤백 계획
1. 코드 롤백: `git revert` — 단일 패키지 변경
2. 부분 비활성: `cmd/issuetracker/main.go` 에서 `NewRawIDTrackerWithFreshness` → `NewRawIDTracker` 호출로 환원

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Issue tracker now filters out stale raw ID entries when freshness filtering is enabled, preventing outdated data from being returned. Freshness timing is aligned with content cleanup operations for improved data consistency.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/EinSofINTEREST/IssueTracker/pull/343)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->