### PR TITLE
[FIX#345] Makefile chrome wiring — docker compose --scale 통일

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -72,8 +72,11 @@ start: ## Crawler + Processor 통합 실행 (의존: chrome, kafka 자동 기동
 	@$(MAKE) run-issuetracker
 
 chrome-ensure: ## Chrome compose 서비스가 WORKER_COUNT 이상 실행 중이 아니면 chrome-start 호출
-	@running=$$($(COMPOSE) -f $(COMPOSE_FILE) ps -q $(CHROME_COMPOSE_SERVICE) 2>/dev/null | wc -l); \
-	target=$(CHROME_WORKER_COUNT); \
+	@target=$(CHROME_WORKER_COUNT); \
+	case "$$target" in \
+	  ''|*[!0-9]*) echo "Invalid CHROME_WORKER_COUNT='$$target' (must be non-negative integer)"; exit 1;; \
+	esac; \
+	running=$$($(COMPOSE) -f $(COMPOSE_FILE) ps --status running -q $(CHROME_COMPOSE_SERVICE) 2>/dev/null | wc -l); \
 	if [ "$$running" -lt "$$target" ]; then \
 	  echo "Chrome compose service running=$$running, target=$$target — starting..."; \
 	  $(MAKE) chrome-start; \

--- a/Makefile
+++ b/Makefile
@@ -25,9 +25,17 @@ GO=go
 GOFLAGS=-v
 
 # Docker Chrome 변수
+# 메인 chrome 운영은 docker compose --scale 으로 N replica (chrome-1 ... chrome-N).
+# 아래 단일 컨테이너 변수 (CHROME_CONTAINER) 는 legacy run-example-docker 용으로만 유지.
 CHROME_IMAGE=chromedp/headless-shell
 CHROME_PORT=9222
 CHROME_CONTAINER=issuetracker-chrome
+
+# Chrome compose-based 변수 (단일 docker run → docker compose --scale 전환)
+# CHROME_WORKER_COUNT 는 deployments/docker/.env 의 FETCHER_CHROMEDP_WORKER_COUNT 사용 — 미설정 시 2.
+CHROME_COMPOSE_SERVICE=chrome
+CHROME_WORKER_COUNT_RAW=$(shell [ -f $(KAFKA_ENV_FILE) ] && grep -E '^FETCHER_CHROMEDP_WORKER_COUNT=' $(KAFKA_ENV_FILE) | head -1 | cut -d= -f2- | tr -d '"' | tr -d "'")
+CHROME_WORKER_COUNT=$(if $(CHROME_WORKER_COUNT_RAW),$(CHROME_WORKER_COUNT_RAW),2)
 
 # Kafka Docker Compose 변수
 COMPOSE_FILE=deployments/docker/docker-compose.yml
@@ -63,12 +71,14 @@ start: ## Crawler + Processor 통합 실행 (의존: chrome, kafka 자동 기동
 	@$(MAKE) kafka-ensure
 	@$(MAKE) run-issuetracker
 
-chrome-ensure: ## Chrome 컨테이너가 실행 중이 아니면 chrome-start 호출
-	@if [ -z "$$(docker ps --filter name=^/$(CHROME_CONTAINER)$$ --filter status=running --quiet)" ]; then \
-	  echo "Chrome container '$(CHROME_CONTAINER)' not running, starting..."; \
+chrome-ensure: ## Chrome compose 서비스가 WORKER_COUNT 이상 실행 중이 아니면 chrome-start 호출
+	@running=$$($(COMPOSE) -f $(COMPOSE_FILE) ps -q $(CHROME_COMPOSE_SERVICE) 2>/dev/null | wc -l); \
+	target=$(CHROME_WORKER_COUNT); \
+	if [ "$$running" -lt "$$target" ]; then \
+	  echo "Chrome compose service running=$$running, target=$$target — starting..."; \
 	  $(MAKE) chrome-start; \
 	else \
-	  echo "Chrome container '$(CHROME_CONTAINER)' already running"; \
+	  echo "Chrome compose service has $$running running container(s) (target=$$target)"; \
 	fi
 
 kafka-ensure: ## Kafka 컨테이너가 실행 중이 아니면 kafka-start, 이미 실행 중이면 토픽 멱등 초기화
@@ -112,25 +122,19 @@ run-kafka-pipeline: $(KAFKA_PIPELINE_BINARY) ## Kafka 파이프라인 예제 실
 	@echo "Running Kafka pipeline example..."
 	./$(KAFKA_PIPELINE_BINARY)
 
