### PR TITLE
[FIX#348] Makefile run-issuetracker — chrome 실제 포트 dynamic discovery

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -105,19 +105,39 @@ run-processor: build ## Validate processor 실행
 	./$(PROCESSOR_BINARY)
 
 run-issuetracker: build ## Crawler + Processor 통합 실행 (chrome 실제 포트 자동 매핑 — 이슈 #348)
-	@urls=$$($(MAKE) -s chrome-remote-urls 2>/dev/null); \
-	if [ -n "$$urls" ]; then \
-	  echo "Discovered chrome remote URLs: $$urls"; \
+	@urls=$$($(MAKE) -s chrome-remote-urls 2>/tmp/chrome-urls.err); \
+	rc=$$?; \
+	if [ $$rc -ne 0 ]; then \
+	  echo "ERROR: chrome-remote-urls failed (rc=$$rc):" >&2; \
+	  cat /tmp/chrome-urls.err >&2; \
+	  rm -f /tmp/chrome-urls.err; \
+	  exit $$rc; \
+	fi; \
+	rm -f /tmp/chrome-urls.err; \
+	if [ -z "$$urls" ]; then \
+	  echo "No chrome compose containers running — falling back to .env FETCHER_CHROMEDP_REMOTE_URLS"; \
 	  echo "Running issuetracker (crawler + processor)..."; \
-	  FETCHER_CHROMEDP_REMOTE_URLS="$$urls" ./scripts/entrypoint.sh; \
-	else \
-	  echo "No chrome compose containers found — falling back to .env FETCHER_CHROMEDP_REMOTE_URLS"; \
+	  exec ./scripts/entrypoint.sh; \
+	fi; \
+	found=$$(echo "$$urls" | awk -F',' '{print NF}'); \
+	target=$(CHROME_WORKER_COUNT); \
+	if [ "$$found" -ne "$$target" ]; then \
+	  echo "WARNING: discovered $$found chrome URL(s) but FETCHER_CHROMEDP_WORKER_COUNT=$$target — degraded mode (overriding both to $$found)"; \
 	  echo "Running issuetracker (crawler + processor)..."; \
-	  ./scripts/entrypoint.sh; \
-	fi
+	  FETCHER_CHROMEDP_REMOTE_URLS="$$urls" FETCHER_CHROMEDP_WORKER_COUNT="$$found" exec ./scripts/entrypoint.sh; \
+	fi; \
+	echo "Discovered chrome remote URLs ($$found): $$urls"; \
+	echo "Running issuetracker (crawler + processor)..."; \
+	FETCHER_CHROMEDP_REMOTE_URLS="$$urls" exec ./scripts/entrypoint.sh
 
 chrome-remote-urls: ## chrome compose 컨테이너의 실제 host 포트를 ws:// URL 목록으로 출력 (이슈 #348)
-	@$(CHROME_COMPOSE) ps --status running --format '{{.Ports}}' $(CHROME_COMPOSE_SERVICE) 2>/dev/null \
+	@out=$$($(CHROME_COMPOSE) ps --status running --format '{{.Ports}}' $(CHROME_COMPOSE_SERVICE) 2>&1); \
+	rc=$$?; \
+	if [ $$rc -ne 0 ]; then \
+	  echo "docker compose ps failed (rc=$$rc): $$out" >&2; \
+	  exit $$rc; \
+	fi; \
+	echo "$$out" \
 	  | grep -oE '0\.0\.0\.0:[0-9]+->9222/tcp' \
 	  | grep -oE '^0\.0\.0\.0:[0-9]+' \
 	  | grep -oE '[0-9]+$$' \

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .PHONY: help build build-all test clean run-processor run-issuetracker run-example lint coverage \
         start chrome-ensure kafka-ensure \
-        chrome-start chrome-stop chrome-status run-example-docker \
+        chrome-start chrome-stop chrome-status chrome-remote-urls run-example-docker \
         run-kafka-pipeline \
         kafka-start kafka-stop kafka-clean kafka-status kafka-logs kafka-topics kafka-init \
         pg-start pg-stop pg-clean pg-migrate pg-status pg-psql \
@@ -104,9 +104,27 @@ run-processor: build ## Validate processor 실행
 	@echo "Running processor..."
 	./$(PROCESSOR_BINARY)
 
-run-issuetracker: build ## Crawler + Processor 통합 실행
-	@echo "Running issuetracker (crawler + processor)..."
-	./scripts/entrypoint.sh
+run-issuetracker: build ## Crawler + Processor 통합 실행 (chrome 실제 포트 자동 매핑 — 이슈 #348)
+	@urls=$$($(MAKE) -s chrome-remote-urls 2>/dev/null); \
+	if [ -n "$$urls" ]; then \
+	  echo "Discovered chrome remote URLs: $$urls"; \
+	  echo "Running issuetracker (crawler + processor)..."; \
+	  FETCHER_CHROMEDP_REMOTE_URLS="$$urls" ./scripts/entrypoint.sh; \
+	else \
+	  echo "No chrome compose containers found — falling back to .env FETCHER_CHROMEDP_REMOTE_URLS"; \
+	  echo "Running issuetracker (crawler + processor)..."; \
+	  ./scripts/entrypoint.sh; \
+	fi
+
+chrome-remote-urls: ## chrome compose 컨테이너의 실제 host 포트를 ws:// URL 목록으로 출력 (이슈 #348)
+	@$(CHROME_COMPOSE) ps --status running --format '{{.Ports}}' $(CHROME_COMPOSE_SERVICE) 2>/dev/null \
+	  | grep -oE '0\.0\.0\.0:[0-9]+->9222/tcp' \
+	  | grep -oE '^0\.0\.0\.0:[0-9]+' \
+	  | grep -oE '[0-9]+$$' \
+	  | sort -n \
+	  | head -n $(CHROME_WORKER_COUNT) \
+	  | sed 's|^|ws://localhost:|' \
+	  | paste -sd,
 
 $(EXAMPLE_BINARY): ./examples/basic_usage/
 	@mkdir -p $(BINARY_DIR)

--- a/Makefile
+++ b/Makefile
@@ -138,10 +138,9 @@ chrome-remote-urls: ## chrome compose 컨테이너의 실제 host 포트를 ws:/
 	  exit $$rc; \
 	fi; \
 	echo "$$out" \
-	  | grep -oE '0\.0\.0\.0:[0-9]+->9222/tcp' \
-	  | grep -oE '^0\.0\.0\.0:[0-9]+' \
-	  | grep -oE '[0-9]+$$' \
-	  | sort -n \
+	  | tr ',' '\n' \
+	  | sed -nE 's/.*:([0-9]+)->9222\/tcp/\1/p' \
+	  | sort -un \
 	  | head -n $(CHROME_WORKER_COUNT) \
 	  | sed 's|^|ws://localhost:|' \
 	  | paste -sd,


### PR DESCRIPTION
## 연관 이슈
Closes #348

## 배경

compose chrome 서비스의 \`ports: \"${FETCHER_CHROMEDP_HOST_PORT_RANGE:-9222-9229}:9222\"\` 가 Docker engine 의 internal counter drift 로 9222/9223 이 아닌 9226/9227 등에 할당. 그러나 앱의 \`FETCHER_CHROMEDP_REMOTE_URLS\` 는 정적 → 라이브 boot 시 chrome 연결 불가.

라이브 매번 \`FETCHER_CHROMEDP_REMOTE_URLS=ws://localhost:9226,9227 ./bin/issuetracker\` 식 env override 필요했음.

## 구현 — option C (dynamic env discovery)

이슈 #348 의 4가지 옵션 (A 단일 포트 고정 / B Docker counter reset / C 동적 env 생성 / D 호스트 매핑 제거) 중 호스트 binary 실행 모드를 유지하면서 가장 깨끗한 **option C**.

### `chrome-remote-urls` target 신설
\`\`\`make
chrome-remote-urls:
    @$(CHROME_COMPOSE) ps --status running --format '{{.Ports}}' chrome 2>/dev/null \\
      | grep -oE '0\\.0\\.0\\.0:[0-9]+->9222/tcp' \\
      | grep -oE '^0\\.0\\.0\\.0:[0-9]+' \\
      | grep -oE '[0-9]+$$' \\
      | sort -n \\
      | head -n $(CHROME_WORKER_COUNT) \\
      | sed 's|^|ws://localhost:|' \\
      | paste -sd,
\`\`\`
- compose ps 출력에서 \`HOST_PORT->9222/tcp\` 패턴 파싱
- \`CHROME_WORKER_COUNT\` 만큼만 선택 (정렬 후 head)
- \`ws://localhost:9226,ws://localhost:9227\` 형식 콤마 구분 URL 출력
- inspection / 재사용 가능한 단일 책임 target

### `run-issuetracker` 통합
- build 후 `chrome-remote-urls` 결과를 export 한 채 entrypoint 실행
- URLs 가 빈 문자열 (chrome 컨테이너 부재) 이면 .env 의 정적 값으로 fallback — 기존 동작 보존
- 발견된 URL 을 로그에 표시 — 운영자가 매핑 가시화

## 검증

chrome 이 9226/9227 에 할당된 상태에서:
\`\`\`bash
$ make run-issuetracker
...
Discovered chrome remote URLs: ws://localhost:9226,ws://localhost:9227
Running issuetracker (crawler + processor)...
{\"level\":\"info\",...,\"message\":\"starting IssueTracker\"}
{\"level\":\"info\",\"source\":\"inven\",...,\"message\":\"crawler registered from db\"}
... (모든 crawler 등록 + scheduler tick 정상)
\`\`\`

## CI / 머지 게이트 점검
- [x] Makefile 단독 변경 — go build/test 영향 없음
- [x] 라이브 환경에서 chrome-remote-urls + run-issuetracker 정상 동작 확인

## 변경 영향 범위 + 위험도
- **영향**: `make run-issuetracker` 가 자동으로 실제 chrome 포트 매핑 — 매번 env override 불필요
- **위험도**: 낮음
  - chrome 컨테이너 부재 시 .env fallback — 기존 동작 보존
  - 파싱은 IPv4 (0.0.0.0:) 만 인식 — IPv6 only 환경에서는 fallback 필요
  - `paste -sd,` 가 콤마 구분 single line 보장
  - WORKER_COUNT > 실제 running 개수면 found 만큼만 export

## 롤백 계획
1. `git revert` — Makefile 단일 파일 변경
2. 운영자 매번 env override 패턴으로 환원

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved application startup process with automatic service discovery. The system now intelligently detects and configures available services during initialization, completely eliminating the need for manual setup steps. If required services are unavailable, the application gracefully falls back to existing environment configuration, ensuring flexibility and improved reliability across different deployment environments.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/EinSofINTEREST/IssueTracker/pull/349)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->