### PR TITLE
[FIX#321] validate worker — ErrNotFound 강등으로 STORAGE_001 false-positive 차단

### DIFF
--- a/internal/processor/validate/worker.go
+++ b/internal/processor/validate/worker.go
@@ -225,7 +225,7 @@ func (w *Worker) process(ctx context.Context, msg *queue.Message) error {
 			log.WithFields(map[string]interface{}{
 				"job_id": pm.ID,
 				"ref_id": ref.ID,
-			}).Info("content already processed (duplicate delivery), skipping silently")
+			}).Info("content already processed (duplicate delivery), skipping")
 			return w.commit(ctx, msg)
 		}
 		log.WithFields(map[string]interface{}{

--- a/internal/processor/validate/worker.go
+++ b/internal/processor/validate/worker.go
@@ -216,6 +216,18 @@ func (w *Worker) process(ctx context.Context, msg *queue.Message) error {
 	// DB에서 Content 조회 (content_bodies, content_meta 포함)
 	content, err := w.contentSvc.GetByID(ctx, ref.ID)
 	if err != nil {
+		// ErrNotFound = 이미 처리되어 row 삭제된 상태 (이슈 #321).
+		// Kafka at-least-once + 상위 producer retry / validate 자체 requeue loop 로 같은 ref.ID 가
+		// 여러 번 deliver 될 수 있음. 첫 처리에서 validation fail (max retries) → contents.Delete →
+		// commit. 그 후 도착한 duplicate 들은 row 없음 → 본 분기. **idempotent 정상 분기** —
+		// DLQ 보낼 사안 아님 + ERROR 알람 false-positive 회피. info 레벨로 가시성 유지.
+		if errors.Is(err, storage.ErrNotFound) {
+			log.WithFields(map[string]interface{}{
+				"job_id": pm.ID,
+				"ref_id": ref.ID,
+			}).Info("content already processed (duplicate delivery), skipping silently")
+			return w.commit(ctx, msg)
+		}
 		log.WithFields(map[string]interface{}{
 			"job_id": pm.ID,
 			"ref_id": ref.ID,

--- a/test/internal/processor/validate/worker_test.go
+++ b/test/internal/processor/validate/worker_test.go
@@ -796,8 +796,8 @@ func TestValidateWorker_NotFound_CommitsWithoutDLQ(t *testing.T) {
 	// 운영의 contentService.GetByID 는 storage.ErrNotFound 를 core.NewStorageError 로 wrap 함
 	// (gemini Medium 반영) — 테스트도 동일하게 wrap 하여 errors.Is 가 chain 을 정확히 관통하는지 검증.
 	wrappedNotFound := core.NewStorageError(core.CodeStorageRead, "get content by id", true, storage.ErrNotFound)
-	contentSvc.On("GetByID", mock.Anything, content.ID).Return((*core.Content)(nil), wrappedNotFound)
-	consumer.On("CommitMessages", mock.Anything, mock.Anything).Return(nil)
+	contentSvc.On("GetByID", mock.Anything, content.ID).Return((*core.Content)(nil), wrappedNotFound).Once()
+	consumer.On("CommitMessages", mock.Anything, mock.Anything).Return(nil).Once()
 
 	runWorker(t, consumer, w, msg)
 
@@ -809,8 +809,11 @@ func TestValidateWorker_NotFound_CommitsWithoutDLQ(t *testing.T) {
 		return m.Topic == queue.TopicValidated
 	}))
 	contentSvc.AssertNotCalled(t, "Delete", mock.Anything, mock.Anything)
-	// commit 은 정확히 1회 호출됨 (consumer mock 의 Setup 검증).
-	consumer.AssertCalled(t, "CommitMessages", mock.Anything, mock.Anything)
+	// GetByID / CommitMessages 정확히 1회 호출 (Copilot 반영) — ErrNotFound 분기 진입 + commit 수행 보증.
+	contentSvc.AssertNumberOfCalls(t, "GetByID", 1)
+	consumer.AssertNumberOfCalls(t, "CommitMessages", 1)
+	contentSvc.AssertExpectations(t)
+	consumer.AssertExpectations(t)
 }
 
 // TestValidateWorker_OtherFetchError_SendsToDLQ — 이슈 #321 회귀 방지.
@@ -827,11 +830,11 @@ func TestValidateWorker_OtherFetchError_SendsToDLQ(t *testing.T) {
 
 	// 의도적으로 ErrNotFound 가 아닌 다른 에러.
 	fetchErr := errors.New("simulated db connection error")
-	contentSvc.On("GetByID", mock.Anything, content.ID).Return((*core.Content)(nil), fetchErr)
+	contentSvc.On("GetByID", mock.Anything, content.ID).Return((*core.Content)(nil), fetchErr).Once()
 	producer.On("Publish", mock.Anything, mock.MatchedBy(func(m queue.Message) bool {
 		return m.Topic == queue.TopicDLQ
-	})).Return(nil)
-	consumer.On("CommitMessages", mock.Anything, mock.Anything).Return(nil)
+	})).Return(nil).Once()
+	consumer.On("CommitMessages", mock.Anything, mock.Anything).Return(nil).Once()
 
 	runWorker(t, consumer, w, msg)
 
@@ -840,4 +843,10 @@ func TestValidateWorker_OtherFetchError_SendsToDLQ(t *testing.T) {
 		return m.Topic == queue.TopicDLQ
 	}))
 	contentSvc.AssertNotCalled(t, "Delete", mock.Anything, mock.Anything)
