### PR TITLE
[FIX#320] semantic validator — MaxTokens 상향 + truncate 감지 + verdict salvage

### DIFF
--- a/internal/processor/parser/rule/validator/llm_validator.go
+++ b/internal/processor/parser/rule/validator/llm_validator.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"regexp"
 	"strings"
 
 	"issuetracker/internal/storage"
@@ -12,11 +13,38 @@ import (
 	"issuetracker/pkg/llm/prompt"
 )
 
+// validatorMaxTokens 는 LLM 검증 응답의 최대 토큰 수입니다 (이슈 #320).
+//
+// 256 → 512 상향: 256 은 마크다운 코드 펜스 + JSON 키 + 한국어 reason 한 문장이 빠르게 도달.
+// 라이브 (2026-05-08) 8h log 에서 best-effort fallback 10건 모두 `"valid": false,` 또는
+// reason 중간에서 truncate. 512 면 reason 1~2 문장 + 펜스 여유 확보.
+const validatorMaxTokens = 512
+
+// truncatedStopReasons 는 provider 가 max-tokens 도달로 응답을 truncate 한 경우의 StopReason 값입니다.
+//
+//   - openai     : "length"
+//   - gemini     : "MAX_TOKENS"
+//   - anthropic  : "max_tokens"
+//
+// 검증 응답에서 본 값을 만나면 명시 에러로 분류 — best-effort fallback 진입 전에 운영 로그로
+// truncate 발생을 가시화 + 후속 MaxTokens 조정 신호로 활용.
+var truncatedStopReasons = map[string]struct{}{
+	"length":     {},
+	"max_tokens": {},
+	"MAX_TOKENS": {},
+}
+
 // llmValidationResponse 는 LLM 의 검증 응답 JSON 구조입니다.
 type llmValidationResponse struct {
 	Valid  bool   `json:"valid"`
 	Reason string `json:"reason"`
 }
+
+// validRegex 는 unmarshal 실패 시 verdict 만 salvage 하기 위한 regex fallback 입니다 (이슈 #320).
+//
+// reason 이 truncate 되어 unmarshal 이 실패해도 "valid": true|false 만 추출하면 검증 결과 자체는
+// 유효 — best-effort 통과 (validation skip) 보다 정확. reason 은 빈 문자열로 보고.
+var validRegex = regexp.MustCompile(`"valid"\s*:\s*(true|false)`)
 
 // LLMValidator 는 pkg/llm.Provider 기반 의미 검증 구현체입니다.
 type LLMValidator struct {
@@ -55,7 +83,7 @@ func (v *LLMValidator) Validate(ctx context.Context, html string, selectors stor
 			{Role: llm.RoleUser, Content: user},
 		},
 		TaskHint:  llm.TaskHintJSON,
-		MaxTokens: 256,
+		MaxTokens: validatorMaxTokens,
 	})
 	if err != nil {
 		return Result{}, fmt.Errorf("llm validation call: %w", err)
@@ -65,8 +93,14 @@ func (v *LLMValidator) Validate(ctx context.Context, html string, selectors stor
 	}
 
 	var vr llmValidationResponse
-	if err := parseValidationResponse(resp.Content, &vr); err != nil {
-		return Result{}, fmt.Errorf("parse validation response: %w", err)
+	if perr := parseValidationResponse(resp.Content, &vr); perr != nil {
+		// truncate 감지: provider StopReason 이 max-tokens 신호이면 별도 에러로 가시화 (이슈 #320).
+		// 운영자가 MaxTokens 증대 / prompt 단축 결정에 활용.
+		if _, truncated := truncatedStopReasons[resp.StopReason]; truncated {
+			return Result{}, fmt.Errorf("llm validation response truncated (stop_reason=%s, max_tokens=%d): %w",
+				resp.StopReason, validatorMaxTokens, perr)
+		}
+		return Result{}, fmt.Errorf("parse validation response: %w", perr)
 	}
 	return Result(vr), nil
 }
@@ -108,8 +142,11 @@ func buildValidationPrompt(ec extractedContent, targetType storage.TargetType, l
 }
 
 // parseValidationResponse 는 LLM 응답에서 JSON 객체를 추출하여 파싱합니다.
+//
+// 우선 첫 `{` ~ 마지막 `}` 추출 후 unmarshal 을 시도하고, 실패 시 (응답 truncate 등) regex
+// fallback 으로 `valid` verdict 만 salvage 합니다 (이슈 #320). reason 누락은 운영 영향 없음 —
+// 잘못된 selector 가 통과하는 best-effort silent skip 보다 정확.
 func parseValidationResponse(content string, out *llmValidationResponse) error {
-	// JSON 블록 추출 — LLM 이 마크다운 코드 블록으로 감쌀 수 있음
 	s := content
 	if i := strings.Index(s, "{"); i >= 0 {
 		s = s[i:]
@@ -117,8 +154,25 @@ func parseValidationResponse(content string, out *llmValidationResponse) error {
 	if i := strings.LastIndex(s, "}"); i >= 0 {
 		s = s[:i+1]
 	}
-	if err := json.Unmarshal([]byte(s), out); err != nil {
+	if err := json.Unmarshal([]byte(s), out); err == nil {
+		return nil
+	} else if salvageErr := salvageValid(content, out); salvageErr == nil {
+		return nil
+	} else {
 		return fmt.Errorf("unmarshal: %w (raw: %q)", err, content)
 	}
+}
+
+// salvageValid 는 unmarshal 실패한 LLM 응답에서 regex 로 valid verdict 만 추출합니다 (이슈 #320).
+//
+// 매칭 실패 시 error 반환 — 호출자가 원본 unmarshal 에러 메시지를 그대로 노출하여 운영 진단성 보존.
+// 매칭 성공 시 out.Valid 만 채움 (Reason 은 빈 문자열).
+func salvageValid(content string, out *llmValidationResponse) error {
+	m := validRegex.FindStringSubmatch(content)
+	if len(m) < 2 {
+		return errors.New("salvage: no valid key found in truncated response")
+	}
+	out.Valid = m[1] == "true"
+	out.Reason = ""
 	return nil
 }

--- a/internal/processor/parser/rule/validator/llm_validator.go
+++ b/internal/processor/parser/rule/validator/llm_validator.go
@@ -156,7 +156,7 @@ func parseValidationResponse(content string, out *llmValidationResponse) error {
 	}
 	if err := json.Unmarshal([]byte(s), out); err == nil {
 		return nil
-	} else if salvageErr := salvageValid(content, out); salvageErr == nil {
+	} else if salvageErr := salvageValid(s, out); salvageErr == nil {
 		return nil
 	} else {
 		return fmt.Errorf("unmarshal: %w (raw: %q)", err, content)
@@ -165,10 +165,14 @@ func parseValidationResponse(content string, out *llmValidationResponse) error {
 
 // salvageValid 는 unmarshal 실패한 LLM 응답에서 regex 로 valid verdict 만 추출합니다 (이슈 #320).
 //
+// 인자 s 는 parseValidationResponse 가 첫 `{` ~ 마지막 `}` 로 trim 한 결과 — LLM 이 응답 서두에
+// prompt 를 echo 하거나 prose 를 출력해도 그 영역의 \"valid\": true 같은 문자열을 verdict 로 오인
+// 하지 않도록 JSON 블록 내부만 검사 (gemini Medium 반영).
+//
 // 매칭 실패 시 error 반환 — 호출자가 원본 unmarshal 에러 메시지를 그대로 노출하여 운영 진단성 보존.
 // 매칭 성공 시 out.Valid 만 채움 (Reason 은 빈 문자열).
-func salvageValid(content string, out *llmValidationResponse) error {
-	m := validRegex.FindStringSubmatch(content)
+func salvageValid(s string, out *llmValidationResponse) error {
+	m := validRegex.FindStringSubmatch(s)
 	if len(m) < 2 {
 		return errors.New("salvage: no valid key found in truncated response")
 	}

--- a/test/internal/processor/parser/rule/validator/validator_test.go
+++ b/test/internal/processor/parser/rule/validator/validator_test.go
@@ -35,18 +35,21 @@ func newTestLLMValidator(t *testing.T, provider llm.Provider) *validator.LLMVali
 // ─────────────────────────────────────────────────────────────────────────────
 
 type fakeProvider struct {
-	response string
-	err      error
-	calls    int
+	response      string
+	stopReason    string // 빈 문자열이면 응답에서 미설정
+	err           error
+	calls         int
+	lastMaxTokens int // Validator 가 전달한 MaxTokens 검증용
 }
 
 func (f *fakeProvider) Name() string { return "fake" }
-func (f *fakeProvider) Generate(_ context.Context, _ llm.Request) (*llm.Response, error) {
+func (f *fakeProvider) Generate(_ context.Context, req llm.Request) (*llm.Response, error) {
 	f.calls++
+	f.lastMaxTokens = req.MaxTokens
 	if f.err != nil {
 		return nil, f.err
 	}
-	return &llm.Response{Content: f.response, Model: "fake-model"}, nil
+	return &llm.Response{Content: f.response, StopReason: f.stopReason, Model: "fake-model"}, nil
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -138,6 +141,90 @@ func TestLLMValidator_ResponseWrappedInMarkdown(t *testing.T) {
 	res, err := v.Validate(context.Background(), samplePageHTML, pageSelectors, storage.TargetTypePage)
 	require.NoError(t, err)
 	assert.True(t, res.Valid)
+}
+
+// TestLLMValidator_MaxTokensIncreasedTo512 — 이슈 #320 의 #1 수정 검증.
+// Validator 가 Generate 호출 시 MaxTokens=512 를 전달하는지 fakeProvider 가 기록한 값으로 확인.
+func TestLLMValidator_MaxTokensIncreasedTo512(t *testing.T) {
+	provider := &fakeProvider{response: `{"valid": true, "reason": "ok"}`}
+	v := newTestLLMValidator(t, provider)
+
+	_, err := v.Validate(context.Background(), samplePageHTML, pageSelectors, storage.TargetTypePage)
+	require.NoError(t, err)
+	assert.Equal(t, 512, provider.lastMaxTokens, "MaxTokens 가 512 로 상향됨")
+}
+
+// TestLLMValidator_TruncatedResponseSalvagesValidVerdict — 이슈 #320 의 #3 (regex fallback).
+// 응답이 reason 중간에 truncate 되어도 "valid" verdict 만큼은 salvage 되어 결과 반환.
+func TestLLMValidator_TruncatedResponseSalvagesValidVerdict(t *testing.T) {
+	provider := &fakeProvider{
+		response: `{"valid": false, "reason": "The extracted`, // mid-reason 잘림
+	}
+	v := newTestLLMValidator(t, provider)
+
+	res, err := v.Validate(context.Background(), samplePageHTML, pageSelectors, storage.TargetTypePage)
+	require.NoError(t, err, "regex salvage 로 verdict 추출 성공")
+	assert.False(t, res.Valid, "valid: false 추출 확인")
+	assert.Empty(t, res.Reason, "reason 은 truncate 되어 빈 문자열")
+}
+
+// TestLLMValidator_TruncatedResponseTrueVerdict — true verdict 도 동일하게 salvage.
+func TestLLMValidator_TruncatedResponseTrueVerdict(t *testing.T) {
+	provider := &fakeProvider{
+		response: "```json\n{\n  \"valid\": true, \"reason\": \"looks like a valid",
+	}
+	v := newTestLLMValidator(t, provider)
+
+	res, err := v.Validate(context.Background(), samplePageHTML, pageSelectors, storage.TargetTypePage)
+	require.NoError(t, err)
+	assert.True(t, res.Valid)
+}
+
+// TestLLMValidator_TruncatedAtValidKey_ReturnsTruncateError — 이슈 #320 의 #2 (truncate 명시 에러).
+// 응답이 "valid" 키 도달 전에 truncate 되어 salvage 도 실패 + StopReason 이 max-tokens 신호면
+// 명시 truncate 에러로 반환.
+func TestLLMValidator_TruncatedAtValidKey_ReturnsTruncateError(t *testing.T) {
+	provider := &fakeProvider{
+		response:   "```json\n{",
+		stopReason: "MAX_TOKENS",
+	}
+	v := newTestLLMValidator(t, provider)
+
+	_, err := v.Validate(context.Background(), samplePageHTML, pageSelectors, storage.TargetTypePage)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "truncated", "truncate 명시 에러 메시지")
+	assert.Contains(t, err.Error(), "stop_reason=MAX_TOKENS")
+	assert.Contains(t, err.Error(), "max_tokens=512")
+}
+
+// TestLLMValidator_TruncateDetection_OpenAI — provider 별 StopReason 모두 인식.
+func TestLLMValidator_TruncateDetection_StopReasons(t *testing.T) {
+	cases := []string{"length", "max_tokens", "MAX_TOKENS"}
+	for _, sr := range cases {
+		sr := sr
+		t.Run(sr, func(t *testing.T) {
+			provider := &fakeProvider{response: "incomplete", stopReason: sr}
+			v := newTestLLMValidator(t, provider)
+			_, err := v.Validate(context.Background(), samplePageHTML, pageSelectors, storage.TargetTypePage)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "truncated")
+		})
+	}
+}
+
+// TestLLMValidator_NonTruncateError_NoTruncateMessage — StopReason 이 일반 종료 (stop / end_turn)
+// 인데 unmarshal 실패하면 기존 unmarshal 에러 메시지 그대로 — truncate 메시지 추가 X (오분류 방지).
+func TestLLMValidator_NonTruncateError_NoTruncateMessage(t *testing.T) {
+	provider := &fakeProvider{
+		response:   "not valid json",
+		stopReason: "stop",
+	}
+	v := newTestLLMValidator(t, provider)
+
+	_, err := v.Validate(context.Background(), samplePageHTML, pageSelectors, storage.TargetTypePage)
+	require.Error(t, err)
+	assert.NotContains(t, err.Error(), "truncated", "stop 은 정상 종료 — truncate 분류 안 함")
+	assert.Contains(t, err.Error(), "parse validation response")
 }
 
 // ─────────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## 연관 이슈
Closes #320

## 배경

라이브 (2026-05-08, 8h log) 에서 의미 검증 (`validator.LLMValidator`) 의 best-effort fallback 10건 발생. 모두 LLM 응답이 `\"valid\": false, ...` 또는 reason 중간에서 truncate 되어 unmarshal 실패. 현재 상태는 **silent best-effort 통과** — 잘못된 selector (광고/네비게이션 매칭) 가 INSERT 될 위험.

직접 검증한 truncation 패턴 (현재 log 의 unique 응답 raw):
```
```json\n{\"valid\": false,
```json\n{\\n  \"valid\": false,
{\"valid\": false, \"reason\": \"The
{\"valid\": false, \"reason\": \"The extracted
```

## 구현 — 이슈 본문의 제안 1/2/3

### 1. MaxTokens 256 → 512
- [llm_validator.go:58](internal/processor/parser/rule/validator/llm_validator.go#L58) 의 `MaxTokens: 256` → `MaxTokens: validatorMaxTokens` (512)
- 256 은 마크다운 펜스 + JSON 키 + 한국어 reason 한 문장에 빠르게 도달
- 512 면 reason 1~2 문장 + 펜스 여유 확보

### 2. `StopReason` 기반 truncate 감지
- provider 별 max-tokens 신호 set: `openai` \"length\" / `gemini` \"MAX_TOKENS\" / `anthropic` \"max_tokens\"
- parse 실패 + StopReason 매칭 시 `\"truncated (stop_reason=X, max_tokens=Y): ...\"` 명시 에러
- 운영자가 MaxTokens 조정 / prompt 단축 결정 신호로 활용

### 3. Robust parse fallback (regex salvage)
- unmarshal 실패 시 `\"valid\":\\s*(true|false)` regex 로 verdict 추출
- reason 누락은 운영 영향 없음 — silent skip 보다 정확한 verdict 활용
- 매칭 실패 시 원본 unmarshal 에러 그대로 노출 (운영 진단성 보존)

**처리 순서**:
1. unmarshal → 성공: 그대로 반환
2. regex salvage → 성공: verdict 만 사용 (Reason=빈 문자열)
3. 모두 실패: StopReason 매칭 시 truncate 명시 에러, 그렇지 않으면 원본 unmarshal 에러

### Scope 외 (의도적 제외)
- **System prompt 보강 (이슈 #4번 제안)** — 본 PR 미포함. 사용자 요청.

## 테스트 (test/internal/processor/parser/rule/validator/validator_test.go) — 6건 추가
- `MaxTokensIncreasedTo512` — Validator 가 Request 에 MaxTokens=512 전달
- `TruncatedResponseSalvagesValidVerdict` — reason 중간 truncate → verdict salvage
- `TruncatedResponseTrueVerdict` — markdown 펜스 + true verdict 도 salvage
- `TruncatedAtValidKey_ReturnsTruncateError` — valid 키 도달 전 truncate + MAX_TOKENS → 명시 에러
- `TruncateDetection_StopReasons` — length / max_tokens / MAX_TOKENS 3개 provider 신호 인식
- `NonTruncateError_NoTruncateMessage` — `stop` (정상 종료) 시 truncate 분류 안 함

`fakeProvider` 에 `stopReason` / `lastMaxTokens` 필드 추가 — 기존 7개 테스트는 backward compat 유지.

## CI / 머지 게이트 점검
- [x] `go build ./...` 통과
- [x] `go test -race -count=1 ./test/...` 전부 ok
- [x] `go vet ./...` 깨끗
- [x] gofmt 정리

## 변경 영향 범위 + 위험도
- **영향**: silent best-effort fallback 으로 우회되던 검증 결과가 정확한 verdict 로 회복 — 잘못된 selector 가 silently INSERT 될 위험 감소
- **위험도**: 낮음
  - MaxTokens 상향만으로도 라이브 truncation 케이스 대부분 cover (관찰된 응답 모두 < 200 토큰)
  - regex salvage 는 verdict 만 추출 — reason 누락은 silent skip 보다 항상 우월
  - StopReason 매칭 안 되는 unknown provider 응답은 기존 unmarshal 에러 그대로 (back-compat)

## 롤백 계획
1. 코드 롤백: `git revert` — 단일 파일 변경
2. 부분 조정: `validatorMaxTokens` 상수만 256 으로 환원 가능

🤖 Generated with [Claude Code](https://claude.com/claude-code)