### PR TITLE
[FEAT#355] parser worker StageGate 위임 + per-stage Semaphore cap

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -207,3 +207,10 @@ LLM_POLICY=chain
 # 형식: "cost,latency,failure_rate" — 음수 거부, 합이 1.0 일 필요 없음 (각 시그널 normalize 후 가중 합산)
 # default: 1.0,1.0,0.5 (Cost 와 Latency 동일, FailureRate 는 그 절반)
 LLM_HYBRID_WEIGHTS=1.0,1.0,0.5
+
+# Parser stage gate concurrency cap (이슈 #355)
+# parser stage 의 Semaphore capacity 상한. 0 / 미설정 → worker_count/2 (자동).
+# 양수 → min(value, worker_count/2) 채택. parserWorkerCount=6 인 현 설정에서 worker_count/2=3.
+# StageGate = ProcessingLock (URL 중복 차단) + Semaphore (stage 동시 슬롯 cap) 합성.
+# Issue #353 설계 제약: 각 stage cap 은 stage worker 수의 절반 이하.
+PARSER_MAX_CONCURRENT_PER_STAGE=0

--- a/cmd/issuetracker/main.go
+++ b/cmd/issuetracker/main.go
@@ -515,6 +515,27 @@ func main() {
 	// sample URL 누적 — parser_worker 가 정상 파싱 후 누적, 단계 4-2 의 정밀화 트리거 입력.
 	sampleRepo := pgstore.NewSampleURLRepository(pool, log)
 
+	// Parser StageGate (이슈 #355) — ProcessingLock + per-stage Semaphore 합성.
+	// Semaphore capacity 는 PARSER_MAX_CONCURRENT_PER_STAGE 와 worker_count/2 의 min.
+	stageGateCfg, err := config.LoadStageGate()
+	if err != nil {
+		log.WithError(err).Fatal("failed to load stage gate config")
+	}
+	parserCap := config.CapPerStage(parserWorkerCount, stageGateCfg.ParserMaxConcurrentPerStage)
+	parserSem := locks.NewSemaphore(parserCap)
+	var parserGate locks.StageGate
+	if procLock != nil {
+		parserGate = locks.NewStageGate(locks.StageParser, parserSem, procLock, log)
+		log.WithFields(map[string]interface{}{
+			"worker_count": parserWorkerCount,
+			"capacity":     parserCap,
+			"configured":   stageGateCfg.ParserMaxConcurrentPerStage,
+		}).Info("parser stage gate enabled (ProcessingLock + Semaphore)")
+	} else {
+		parserGate = locks.NewNoopStageGate()
+		log.Warn("processing lock unavailable, parser stage gate falls back to noop")
+	}
+
 	pw := parserWorker.NewParserWorker(
 		parserConsumer,
 		crawlerProducer, // normalized 토픽 발행 + chained article jobs 발행 시 publisher 가 동일 producer 사용
@@ -524,7 +545,7 @@ func main() {
 		ruleParser,
 		ruleResolver, // sample 누적 시 매칭 rule lookup
 		sampleRepo,
-		procLock, // fetcher / parser / validator 가 동일 ProcessingLock 인스턴스 공유
+		parserGate, // fetcher / parser / validator 가 동일 ProcessingLock 공유 + parser stage Semaphore
 		llmGen,
 		failureCounter,  // host 단위 fetcher 실패 카운터
 		rawIDTracker,    // host 별 실패 raw_id 추적기

--- a/internal/processor/parser/worker/parser_worker.go
+++ b/internal/processor/parser/worker/parser_worker.go
@@ -59,7 +59,7 @@ type ParserWorker struct {
 	parser     *rule.Parser
 	resolver   *rule.Resolver              // sample 누적 시 매칭된 rule lookup
 	sampleSvc  storage.SampleURLRepository // nil 허용 — nil 이면 sample 누적 skip (단계 4-1)
-	procLock   locks.ProcessingLock        // nil 이면 NoopProcessingLock 사용 (단일 인스턴스 fallback)
+	gate       locks.StageGate             // nil 이면 NoopStageGate 사용 — 이슈 #355 (StageGate 합성: ProcessingLock + per-stage Semaphore)
 	llmGen     *llmgen.Generator           // nil 허용 — nil 이면 ErrNoRule 시 raw 잔존만 (LLM auto-rule 비활성)
 
 	// failureCounter: host 단위 fetcher 실패 카운터.
@@ -114,7 +114,7 @@ type PipelineGuard interface {
 // NewParserWorker 는 ParserWorker 를 생성합니다.
 //
 //   - publisher 는 nil 허용 — nil 이면 카테고리 chained jobs 발행 건너뜀 (이런 모드는 보통 운영 금지)
-//   - procLock 은 nil 허용 — nil 이면 NoopProcessingLock 으로 fallback (단일 인스턴스 환경에서 dedup 비활성)
+//   - gate 는 nil 허용 — nil 이면 NoopStageGate 로 fallback (단일 인스턴스 환경에서 dedup + cap 비활성)
 //   - llmGen 은 nil 허용 — nil 이면 ErrNoRule 시 raw 잔존만 (LLM auto-rule 비활성)
 //   - resolver / sampleSvc 는 nil 허용 — nil 이면 sample 누적 skip
 //   - failureCounter 는 nil 허용 — nil 이면 NoopFailureCounter 로 fallback
@@ -123,8 +123,9 @@ type PipelineGuard interface {
 // 도메인 중립화 이후 news_articles 도메인 특화 보존은 제거됐습니다 — 모든 article
 // 결과는 contentSvc.Store 로 contents 단일 테이블에 저장됩니다.
 //
-// ProcessingLock 으로 fetcher / parser / validator 가 동일 인터페이스로 단계별 dedup.
-// parser 단계는 raw.URL 단위로 acquire — Kafka rebalance 시 같은 raw 가 두 worker 에 도달해도 1회만 파싱.
+// StageGate (ProcessingLock + Semaphore 합성, 이슈 #353/#354) 로 fetcher / parser / validator
+// 가 동일 패턴으로 stage 별 동시성 cap + URL 중복 처리 차단을 단일 API 로 적용 — parser 단계는
+// raw.URL 단위로 acquire, Kafka rebalance 시 같은 raw 가 두 worker 에 도달해도 1회만 파싱.
 func NewParserWorker(
 	consumer *queue.KafkaConsumer,
 	producer queue.Producer,
@@ -134,7 +135,7 @@ func NewParserWorker(
 	parser *rule.Parser,
 	resolver *rule.Resolver,
 	sampleSvc storage.SampleURLRepository,
-	procLock locks.ProcessingLock,
+	gate locks.StageGate,
 	llmGen *llmgen.Generator,
 	failureCounter storage.FailureCounter,
 	rawIDTracker storage.RawIDTracker,
@@ -147,8 +148,8 @@ func NewParserWorker(
 	if workerCount <= 0 {
 		workerCount = 1
 	}
-	if procLock == nil {
-		procLock = locks.NoopProcessingLock{}
+	if gate == nil {
+		gate = locks.NewNoopStageGate()
 	}
 	if failureCounter == nil {
 		failureCounter = storage.NewNoopFailureCounter()
@@ -165,7 +166,7 @@ func NewParserWorker(
 		parser:              parser,
 		resolver:            resolver,
 		sampleSvc:           sampleSvc,
-		procLock:            procLock,
+		gate:                gate,
 		llmGen:              llmGen,
 		failureCounter:      failureCounter,
 		rawIDTracker:        rawIDTracker,
@@ -287,26 +288,19 @@ func (w *ParserWorker) processMessage(ctx context.Context, msg *queue.Message) e
 		"url":    ref.URL,
 	})
 
-	// parser 단계 ProcessingLock — 같은 URL 의 동시 파싱을 차단.
+	// parser 단계 StageGate (ProcessingLock + Semaphore 합성, 이슈 #355) —
+	// 같은 URL 의 동시 파싱 차단 + parser stage 의 동시 처리 슬롯 cap.
 	// Kafka rebalance / 재배달 시 같은 raw 가 두 parser worker 에 도달해도 1회만 처리.
 	// ref.URL 은 fetcher 가 정규화한 URL — Ingestion Lock 키와 같은 정규형 사용.
-	procKey := locks.ProcessingKey(locks.StageParser, ref.URL)
-	acquired, lockErr := w.procLock.Acquire(ctx, procKey)
-	if lockErr != nil {
-		mlog.WithError(lockErr).Warn("failed to acquire parser processing lock, proceeding without lock")
+	release, acquired, gateErr := w.gate.Acquire(ctx, ref.URL)
+	if gateErr != nil {
+		mlog.WithError(gateErr).Warn("failed to acquire parser stage gate, proceeding without gate")
 	} else if !acquired {
 		mlog.Debug("parser processing lock already held by another worker, skipping")
 		// 다른 parser worker 가 처리 중 — commit 없이 종료. 처리 담당 worker 의 commit 에 의존.
 		return nil
 	} else {
-		defer func() {
-			// 셧다운 시 ctx cancel 되어도 락 해제 보장 + trace ID 등 메타데이터 보존.
-			releaseCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 5*time.Second)
-			defer cancel()
-			if releaseErr := w.procLock.Release(releaseCtx, procKey); releaseErr != nil {
-				mlog.WithError(releaseErr).Warn("failed to release parser processing lock")
-			}
-		}()
+		defer release()
 	}
 
 	raw, err := w.rawSvc.GetByID(ctx, ref.ID)

--- a/internal/processor/parser/worker/parser_worker.go
+++ b/internal/processor/parser/worker/parser_worker.go
@@ -254,7 +254,14 @@ func (w *ParserWorker) runWorker(ctx context.Context, idx int) {
 			continue
 		}
 
-		if err := w.processMessage(ctx, msg); err != nil {
+		if err := w.ProcessMessage(ctx, msg); err != nil {
+			// StageGate not-acquired sentinel — commit 없이 다음 메시지로. 다른 worker 가 처리 중이므로
+			// 시끄러운 Warn 대신 Debug. Kafka 가 같은 partition 의 다음 offset 으로 fetch 진행 — 같은
+			// msg 재배달은 lock 해제 + 재시도 stream 에서 발생 (이슈 #355 PR #358 리뷰 반영).
+			if errors.Is(err, ErrStageGateNotAcquired) {
+				wlog.WithField("offset", msg.Offset).Debug("stage gate not acquired by this worker, uncommitted")
+				continue
+			}
 			// processMessage 가 commit 안 한 경우 — 재시도 위해 commit skip (Kafka 가 redeliver).
 			wlog.WithError(err).WithField("offset", msg.Offset).Warn("process message failed, will be redelivered")
 			continue
@@ -268,14 +275,29 @@ func (w *ParserWorker) runWorker(ctx context.Context, idx int) {
 	}
 }
 
-// processMessage 는 단일 메시지 처리 흐름. 성공 시 nil, 재시도 필요 시 error 반환.
+// ErrStageGateNotAcquired 는 parser stage 의 ProcessingLock 이 다른 worker 에 점유 중이라
+// 본 worker 가 스킵해야 함을 나타내는 sentinel. runWorker 가 본 에러를 감지하면 Warn 대신
+// Debug 로 처리하여 정상 dedup 경로를 시끄럽게 만들지 않습니다 (PR #358 리뷰 반영).
+//
+// commit 정책: 본 sentinel 반환 시 호출자는 commit 하지 않음 — 같은 partition 의 다음 msg
+// 처리로 진행하고, 본 offset 의 commit 은 실제 처리 담당 worker 가 수행 (또는 재배달 stream
+// 에서 다시 결정).
+//
+// exported 이유: 외부 테스트 / 모니터링 코드에서 errors.Is 매칭으로 dedup-skip 을 일반 실패와
+// 구분할 수 있도록.
+var ErrStageGateNotAcquired = errors.New("parser stage gate not acquired by this worker")
+
+// ProcessMessage 는 단일 메시지 처리 흐름. 성공 시 nil, 재시도 필요 시 error 반환.
 //
 // Commit 정책:
 //   - 정상 처리 → 호출자가 commit
 //   - rule.Error (parse 실패) → commit (raw 잔존, 재시도 X)
 //   - payload 손상 → commit (DLQ 발행 후, 재시도 무의미)
 //   - 기타 transient → commit 안 함 (재시도)
-func (w *ParserWorker) processMessage(ctx context.Context, msg *queue.Message) error {
+//
+// 일반적으로 runWorker 가 내부에서 호출하지만, 외부 테스트가 분기별 행동을 black-box 로
+// 검증할 수 있도록 exported. consumer 가 nil 인 worker 도 본 메소드는 호출 가능.
+func (w *ParserWorker) ProcessMessage(ctx context.Context, msg *queue.Message) error {
 	var ref core.RawContentRef
 	if err := json.Unmarshal(msg.Value, &ref); err != nil {
 		w.log.WithError(err).Error("malformed RawContentRef payload, dropping")
@@ -294,11 +316,20 @@ func (w *ParserWorker) processMessage(ctx context.Context, msg *queue.Message) e
 	// ref.URL 은 fetcher 가 정규화한 URL — Ingestion Lock 키와 같은 정규형 사용.
 	release, acquired, gateErr := w.gate.Acquire(ctx, ref.URL)
 	if gateErr != nil {
+		// ctx cancel / deadline — shutdown 또는 semaphore 대기 timeout. fail-open 으로 진행하면
+		// 취소된 ctx 로 쓸데없는 작업 + per-stage cap 무력화 위험 (PR #358 gemini / Copilot 반영).
+		// commit 안 하고 종료 → Kafka redeliver 보장.
+		// SoT: ctx.Err() != nil (errors.Is(ctx.Canceled) 대비 정확 — 종료 사유 단일화).
+		if ctx.Err() != nil {
+			return fmt.Errorf("stage gate acquire aborted by ctx: %w", gateErr)
+		}
+		// 그 외 인프라 에러 (예: Redis 장애) — fail-open. 다른 worker 와의 dedup 만 일시 비활성화.
 		mlog.WithError(gateErr).Warn("failed to acquire parser stage gate, proceeding without gate")
 	} else if !acquired {
 		mlog.Debug("parser processing lock already held by another worker, skipping")
-		// 다른 parser worker 가 처리 중 — commit 없이 종료. 처리 담당 worker 의 commit 에 의존.
-		return nil
+		// 다른 parser worker 가 처리 중 — sentinel 반환으로 commit skip. runWorker 가 Warn 대신
+		// Debug 로 처리. 처리 담당 worker 가 commit 책임 (PR #358 CodeRabbit 반영).
+		return ErrStageGateNotAcquired
 	} else {
 		defer release()
 	}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -255,6 +255,68 @@ func LoadValidate(envFiles ...string) (ValidateConfig, error) {
 	return cfg, nil
 }
 
+// StageGateConfig 는 stage 별 StageGate 의 동시 처리 슬롯 상한을 나타냅니다 (이슈 #355).
+//
+// 각 stage 의 Semaphore capacity 는 worker_count/2 를 넘지 않아야 함 — 이슈 #353 설계 제약.
+// 환경변수로 명시적 cap 을 받아 worker_count/2 와 비교 후 작은 값을 채택.
+type StageGateConfig struct {
+	// ParserMaxConcurrentPerStage: parser stage 의 Semaphore capacity 상한.
+	// 0 이하면 worker_count/2 (floor) 사용. 양수면 min(value, worker_count/2) 채택.
+	ParserMaxConcurrentPerStage int
+}
+
+// DefaultStageGateConfig 는 0 (worker_count/2 자동) 기본값을 반환합니다.
+func DefaultStageGateConfig() StageGateConfig {
+	return StageGateConfig{
+		ParserMaxConcurrentPerStage: 0,
+	}
+}
+
+// LoadStageGate 는 .env + OS 환경변수로 StageGateConfig 를 구성합니다.
+func LoadStageGate(envFiles ...string) (StageGateConfig, error) {
+	if len(envFiles) == 0 {
+		envFiles = []string{".env"}
+	}
+	if err := godotenv.Load(envFiles...); err != nil && !errors.Is(err, os.ErrNotExist) {
+		return StageGateConfig{}, fmt.Errorf("failed to load env files %v: %w", envFiles, err)
+	}
+
+	cfg := DefaultStageGateConfig()
+	if v := os.Getenv("PARSER_MAX_CONCURRENT_PER_STAGE"); v != "" {
+		n, err := strconv.Atoi(v)
+		if err != nil {
+			return StageGateConfig{}, fmt.Errorf("parse PARSER_MAX_CONCURRENT_PER_STAGE %q: %w", v, err)
+		}
+		cfg.ParserMaxConcurrentPerStage = n
+	}
+	return cfg, nil
+}
+
+// CapPerStage 는 worker_count 와 설정된 explicit cap 을 조합하여 Semaphore capacity 를 결정합니다.
+//
+// 규칙 (이슈 #353):
+//   - workerCount < 2 면 1 반환 (semaphore 최소 1 보장)
+//   - configured <= 0 이면 workerCount/2 (floor)
+//   - configured > 0 이면 min(configured, workerCount/2)
+//
+// floor 결과가 0 이면 1 로 보정 — semaphore.NewSemaphore 가 capacity >= 1 요구.
+func CapPerStage(workerCount, configured int) int {
+	if workerCount < 2 {
+		return 1
+	}
+	half := workerCount / 2
+	if half < 1 {
+		half = 1
+	}
+	if configured <= 0 {
+		return half
+	}
+	if configured < half {
+		return configured
+	}
+	return half
+}
+
 // ClassifierConfig는 Classifier 서비스 연결 설정을 나타냅니다.
 // 모든 필드는 환경변수(LoadClassifier 참조)로 덮어쓸 수 있습니다.
 type ClassifierConfig struct {

--- a/test/internal/processor/parser/worker/helpers_test.go
+++ b/test/internal/processor/parser/worker/helpers_test.go
@@ -20,7 +20,7 @@ func newMinimalWorker(prod queue.Producer, log *logger.Logger) *worker.ParserWor
 		nil,  // parser
 		nil,  // resolver
 		nil,  // sampleSvc
-		nil,  // procLock
+		nil,  // gate
 		nil,  // llmGen
 		nil,  // failureCounter
 		nil,  // rawIDTracker

--- a/test/internal/processor/parser/worker/stage_gate_test.go
+++ b/test/internal/processor/parser/worker/stage_gate_test.go
@@ -1,0 +1,176 @@
+package worker_test
+
+// stage_gate_test.go — PR #358 리뷰 (CodeRabbit / Copilot / gemini) 반영 테스트.
+//
+// 검증 항목:
+//  1. acquired=false → errStageGateNotAcquired sentinel 반환 (commit 안 함 의도)
+//  2. gateErr + ctx.Err()!=nil → wrapped gateErr 반환 (commit 안 함 + ctx abort)
+//  3. gateErr + ctx ok → fail-open 진행 (rawSvc 까지 도달)
+//  4. acquired=true → release 호출 보장
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"issuetracker/internal/locks"
+	"issuetracker/internal/processor/fetcher/core"
+	parserWorker "issuetracker/internal/processor/parser/worker"
+	"issuetracker/internal/storage"
+	"issuetracker/pkg/logger"
+	"issuetracker/pkg/queue"
+)
+
+// fakeStageGate 는 StageGate 의 black-box stub 입니다.
+type fakeStageGate struct {
+	acquireCalls int64
+	releaseCalls int64
+	// 반환값 설정
+	acquired bool
+	err      error
+}
+
+func (g *fakeStageGate) Acquire(_ context.Context, _ string) (func(), bool, error) {
+	atomic.AddInt64(&g.acquireCalls, 1)
+	if g.err != nil {
+		return nil, false, g.err
+	}
+	if !g.acquired {
+		return nil, false, nil
+	}
+	return func() { atomic.AddInt64(&g.releaseCalls, 1) }, true, nil
+}
+
+// newGatedWorker 는 gate + rawSvc 를 주입한 ParserWorker 를 생성합니다.
+func newGatedWorker(gate locks.StageGate, rawSvc *fakeRawSvc, log *logger.Logger) *parserWorker.ParserWorker {
+	return parserWorker.NewParserWorker(
+		nil,    // consumer
+		nil,    // producer
+		rawSvc, // rawSvc
+		nil,    // contentSvc
+		nil,    // publisher
+		nil,    // parser
+		nil,    // resolver
+		nil,    // sampleSvc
+		gate,   // stage gate
+		nil,    // llmGen
+		nil,    // failureCounter
+		nil,    // rawIDTracker
+		nil,    // upgrader
+		0,      // emptyBodyTitleMin
+		0,      // emptyBodyContentMin
+		1,      // workerCount
+		log,
+	)
+}
+
+func newMsgForURL(t *testing.T, id, url string) *queue.Message {
+	t.Helper()
+	ref := core.RawContentRef{
+		ID:        id,
+		URL:       url,
+		FetchedAt: time.Now(),
+		SourceInfo: core.SourceInfo{
+			Name:    "test-crawler",
+			Country: "KR",
+		},
+	}
+	body, err := json.Marshal(ref)
+	require.NoError(t, err)
+	return &queue.Message{
+		Topic:   queue.TopicFetched,
+		Value:   body,
+		Headers: map[string]string{"crawler": "test-crawler"},
+	}
+}
+
+// TestProcessMessage_GateNotAcquired_ReturnsSentinel 은 gate.Acquire 가 (nil, false, nil)
+// 을 반환하면 (다른 worker 가 lock 보유) processMessage 가 errStageGateNotAcquired 를
+// 반환하여 commit 을 회피하는지 검증합니다. (PR #358 CodeRabbit 반영)
+func TestProcessMessage_GateNotAcquired_ReturnsSentinel(t *testing.T) {
+	gate := &fakeStageGate{acquired: false, err: nil}
+	rawSvc := &fakeRawSvc{}
+	log := logger.New(logger.DefaultConfig())
+
+	pw := newGatedWorker(gate, rawSvc, log)
+	msg := newMsgForURL(t, "raw-001", "https://example.com/a")
+
+	err := pw.ProcessMessage(context.Background(), msg)
+
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, parserWorker.ErrStageGateNotAcquired),
+		"acquired=false 시 sentinel 반환 필요")
+	assert.Equal(t, int64(1), atomic.LoadInt64(&gate.acquireCalls))
+	assert.Equal(t, int64(0), atomic.LoadInt64(&gate.releaseCalls), "획득 실패 시 release 호출 X")
+	assert.Equal(t, int64(0), atomic.LoadInt64(&rawSvc.getCalls), "lock 미획득 시 rawSvc 미도달")
+}
+
+// TestProcessMessage_GateErrWithCtxCancel_ReturnsError 는 gate.Acquire 가 ctx cancel/deadline
+// 으로 인해 error 를 반환하면 processMessage 가 wrapped error 를 반환하여 commit 을
+// 회피하는지 검증합니다. (PR #358 gemini / Copilot 반영)
+func TestProcessMessage_GateErrWithCtxCancel_ReturnsError(t *testing.T) {
+	gate := &fakeStageGate{err: context.Canceled}
+	rawSvc := &fakeRawSvc{}
+	log := logger.New(logger.DefaultConfig())
+
+	pw := newGatedWorker(gate, rawSvc, log)
+	msg := newMsgForURL(t, "raw-002", "https://example.com/b")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // ctx 종료 상태로 호출
+
+	err := pw.ProcessMessage(ctx, msg)
+
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, context.Canceled), "ctx cancel 원인 err 보존")
+	assert.False(t, errors.Is(err, parserWorker.ErrStageGateNotAcquired),
+		"sentinel 이 아닌 일반 error 로 분류")
+	assert.Equal(t, int64(0), atomic.LoadInt64(&rawSvc.getCalls), "ctx cancel 시 rawSvc 미도달")
+}
+
+// TestProcessMessage_GateErrInfraFailureProceeds 는 gate.Acquire 가 ctx 정상 상태에서 인프라
+// 에러 (예: Redis 장애) 를 반환하면 fail-open 으로 rawSvc 까지 진행하는지 검증합니다.
+// (PR #358 Copilot 반영 — 인프라 에러는 graceful degrade 유지)
+func TestProcessMessage_GateErrInfraFailureProceeds(t *testing.T) {
+	infraErr := errors.New("redis: connection refused")
+	gate := &fakeStageGate{err: infraErr}
+	rawSvc := &fakeRawSvc{} // GetByID 는 ErrNotFound 반환 → processMessage 가 정상 종료 (nil)
+	log := logger.New(logger.DefaultConfig())
+
+	pw := newGatedWorker(gate, rawSvc, log)
+	msg := newMsgForURL(t, "raw-003", "https://example.com/c")
+
+	err := pw.ProcessMessage(context.Background(), msg)
+
+	// rawSvc.GetByID 가 ErrNotFound 반환 → processMessage 가 nil 반환 (정상 skip).
+	// 중요한 건 rawSvc 까지 도달했다는 사실 (fail-open).
+	assert.NoError(t, err, "인프라 에러 + ctx ok → fail-open 진행 후 정상 종료")
+	assert.Equal(t, int64(1), atomic.LoadInt64(&rawSvc.getCalls), "fail-open 시 rawSvc.GetByID 도달 필요")
+}
+
+// TestProcessMessage_GateAcquired_ReleasesAfter 는 acquired=true 시 processMessage 종료 후
+// release 가 호출되는지 (defer release()) 검증합니다.
+func TestProcessMessage_GateAcquired_ReleasesAfter(t *testing.T) {
+	gate := &fakeStageGate{acquired: true, err: nil}
+	rawSvc := &fakeRawSvc{} // GetByID → ErrNotFound 로 빠르게 종료
+	log := logger.New(logger.DefaultConfig())
+
+	pw := newGatedWorker(gate, rawSvc, log)
+	msg := newMsgForURL(t, "raw-004", "https://example.com/d")
+
+	err := pw.ProcessMessage(context.Background(), msg)
+
+	assert.NoError(t, err)
+	assert.Equal(t, int64(1), atomic.LoadInt64(&gate.acquireCalls))
+	assert.Equal(t, int64(1), atomic.LoadInt64(&gate.releaseCalls), "성공 후 release 1회 보장")
+	assert.Equal(t, int64(1), atomic.LoadInt64(&rawSvc.getCalls), "정상 acquire 시 rawSvc 도달")
+}
+
+// 컴파일 타임 contract — storage.ErrNotFound 가 변경되어도 import 가 유지되도록.
+var _ = storage.ErrNotFound

--- a/test/pkg/config/stage_gate_test.go
+++ b/test/pkg/config/stage_gate_test.go
@@ -1,0 +1,56 @@
+package config_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"issuetracker/pkg/config"
+)
+
+func TestLoadStageGate_DefaultValues(t *testing.T) {
+	t.Setenv("PARSER_MAX_CONCURRENT_PER_STAGE", "")
+	cfg, err := config.LoadStageGate("/tmp/nonexistent-env-file.env")
+	require.NoError(t, err)
+	require.Equal(t, 0, cfg.ParserMaxConcurrentPerStage)
+}
+
+func TestLoadStageGate_EnvOverride(t *testing.T) {
+	t.Setenv("PARSER_MAX_CONCURRENT_PER_STAGE", "4")
+	cfg, err := config.LoadStageGate("/tmp/nonexistent-env-file.env")
+	require.NoError(t, err)
+	require.Equal(t, 4, cfg.ParserMaxConcurrentPerStage)
+}
+
+func TestLoadStageGate_InvalidValue(t *testing.T) {
+	t.Setenv("PARSER_MAX_CONCURRENT_PER_STAGE", "not-a-number")
+	_, err := config.LoadStageGate("/tmp/nonexistent-env-file.env")
+	require.Error(t, err)
+}
+
+func TestCapPerStage(t *testing.T) {
+	tests := []struct {
+		name        string
+		workerCount int
+		configured  int
+		want        int
+	}{
+		{"workerCount<2 returns 1", 1, 0, 1},
+		{"workerCount<2 ignores configured", 1, 99, 1},
+		{"zero configured uses half", 6, 0, 3},
+		{"negative configured uses half", 6, -1, 3},
+		{"configured caps at half", 6, 5, 3},
+		{"configured smaller than half", 6, 2, 2},
+		{"configured equals half", 6, 3, 3},
+		{"odd worker count floor", 7, 0, 3},
+		{"even worker count 4", 4, 0, 2},
+		{"worker count 2 gives 1", 2, 0, 1},
+		{"explicit cap below worker_count/2 honored", 8, 1, 1},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := config.CapPerStage(tt.workerCount, tt.configured)
+			require.Equal(t, tt.want, got)
+		})
+	}
+}


### PR DESCRIPTION
## 연관 이슈
- Closes #355

<br>

## 구현 내용
이슈 #353 의 Sub B — parser worker 를 StageGate (이슈 #354 / PR #357) 로 마이그레이션.

- **`internal/processor/parser/worker/parser_worker.go`**
  - 필드 `procLock locks.ProcessingLock` → `gate locks.StageGate`
  - 생성자 시그니처 변경, nil 입력은 `NoopStageGate` 로 fallback
  - dispatch 사이트: `gate.Acquire(ctx, ref.URL)` → `(release, acquired, err)` 단일 호출로 정리
  - URL 기반 lock 의미는 그대로 유지 (StageParser prefix + ref.URL)

- **`pkg/config/config.go`**
  - `StageGateConfig` + `LoadStageGate` + `CapPerStage` 헬퍼 추가
  - `PARSER_MAX_CONCURRENT_PER_STAGE` 환경변수 (0 → worker_count/2 자동, 양수 → min(value, worker_count/2))
  - 이슈 #353 의 설계 제약 (cap ≤ worker 수/2) 을 헬퍼로 보장

- **`cmd/issuetracker/main.go`**
  - `parserGate = NewStageGate(StageParser, NewSemaphore(cap), procLock, log)` 생성
  - procLock 부재 시 NoopStageGate 로 graceful degrade
  - parserCap 정보 INFO 로깅

- **`.env.example`**
  - `PARSER_MAX_CONCURRENT_PER_STAGE=0` 문서화

- **테스트**
  - `test/pkg/config/stage_gate_test.go` — LoadStageGate (default/override/invalid) + CapPerStage 경계 (workerCount<2, configured=0/음수, configured > half, odd worker count 등 11 케이스)
  - `test/internal/processor/parser/worker/helpers_test.go` — 주석 `// procLock` → `// gate` 갱신

<br>

## CI / 머지 게이트 점검

### 변경 영향 범위
- 영향 패키지/모듈: `internal/processor/parser/worker`, `cmd/issuetracker`, `pkg/config`
- 위험도(택1): **Low** — StageGate 자체는 #357 에서 머지됨. 본 PR 은 wiring 만 교체. NoopStageGate fallback 으로 procLock 부재 시에도 안전.

### Required Status Checks
- 통과 확인 대상 (PR Checks 탭에서 확인):
  - [ ] `Commit Lint`
  - [ ] `PR Title Lint`
  - [ ] `Linked Issue Check`
  - [ ] `Format Check`
  - [ ] `Build`
  - [ ] `Test`
  - [ ] `Lint`

### 롤백 계획
- `PARSER_MAX_CONCURRENT_PER_STAGE` 운영 cap 조정으로 1차 대응 (예: 1 로 강제하여 동시 1 슬롯)
- 회귀 시 PR revert — 이전 직접 `procLock` 호출 패턴으로 복귀, StageGate infra 자체는 #357 로 잔존

<br>

## 후속 작업
- Sub C (#356) — fetcher / validator worker 도 동일 패턴으로 StageGate 위임

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Parser operations now support configurable per-stage concurrency limits through advanced capacity gating, optimizing resource allocation and preventing bottlenecks in parallel processing pipelines.

* **Configuration**
  * New `PARSER_MAX_CONCURRENT_PER_STAGE` environment variable enables fine-grained control over parser concurrency behavior with automatic computation of optimal capacity based on worker thread availability.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/EinSofINTEREST/IssueTracker/pull/358)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->