+	// GetByID / DLQ Publish / CommitMessages 각 1회 호출 보증 (Copilot 반영).
+	contentSvc.AssertNumberOfCalls(t, "GetByID", 1)
+	consumer.AssertNumberOfCalls(t, "CommitMessages", 1)
+	contentSvc.AssertExpectations(t)
+	producer.AssertExpectations(t)
+	consumer.AssertExpectations(t)
 }

--- a/test/internal/processor/validate/worker_test.go
+++ b/test/internal/processor/validate/worker_test.go
@@ -778,3 +778,63 @@ func TestValidateWorker_RecordRejectedFailure_DoesNotBlockMainFlow(t *testing.T)
 		return m.Topic == queue.TopicDLQ
 	}))
 }
+
+// TestValidateWorker_NotFound_CommitsWithoutDLQ — 이슈 #321.
+// GetByID 가 ErrNotFound 반환 시 (이미 처리되어 row 삭제됨) DLQ 발송하지 않고 commit 만 수행해야 함.
+// duplicate Kafka delivery (at-least-once) 의 idempotent 정상 분기.
+func TestValidateWorker_NotFound_CommitsWithoutDLQ(t *testing.T) {
+	consumer := new(mockConsumer)
+	producer := new(mockProducer)
+	contentSvc := newMockContentService()
+
+	w := newWorker(consumer, producer, contentSvc)
+
+	content := newNewsContent()
+	msg := makeProcessingMessage(content, 0)
+
+	// GetByID 가 ErrNotFound — 이미 다른 worker (또는 이전 retry) 가 처리하여 row 삭제됨.
+	contentSvc.On("GetByID", mock.Anything, content.ID).Return((*core.Content)(nil), storage.ErrNotFound)
+	consumer.On("CommitMessages", mock.Anything, mock.Anything).Return(nil)
+
+	runWorker(t, consumer, w, msg)
+
+	// DLQ 발송 / Delete / Validated publish 모두 호출되지 않아야 함.
+	producer.AssertNotCalled(t, "Publish", mock.Anything, mock.MatchedBy(func(m queue.Message) bool {
+		return m.Topic == queue.TopicDLQ
+	}))
+	producer.AssertNotCalled(t, "Publish", mock.Anything, mock.MatchedBy(func(m queue.Message) bool {
+		return m.Topic == queue.TopicValidated
+	}))
+	contentSvc.AssertNotCalled(t, "Delete", mock.Anything, mock.Anything)
+	// commit 은 정확히 1회 호출됨 (consumer mock 의 Setup 검증).
+	consumer.AssertCalled(t, "CommitMessages", mock.Anything, mock.Anything)
+}
+
+// TestValidateWorker_OtherFetchError_SendsToDLQ — 이슈 #321 회귀 방지.
+// ErrNotFound 가 아닌 다른 fetch 에러 (DB connection 등) 는 여전히 DLQ 로 보내야 함 — 기존 동작 보존.
+func TestValidateWorker_OtherFetchError_SendsToDLQ(t *testing.T) {
+	consumer := new(mockConsumer)
+	producer := new(mockProducer)
+	contentSvc := newMockContentService()
+
+	w := newWorker(consumer, producer, contentSvc)
+
+	content := newNewsContent()
+	msg := makeProcessingMessage(content, 0)
+
+	// 의도적으로 ErrNotFound 가 아닌 다른 에러.
+	fetchErr := errors.New("simulated db connection error")
+	contentSvc.On("GetByID", mock.Anything, content.ID).Return((*core.Content)(nil), fetchErr)
+	producer.On("Publish", mock.Anything, mock.MatchedBy(func(m queue.Message) bool {
+		return m.Topic == queue.TopicDLQ
+	})).Return(nil)
+	consumer.On("CommitMessages", mock.Anything, mock.Anything).Return(nil)
+
+	runWorker(t, consumer, w, msg)
+
+	// DLQ 발송됨 — 기존 동작 보존.
+	producer.AssertCalled(t, "Publish", mock.Anything, mock.MatchedBy(func(m queue.Message) bool {
+		return m.Topic == queue.TopicDLQ
+	}))
+	contentSvc.AssertNotCalled(t, "Delete", mock.Anything, mock.Anything)
+}