-chrome-start: ## Docker Chrome 컨테이너 시작 (포트 9222)
-	@echo "Starting Chrome container ($(CHROME_IMAGE))..."
-	@docker run -d --rm \
-	  -p $(CHROME_PORT):9222 \
-	  --name $(CHROME_CONTAINER) \
-	  $(CHROME_IMAGE)
-	@echo "Waiting for Chrome to be ready..."
-	@sleep 2
-	@echo "Chrome started → ws://localhost:$(CHROME_PORT)"
+chrome-start: ## docker compose --scale 로 Chrome N replica 시작 (포트 9222-922N)
+	@echo "Starting Chrome ($(CHROME_WORKER_COUNT) replicas via docker compose)..."
+	$(COMPOSE) -f $(COMPOSE_FILE) $(KAFKA_ENV_ARGS) up -d --scale $(CHROME_COMPOSE_SERVICE)=$(CHROME_WORKER_COUNT) $(CHROME_COMPOSE_SERVICE)
+	@echo "Chrome started — replicas=$(CHROME_WORKER_COUNT) → ws://localhost:9222..."
 
-chrome-stop: ## Docker Chrome 컨테이너 중지
-	@echo "Stopping Chrome container..."
-	-@docker stop $(CHROME_CONTAINER) 2>/dev/null
+chrome-stop: ## Chrome compose 서비스 중지 + 컨테이너 제거
+	@echo "Stopping Chrome compose service..."
+	-@$(COMPOSE) -f $(COMPOSE_FILE) $(KAFKA_ENV_ARGS) stop $(CHROME_COMPOSE_SERVICE) 2>/dev/null
+	-@$(COMPOSE) -f $(COMPOSE_FILE) $(KAFKA_ENV_ARGS) rm -f $(CHROME_COMPOSE_SERVICE) 2>/dev/null
 	@echo "Chrome stopped"
 
-chrome-status: ## Docker Chrome 컨테이너 상태 확인
-	@docker ps --filter name=$(CHROME_CONTAINER) \
-	  --format "table {{.Names}}\t{{.Status}}\t{{.Ports}}" \
-	  | { read header; read line 2>/dev/null && echo "$$header" && echo "$$line" || echo "$$header\n(not running)"; }
+chrome-status: ## Chrome compose 서비스 상태 확인 (전 replica)
+	@$(COMPOSE) -f $(COMPOSE_FILE) ps $(CHROME_COMPOSE_SERVICE)
 
 run-example-docker: $(EXAMPLE_BINARY) ## Docker Chrome으로 basic example 실행 (컨테이너 자동 시작/중지)
 	@echo "=== Docker Chrome + Basic Example ==="

--- a/Makefile
+++ b/Makefile
@@ -33,9 +33,15 @@ CHROME_CONTAINER=issuetracker-chrome
 
 # Chrome compose-based 변수 (단일 docker run → docker compose --scale 전환)
 # CHROME_WORKER_COUNT 는 deployments/docker/.env 의 FETCHER_CHROMEDP_WORKER_COUNT 사용 — 미설정 시 2.
+# CHROME_PROJECT_NAME: compose project 명시 고정 (Copilot 피드백) — working dir 에 무관하게
+# 동일 project 의 chrome replica 를 일관 인식. 기본값 'docker' 는 compose-file 디렉토리 basename
+# (deployments/docker) 과 일치하여 운영 환경에 이미 떠 있는 docker-chrome-{N} 컨테이너와 정합.
 CHROME_COMPOSE_SERVICE=chrome
-CHROME_WORKER_COUNT_RAW=$(shell [ -f $(KAFKA_ENV_FILE) ] && grep -E '^FETCHER_CHROMEDP_WORKER_COUNT=' $(KAFKA_ENV_FILE) | head -1 | cut -d= -f2- | tr -d '"' | tr -d "'")
+CHROME_PROJECT_NAME=docker
+CHROME_WORKER_COUNT_RAW=$(shell [ -f $(KAFKA_ENV_FILE) ] && grep -E '^FETCHER_CHROMEDP_WORKER_COUNT=' $(KAFKA_ENV_FILE) | head -1 | cut -d= -f2- | tr -d '"' | tr -d "'" | tr -d ' ')
 CHROME_WORKER_COUNT=$(if $(CHROME_WORKER_COUNT_RAW),$(CHROME_WORKER_COUNT_RAW),2)
+# Chrome compose 호출 공통 prefix — project name + compose file 명시.
+CHROME_COMPOSE=$(COMPOSE) -p $(CHROME_PROJECT_NAME) -f $(COMPOSE_FILE) $(KAFKA_ENV_ARGS)
 
 # Kafka Docker Compose 변수
 COMPOSE_FILE=deployments/docker/docker-compose.yml
