### PR TITLE
[FIX#347] fetcher registry — BaseURL strict check 제거 + 호스트별 base_url 허용

### DIFF
--- a/internal/processor/fetcher/domain/general/sources/registry.go
+++ b/internal/processor/fetcher/domain/general/sources/registry.go
@@ -64,36 +64,9 @@ func RegisterAll(
 		return fmt.Errorf("list fetcher rules: %w", err)
 	}
 
-	// 단일 루프에서 canonical row(bySource)와 host 목록(hostsBySource) 동시 수집 (Gemini Medium 반영).
-	// - base_url hostname == host_pattern 인 row 를 canonical 로 우선 선택
-	// - 동일 source_name 내 SourceInfo 불일치 시 즉시 에러
-	type sourceEntry struct {
-		rec      *storage.FetcherRuleRecord
-		hasExact bool
-	}
-	bySource := make(map[string]sourceEntry)
-	hostsBySource := make(map[string][]string)
-	for _, r := range rules {
-		if r.SourceName == "" {
-			continue
-		}
-		hostsBySource[r.SourceName] = append(hostsBySource[r.SourceName], r.HostPattern)
-		if prev, seen := bySource[r.SourceName]; seen {
-			if prev.rec.Country != r.Country ||
-				prev.rec.Language != r.Language ||
-				prev.rec.BaseURL != r.BaseURL ||
-				prev.rec.SourceType != r.SourceType ||
-				prev.rec.RequestsPerHour != r.RequestsPerHour {
-				return fmt.Errorf("inconsistent source metadata for source_name=%q (host=%q vs host=%q)",
-					r.SourceName, prev.rec.HostPattern, r.HostPattern)
-			}
-			// canonical 우선: base_url hostname == host_pattern 인 row 로 교체.
-			if !prev.hasExact && isCanonicalHost(r) {
-				bySource[r.SourceName] = sourceEntry{rec: r, hasExact: true}
-			}
-			continue
-		}
-		bySource[r.SourceName] = sourceEntry{rec: r, hasExact: isCanonicalHost(r)}
+	bySource, hostsBySource, baseURLsBySource, aerr := AnalyzeSources(rules)
+	if aerr != nil {
+		return aerr
 	}
 
 	if len(bySource) == 0 {
@@ -114,7 +87,7 @@ func RegisterAll(
 	// source_name 별로 handler 를 빌드한 뒤, source_name 과 각 host_pattern 양쪽으로 등록.
 	// CrawlerName 이 host 기반으로 통일 (#248) — source_name 키는 하위 호환 유지.
 	for sourceName, entry := range bySource {
-		h, err := buildHandler(sourceName, entry.rec,
+		h, err := buildHandler(sourceName, entry.Rec,
 			baseConfig, rawSvc, producer, resolver, chromedpRemoteURLs, dnsResolver, sourceConfigResolver, log)
 		if err != nil {
 			return err
@@ -124,16 +97,29 @@ func RegisterAll(
 			registry.Register(host, h)
 		}
 		rateLimitMode := "unlimited"
-		if entry.rec.RequestsPerHour > 0 {
+		if entry.Rec.RequestsPerHour > 0 {
 			rateLimitMode = "enforced"
 		}
-		log.WithFields(map[string]interface{}{
+		fields := map[string]interface{}{
 			"source":            sourceName,
 			"hosts":             hostsBySource[sourceName],
-			"requests_per_hour": entry.rec.RequestsPerHour,
+			"requests_per_hour": entry.Rec.RequestsPerHour,
 			"burst":             defaultRateLimitBurst,
 			"rate_limit":        rateLimitMode,
-		}).Info("crawler registered from db")
+		}
+		// 같은 source_name 의 host 들이 다른 base_url 을 가지면 운영 가시성을 위해 명시 (이슈 #347).
+		// HealthCheck 는 canonical 만 사용 — 비-canonical 의 base_url 은 기능적으로 무시됨.
+		if urls := baseURLsBySource[sourceName]; len(urls) > 1 {
+			distinct := make([]string, 0, len(urls))
+			for u := range urls {
+				distinct = append(distinct, u)
+			}
+			fields["base_urls"] = distinct
+			fields["canonical_base_url"] = entry.Rec.BaseURL
+			log.WithFields(fields).Info("crawler registered from db (multiple base_urls — canonical used for HealthCheck only)")
+		} else {
+			log.WithFields(fields).Info("crawler registered from db")
+		}
 	}
 	return nil
 }
@@ -204,6 +190,60 @@ func buildHandler(
 	}
 
 	return general.NewChainHandler(crawler, defaultChain, chromedpChains, resolver, rawSvc, producer, log), nil
+}
+
+// SourceEntry 는 source_name 별 canonical row 와 그 row 가 canonical (base_url hostname ==
+// host_pattern) 인지 여부를 보관합니다 — AnalyzeSources 가 채워서 반환.
+type SourceEntry struct {
+	Rec      *storage.FetcherRuleRecord
+	HasExact bool
+}
+
+// AnalyzeSources 는 fetcher_rules 의 rows 를 source_name 별로 분석하여 다음을 반환합니다:
+//   - bySource         : source_name → canonical FetcherRuleRecord (base_url hostname == host_pattern 우선)
+//   - hostsBySource    : source_name → []HostPattern (모든 host 보존)
+//   - baseURLsBySource : source_name → 등장한 BaseURL set (다양성 감지 로깅용)
+//
+// 동일 source_name 내 SourceInfo 불일치 (Country / Language / SourceType / RequestsPerHour) 시
+// error 즉시 반환. **BaseURL 은 strict check 에서 제외** (이슈 #347) — host 별로 다를 수 있으며
+// canonical 만 HealthCheck 에 사용. baseURLsBySource 로 다양성 감지하여 운영 로그.
+//
+// source_name 이 빈 row 는 skip (legacy).
+func AnalyzeSources(rules []*storage.FetcherRuleRecord) (
+	bySource map[string]SourceEntry,
+	hostsBySource map[string][]string,
+	baseURLsBySource map[string]map[string]struct{},
+	err error,
+) {
+	bySource = make(map[string]SourceEntry)
+	hostsBySource = make(map[string][]string)
+	baseURLsBySource = make(map[string]map[string]struct{})
+	for _, r := range rules {
+		if r.SourceName == "" {
+			continue
+		}
+		hostsBySource[r.SourceName] = append(hostsBySource[r.SourceName], r.HostPattern)
+		if _, ok := baseURLsBySource[r.SourceName]; !ok {
+			baseURLsBySource[r.SourceName] = map[string]struct{}{}
+		}
+		baseURLsBySource[r.SourceName][r.BaseURL] = struct{}{}
+		if prev, seen := bySource[r.SourceName]; seen {
+			if prev.Rec.Country != r.Country ||
+				prev.Rec.Language != r.Language ||
+				prev.Rec.SourceType != r.SourceType ||
+				prev.Rec.RequestsPerHour != r.RequestsPerHour {
+				return nil, nil, nil, fmt.Errorf("inconsistent source metadata for source_name=%q (host=%q vs host=%q)",
+					r.SourceName, prev.Rec.HostPattern, r.HostPattern)
+			}
+			// canonical 우선: base_url hostname == host_pattern 인 row 로 교체.
+			if !prev.HasExact && isCanonicalHost(r) {
+				bySource[r.SourceName] = SourceEntry{Rec: r, HasExact: true}
+			}
+			continue
+		}
+		bySource[r.SourceName] = SourceEntry{Rec: r, HasExact: isCanonicalHost(r)}
+	}
+	return bySource, hostsBySource, baseURLsBySource, nil
 }
 
 // isCanonicalHost 는 r.BaseURL 의 hostname 이 r.HostPattern 과 일치하면 true 를 반환합니다.

--- a/internal/processor/fetcher/domain/general/sources/registry.go
+++ b/internal/processor/fetcher/domain/general/sources/registry.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"fmt"
 	"net/url"
+	"sort"
 	"time"
 
 	"issuetracker/internal/processor/fetcher/core"
@@ -66,7 +67,7 @@ func RegisterAll(
 
 	bySource, hostsBySource, baseURLsBySource, aerr := AnalyzeSources(rules)
 	if aerr != nil {
-		return aerr
+		return fmt.Errorf("analyze sources: %w", aerr)
 	}
 
 	if len(bySource) == 0 {
@@ -114,6 +115,8 @@ func RegisterAll(
 			for u := range urls {
 				distinct = append(distinct, u)
 			}
+			// 로그 안정성 — map iteration 비결정성 흡수 (Copilot 반영).
+			sort.Strings(distinct)
 			fields["base_urls"] = distinct
 			fields["canonical_base_url"] = entry.Rec.BaseURL
 			log.WithFields(fields).Info("crawler registered from db (multiple base_urls — canonical used for HealthCheck only)")
@@ -209,6 +212,11 @@ type SourceEntry struct {
 // canonical 만 HealthCheck 에 사용. baseURLsBySource 로 다양성 감지하여 운영 로그.
 //
 // source_name 이 빈 row 는 skip (legacy).
+//
+// 노출 사유 (gemini Medium 응답): 프로젝트 규칙 .claude/rules/05-testing.md 에 따라 모든 테스트는
+// test/internal/<pkg>/ 하위에 외부 _test 패키지로 작성. 내부 helper 의 unit test 를 위한
+// internal/<pkg>/*_test.go (same-package) 패턴은 본 repo 의 디렉토리 컨벤션 위반이므로,
+// testability 최소 노출로 본 함수를 export. API 안정 약속 아님 — 내부 도우미.
 func AnalyzeSources(rules []*storage.FetcherRuleRecord) (
 	bySource map[string]SourceEntry,
 	hostsBySource map[string][]string,
@@ -228,12 +236,21 @@ func AnalyzeSources(rules []*storage.FetcherRuleRecord) (
 		}
 		baseURLsBySource[r.SourceName][r.BaseURL] = struct{}{}
 		if prev, seen := bySource[r.SourceName]; seen {
-			if prev.Rec.Country != r.Country ||
-				prev.Rec.Language != r.Language ||
-				prev.Rec.SourceType != r.SourceType ||
-				prev.Rec.RequestsPerHour != r.RequestsPerHour {
-				return nil, nil, nil, fmt.Errorf("inconsistent source metadata for source_name=%q (host=%q vs host=%q)",
-					r.SourceName, prev.Rec.HostPattern, r.HostPattern)
+			// 어느 필드가 mismatch 했는지 명시 (gemini Medium 반영) — 운영 boot fail 시 즉시 진단.
+			var mismatched string
+			switch {
+			case prev.Rec.Country != r.Country:
+				mismatched = "Country"
+			case prev.Rec.Language != r.Language:
+				mismatched = "Language"
+			case prev.Rec.SourceType != r.SourceType:
+				mismatched = "SourceType"
+			case prev.Rec.RequestsPerHour != r.RequestsPerHour:
+				mismatched = "RequestsPerHour"
+			}
+			if mismatched != "" {
+				return nil, nil, nil, fmt.Errorf("inconsistent %s for source_name=%q (host=%q vs host=%q)",
+					mismatched, r.SourceName, prev.Rec.HostPattern, r.HostPattern)
 			}
 			// canonical 우선: base_url hostname == host_pattern 인 row 로 교체.
 			if !prev.HasExact && isCanonicalHost(r) {

--- a/migrations/down/025_fetcher_rules_per_host_base_url.sql
+++ b/migrations/down/025_fetcher_rules_per_host_base_url.sql
@@ -1,0 +1,23 @@
+-- 025 DOWN: 라이브 #11 의 manual 우회 상태로 복원 (host 별 base_url 통일).
+--
+-- 본 DOWN 은 이슈 #347 의 strict check 가 다시 활성화된 환경에서만 의미 있음.
+-- 현재 코드에서는 BaseURL 차이가 허용되므로 DOWN 적용 시 기능적 영향 없음 (HealthCheck 가
+-- canonical 만 사용).
+
+UPDATE fetcher_rules
+   SET base_url = 'https://gall.dcinside.com'
+ WHERE host_pattern = 'gallery.dcinside.com'
+   AND source_name = 'dcinside'
+   AND base_url <> 'https://gall.dcinside.com';
+
+UPDATE fetcher_rules
+   SET base_url = 'https://old.reddit.com'
+ WHERE host_pattern = 'www.reddit.com'
+   AND source_name = 'reddit'
+   AND base_url <> 'https://old.reddit.com';
+
+UPDATE fetcher_rules
+   SET base_url = 'https://slashdot.org'
+ WHERE host_pattern = 'news.slashdot.org'
+   AND source_name = 'slashdot'
+   AND base_url <> 'https://slashdot.org';

--- a/migrations/down/025_fetcher_rules_per_host_base_url.sql
+++ b/migrations/down/025_fetcher_rules_per_host_base_url.sql
@@ -8,16 +8,16 @@ UPDATE fetcher_rules
    SET base_url = 'https://gall.dcinside.com'
  WHERE host_pattern = 'gallery.dcinside.com'
    AND source_name = 'dcinside'
-   AND base_url <> 'https://gall.dcinside.com';
+   AND base_url IS DISTINCT FROM 'https://gall.dcinside.com';
 
 UPDATE fetcher_rules
    SET base_url = 'https://old.reddit.com'
  WHERE host_pattern = 'www.reddit.com'
    AND source_name = 'reddit'
-   AND base_url <> 'https://old.reddit.com';
+   AND base_url IS DISTINCT FROM 'https://old.reddit.com';
 
 UPDATE fetcher_rules
    SET base_url = 'https://slashdot.org'
  WHERE host_pattern = 'news.slashdot.org'
    AND source_name = 'slashdot'
-   AND base_url <> 'https://slashdot.org';
+   AND base_url IS DISTINCT FROM 'https://slashdot.org';

--- a/migrations/up/025_fetcher_rules_per_host_base_url.sql
+++ b/migrations/up/025_fetcher_rules_per_host_base_url.sql
@@ -1,0 +1,39 @@
+-- 025_fetcher_rules_per_host_base_url: PR #334/#335 의도 복원 — host 별 자기 base_url (이슈 #347)
+--
+-- 배경:
+--   PR #334 (dcinside dual-host) / PR #335 (slashdot/reddit dual-host) 가 host_pattern 별
+--   자기 base_url 을 seed 했으나, RegisterAll 의 strict consistency check 가 BaseURL 차이도
+--   거부 → boot fail. 즉시 우회로 운영자가 base_url 을 source_name 별 단일 값으로 통일하는
+--   manual SQL 실행 (라이브 #11). 본 마이그레이션은 #347 PR 에서 strict check 완화 후의
+--   정합 상태 복원.
+--
+-- 변경:
+--   - dcinside: gallery.dcinside.com 의 base_url → https://gallery.dcinside.com
+--   - reddit:   www.reddit.com 의 base_url → https://www.reddit.com
+--   - slashdot: news.slashdot.org 의 base_url → https://news.slashdot.org
+--
+-- 동작 영향:
+--   본 base_url 은 GoQuery/Generic HealthCheck 외에는 runtime 영향이 없음 (이슈 #347 분석).
+--   canonical 선택 (isCanonicalHost) 이 HealthCheck 용 단일 base_url 을 결정하므로 다른 host
+--   의 base_url 은 기능적으로 무시되지만, DB 상 의도된 host-specific 값으로 정합 보존.
+--
+-- 멱등:
+--   각 UPDATE 는 host_pattern 으로 정확히 식별. 이미 해당 값이면 변경 없음.
+
+UPDATE fetcher_rules
+   SET base_url = 'https://gallery.dcinside.com'
+ WHERE host_pattern = 'gallery.dcinside.com'
+   AND source_name = 'dcinside'
+   AND base_url <> 'https://gallery.dcinside.com';
+
+UPDATE fetcher_rules
+   SET base_url = 'https://www.reddit.com'
+ WHERE host_pattern = 'www.reddit.com'
+   AND source_name = 'reddit'
+   AND base_url <> 'https://www.reddit.com';
+
+UPDATE fetcher_rules
+   SET base_url = 'https://news.slashdot.org'
+ WHERE host_pattern = 'news.slashdot.org'
+   AND source_name = 'slashdot'
+   AND base_url <> 'https://news.slashdot.org';

--- a/migrations/up/025_fetcher_rules_per_host_base_url.sql
+++ b/migrations/up/025_fetcher_rules_per_host_base_url.sql
@@ -24,16 +24,16 @@ UPDATE fetcher_rules
    SET base_url = 'https://gallery.dcinside.com'
  WHERE host_pattern = 'gallery.dcinside.com'
    AND source_name = 'dcinside'
-   AND base_url <> 'https://gallery.dcinside.com';
+   AND base_url IS DISTINCT FROM 'https://gallery.dcinside.com';
 
 UPDATE fetcher_rules
    SET base_url = 'https://www.reddit.com'
  WHERE host_pattern = 'www.reddit.com'
    AND source_name = 'reddit'
-   AND base_url <> 'https://www.reddit.com';
+   AND base_url IS DISTINCT FROM 'https://www.reddit.com';
 
 UPDATE fetcher_rules
    SET base_url = 'https://news.slashdot.org'
  WHERE host_pattern = 'news.slashdot.org'
    AND source_name = 'slashdot'
-   AND base_url <> 'https://news.slashdot.org';
+   AND base_url IS DISTINCT FROM 'https://news.slashdot.org';

--- a/test/internal/processor/fetcher/domain/general/sources/analyze_test.go
+++ b/test/internal/processor/fetcher/domain/general/sources/analyze_test.go
@@ -78,7 +78,7 @@ func TestAnalyzeSources_RPHMismatch_Rejected(t *testing.T) {
 	}
 	_, _, _, err := sources.AnalyzeSources(rules)
 	require.Error(t, err, "RPH 불일치는 reject")
-	assert.Contains(t, err.Error(), "inconsistent source metadata")
+	assert.Contains(t, err.Error(), "inconsistent ")
 }
 
 // TestAnalyzeSources_CountryMismatch_Rejected — 의미론적 metadata 불일치는 reject.
@@ -90,7 +90,7 @@ func TestAnalyzeSources_CountryMismatch_Rejected(t *testing.T) {
 	}
 	_, _, _, err := sources.AnalyzeSources(rules)
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "inconsistent source metadata")
+	assert.Contains(t, err.Error(), "inconsistent ")
 }
 
 // TestAnalyzeSources_LanguageMismatch_Rejected — Language 불일치 reject.

--- a/test/internal/processor/fetcher/domain/general/sources/analyze_test.go
+++ b/test/internal/processor/fetcher/domain/general/sources/analyze_test.go
@@ -1,0 +1,157 @@
+package sources_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"issuetracker/internal/processor/fetcher/domain/general/sources"
+	"issuetracker/internal/storage"
+)
+
+// TestAnalyzeSources_MultiHostDifferentBaseURLs_Pass — 이슈 #347 의 핵심 회귀 테스트.
+// 같은 source_name 의 host 들이 서로 다른 base_url 을 가져도 RegisterAll 이 boot fail 하지 않아야 함.
+//
+// 예: dcinside / reddit / slashdot 의 dual-host seed (PR #334/#335 의 의도).
+func TestAnalyzeSources_MultiHostDifferentBaseURLs_Pass(t *testing.T) {
+	t.Parallel()
+	rules := []*storage.FetcherRuleRecord{
+		{
+			SourceName: "dcinside", HostPattern: "gall.dcinside.com",
+			SourceType: "community", Country: "KR", Language: "ko",
+			BaseURL: "https://gall.dcinside.com", RequestsPerHour: 100,
+		},
+		{
+			SourceName: "dcinside", HostPattern: "gallery.dcinside.com",
+			SourceType: "community", Country: "KR", Language: "ko",
+			BaseURL:         "https://gallery.dcinside.com", // 다른 BaseURL — 이전에는 reject
+			RequestsPerHour: 100,
+		},
+	}
+	bySource, hostsBySource, baseURLsBySource, err := sources.AnalyzeSources(rules)
+	require.NoError(t, err, "BaseURL 만 다른 경우 boot fail 하면 안 됨 (이슈 #347)")
+	assert.Contains(t, bySource, "dcinside")
+	assert.ElementsMatch(t, []string{"gall.dcinside.com", "gallery.dcinside.com"}, hostsBySource["dcinside"])
+	// 두 base_url 모두 set 에 캡쳐 — 운영 로그용
+	assert.Len(t, baseURLsBySource["dcinside"], 2)
+}
+
+// TestAnalyzeSources_CanonicalSelection_PrefersBaseURLHostMatch — canonical 선택 동작 보존.
+// base_url hostname == host_pattern 인 row 가 canonical 로 선택되어야 함 (HealthCheck 사용).
+func TestAnalyzeSources_CanonicalSelection_PrefersBaseURLHostMatch(t *testing.T) {
+	t.Parallel()
+	rules := []*storage.FetcherRuleRecord{
+		// 첫 row 는 base_url 이 다른 host 를 가리킴 (non-canonical)
+		{
+			SourceName: "slashdot", HostPattern: "news.slashdot.org",
+			SourceType: "community", Country: "US", Language: "en",
+			BaseURL: "https://slashdot.org", RequestsPerHour: 200,
+		},
+		// 둘째 row 는 base_url hostname 이 host_pattern 과 일치 — canonical
+		{
+			SourceName: "slashdot", HostPattern: "slashdot.org",
+			SourceType: "community", Country: "US", Language: "en",
+			BaseURL: "https://slashdot.org", RequestsPerHour: 200,
+		},
+	}
+	bySource, _, _, err := sources.AnalyzeSources(rules)
+	require.NoError(t, err)
+	assert.Equal(t, "slashdot.org", bySource["slashdot"].Rec.HostPattern, "canonical 선택 = base_url hostname == host_pattern")
+}
+
+// TestAnalyzeSources_RPHMismatch_Rejected — RequestsPerHour 불일치는 여전히 reject.
+// IP-bucket race 보호를 위해 유지 (이슈 #347 분석 참고).
+func TestAnalyzeSources_RPHMismatch_Rejected(t *testing.T) {
+	t.Parallel()
+	rules := []*storage.FetcherRuleRecord{
+		{
+			SourceName: "dcinside", HostPattern: "gall.dcinside.com",
+			SourceType: "community", Country: "KR", Language: "ko",
+			BaseURL: "https://gall.dcinside.com", RequestsPerHour: 100,
+		},
+		{
+			SourceName: "dcinside", HostPattern: "gallery.dcinside.com",
+			SourceType: "community", Country: "KR", Language: "ko",
+			BaseURL: "https://gallery.dcinside.com", RequestsPerHour: 200, // mismatch
+		},
+	}
+	_, _, _, err := sources.AnalyzeSources(rules)
+	require.Error(t, err, "RPH 불일치는 reject")
+	assert.Contains(t, err.Error(), "inconsistent source metadata")
+}
+
+// TestAnalyzeSources_CountryMismatch_Rejected — 의미론적 metadata 불일치는 reject.
+func TestAnalyzeSources_CountryMismatch_Rejected(t *testing.T) {
+	t.Parallel()
+	rules := []*storage.FetcherRuleRecord{
+		{SourceName: "foo", HostPattern: "a.com", SourceType: "news", Country: "KR", Language: "ko", BaseURL: "https://a.com", RequestsPerHour: 100},
+		{SourceName: "foo", HostPattern: "b.com", SourceType: "news", Country: "US", Language: "ko", BaseURL: "https://b.com", RequestsPerHour: 100},
+	}
+	_, _, _, err := sources.AnalyzeSources(rules)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "inconsistent source metadata")
+}
+
+// TestAnalyzeSources_LanguageMismatch_Rejected — Language 불일치 reject.
+func TestAnalyzeSources_LanguageMismatch_Rejected(t *testing.T) {
+	t.Parallel()
+	rules := []*storage.FetcherRuleRecord{
+		{SourceName: "foo", HostPattern: "a.com", SourceType: "news", Country: "KR", Language: "ko", BaseURL: "https://a.com", RequestsPerHour: 100},
+		{SourceName: "foo", HostPattern: "b.com", SourceType: "news", Country: "KR", Language: "en", BaseURL: "https://b.com", RequestsPerHour: 100},
+	}
+	_, _, _, err := sources.AnalyzeSources(rules)
+	require.Error(t, err)
+}
+
+// TestAnalyzeSources_SourceTypeMismatch_Rejected — SourceType 불일치 reject.
+func TestAnalyzeSources_SourceTypeMismatch_Rejected(t *testing.T) {
+	t.Parallel()
+	rules := []*storage.FetcherRuleRecord{
+		{SourceName: "foo", HostPattern: "a.com", SourceType: "news", Country: "KR", Language: "ko", BaseURL: "https://a.com", RequestsPerHour: 100},
+		{SourceName: "foo", HostPattern: "b.com", SourceType: "community", Country: "KR", Language: "ko", BaseURL: "https://b.com", RequestsPerHour: 100},
+	}
+	_, _, _, err := sources.AnalyzeSources(rules)
+	require.Error(t, err)
+}
+
+// TestAnalyzeSources_EmptySourceNameSkipped — source_name 이 빈 row 는 skip (legacy).
+func TestAnalyzeSources_EmptySourceNameSkipped(t *testing.T) {
+	t.Parallel()
+	rules := []*storage.FetcherRuleRecord{
+		{SourceName: "", HostPattern: "x.com"}, // skip
+		{SourceName: "foo", HostPattern: "y.com", SourceType: "news", Country: "KR", Language: "ko", BaseURL: "https://y.com", RequestsPerHour: 100},
+	}
+	bySource, hostsBySource, _, err := sources.AnalyzeSources(rules)
+	require.NoError(t, err)
+	assert.Len(t, bySource, 1)
+	assert.NotContains(t, hostsBySource, "")
+}
+
+// TestAnalyzeSources_BaseURLsSetCapturesAllVariants — baseURLsBySource 가 모든 variant 캡쳐.
+func TestAnalyzeSources_BaseURLsSetCapturesAllVariants(t *testing.T) {
+	t.Parallel()
+	rules := []*storage.FetcherRuleRecord{
+		{SourceName: "reddit", HostPattern: "www.reddit.com", SourceType: "community", Country: "US", Language: "en", BaseURL: "https://www.reddit.com", RequestsPerHour: 200},
+		{SourceName: "reddit", HostPattern: "old.reddit.com", SourceType: "community", Country: "US", Language: "en", BaseURL: "https://old.reddit.com", RequestsPerHour: 200},
+	}
+	_, _, baseURLsBySource, err := sources.AnalyzeSources(rules)
+	require.NoError(t, err)
+	urls := baseURLsBySource["reddit"]
+	assert.Len(t, urls, 2)
+	_, hasWww := urls["https://www.reddit.com"]
+	_, hasOld := urls["https://old.reddit.com"]
+	assert.True(t, hasWww)
+	assert.True(t, hasOld)
+}
+
+// TestAnalyzeSources_SingleHostUniformBaseURLsSet — 단일 host 경우 set size=1.
+func TestAnalyzeSources_SingleHostUniformBaseURLsSet(t *testing.T) {
+	t.Parallel()
+	rules := []*storage.FetcherRuleRecord{
+		{SourceName: "cnn", HostPattern: "edition.cnn.com", SourceType: "news", Country: "US", Language: "en", BaseURL: "https://edition.cnn.com", RequestsPerHour: 100},
+	}
+	_, _, baseURLsBySource, err := sources.AnalyzeSources(rules)
+	require.NoError(t, err)
+	assert.Len(t, baseURLsBySource["cnn"], 1)
+}


### PR DESCRIPTION
## 연관 이슈
Closes #347

## 배경 — 라이브 #11 boot fail

\`make build && ./bin/issuetracker\` 라이브 기동 시 fatal:
\`\`\`
{\"level\":\"fatal\",\"error\":\"inconsistent source metadata for source_name=\\\"dcinside\\\" (host=\\\"gall.dcinside.com\\\" vs host=\\\"gallery.dcinside.com\\\")\",...}
\`\`\`

dcinside / reddit / slashdot 의 host 별 다른 base_url (PR #334/#335 의도) 이 \`RegisterAll\` 의 strict check 에 거부됨.

## 심층 분석 결과 (issue #347 본문에 기록)

### BaseURL 의 실제 사용처
| 경로 | 사용 위치 | 영향 |
|---|---|---|
| GoQuery/Generic HealthCheck | crawler.go 3 line | HTTP GET 가용성 확인 |
| raw_contents persistence | DB 컬럼 | 메타데이터만 |
| **나머지 모든 곳** | — | **사용 안 함** |

### rate_limiter 의 RPH lookup
- \`IPRateLimiterRegistry.Wait(rawURL)\` 가 host 별 \`SourceConfigResolver.Resolve(host_pattern)\` 호출
- BaseURL 무관 — host_pattern 으로 \`fetcher_rules.requests_per_hour\` exact match
- → **rate_limiter 는 source_name 단일 BaseURL 가정과 무관**

### `bySource` collapse 의 실상
- 동일 source_name 의 모든 row 를 **하나의 canonical entry 로 축소** (\`isCanonicalHost\` 우선)
- 비-canonical row 의 BaseURL 은 **이미 폐기**되고 있었음
- → strict check 가 다른 BaseURL 을 거부한 것은 **저장도 안 되는 값에 대한 보호** — 거짓 양성

### 결론
- BaseURL 의 strict check 는 보호 가치 0, 거짓 양성만 발생
- Country / Language / SourceType / RequestsPerHour 는 보호 가치 유지 (RPH 는 같은 IP 공유 시 race 방어)

## 구현

### 1. `AnalyzeSources` 함수 분리 (testability)
\`RegisterAll\` 안에 inline 되어 있던 collapse 로직을 패키지 레벨 함수로 추출:
\`\`\`go
func AnalyzeSources(rules []*storage.FetcherRuleRecord) (
    bySource         map[string]SourceEntry,
    hostsBySource    map[string][]string,
    baseURLsBySource map[string]map[string]struct{},
    err              error,
)
\`\`\`
\`SourceEntry { Rec, HasExact }\` 도 export — 단위 테스트 친화.

### 2. strict check 에서 BaseURL 제외
\`\`\`go
if prev.Rec.Country != r.Country ||
    prev.Rec.Language != r.Language ||
    // BaseURL 제거 — HealthCheck 만 사용, 호스트별 차이 허용
    prev.Rec.SourceType != r.SourceType ||
    prev.Rec.RequestsPerHour != r.RequestsPerHour {
    return ..., fmt.Errorf(\"inconsistent source metadata ...\")
}
\`\`\`

### 3. 등록 로그 강화
같은 source_name 의 host 들이 다른 base_url 을 가지면 운영 가시성 위해 명시:
\`\`\`
crawler registered from db (multiple base_urls — canonical used for HealthCheck only)
  source=dcinside hosts=[gall.dcinside.com gallery.dcinside.com]
  base_urls=[https://gall.dcinside.com https://gallery.dcinside.com]
  canonical_base_url=https://gall.dcinside.com
\`\`\`

### 4. Migration 025 — 라이브 우회 정리
라이브 #11 의 manual SQL (운영자가 base_url 통일) 을 host-specific 값으로 정합 복원:
- dcinside / gallery.dcinside.com → \`https://gallery.dcinside.com\`
- reddit / www.reddit.com → \`https://www.reddit.com\`
- slashdot / news.slashdot.org → \`https://news.slashdot.org\`

기능 영향 0 (HealthCheck canonical 만 사용), DB 의 의도된 host-specific 값 정합 보존.

## 테스트 (9건)

\`test/internal/processor/fetcher/domain/general/sources/analyze_test.go\`:
- **MultiHostDifferentBaseURLs_Pass** — 이슈 #347 핵심 회귀 (dcinside dual-host)
- **CanonicalSelection_PrefersBaseURLHostMatch** — canonical 선택 보존
- **RPHMismatch_Rejected** — RPH 불일치는 여전히 reject (race 방어)
- **CountryMismatch / LanguageMismatch / SourceTypeMismatch_Rejected** — 의미론적 metadata 불일치 reject
- **EmptySourceNameSkipped** — legacy row skip
- **BaseURLsSetCapturesAllVariants** — 다양성 캡쳐
- **SingleHostUniformBaseURLsSet** — 단일 host set size=1

## CI / 머지 게이트 점검
- [x] \`go build ./...\` 통과
- [x] \`go test -race -count=1 ./test/...\` 전부 ok
- [x] \`go vet ./...\` 깨끗
- [x] gofmt 정리
- [x] 로컬 DB 에 migration 025 적용 검증 — 3 source 의 host-specific base_url 복원 확인

## 변경 영향 범위 + 위험도
- **영향**: BaseURL 불일치로 인한 boot fail 제거. dcinside/reddit/slashdot 의 다중 host seed 가 정상 등록됨.
- **위험도**: 낮음
  - canonical 선택 로직 + HealthCheck 동작 보존
  - rate_limiter / handler routing 영향 없음 (BaseURL 사용 안 함)
  - RPH strict check 유지 — race 방어 보존

## 롤백 계획
1. 코드 롤백: \`git revert\` — registry.go + AnalyzeSources export 되돌리기
2. Migration 025 down: 라이브 #11 의 manual 우회 상태로 환원
3. 부분 롤백: registry.go 에 BaseURL strict check 만 복원 가능 (다른 변경은 무관)

🤖 Generated with [Claude Code](https://claude.com/claude-code)