--- a/test/internal/processor/validate/worker_test.go
+++ b/test/internal/processor/validate/worker_test.go
@@ -793,7 +793,10 @@ func TestValidateWorker_NotFound_CommitsWithoutDLQ(t *testing.T) {
 	msg := makeProcessingMessage(content, 0)
 
 	// GetByID 가 ErrNotFound — 이미 다른 worker (또는 이전 retry) 가 처리하여 row 삭제됨.
-	contentSvc.On("GetByID", mock.Anything, content.ID).Return((*core.Content)(nil), storage.ErrNotFound)
+	// 운영의 contentService.GetByID 는 storage.ErrNotFound 를 core.NewStorageError 로 wrap 함
+	// (gemini Medium 반영) — 테스트도 동일하게 wrap 하여 errors.Is 가 chain 을 정확히 관통하는지 검증.
+	wrappedNotFound := core.NewStorageError(core.CodeStorageRead, "get content by id", true, storage.ErrNotFound)
+	contentSvc.On("GetByID", mock.Anything, content.ID).Return((*core.Content)(nil), wrappedNotFound)
 	consumer.On("CommitMessages", mock.Anything, mock.Anything).Return(nil)
 
 	runWorker(t, consumer, w, msg)


### PR DESCRIPTION
## 연관 이슈
Closes #321

## 배경 — 라이브 빈도 확대

| 시점 | 발생 빈도 |
|---|---|
| 2026-05-08 (이슈 작성) | 7시간 / 3건 |
| **2026-05-11 20:41 (3분 라이브)** | **8초 / 4건 (같은 ref_id)** |

같은 \`ref_id=630b6575b694262f4ea6d5eef6fca2af\` 가 20:41:03 (2회) + 20:41:11 (2회) 4번 ERROR + DLQ.

## 원인

**[worker.go:217](internal/processor/validate/worker.go#L217)**:
\`\`\`go
content, err := w.contentSvc.GetByID(ctx, ref.ID)
if err != nil {
    log.WithError(err).Error(\"failed to fetch content from db, sending to dlq\")
    w.sendToDLQ(ctx, msg, err)
    return w.commit(ctx, msg)
}
\`\`\`

- ErrNotFound 도 다른 모든 에러와 동일하게 ERROR + DLQ 처리
- 실제로는 **idempotent 정상 분기** — 첫 처리에서 fail (max retries) → contents.Delete → commit.
  그 후 도착한 duplicate Kafka delivery 가 row 부재 만나면 발생
- 시스템 동작은 정상, 단 production alert false-positive + 무의미한 DLQ record 누적

**Duplicate delivery 의 source** (별도 후속 조사 필요):
- Kafka at-least-once + producer transparent retry
- validate worker 자체의 [requeue loop](internal/processor/validate/worker.go#L268)
- publish-then-commit 의 부분 실패

ProcessingLock 은 **URL 기반 유지** (운영자 결정) — 동일 URL 의 동시 처리 차단 목적. ref.ID 기반으로 좁히면 동일 URL 의 row 가 동시 존재할 경우의 race 가 미보호됨.

## 구현

\`\`\`go
content, err := w.contentSvc.GetByID(ctx, ref.ID)
if err != nil {
    if errors.Is(err, storage.ErrNotFound) {
        log.WithFields(...).Info(\"content already processed (duplicate delivery), skipping silently\")
        return w.commit(ctx, msg)  // DLQ X
    }
    log.WithError(err).Error(\"failed to fetch content from db, sending to dlq\")
    w.sendToDLQ(ctx, msg, err)
    return w.commit(ctx, msg)
}
\`\`\`

- **ErrNotFound** → Info 레벨 로그 + commit, **DLQ X / Delete X / Validated publish X**
- **다른 모든 fetch 에러** (DB connection / timeout 등) → 기존 동작 (ERROR + DLQ)

## 테스트 (2건 추가)

- **NotFound_CommitsWithoutDLQ** — ErrNotFound 시 DLQ X / Delete X / Validated publish X, commit O
- **OtherFetchError_SendsToDLQ** — 다른 fetch 에러는 여전히 DLQ (회귀 방지)

## CI / 머지 게이트 점검
- [x] \`go build ./...\` 통과
- [x] \`go test -race -count=1 ./test/...\` 전부 ok (validate worker 11건 + 신규 2건 모두 통과)
- [x] \`go vet ./...\` 깨끗

## 변경 영향 범위 + 위험도
- **영향**: STORAGE_001 ERROR 의 가장 흔한 케이스 (idempotent re-delivery) 가 Info 로 강등 — production alert 노이즈 제거 + DLQ retention 절약
- **위험도**: 낮음
  - 진짜 에러 (DB down 등) 는 여전히 ERROR + DLQ
  - skip 분기는 commit 만 수행 — 데이터 손실 없음 (row 자체가 부재)
  - 다른 worker 동작 / API 변경 없음

## 후속 작업 (별도 이슈)
- duplicate delivery 의 정확한 source 추적: requeue 빈도 / Kafka producer retry 발생률 metric
- 동일 ref_id 반복 발행 횟수 측정 가능한 dashboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of duplicate message deliveries in the validation processor to prevent them from being incorrectly flagged as failures.

* **Tests**
  * Added test coverage for edge cases in message delivery and error handling paths.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/EinSofINTEREST/IssueTracker/pull/351)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->