### PR TITLE
[FEAT#354] StageGate + Semaphore — stage 별 동시성 cap + ProcessingLock 합성 (#353 Sub A)

### DIFF
--- a/internal/locks/semaphore.go
+++ b/internal/locks/semaphore.go
@@ -1,0 +1,84 @@
+package locks
+
+import (
+	"context"
+	"errors"
+	"sync/atomic"
+
+	xsem "golang.org/x/sync/semaphore"
+)
+
+// Semaphore 는 동시 실행 슬롯 수 (capacity) 를 cap 하는 간단한 동시성 제어 primitive 입니다.
+//
+// ProcessingLock 이 \"같은 URL 의 중복 처리 차단\" 을 담당한다면, Semaphore 는 \"stage 의 동시 처리
+// 슬롯이 가용한가\" 를 담당. StageGate 가 두 컴포넌트를 합성하여 worker 입장에서 단일 API 로 노출.
+//
+// 모든 구현체는 goroutine-safe 해야 합니다.
+type Semaphore interface {
+	// Acquire 는 slot 을 1개 점유합니다. capacity 가 가득 차 있으면 다른 slot 이 release 될 때까지
+	// block. ctx cancel/deadline 시 즉시 ctx.Err() 반환.
+	Acquire(ctx context.Context) error
+
+	// Release 는 slot 1개를 반납합니다. Acquire 없이 Release 호출은 panic 위험 — 호출자가
+	// defer 로 1:1 보장해야 함.
+	Release()
+
+	// Capacity 는 총 slot 수 (생성 시 설정값) 를 반환합니다 — 운영 진단 / 로깅용.
+	Capacity() int
+
+	// InFlight 는 현재 Acquire 되어 있는 slot 수를 반환합니다 — 운영 진단 / 로깅용.
+	// goroutine-safe 한 snapshot — 호출 직후의 값일 수 있음.
+	InFlight() int
+}
+
+// weightedSemaphore 는 golang.org/x/sync/semaphore.Weighted 기반 구현체입니다.
+//
+// weight=1 단순 사용으로 capacity = 동시 슬롯 수. ctx 친화적 Acquire + Release 시맨틱은
+// x/sync/semaphore 그대로.
+type weightedSemaphore struct {
+	sem      *xsem.Weighted
+	capacity int
+	inFlight atomic.Int64
+}
+
+// NewSemaphore 는 capacity slot 의 Semaphore 를 생성합니다.
+//
+// capacity < 1 이면 panic — wiring 실수 즉시 발견. 호출자가 0/음수 입력을 사전에 sanitize.
+func NewSemaphore(capacity int) Semaphore {
+	if capacity < 1 {
+		panic("locks: NewSemaphore requires capacity >= 1")
+	}
+	return &weightedSemaphore{
+		sem:      xsem.NewWeighted(int64(capacity)),
+		capacity: capacity,
+	}
+}
+
+func (w *weightedSemaphore) Acquire(ctx context.Context) error {
+	if err := w.sem.Acquire(ctx, 1); err != nil {
+		return err
+	}
+	w.inFlight.Add(1)
+	return nil
+}
+
+func (w *weightedSemaphore) Release() {
+	if w.inFlight.Load() <= 0 {
+		// double-release 또는 acquire 없이 release — 호출 패턴 버그. defensive: 카운터만 비정상 방지.
+		// x/sync/semaphore 자체는 panic 발생 가능 — 호출자가 1:1 보장해야 함.
+		return
+	}
+	w.inFlight.Add(-1)
+	w.sem.Release(1)
+}
+
+func (w *weightedSemaphore) Capacity() int { return w.capacity }
+
+func (w *weightedSemaphore) InFlight() int { return int(w.inFlight.Load()) }
+
+// ErrSemaphoreNil 은 nil Semaphore 가 의도치 않은 곳에서 사용될 때 호출자가 errors.Is 로 식별
+// 가능하도록 노출 — wiring 단계에서 NewSemaphore 가 호출되지 않은 케이스 진단용.
+var ErrSemaphoreNil = errors.New("locks: nil semaphore")
+
+// 컴파일 타임 contract 보증.
+var _ Semaphore = (*weightedSemaphore)(nil)

--- a/internal/locks/semaphore.go
+++ b/internal/locks/semaphore.go
@@ -63,13 +63,22 @@ func (w *weightedSemaphore) Acquire(ctx context.Context) error {
 }
 
 func (w *weightedSemaphore) Release() {
-	if w.inFlight.Load() <= 0 {
-		// double-release 또는 acquire 없이 release — 호출 패턴 버그. defensive: 카운터만 비정상 방지.
-		// x/sync/semaphore 자체는 panic 발생 가능 — 호출자가 1:1 보장해야 함.
-		return
+	// CompareAndSwap loop — Load + Add 분리 시 race (gemini 반영): 두 goroutine 이 동시에
+	// Load=1 후 둘 다 Add(-1) → inFlight=-1 + sem.Release(1) 2회 호출 → x/sync/semaphore panic.
+	// CAS 로 atomic 감소 + 음수 가드 동시 보장.
+	for {
+		current := w.inFlight.Load()
+		if current <= 0 {
+			// double-release 또는 acquire 없이 release — 호출 패턴 버그. defensive: 카운터만 비정상 방지.
+			// x/sync/semaphore 자체는 panic 발생 가능하므로 본 가드로 차단.
+			return
+		}
+		if w.inFlight.CompareAndSwap(current, current-1) {
+			w.sem.Release(1)
+			return
+		}
+		// CAS 실패 — 다른 goroutine 이 변경. 다시 시도.
 	}
-	w.inFlight.Add(-1)
-	w.sem.Release(1)
 }
 
 func (w *weightedSemaphore) Capacity() int { return w.capacity }

--- a/internal/locks/stage_gate.go
+++ b/internal/locks/stage_gate.go
@@ -3,9 +3,18 @@ package locks
 import (
 	"context"
 	"errors"
+	"reflect"
+	"sync/atomic"
+	"time"
 
 	"issuetracker/pkg/logger"
 )
+
+// stageGateLockReleaseTimeout 은 release 시 lock.Release 호출에 적용되는 best-effort timeout 입니다.
+//
+// Redis / network 지연 시 worker 의 semaphore slot 이 장기 점유되는 것을 방지 (Copilot 반영).
+// 5s 면 일반적 Redis lock release 보다 훨씬 여유 — 진짜 stall 만 cap.
+const stageGateLockReleaseTimeout = 5 * time.Second
 
 // StageGate 는 stage 별 worker pool 진입 시 다음을 합성하여 단일 API 로 노출합니다 (이슈 #353/#354):
 //
@@ -50,16 +59,32 @@ func NewStageGate(stage string, sem Semaphore, lock ProcessingLock, log *logger.
 	if stage == "" {
 		panic("locks: NewStageGate requires non-empty stage")
 	}
-	if sem == nil {
+	if isNilInterface(sem) {
 		panic("locks: NewStageGate requires non-nil semaphore")
 	}
-	if lock == nil {
+	if isNilInterface(lock) {
 		panic("locks: NewStageGate requires non-nil lock")
 	}
 	if log == nil {
 		panic("locks: NewStageGate requires non-nil logger")
 	}
 	return &stageGate{stage: stage, sem: sem, lock: lock, log: log}
+}
+
+// isNilInterface 는 nil interface (untyped) 와 typed-nil (예: var p *T; var i I = p) 양쪽을 감지합니다.
+//
+// Copilot 반영 — 단순 \`v == nil\` 검사는 typed-nil 을 못 잡아 Acquire 호출 시 nil pointer
+// deref 로 늦은 panic 발생. constructor 에서 reflect 로 한 번만 검사 (hot path 아님).
+func isNilInterface(v interface{}) bool {
+	if v == nil {
+		return true
+	}
+	rv := reflect.ValueOf(v)
+	switch rv.Kind() {
+	case reflect.Ptr, reflect.Interface, reflect.Chan, reflect.Func, reflect.Map, reflect.Slice:
+		return rv.IsNil()
+	}
+	return false
 }
 
 func (g *stageGate) Acquire(ctx context.Context, url string) (func(), bool, error) {
@@ -80,17 +105,18 @@ func (g *stageGate) Acquire(ctx context.Context, url string) (func(), bool, erro
 		return nil, false, nil
 	}
 
-	// 3. 성공 — release 함수 반환 (idempotent).
-	released := false
+	// 3. 성공 — release 함수 반환 (idempotent + goroutine-safe).
+	var released atomic.Bool
 	release := func() {
-		if released {
-			return
+		if !released.CompareAndSwap(false, true) {
+			return // 이미 release 호출됨 — 중복 lock/sem Release 회피 (gemini High / Copilot 반영).
 		}
-		released = true
-		// lock.Release 가 ctx cancel 등으로 실패해도 semaphore 는 반드시 반납.
-		// release 자체는 호출자가 ctx.Err 무시하고 defer 로 호출하는 것을 전제 —
-		// graceful shutdown 시 별도 drain ctx 사용 가능하도록 ctx 분리.
-		drainCtx, cancel := context.WithCancel(context.Background())
+		// 순서: semaphore 먼저 반납 (다른 worker 진입 가능하게) → lock Release 는 best-effort timeout (Copilot 반영).
+		// 이전: lock.Release 가 Redis 지연 시 semaphore slot 장기 점유 → worker 정체.
+		g.sem.Release()
+
+		// drainCtx — parent ctx 의 trace ID / logger fields 보존 + 부모 cancel 영향 없이 timeout cap (gemini 반영).
+		drainCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), stageGateLockReleaseTimeout)
 		defer cancel()
 		if err := g.lock.Release(drainCtx, key); err != nil {
 			g.log.WithFields(map[string]interface{}{
@@ -98,7 +124,6 @@ func (g *stageGate) Acquire(ctx context.Context, url string) (func(), bool, erro
 				"url":   url,
 			}).WithError(err).Warn("stage gate lock release failed")
 		}
-		g.sem.Release()
 	}
 	return release, true, nil
 }

--- a/internal/locks/stage_gate.go
+++ b/internal/locks/stage_gate.go
@@ -1,0 +1,127 @@
+package locks
+
+import (
+	"context"
+	"errors"
+
+	"issuetracker/pkg/logger"
+)
+
+// StageGate 는 stage 별 worker pool 진입 시 다음을 합성하여 단일 API 로 노출합니다 (이슈 #353/#354):
+//
+//  1. Semaphore — \"stage 의 동시 처리 슬롯이 가용한가\"
+//  2. ProcessingLock(stage, url) — \"이 URL 이 현재 stage 에서 처리 중인가\"
+//
+// 두 컴포넌트는 단일 책임 (Single Responsibility) 으로 분리되어 있으며 StageGate 는 composition
+// 으로 합성. worker 가 \`gate.Acquire(ctx, url)\` 한 번 호출로 stage 진입 검증 + slot 점유 +
+// URL lock 획득을 모두 수행하고, 반환된 release 함수로 한 번에 정리.
+//
+// 동작:
+//   - Semaphore.Acquire(ctx) — capacity 가 차 있으면 block, ctx cancel 시 즉시 반환
+//   - ProcessingLock.Acquire — 이미 처리 중이면 (release=nil, acquired=false, err=nil) → 호출자 skip
+//   - Lock 에러 시 — Semaphore.Release 후 (nil, false, err)
+//   - 성공 시 — (release, true, nil) 반환, release 호출 시 Lock.Release + Semaphore.Release 양쪽 정리
+//
+// 모든 구현체는 goroutine-safe 해야 합니다.
+type StageGate interface {
+	// Acquire 는 stage 진입 권한을 획득합니다.
+	//
+	// release: 정리 함수 — 호출자가 defer 로 호출해야 함. acquired=false 또는 err 발생 시 nil.
+	//          idempotent — 두 번 호출되어도 panic 없이 안전.
+	// acquired: true 면 진입 성공, false 면 lock 이 다른 worker 에 잡혀 있음 (skip 권장).
+	// err: ctx cancel / 인프라 에러 등. graceful degrade 시 호출자 정책.
+	Acquire(ctx context.Context, url string) (release func(), acquired bool, err error)
+}
+
+// stageGate 는 StageGate 의 기본 구현체입니다.
+type stageGate struct {
+	stage string
+	sem   Semaphore
+	lock  ProcessingLock
+	log   *logger.Logger
+}
+
+// NewStageGate 는 (stage, semaphore, lock) 합성 StageGate 를 생성합니다.
+//
+// stage / semaphore / lock 모두 비-nil 필수. log 는 nil 이면 panic — wiring 실수 즉시 발견.
+//
+// stage 표준 값: StageFetcher / StageParser / StageValidator (processing_lock.go 의 상수).
+func NewStageGate(stage string, sem Semaphore, lock ProcessingLock, log *logger.Logger) StageGate {
+	if stage == "" {
+		panic("locks: NewStageGate requires non-empty stage")
+	}
+	if sem == nil {
+		panic("locks: NewStageGate requires non-nil semaphore")
+	}
+	if lock == nil {
+		panic("locks: NewStageGate requires non-nil lock")
+	}
+	if log == nil {
+		panic("locks: NewStageGate requires non-nil logger")
+	}
+	return &stageGate{stage: stage, sem: sem, lock: lock, log: log}
+}
+
+func (g *stageGate) Acquire(ctx context.Context, url string) (func(), bool, error) {
+	// 1. Semaphore Acquire — capacity 한계 시 block, ctx 친화.
+	if err := g.sem.Acquire(ctx); err != nil {
+		return nil, false, err
+	}
+
+	// 2. ProcessingLock Acquire — 이미 처리 중이면 semaphore release 후 (nil, false, nil) 반환.
+	key := ProcessingKey(g.stage, url)
+	acquired, lockErr := g.lock.Acquire(ctx, key)
+	if lockErr != nil {
+		g.sem.Release()
+		return nil, false, lockErr
+	}
+	if !acquired {
+		g.sem.Release()
+		return nil, false, nil
+	}
+
+	// 3. 성공 — release 함수 반환 (idempotent).
+	released := false
+	release := func() {
+		if released {
+			return
+		}
+		released = true
+		// lock.Release 가 ctx cancel 등으로 실패해도 semaphore 는 반드시 반납.
+		// release 자체는 호출자가 ctx.Err 무시하고 defer 로 호출하는 것을 전제 —
+		// graceful shutdown 시 별도 drain ctx 사용 가능하도록 ctx 분리.
+		drainCtx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		if err := g.lock.Release(drainCtx, key); err != nil {
+			g.log.WithFields(map[string]interface{}{
+				"stage": g.stage,
+				"url":   url,
+			}).WithError(err).Warn("stage gate lock release failed")
+		}
+		g.sem.Release()
+	}
+	return release, true, nil
+}
+
+// NoopStageGate 는 lock / semaphore 모두 비활성화된 no-op 구현체입니다.
+//
+// wiring 단계에서 Redis 미연결 / 운영자 명시적 비활성화 시 fallback. Acquire 는 항상
+// (noopRelease, true, nil) — 모든 호출이 자유롭게 통과.
+type NoopStageGate struct{}
+
+// NewNoopStageGate 는 NoopStageGate 인스턴스를 반환합니다.
+func NewNoopStageGate() StageGate { return NoopStageGate{} }
+
+// Acquire 는 항상 (noopRelease, true, nil) 반환.
+func (NoopStageGate) Acquire(_ context.Context, _ string) (func(), bool, error) {
+	return func() {}, true, nil
+}
+
+// ErrStageGateNil 은 nil StageGate 가 의도치 않게 사용될 때 식별용.
+var ErrStageGateNil = errors.New("locks: nil stage gate")
+
+// 컴파일 타임 contract 보증.
+var (
+	_ StageGate = (*stageGate)(nil)
+	_ StageGate = NoopStageGate{}
+)

--- a/test/internal/locks/stage_gate_test.go
+++ b/test/internal/locks/stage_gate_test.go
@@ -267,6 +267,58 @@ func TestStageGate_ConcurrentAcquireRespectsCapacity(t *testing.T) {
 	assert.Equal(t, 0, sem.InFlight(), "모든 release 후 0")
 }
 
+// TestStageGate_ReleaseConcurrent — release 함수가 여러 goroutine 에서 동시 호출되어도 정확히 1회만
+// 실효 (gemini High / Copilot 반영). atomic.Bool CAS 가 lock/sem 중복 Release 차단.
+func TestStageGate_ReleaseConcurrent(t *testing.T) {
+	t.Parallel()
+	sem := locks.NewSemaphore(2)
+	lk := newStubLock(true)
+	gate := locks.NewStageGate(locks.StageFetcher, sem, lk, newTestLog(t))
+
+	release, acquired, err := gate.Acquire(context.Background(), "https://example.com/a")
+	require.NoError(t, err)
+	require.True(t, acquired)
+
+	var wg sync.WaitGroup
+	for i := 0; i < 50; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			release()
+		}()
+	}
+	wg.Wait()
+
+	_, rel := lk.callCounts()
+	assert.Equal(t, 1, rel, "concurrent release 50회 호출해도 lock.Release 정확히 1회")
+	assert.Equal(t, 0, sem.InFlight(), "semaphore 도 정확히 1회 반납")
+}
+
+// TestSemaphore_ReleaseConcurrent — Release 의 atomic CAS 가 동시 호출에서도 음수로 못 내려가는지 확인.
+// 호출 패턴 버그 (over-release) 가 panic 으로 전파되지 않고 noop 으로 흡수.
+func TestSemaphore_ReleaseConcurrent(t *testing.T) {
+	t.Parallel()
+	sem := locks.NewSemaphore(5)
+	for i := 0; i < 3; i++ {
+		require.NoError(t, sem.Acquire(context.Background()))
+	}
+	assert.Equal(t, 3, sem.InFlight())
+
+	// 5개의 release 를 동시 시도 — 3개만 실효 + 2개는 noop guard.
+	var wg sync.WaitGroup
+	for i := 0; i < 5; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			sem.Release()
+		}()
+	}
+	wg.Wait()
+
+	// in-flight 0 이하로 내려가지 않고 정확히 0.
+	assert.Equal(t, 0, sem.InFlight(), "over-release 가 noop 흡수, 음수 미발생")
+}
+
 func TestNoopStageGate_AlwaysAcquired(t *testing.T) {
 	t.Parallel()
 	gate := locks.NewNoopStageGate()
@@ -288,4 +340,9 @@ func TestNewStageGate_PanicsOnInvalidArgs(t *testing.T) {
 	assert.Panics(t, func() { locks.NewStageGate(locks.StageFetcher, nil, lk, log) })
 	assert.Panics(t, func() { locks.NewStageGate(locks.StageFetcher, sem, nil, log) })
 	assert.Panics(t, func() { locks.NewStageGate(locks.StageFetcher, sem, lk, nil) })
+
+	// typed-nil 검출 (Copilot 반영) — 단순 == nil 검사가 못 잡는 케이스.
+	var typedNilLock *locks.RedisProcessingLock // typed nil
+	assert.Panics(t, func() { locks.NewStageGate(locks.StageFetcher, sem, typedNilLock, log) },
+		"typed-nil ProcessingLock 도 constructor 에서 panic 으로 감지")
 }

--- a/test/internal/locks/stage_gate_test.go
+++ b/test/internal/locks/stage_gate_test.go
@@ -1,0 +1,291 @@
+package locks_test
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"issuetracker/internal/locks"
+	"issuetracker/pkg/logger"
+)
+
+// stubLock 는 ProcessingLock 의 in-memory 테스트 더블입니다 — 호출자가 Acquire 결과 / Release 동작을
+// 미리 설정할 수 있고, 호출 횟수를 추적합니다.
+type stubLock struct {
+	mu            sync.Mutex
+	acquireResult bool
+	acquireErr    error
+	releaseErr    error
+	acquireCalls  int
+	releaseCalls  int
+	heldKeys      map[string]struct{}
+}
+
+func newStubLock(acquireResult bool) *stubLock {
+	return &stubLock{
+		acquireResult: acquireResult,
+		heldKeys:      map[string]struct{}{},
+	}
+}
+
+func (s *stubLock) Acquire(_ context.Context, key string) (bool, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.acquireCalls++
+	if s.acquireErr != nil {
+		return false, s.acquireErr
+	}
+	if s.acquireResult {
+		s.heldKeys[key] = struct{}{}
+	}
+	return s.acquireResult, nil
+}
+
+func (s *stubLock) Release(_ context.Context, key string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.releaseCalls++
+	delete(s.heldKeys, key)
+	return s.releaseErr
+}
+
+func (s *stubLock) callCounts() (acquire, release int) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.acquireCalls, s.releaseCalls
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Semaphore 단위 테스트
+// ─────────────────────────────────────────────────────────────────────────────
+
+func TestSemaphore_AcquireRelease(t *testing.T) {
+	t.Parallel()
+	sem := locks.NewSemaphore(2)
+	assert.Equal(t, 2, sem.Capacity())
+	assert.Equal(t, 0, sem.InFlight())
+
+	require.NoError(t, sem.Acquire(context.Background()))
+	assert.Equal(t, 1, sem.InFlight())
+
+	require.NoError(t, sem.Acquire(context.Background()))
+	assert.Equal(t, 2, sem.InFlight())
+
+	sem.Release()
+	assert.Equal(t, 1, sem.InFlight())
+
+	sem.Release()
+	assert.Equal(t, 0, sem.InFlight())
+}
+
+func TestSemaphore_CapacityFullBlocksUntilRelease(t *testing.T) {
+	t.Parallel()
+	sem := locks.NewSemaphore(1)
+	require.NoError(t, sem.Acquire(context.Background()))
+
+	// 두 번째 Acquire 는 첫 release 까지 block. 별도 goroutine 에서 시도.
+	done := make(chan struct{})
+	go func() {
+		_ = sem.Acquire(context.Background())
+		close(done)
+	}()
+
+	// short wait — block 상태인지 확인.
+	select {
+	case <-done:
+		t.Fatal("second Acquire returned without first Release")
+	case <-time.After(20 * time.Millisecond):
+	}
+
+	sem.Release()
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("second Acquire did not unblock after Release")
+	}
+	sem.Release()
+}
+
+func TestSemaphore_ContextCancelInterruptsAcquire(t *testing.T) {
+	t.Parallel()
+	sem := locks.NewSemaphore(1)
+	require.NoError(t, sem.Acquire(context.Background()))
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Millisecond)
+	defer cancel()
+
+	err := sem.Acquire(ctx)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, context.DeadlineExceeded)
+	sem.Release()
+}
+
+func TestSemaphore_PanicsOnZeroCapacity(t *testing.T) {
+	t.Parallel()
+	assert.Panics(t, func() { locks.NewSemaphore(0) })
+	assert.Panics(t, func() { locks.NewSemaphore(-1) })
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// StageGate 단위 테스트
+// ─────────────────────────────────────────────────────────────────────────────
+
+func newTestLog(t *testing.T) *logger.Logger {
+	t.Helper()
+	return logger.New(logger.Config{Level: "error"})
+}
+
+func TestStageGate_Acquire_Success(t *testing.T) {
+	t.Parallel()
+	sem := locks.NewSemaphore(2)
+	lk := newStubLock(true)
+	gate := locks.NewStageGate(locks.StageFetcher, sem, lk, newTestLog(t))
+
+	release, acquired, err := gate.Acquire(context.Background(), "https://example.com/a")
+	require.NoError(t, err)
+	require.True(t, acquired)
+	require.NotNil(t, release)
+	assert.Equal(t, 1, sem.InFlight())
+
+	release()
+	assert.Equal(t, 0, sem.InFlight())
+	acq, rel := lk.callCounts()
+	assert.Equal(t, 1, acq)
+	assert.Equal(t, 1, rel)
+}
+
+func TestStageGate_LockAlreadyHeld_ReleasesSemaphore(t *testing.T) {
+	t.Parallel()
+	sem := locks.NewSemaphore(2)
+	lk := newStubLock(false) // 다른 worker 가 lock 잡고 있음
+	gate := locks.NewStageGate(locks.StageParser, sem, lk, newTestLog(t))
+
+	release, acquired, err := gate.Acquire(context.Background(), "https://example.com/a")
+	require.NoError(t, err)
+	assert.False(t, acquired)
+	assert.Nil(t, release)
+	// semaphore slot 은 반납되어야 함 — 다른 worker 가 진입 가능해야 함.
+	assert.Equal(t, 0, sem.InFlight(), "lock 미획득 시 semaphore 즉시 반납")
+}
+
+func TestStageGate_LockError_ReleasesSemaphore(t *testing.T) {
+	t.Parallel()
+	sem := locks.NewSemaphore(2)
+	lk := newStubLock(false)
+	lk.acquireErr = errors.New("redis down")
+	gate := locks.NewStageGate(locks.StageValidator, sem, lk, newTestLog(t))
+
+	release, acquired, err := gate.Acquire(context.Background(), "https://example.com/a")
+	require.Error(t, err)
+	assert.False(t, acquired)
+	assert.Nil(t, release)
+	assert.Equal(t, 0, sem.InFlight(), "lock 에러 시도 semaphore 반납")
+}
+
+func TestStageGate_SemaphoreFull_ContextTimeout(t *testing.T) {
+	t.Parallel()
+	sem := locks.NewSemaphore(1)
+	lk := newStubLock(true)
+	gate := locks.NewStageGate(locks.StageFetcher, sem, lk, newTestLog(t))
+
+	// 첫 acquire — semaphore 1 점유.
+	release1, acquired1, err := gate.Acquire(context.Background(), "https://example.com/a")
+	require.NoError(t, err)
+	require.True(t, acquired1)
+	defer release1()
+
+	// 둘째 acquire 는 semaphore full + ctx timeout.
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Millisecond)
+	defer cancel()
+	release2, acquired2, err := gate.Acquire(ctx, "https://example.com/b")
+	require.Error(t, err)
+	assert.ErrorIs(t, err, context.DeadlineExceeded)
+	assert.False(t, acquired2)
+	assert.Nil(t, release2)
+}
+
+func TestStageGate_ReleaseIdempotent(t *testing.T) {
+	t.Parallel()
+	sem := locks.NewSemaphore(2)
+	lk := newStubLock(true)
+	gate := locks.NewStageGate(locks.StageFetcher, sem, lk, newTestLog(t))
+
+	release, acquired, err := gate.Acquire(context.Background(), "https://example.com/a")
+	require.NoError(t, err)
+	require.True(t, acquired)
+
+	release()
+	release() // 두 번째 호출 — panic 없이 무시되어야 함.
+	release() // 세 번째도 idempotent.
+
+	_, rel := lk.callCounts()
+	assert.Equal(t, 1, rel, "lock.Release 는 정확히 1회만 호출")
+	assert.Equal(t, 0, sem.InFlight(), "semaphore 도 정확히 1회 반납")
+}
+
+func TestStageGate_ConcurrentAcquireRespectsCapacity(t *testing.T) {
+	t.Parallel()
+	cap := 3
+	sem := locks.NewSemaphore(cap)
+	lk := newStubLock(true)
+	gate := locks.NewStageGate(locks.StageFetcher, sem, lk, newTestLog(t))
+
+	var (
+		maxInFlight atomic.Int64
+		wg          sync.WaitGroup
+	)
+	for i := 0; i < 20; i++ {
+		i := i
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			release, acquired, err := gate.Acquire(context.Background(), "https://example.com/"+string(rune('a'+i)))
+			if err != nil || !acquired {
+				return
+			}
+			defer release()
+			// peak 측정.
+			cur := int64(sem.InFlight())
+			for {
+				m := maxInFlight.Load()
+				if cur <= m || maxInFlight.CompareAndSwap(m, cur) {
+					break
+				}
+			}
+			time.Sleep(5 * time.Millisecond)
+		}()
+	}
+	wg.Wait()
+	assert.LessOrEqual(t, maxInFlight.Load(), int64(cap), "동시 in-flight 가 capacity 초과 안 함")
+	assert.Equal(t, 0, sem.InFlight(), "모든 release 후 0")
+}
+
+func TestNoopStageGate_AlwaysAcquired(t *testing.T) {
+	t.Parallel()
+	gate := locks.NewNoopStageGate()
+	release, acquired, err := gate.Acquire(context.Background(), "https://example.com/a")
+	require.NoError(t, err)
+	assert.True(t, acquired)
+	require.NotNil(t, release)
+	release() // panic 없어야 함.
+	release() // idempotent (noop 은 항상 안전).
+}
+
+func TestNewStageGate_PanicsOnInvalidArgs(t *testing.T) {
+	t.Parallel()
+	sem := locks.NewSemaphore(1)
+	lk := locks.NoopProcessingLock{}
+	log := newTestLog(t)
+
+	assert.Panics(t, func() { locks.NewStageGate("", sem, lk, log) })
+	assert.Panics(t, func() { locks.NewStageGate(locks.StageFetcher, nil, lk, log) })
+	assert.Panics(t, func() { locks.NewStageGate(locks.StageFetcher, sem, nil, log) })
+	assert.Panics(t, func() { locks.NewStageGate(locks.StageFetcher, sem, lk, nil) })
+}