@@ -74,9 +80,10 @@ start: ## Crawler + Processor 통합 실행 (의존: chrome, kafka 자동 기동
 chrome-ensure: ## Chrome compose 서비스가 WORKER_COUNT 이상 실행 중이 아니면 chrome-start 호출
 	@target=$(CHROME_WORKER_COUNT); \
 	case "$$target" in \
-	  ''|*[!0-9]*) echo "Invalid CHROME_WORKER_COUNT='$$target' (must be non-negative integer)"; exit 1;; \
+	  ''|*[!0-9]*) echo "Invalid CHROME_WORKER_COUNT='$$target' (must be positive integer)"; exit 1;; \
+	  0) echo "Invalid CHROME_WORKER_COUNT=0 (must be >= 1 — chrome 비활성은 FETCHER_CHROMEDP_ENABLED=false 사용)"; exit 1;; \
 	esac; \
-	running=$$($(COMPOSE) -f $(COMPOSE_FILE) ps --status running -q $(CHROME_COMPOSE_SERVICE) 2>/dev/null | wc -l); \
+	running=$$($(CHROME_COMPOSE) ps --status running -q $(CHROME_COMPOSE_SERVICE) 2>/dev/null | wc -l | tr -d ' '); \
 	if [ "$$running" -lt "$$target" ]; then \
 	  echo "Chrome compose service running=$$running, target=$$target — starting..."; \
 	  $(MAKE) chrome-start; \
@@ -125,19 +132,21 @@ run-kafka-pipeline: $(KAFKA_PIPELINE_BINARY) ## Kafka 파이프라인 예제 실
 	@echo "Running Kafka pipeline example..."
 	./$(KAFKA_PIPELINE_BINARY)
 
-chrome-start: ## docker compose --scale 로 Chrome N replica 시작 (포트 9222-922N)
-	@echo "Starting Chrome ($(CHROME_WORKER_COUNT) replicas via docker compose)..."
-	$(COMPOSE) -f $(COMPOSE_FILE) $(KAFKA_ENV_ARGS) up -d --scale $(CHROME_COMPOSE_SERVICE)=$(CHROME_WORKER_COUNT) $(CHROME_COMPOSE_SERVICE)
-	@echo "Chrome started — replicas=$(CHROME_WORKER_COUNT) → ws://localhost:9222..."
+chrome-start: ## docker compose --scale 로 Chrome N replica 시작 (포트는 compose.yml 의 HOST_PORT_RANGE 기준)
+	@port_range=$$([ -f $(KAFKA_ENV_FILE) ] && grep -E '^FETCHER_CHROMEDP_HOST_PORT_RANGE=' $(KAFKA_ENV_FILE) | head -1 | cut -d= -f2- | tr -d '"' | tr -d "'" | tr -d ' '); \
+	port_range=$${port_range:-9222-9229}; \
+	echo "Starting Chrome ($(CHROME_WORKER_COUNT) replicas via docker compose, host port range=$$port_range)..."
+	$(CHROME_COMPOSE) up -d --scale $(CHROME_COMPOSE_SERVICE)=$(CHROME_WORKER_COUNT) $(CHROME_COMPOSE_SERVICE)
+	@echo "Chrome started — replicas=$(CHROME_WORKER_COUNT)"
 
 chrome-stop: ## Chrome compose 서비스 중지 + 컨테이너 제거
 	@echo "Stopping Chrome compose service..."
-	-@$(COMPOSE) -f $(COMPOSE_FILE) $(KAFKA_ENV_ARGS) stop $(CHROME_COMPOSE_SERVICE) 2>/dev/null
-	-@$(COMPOSE) -f $(COMPOSE_FILE) $(KAFKA_ENV_ARGS) rm -f $(CHROME_COMPOSE_SERVICE) 2>/dev/null
+	-@$(CHROME_COMPOSE) stop $(CHROME_COMPOSE_SERVICE) 2>/dev/null
+	-@$(CHROME_COMPOSE) rm -f $(CHROME_COMPOSE_SERVICE) 2>/dev/null
 	@echo "Chrome stopped"
 
 chrome-status: ## Chrome compose 서비스 상태 확인 (전 replica)
-	@$(COMPOSE) -f $(COMPOSE_FILE) ps $(CHROME_COMPOSE_SERVICE)
+	@$(CHROME_COMPOSE) ps $(CHROME_COMPOSE_SERVICE)
 
 run-example-docker: $(EXAMPLE_BINARY) ## Docker Chrome으로 basic example 실행 (컨테이너 자동 시작/중지)
 	@echo "=== Docker Chrome + Basic Example ==="


### PR DESCRIPTION
## 연관 이슈
Closes #345

## 배경 — 운영자 라이브에서 발견

\`make clean start\` 실행 시 port 9222 already allocated 에러로 chrome 기동 실패:

\`\`\`
Chrome container 'issuetracker-chrome' not running, starting...
Starting Chrome container (chromedp/headless-shell)...
docker: Error response from daemon: failed to set up container networking:
  driver failed programming external connectivity on endpoint issuetracker-chrome:
  Bind for 0.0.0.0:9222 failed: port is already allocated
\`\`\`

### 원인

Makefile 의 chrome wiring 이 docker compose 의 chrome scale wiring 과 양립 불가:

| 경로 | 컨테이너 이름 | 포트 |
|---|---|---|
| 기존 `make chrome-start` | 단일 `issuetracker-chrome` (`docker run`) | 9222 |
| `docker compose up --scale chrome=N` | `<project>-chrome-1`, `<project>-chrome-2`, ... | 9222-922N (range) |

`chrome-ensure` 가 컨테이너 **이름** `issuetracker-chrome` 만 체크 — compose 가 띄운 `docker-chrome-1/2` 가 port 9222 점유 중이어도 \"not running\" 으로 오판 → 단일 docker run 시도 → 충돌.

라이브 운영 패턴이 docker compose (scale N) 인데 Makefile 만 단일 `docker run` 으로 분기되어 발생한 wiring 부정합.

## 구현 — chrome 4 target docker compose 기반 통일

| Target | 변경 |
|---|---|
| `chrome-ensure` | `docker ps --name=issuetracker-chrome` → `docker compose ps -q chrome` 로 running replica 수 카운트, `< CHROME_WORKER_COUNT` 일 때만 chrome-start |
| `chrome-start` | `docker run -d --name issuetracker-chrome` → `docker compose up -d --scale chrome=N` |
| `chrome-stop` | `docker stop issuetracker-chrome` → `docker compose stop chrome && rm -f chrome` (전 replica) |
| `chrome-status` | 단일 컨테이너 필터 → `docker compose ps chrome` (전 replica) |

### 새 변수
- `CHROME_COMPOSE_SERVICE=chrome` (compose service 이름)
- `CHROME_WORKER_COUNT`: `deployments/docker/.env` 의 `FETCHER_CHROMEDP_WORKER_COUNT` 읽기, 미설정 시 2. compose.yml 의 `ports: \"${FETCHER_CHROMEDP_HOST_PORT_RANGE:-9222-9229}:9222\"` range 와 자동 정합.

### 호환성 보존
기존 단일 컨테이너 변수 (`CHROME_CONTAINER` / `CHROME_IMAGE` / `CHROME_PORT`) 는 legacy `run-example-docker` target 이 그대로 단일 `docker run` 으로 동작하므로 **유지**. 본 PR scope 밖 분리.

## 검증

운영자 환경에서 `docker-chrome-1/2` (compose 가 띄운 unhealthy 상태) 가 이미 존재:

```bash
$ make chrome-status
NAME              IMAGE                            ...   STATUS                  PORTS
docker-chrome-1   chromedp/headless-shell:latest   ...   Up 4 days (unhealthy)   9223/tcp, 0.0.0.0:9223->9222/tcp
docker-chrome-2   chromedp/headless-shell:latest   ...   Up 4 days (unhealthy)   0.0.0.0:9222->9222/tcp

$ make chrome-ensure
Chrome compose service has 2 running container(s) (target=2)
```

→ 재기동 없이 즉시 통과. `make clean start` 의 chrome 단계 unblock 확인.

## CI / 머지 게이트 점검
- [x] Makefile 단독 변경 — go build/test 영향 없음
- [x] 운영자 라이브 환경에서 chrome-ensure / chrome-status 정상 동작 확인

## 변경 영향 범위 + 위험도
- **영향**: `make start` / `make chrome-*` target 의 chrome 컨테이너 관리 경로가 compose 로 일원화 — 이중 wiring 충돌 해소
- **위험도**: 낮음
  - 기존 `issuetracker-chrome` 컨테이너가 떠 있는 환경에서는 chrome-ensure 가 0 running 으로 인식 → chrome-start 가 compose 로 새 replica 시도 → 이름 다른 새 컨테이너 생성. 운영자가 기존 단일 컨테이너 수동 정리 필요 (1회성).
  - legacy `run-example-docker` 는 영향 없음 — 단일 docker run 그대로 사용

## 롤백 계획
1. `git revert` — Makefile 단일 파일 변경
2. 기존 단일 docker run wiring 으로 환원 + compose chrome 컨테이너 수동 정리 필요

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved Chrome worker container management infrastructure to support dynamic scaling and enhanced deployment efficiency.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/EinSofINTEREST/IssueTracker/pull/346)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->