### PR DESCRIPTION
## 연관 이슈
Closes #354 (#353 의 phase 1)

## 배경

#353 (ProcessingLock URL-기반 stage 전체 확장 + per-stage 세마포어) 의 인프라 phase. **객체지향 원칙** (composition over inheritance, Single Responsibility) 으로 stage 진입 검증을 단일 API 로 노출하여 #355 (parser wiring) / #356 (fetcher/validator migration) 이 통일된 패턴으로 사용.

라이브 (2026-05-11 22:39~) 분석에서 발견된 검증 실패율 88% 의 일부는 same-URL stage-duplicate 처리 cascade 의 영향. stage 별 동시 처리 cap + URL lock 일관 적용으로 burstiness 평탄화.

## 구현

### 1. Semaphore primitive ([\`internal/locks/semaphore.go\`](internal/locks/semaphore.go))
- \`golang.org/x/sync/semaphore.Weighted\` 기반 capacity-bounded primitive (이미 go.mod 의존)
- API: \`Acquire(ctx) / Release / Capacity / InFlight\`
- atomic in-flight counter — 운영 진단 / 로깅용
- \`NewSemaphore(cap)\` — cap<1 시 panic (wiring 실수 즉시 발견)

### 2. StageGate ([\`internal/locks/stage_gate.go\`](internal/locks/stage_gate.go))
- \`Semaphore\` + \`ProcessingLock\` 의 **합성** (composition):
\`\`\`go
func (g *stageGate) Acquire(ctx, url) (release func(), acquired bool, err error) {
    sem.Acquire(ctx)  // 1. slot 점유
    acquired, lockErr := lock.Acquire(ctx, key)
    if !acquired || lockErr != nil {
        sem.Release()  // 2. lock 미획득 / 에러 시 즉시 반납
        return ...
    }
    return release, true, nil  // 3. release 가 lock.Release + sem.Release 양쪽 정리
}
\`\`\`
- release 함수 **idempotent** — 두 번 호출되어도 panic 없이 안전 (released sentinel)
- lock.Release 는 별도 \`drainCtx\` 사용 — graceful shutdown 시 ctx cancel 영향 없음
- 검증 panic: stage 빈 문자열 / sem nil / lock nil / log nil 시 wiring 실수 즉시 발견

### 3. NoopStageGate
- Redis 미연결 / 운영자 명시 비활성화 시 fallback
- 모든 호출 \`(release=noop, acquired=true, err=nil)\` — 기존 \`NoopProcessingLock\` 패턴 일관

### 단일 책임 분리
| 컴포넌트 | 책임 |
|---|---|
| \`ProcessingLock\` | \"이 URL 이 현재 stage 에서 처리 중인가\" |
| \`Semaphore\` | \"stage 의 동시 처리 슬롯이 가용한가\" |
| \`StageGate\` | 두 컴포넌트 합성 + 정리 책임 — worker 가 한 번 호출 |

## 테스트 (11건)

\`test/internal/locks/stage_gate_test.go\`:
**Semaphore (4건)**: AcquireRelease / CapacityFullBlocksUntilRelease / ContextCancelInterruptsAcquire / PanicsOnZeroCapacity
**StageGate (6건)**: Acquire_Success / LockAlreadyHeld_ReleasesSemaphore / LockError_ReleasesSemaphore / SemaphoreFull_ContextTimeout / ReleaseIdempotent / ConcurrentAcquireRespectsCapacity
**NoopStageGate (1건)**: AlwaysAcquired
**PanicGuards (1건)**: NewStageGate panics on invalid args

\`ConcurrentAcquireRespectsCapacity\` 는 20 goroutine 동시 acquire 시 peak in-flight 가 capacity 초과하지 않음 검증 — atomic CAS 로 race 검출.

## CI / 머지 게이트 점검
- [x] \`go build ./...\` 통과
- [x] \`go test -race -count=1 ./test/...\` 전부 ok
- [x] \`go vet ./...\` 깨끗
- [x] gofmt 정리

## 변경 영향 범위 + 위험도
- **영향**: 본 PR 만으로는 동작 변화 **0** — 사용처 (#355 parser wiring / #356 fetcher/validator migration) 가 wiring 해야 효과 발생
- **위험도**: 매우 낮음 — 인프라 코드 추가만, 기존 호출자 무관

## 후속
- **#355 Sub B**: parser worker 의 StageGate 신규 wiring (\`PARSER_MAX_CONCURRENT_PER_STAGE\` env + cap 로직)
- **#356 Sub C**: fetcher / validate worker 의 기존 ProcessingLock 직접 사용 → StageGate 마이그레이션

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Rate limiting with capacity tracking and in-flight operation monitoring to control concurrent workload and manage system resources effectively.
  * Stage-level locking to prevent duplicate processing of the same resources and coordinate work safely across processing pipeline stages.

* **Tests**
  * Comprehensive test coverage for concurrency control, capacity enforcement, timeout scenarios, and duplicate prevention.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/EinSofINTEREST/IssueTracker/pull/357)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->