### PR TITLE
[FEAT#356] fetcher / validate worker StageGate 마이그레이션 (#353 Sub C)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -208,9 +208,15 @@ LLM_POLICY=chain
 # default: 1.0,1.0,0.5 (Cost 와 Latency 동일, FailureRate 는 그 절반)
 LLM_HYBRID_WEIGHTS=1.0,1.0,0.5
 
-# Parser stage gate concurrency cap (이슈 #355)
-# parser stage 의 Semaphore capacity 상한. 0 / 미설정 → worker_count/2 (자동).
-# 양수 → min(value, worker_count/2) 채택. parserWorkerCount=6 인 현 설정에서 worker_count/2=3.
+# Stage gate concurrency caps (이슈 #353/#355/#356)
+# 각 stage 의 Semaphore capacity 상한. 0 / 미설정 → worker_count/2 (자동).
+# 양수 → min(value, worker_count/2) 채택. 설계 제약: cap ≤ stage worker 수의 절반 이하.
 # StageGate = ProcessingLock (URL 중복 차단) + Semaphore (stage 동시 슬롯 cap) 합성.
-# Issue #353 설계 제약: 각 stage cap 은 stage worker 수의 절반 이하.
+#
+# - FETCHER_MAX_CONCURRENT_PER_STAGE: high/normal/low/chromedp pool 별로 동일 cap 적용.
+#   현 설정에서 high WorkerCount=3 → cap=1, normal=6 → cap=3, low=2 → cap=1.
+# - PARSER_MAX_CONCURRENT_PER_STAGE: parserWorkerCount=6 → cap=3.
+# - VALIDATE_MAX_CONCURRENT_PER_STAGE: validateWorkerCount=8 → cap=4.
+FETCHER_MAX_CONCURRENT_PER_STAGE=0
 PARSER_MAX_CONCURRENT_PER_STAGE=0
+VALIDATE_MAX_CONCURRENT_PER_STAGE=0

--- a/cmd/issuetracker/main.go
+++ b/cmd/issuetracker/main.go
@@ -324,13 +324,27 @@ func main() {
 		}).Info("publisher pipeline guard enabled (Article 24h / Category 단명)")
 	}
 
-	managerCfg := crawlerWorker.ManagerConfig{
-		High:           crawlerWorker.PoolConfig{Consumer: highConsumer, WorkerCount: 3},
-		Normal:         crawlerWorker.PoolConfig{Consumer: normalConsumer, WorkerCount: 6},
-		Low:            crawlerWorker.PoolConfig{Consumer: lowConsumer, WorkerCount: 2},
-		ProcessingLock: procLock,
-		RetryScheduler: retryScheduler,
+	// StageGate 설정 (이슈 #353/#355/#356) — fetcher / parser / validator 의 per-stage Semaphore cap.
+	// 환경변수로 명시 cap 제공, 미지정 시 각 stage 의 worker_count/2 자동.
+	stageGateCfg, err := config.LoadStageGate()
+	if err != nil {
+		log.WithError(err).Fatal("failed to load stage gate config")
 	}
+
+	managerCfg := crawlerWorker.ManagerConfig{
+		High:                  crawlerWorker.PoolConfig{Consumer: highConsumer, WorkerCount: 3},
+		Normal:                crawlerWorker.PoolConfig{Consumer: normalConsumer, WorkerCount: 6},
+		Low:                   crawlerWorker.PoolConfig{Consumer: lowConsumer, WorkerCount: 2},
+		ProcessingLock:        procLock,
+		RetryScheduler:        retryScheduler,
+		MaxConcurrentPerStage: stageGateCfg.FetcherMaxConcurrentPerStage,
+	}
+	log.WithFields(map[string]interface{}{
+		"configured": stageGateCfg.FetcherMaxConcurrentPerStage,
+		"high":       managerCfg.High.WorkerCount,
+		"normal":     managerCfg.Normal.WorkerCount,
+		"low":        managerCfg.Low.WorkerCount,
+	}).Info("fetcher stage gate config loaded (per-pool cap = worker_count/2)")
 
 	// chromedp 전용 worker pool — semaphore 로 Chrome 동시 호출 제한.
 	// chromedpPoolCfg 는 사이트 등록 단계에서 미리 로드됨 (RemoteURLs 가 사이트
@@ -517,22 +531,16 @@ func main() {
 
 	// Parser StageGate (이슈 #355) — ProcessingLock + per-stage Semaphore 합성.
 	// Semaphore capacity 는 PARSER_MAX_CONCURRENT_PER_STAGE 와 worker_count/2 의 min.
-	stageGateCfg, err := config.LoadStageGate()
-	if err != nil {
-		log.WithError(err).Fatal("failed to load stage gate config")
-	}
+	// stageGateCfg 는 fetcher managerCfg 직전 (위쪽) 에서 이미 로드.
 	parserCap := config.CapPerStage(parserWorkerCount, stageGateCfg.ParserMaxConcurrentPerStage)
-	parserSem := locks.NewSemaphore(parserCap)
-	var parserGate locks.StageGate
+	parserGate := locks.BuildStageGate(locks.StageParser, parserCap, procLock, log)
 	if procLock != nil {
-		parserGate = locks.NewStageGate(locks.StageParser, parserSem, procLock, log)
 		log.WithFields(map[string]interface{}{
 			"worker_count": parserWorkerCount,
 			"capacity":     parserCap,
 			"configured":   stageGateCfg.ParserMaxConcurrentPerStage,
 		}).Info("parser stage gate enabled (ProcessingLock + Semaphore)")
 	} else {
-		parserGate = locks.NewNoopStageGate()
 		log.Warn("processing lock unavailable, parser stage gate falls back to noop")
 	}
 
@@ -763,7 +771,20 @@ func main() {
 	validateProducer := queue.NewProducer(validateKafkaCfg)
 	defer validateProducer.Close()
 
-	validateWorker := validate.NewWorker(validateConsumer, validateProducer, contentSvc, procLock, validateWorkerCount, validateCfg)
+	// Validate StageGate (이슈 #356) — ProcessingLock + per-stage Semaphore 합성.
+	validateCap := config.CapPerStage(validateWorkerCount, stageGateCfg.ValidateMaxConcurrentPerStage)
+	validateGate := locks.BuildStageGate(locks.StageValidator, validateCap, procLock, log)
+	if procLock != nil {
+		log.WithFields(map[string]interface{}{
+			"worker_count": validateWorkerCount,
+			"capacity":     validateCap,
+			"configured":   stageGateCfg.ValidateMaxConcurrentPerStage,
+		}).Info("validate stage gate enabled (ProcessingLock + Semaphore)")
+	} else {
+		log.Warn("processing lock unavailable, validate stage gate falls back to noop")
+	}
+
+	validateWorker := validate.NewWorker(validateConsumer, validateProducer, contentSvc, validateGate, validateWorkerCount, validateCfg)
 
 	log.WithFields(map[string]interface{}{
 		"worker_count": validateWorkerCount,

--- a/cmd/issuetracker/main.go
+++ b/cmd/issuetracker/main.go
@@ -339,12 +339,17 @@ func main() {
 		RetryScheduler:        retryScheduler,
 		MaxConcurrentPerStage: stageGateCfg.FetcherMaxConcurrentPerStage,
 	}
+	// per-pool 실제 capacity 를 함께 로깅 — env 양수 override 시 min(configured, worker_count/2) 가
+	// 적용되므로 단순 "worker_count/2" 문구는 부정확. 운영자가 실제 cap 을 즉답 가능하도록.
 	log.WithFields(map[string]interface{}{
 		"configured": stageGateCfg.FetcherMaxConcurrentPerStage,
 		"high":       managerCfg.High.WorkerCount,
 		"normal":     managerCfg.Normal.WorkerCount,
 		"low":        managerCfg.Low.WorkerCount,
-	}).Info("fetcher stage gate config loaded (per-pool cap = worker_count/2)")
+		"high_cap":   config.CapPerStage(managerCfg.High.WorkerCount, stageGateCfg.FetcherMaxConcurrentPerStage),
+		"normal_cap": config.CapPerStage(managerCfg.Normal.WorkerCount, stageGateCfg.FetcherMaxConcurrentPerStage),
+		"low_cap":    config.CapPerStage(managerCfg.Low.WorkerCount, stageGateCfg.FetcherMaxConcurrentPerStage),
+	}).Info("fetcher stage gate config loaded (per-pool cap = min(configured, worker_count/2))")
 
 	// chromedp 전용 worker pool — semaphore 로 Chrome 동시 호출 제한.
 	// chromedpPoolCfg 는 사이트 등록 단계에서 미리 로드됨 (RemoteURLs 가 사이트

--- a/cmd/processor/main.go
+++ b/cmd/processor/main.go
@@ -96,8 +96,8 @@ func main() {
 
 	// ── 5. Validate Worker 시작 ───────────────────────────────────────────────
 	// validator 결과 (passed/rejected) 는 contentSvc.UpdateValidationStatus 로 contents 에 기록.
-	// processor 단독 실행은 dev/test 시나리오 — Redis wiring 없이 NoopProcessingLock 사용.
-	// 다중 인스턴스 운영은 cmd/issuetracker 통합 바이너리에서 Redis 기반 ProcessingLock 공유.
+	// processor 단독 실행은 dev/test 시나리오 — Redis wiring 없이 NoopStageGate 사용 (dedup + cap 비활성).
+	// 다중 인스턴스 운영은 cmd/issuetracker 통합 바이너리에서 Redis 기반 ProcessingLock 합성된 StageGate 공유.
 	worker := validate.NewWorker(consumer, producer, contentSvc, locks.NewNoopStageGate(), validateWorkerCount, validateCfg)
 	worker.Start(ctx)
 

--- a/cmd/processor/main.go
+++ b/cmd/processor/main.go
@@ -98,7 +98,7 @@ func main() {
 	// validator 결과 (passed/rejected) 는 contentSvc.UpdateValidationStatus 로 contents 에 기록.
 	// processor 단독 실행은 dev/test 시나리오 — Redis wiring 없이 NoopProcessingLock 사용.
 	// 다중 인스턴스 운영은 cmd/issuetracker 통합 바이너리에서 Redis 기반 ProcessingLock 공유.
-	worker := validate.NewWorker(consumer, producer, contentSvc, locks.NoopProcessingLock{}, validateWorkerCount, validateCfg)
+	worker := validate.NewWorker(consumer, producer, contentSvc, locks.NewNoopStageGate(), validateWorkerCount, validateCfg)
 	worker.Start(ctx)
 
 	log.WithFields(map[string]interface{}{

--- a/internal/locks/stage_gate.go
+++ b/internal/locks/stage_gate.go
@@ -142,6 +142,29 @@ func (NoopStageGate) Acquire(_ context.Context, _ string) (func(), bool, error) 
 	return func() {}, true, nil
 }
 
+// BuildStageGate 는 (stage, workerCount, configuredCap, procLock, log) 입력으로 StageGate
+// 를 합성하는 wiring 헬퍼입니다 (이슈 #356 — DRY).
+//
+// 동작:
+//   - procLock 이 nil → NoopStageGate 반환 (Redis 부재 등 graceful degrade)
+//   - capacity = config.CapPerStage(workerCount, configuredCap) — 0 이하면 workerCount/2 자동.
+//     semaphore 최소 1 보장.
+//   - 정상 wiring 시 NewStageGate(stage, NewSemaphore(cap), procLock, log) 반환
+//
+// fetcher / parser / validator wiring 시 동일 헬퍼 사용 — capacity 정책 일관성.
+// capacity 계산은 pkg/config.CapPerStage 의 정책을 호출자가 적용한 뒤 본 헬퍼에 전달:
+// 본 헬퍼는 그 값으로 직접 semaphore 를 생성합니다.
+func BuildStageGate(stage string, capacity int, procLock ProcessingLock, log *logger.Logger) StageGate {
+	if procLock == nil {
+		return NewNoopStageGate()
+	}
+	if capacity < 1 {
+		capacity = 1
+	}
+	sem := NewSemaphore(capacity)
+	return NewStageGate(stage, sem, procLock, log)
+}
+
 // ErrStageGateNil 은 nil StageGate 가 의도치 않게 사용될 때 식별용.
 var ErrStageGateNil = errors.New("locks: nil stage gate")
 

--- a/internal/locks/stage_gate.go
+++ b/internal/locks/stage_gate.go
@@ -145,20 +145,19 @@ func (NoopStageGate) Acquire(_ context.Context, _ string) (func(), bool, error) 
 // BuildStageGate 는 (stage, capacity, procLock, log) 입력으로 StageGate 를 합성하는 wiring
 // 헬퍼입니다 (이슈 #356 — DRY).
 //
-// 시그니처 의도:
-//   - capacity 는 이미 계산된 Semaphore 용량을 받습니다. 호출자가 pkg/config.CapPerStage
-//     (worker_count/2 + min(configured) 정책) 로 사전 계산 후 본 헬퍼에 전달.
-//   - 본 헬퍼는 단순히 그 capacity 로 NewSemaphore 를 만들고 NewStageGate 로 합성.
-//
 // 동작:
-//   - procLock 이 nil → NoopStageGate 반환 (Redis 부재 등 graceful degrade)
+//   - procLock 이 nil (untyped 또는 typed-nil) → NoopStageGate 반환 (Redis 부재 등 graceful degrade)
 //   - capacity < 1 → 1 로 보정 (semaphore.NewSemaphore 의 capacity >= 1 보장)
 //   - 정상 wiring 시 NewStageGate(stage, NewSemaphore(capacity), procLock, log) 반환
 //
-// fetcher / parser / validator wiring 모두 동일 헬퍼 사용 — capacity 계산 정책의
-// 단일 소스를 pkg/config.CapPerStage 로 일원화.
+// 인자 설명:
+//   - capacity: 호출자가 사전 계산한 Semaphore 용량 (예: pkg/config.CapPerStage). 본 헬퍼는
+//     계산하지 않으며 최소 1 보장만 수행.
+//   - typed-nil 가드: NewStageGate 자체는 typed-nil procLock 을 panic 으로 검출.
+//     본 헬퍼는 그 대신 NoopStageGate 로 graceful degrade — wiring 단계에서 invariant 위반
+//     없이 fallback 가능하도록.
 func BuildStageGate(stage string, capacity int, procLock ProcessingLock, log *logger.Logger) StageGate {
-	if procLock == nil {
+	if isNilInterface(procLock) {
 		return NewNoopStageGate()
 	}
 	if capacity < 1 {

--- a/internal/locks/stage_gate.go
+++ b/internal/locks/stage_gate.go
@@ -142,18 +142,21 @@ func (NoopStageGate) Acquire(_ context.Context, _ string) (func(), bool, error) 
 	return func() {}, true, nil
 }
 
-// BuildStageGate 는 (stage, workerCount, configuredCap, procLock, log) 입력으로 StageGate
-// 를 합성하는 wiring 헬퍼입니다 (이슈 #356 — DRY).
+// BuildStageGate 는 (stage, capacity, procLock, log) 입력으로 StageGate 를 합성하는 wiring
+// 헬퍼입니다 (이슈 #356 — DRY).
+//
+// 시그니처 의도:
+//   - capacity 는 이미 계산된 Semaphore 용량을 받습니다. 호출자가 pkg/config.CapPerStage
+//     (worker_count/2 + min(configured) 정책) 로 사전 계산 후 본 헬퍼에 전달.
+//   - 본 헬퍼는 단순히 그 capacity 로 NewSemaphore 를 만들고 NewStageGate 로 합성.
 //
 // 동작:
 //   - procLock 이 nil → NoopStageGate 반환 (Redis 부재 등 graceful degrade)
-//   - capacity = config.CapPerStage(workerCount, configuredCap) — 0 이하면 workerCount/2 자동.
-//     semaphore 최소 1 보장.
-//   - 정상 wiring 시 NewStageGate(stage, NewSemaphore(cap), procLock, log) 반환
+//   - capacity < 1 → 1 로 보정 (semaphore.NewSemaphore 의 capacity >= 1 보장)
+//   - 정상 wiring 시 NewStageGate(stage, NewSemaphore(capacity), procLock, log) 반환
 //
-// fetcher / parser / validator wiring 시 동일 헬퍼 사용 — capacity 정책 일관성.
-// capacity 계산은 pkg/config.CapPerStage 의 정책을 호출자가 적용한 뒤 본 헬퍼에 전달:
-// 본 헬퍼는 그 값으로 직접 semaphore 를 생성합니다.
+// fetcher / parser / validator wiring 모두 동일 헬퍼 사용 — capacity 계산 정책의
+// 단일 소스를 pkg/config.CapPerStage 로 일원화.
 func BuildStageGate(stage string, capacity int, procLock ProcessingLock, log *logger.Logger) StageGate {
 	if procLock == nil {
 		return NewNoopStageGate()

--- a/internal/processor/fetcher/worker/manager.go
+++ b/internal/processor/fetcher/worker/manager.go
@@ -8,9 +8,16 @@ import (
 	"issuetracker/internal/locks"
 	"issuetracker/internal/processor/fetcher/core"
 	"issuetracker/internal/storage/service"
+	"issuetracker/pkg/config"
 	"issuetracker/pkg/logger"
 	"issuetracker/pkg/queue"
 )
+
+// buildStageCap 은 fetcher pool 의 Semaphore capacity 를 계산합니다.
+// pkg/config.CapPerStage 의 정책을 본 패키지에서도 사용 — 동일 규칙 (worker_count/2 floor, min cap).
+func buildStageCap(workerCount, configured int) int {
+	return config.CapPerStage(workerCount, configured)
+}
 
 // ─────────────────────────────────────────────────────────────────────────
 // 설정 구조체
@@ -43,6 +50,11 @@ type ManagerConfig struct {
 	Low            PoolConfig
 	ProcessingLock locks.ProcessingLock
 	RetryScheduler RetryScheduler
+
+	// MaxConcurrentPerStage: fetcher stage 의 Semaphore capacity 설정값 (이슈 #356).
+	// 0 이하 → 각 pool 의 WorkerCount/2 (floor) 자동.
+	// 양수 → min(value, WorkerCount/2). pool 별 (high/normal/low/chromedp) 동일 cap 정책 적용.
+	MaxConcurrentPerStage int
 
 	// Chromedp 는 chromedp 전용 pool 의 Consumer + WorkerCount.
 	// Consumer.nil 이면 chromedp pool 비활성.
@@ -88,19 +100,22 @@ func NewPoolManager(
 	log *logger.Logger,
 ) *PoolManager {
 	procLock := cfg.ProcessingLock
-	if procLock == nil {
-		procLock = locks.NoopProcessingLock{}
-	}
-
 	// 세 개 Pool이 동일한 CircuitBreakerRegistry를 공유하여
 	// 소스별 실패 카운팅이 우선순위 경계 없이 누적됩니다.
 	// log 주입 — CB state 전이마다 INFO/WARN 로그.
 	cbRegistry := NewCircuitBreakerRegistry(DefaultCircuitBreakerConfig, log)
 
+	// per-pool StageGate 합성 (이슈 #356) — pool 별 WorkerCount/2 cap.
+	// procLock nil 시 BuildStageGate 가 NoopStageGate 반환 → dedup+cap 자동 비활성.
+	buildGate := func(workerCount int) locks.StageGate {
+		capacity := buildStageCap(workerCount, cfg.MaxConcurrentPerStage)
+		return locks.BuildStageGate(locks.StageFetcher, capacity, procLock, log)
+	}
+
 	newPool := func(pc PoolConfig, priorityName string) *KafkaConsumerPool {
 		pool := NewKafkaConsumerPoolWithOptions(
 			pc.Consumer, producer, handler, contentSvc, pc.WorkerCount,
-			cbRegistry, procLock,
+			cbRegistry, buildGate(pc.WorkerCount),
 		)
 		// heartbeat 식별자 주입 (DEBUG 레벨에서 worker pool status 출력 활성)
 		pool.SetPriority(priorityName)
@@ -127,7 +142,7 @@ func NewPoolManager(
 	if cfg.Chromedp.Consumer != nil && cfg.ChromedpHandler != nil {
 		chromedpPool := NewKafkaConsumerPoolWithOptions(
 			cfg.Chromedp.Consumer, producer, cfg.ChromedpHandler, contentSvc, cfg.Chromedp.WorkerCount,
-			cbRegistry, procLock,
+			cbRegistry, buildGate(cfg.Chromedp.WorkerCount),
 		)
 		chromedpPool.SetPriority("chromedp")
 		if cfg.RetryScheduler != nil {

--- a/internal/processor/fetcher/worker/pool.go
+++ b/internal/processor/fetcher/worker/pool.go
@@ -69,7 +69,7 @@ type KafkaConsumerPool struct {
 	jobs        chan jobItem
 	wg          sync.WaitGroup
 	cbRegistry  *CircuitBreakerRegistry
-	procLock    locks.ProcessingLock
+	stageGate   locks.StageGate // nil 허용 → NoopStageGate (이슈 #356)
 	// normalizer는 URL 정규화기입니다.
 	// 미설정(nil) 이면 정규화가 적용되지 않으며, 기존 동작이 유지됩니다.
 	// atomic.Pointer 를 사용하여 polling/worker goroutine 의 동시 Load 와
@@ -120,7 +120,7 @@ func NewKafkaConsumerPool(
 	return NewKafkaConsumerPoolWithOptions(
 		consumer, producer, handler, contentSvc, workerCount,
 		NewCircuitBreakerRegistry(DefaultCircuitBreakerConfig, nil),
-		locks.NoopProcessingLock{},
+		locks.NewNoopStageGate(),
 	)
 }
 
@@ -137,12 +137,15 @@ func NewKafkaConsumerPoolWithCB(
 	return NewKafkaConsumerPoolWithOptions(
 		consumer, producer, handler, contentSvc, workerCount,
 		cbRegistry,
-		locks.NoopProcessingLock{},
+		locks.NewNoopStageGate(),
 	)
 }
 
 // NewKafkaConsumerPoolWithOptions는 모든 의존성을 외부에서 주입하는 생성자입니다.
-// 테스트에서 circuit breaker, processing lock 을 개별 제어할 때 사용합니다.
+// 테스트에서 circuit breaker, stage gate 를 개별 제어할 때 사용합니다.
+//
+// gate 는 nil 허용 — nil 이면 NoopStageGate 로 fallback (단일 인스턴스 환경에서 dedup + cap 비활성).
+// 이슈 #356 — fetcher / parser / validator 가 동일 StageGate 패턴 사용.
 func NewKafkaConsumerPoolWithOptions(
 	consumer queue.Consumer,
 	producer queue.Producer,
@@ -150,12 +153,12 @@ func NewKafkaConsumerPoolWithOptions(
 	contentSvc service.ContentService,
 	workerCount int,
 	cbRegistry *CircuitBreakerRegistry,
-	procLock locks.ProcessingLock,
+	gate locks.StageGate,
 ) *KafkaConsumerPool {
 	// nil guard — NewParserWorker / validate.NewWorker 와 일관성 보장.
-	// 외부 호출자가 nil 을 전달해도 panic 없이 dedup 비활성으로 동작.
-	if procLock == nil {
-		procLock = locks.NoopProcessingLock{}
+	// 외부 호출자가 nil 을 전달해도 panic 없이 dedup + cap 비활성으로 동작.
+	if gate == nil {
+		gate = locks.NewNoopStageGate()
 	}
 	return &KafkaConsumerPool{
 		consumer:    consumer,
@@ -164,7 +167,7 @@ func NewKafkaConsumerPoolWithOptions(
 		contentSvc:  contentSvc,
 		workerCount: workerCount,
 		cbRegistry:  cbRegistry,
-		procLock:    procLock,
+		stageGate:   gate,
 		// 버퍼 크기: worker 수의 2배로 polling과 처리 사이의 지연을 흡수
 		jobs:     make(chan jobItem, workerCount*2),
 		pollDone: make(chan struct{}),
@@ -452,57 +455,48 @@ func (p *KafkaConsumerPool) processJob(ctx context.Context, item jobItem) (err e
 		}
 	}
 
-	// 동일 URL 이 여러 worker 에서 동시 처리되는 것을 ProcessingLock (stage=fetcher) 로 차단.
+	// fetcher 단계 StageGate (ProcessingLock + Semaphore 합성, 이슈 #356) —
+	// 같은 URL 의 동시 fetch 차단 + per-stage 동시 슬롯 cap.
 	// Kafka rebalance/재시작으로 동일 메시지가 중복 소비될 때 + 같은 URL 의 다른 jobID 가 동시 처리될 때
-	// 모두 흡수. backoff 대기 이후에 Acquire 하여 락 점유 시간을 실제 처리 구간으로 최소화합니다.
-	procKey := locks.ProcessingKey(locks.StageFetcher, item.job.Target.URL)
-	acquired, err := p.procLock.Acquire(ctx, procKey)
-	if err != nil {
-		// 락 획득 오류 시 처리를 건너뛰지 않고 경고 후 진행합니다 (graceful degrade).
-		// ProcessingLock 장애가 크롤링 전체를 중단시키지 않도록 합니다.
+	// 모두 흡수. backoff 대기 이후에 Acquire 하여 슬롯 점유 시간을 실제 처리 구간으로 최소화합니다.
+	release, acquired, gateErr := p.stageGate.Acquire(ctx, item.job.Target.URL)
+	if gateErr != nil {
+		// ctx cancel / deadline → fail-open 시 취소된 ctx 로 불필요 작업 + per-stage cap 무력화 위험.
+		// commit 안 하고 종료 → Kafka redeliver 보장 (PR #358 패턴).
+		if ctx.Err() != nil {
+			return fmt.Errorf("fetcher stage gate acquire aborted by ctx: %w", gateErr)
+		}
+		// 그 외 인프라 에러 — 처리를 건너뛰지 않고 경고 후 진행 (graceful degrade).
+		// StageGate 장애가 크롤링 전체를 중단시키지 않도록 합니다.
 		log.WithFields(map[string]interface{}{
 			"job_id":  item.job.ID,
 			"crawler": item.job.CrawlerName,
 			"url":     item.job.Target.URL,
-		}).WithError(err).Warn("failed to acquire processing lock, proceeding without lock")
+		}).WithError(gateErr).Warn("failed to acquire fetcher stage gate, proceeding without gate")
 	} else if !acquired {
 		log.WithFields(map[string]interface{}{
 			"job_id":  item.job.ID,
 			"crawler": item.job.CrawlerName,
 			"url":     item.job.Target.URL,
-		}).Debug("processing lock already held by another worker, skipping")
+		}).Debug("fetcher processing lock already held by another worker, skipping")
 		// 다른 워커가 처리 중이므로 commit 없이 종료합니다.
 		// 처리 담당 워커의 commit 에 의존하여, 해당 워커 장애 시 재처리가 보장되도록 합니다.
 		return nil
 	} else {
-		// 운영자가 lock 획득 흐름을 추적할 수 있도록 DEBUG 로 success 기록.
-		// ttl_ms 는 ProcessingLock 인스턴스가 custom TTL 로 생성될 수 있어 인터페이스로 노출하지 않으면
-		// 정확치 않으므로 로그에서 제외.
+		// 운영자가 gate 획득 흐름을 추적할 수 있도록 DEBUG 로 success 기록.
 		log.WithFields(map[string]interface{}{
 			"job_id":  item.job.ID,
 			"crawler": item.job.CrawlerName,
 			"url":     item.job.Target.URL,
-		}).Debug("processing lock acquired")
+		}).Debug("fetcher stage gate acquired")
 
 		defer func() {
-			// 셧다운 시 ctx 가 취소되어도 락 해제는 반드시 수행되어야 합니다.
-			// context.WithoutCancel(ctx) 로 trace ID / logger 메타데이터 보존.
-			releaseCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 5*time.Second)
-			defer cancel()
-			if releaseErr := p.procLock.Release(releaseCtx, procKey); releaseErr != nil {
-				log.WithFields(map[string]interface{}{
-					"job_id":  item.job.ID,
-					"crawler": item.job.CrawlerName,
-					"url":     item.job.Target.URL,
-				}).WithError(releaseErr).Warn("failed to release processing lock")
-				return
-			}
-			// release 성공도 DEBUG 로 짝을 맞춰 lifecycle 완성.
+			release() // semaphore + lock 정리, internal 에서 shutdown ctx 보존.
 			log.WithFields(map[string]interface{}{
 				"job_id":  item.job.ID,
 				"crawler": item.job.CrawlerName,
 				"url":     item.job.Target.URL,
-			}).Debug("processing lock released")
+			}).Debug("fetcher stage gate released")
 		}()
 	}
 

--- a/internal/processor/validate/worker.go
+++ b/internal/processor/validate/worker.go
@@ -34,7 +34,7 @@ type Worker struct {
 	consumer    queue.Consumer
 	producer    queue.Producer
 	contentSvc  service.ContentService
-	procLock    locks.ProcessingLock // nil 허용 → NoopProcessingLock 으로 fallback
+	gate        locks.StageGate // nil 허용 → NoopStageGate 로 fallback (이슈 #356)
 	cfg         config.ValidateConfig
 	workerCount int
 	jobs        chan *queue.Message
@@ -45,29 +45,30 @@ type Worker struct {
 
 // NewWorker는 새로운 Worker를 생성합니다.
 // workerCount는 동시에 실행되는 처리 goroutine 수를 결정합니다.
-// procLock 은 nil 허용 — nil 이면 NoopProcessingLock 으로 fallback (단일 인스턴스 환경에서 dedup 비활성).
+// gate 는 nil 허용 — nil 이면 NoopStageGate 로 fallback (단일 인스턴스 환경에서 dedup + cap 비활성).
 //
 // validator 결과 (passed/rejected) 는 contentSvc.UpdateValidationStatus 로 contents 테이블에
 // 기록됩니다.
 //
-// ProcessingLock 으로 fetcher / parser / validator 가 동일 인터페이스로 단계별 dedup.
-// validator 단계는 ContentRef.URL 단위로 acquire — Kafka rebalance 시 같은 ref 가 두 worker 에 도달해도 1회만 검증.
+// StageGate (ProcessingLock + Semaphore 합성, 이슈 #353/#354/#356) 로 fetcher / parser / validator
+// 가 동일 인터페이스로 단계별 dedup + per-stage 동시성 cap. validator 단계는 ContentRef.URL 단위로
+// acquire — Kafka rebalance 시 같은 ref 가 두 worker 에 도달해도 1회만 검증.
 func NewWorker(
 	consumer queue.Consumer,
 	producer queue.Producer,
 	contentSvc service.ContentService,
-	procLock locks.ProcessingLock,
+	gate locks.StageGate,
 	workerCount int,
 	cfg config.ValidateConfig,
 ) *Worker {
-	if procLock == nil {
-		procLock = locks.NoopProcessingLock{}
+	if gate == nil {
+		gate = locks.NewNoopStageGate()
 	}
 	return &Worker{
 		consumer:    consumer,
 		producer:    producer,
 		contentSvc:  contentSvc,
-		procLock:    procLock,
+		gate:        gate,
 		cfg:         cfg,
 		workerCount: workerCount,
 		jobs:        make(chan *queue.Message, workerCount*2),
@@ -183,34 +184,31 @@ func (w *Worker) process(ctx context.Context, msg *queue.Message) error {
 		return w.commit(ctx, msg)
 	}
 
-	// validator 단계 ProcessingLock — 같은 ref.URL 의 동시 검증을 차단.
+	// validator 단계 StageGate (ProcessingLock + Semaphore 합성, 이슈 #356) —
+	// 같은 ref.URL 의 동시 검증 차단 + per-stage 동시 슬롯 cap.
 	// Kafka rebalance / 재배달 시 같은 ref 가 두 validator 에 도달해도 1회만 처리.
-	procKey := locks.ProcessingKey(locks.StageValidator, ref.URL)
-	acquired, lockErr := w.procLock.Acquire(ctx, procKey)
-	if lockErr != nil {
+	release, acquired, gateErr := w.gate.Acquire(ctx, ref.URL)
+	if gateErr != nil {
+		// ctx cancel / deadline → fail-open 시 취소된 ctx 로 불필요 작업 + per-stage cap 무력화 위험.
+		// commit 안 하고 종료 → Kafka redeliver 보장 (PR #358 패턴).
+		if ctx.Err() != nil {
+			return fmt.Errorf("validator stage gate acquire aborted by ctx: %w", gateErr)
+		}
+		// 그 외 인프라 에러 (예: Redis 장애) — fail-open. 다른 worker 와의 dedup 일시 비활성화.
 		log.WithFields(map[string]interface{}{
 			"job_id": pm.ID,
 			"ref_id": ref.ID,
-		}).WithError(lockErr).Warn("failed to acquire validator processing lock, proceeding without lock")
+		}).WithError(gateErr).Warn("failed to acquire validator stage gate, proceeding without gate")
 	} else if !acquired {
 		log.WithFields(map[string]interface{}{
 			"job_id": pm.ID,
 			"ref_id": ref.ID,
 		}).Debug("validator processing lock already held by another worker, skipping")
 		// 다른 validator 가 처리 중 — commit 없이 종료. 처리 담당 worker 의 commit 에 의존.
+		// validate 의 work runner 는 process error 시 commit 안 함 → Kafka redeliver 보장.
 		return nil
 	} else {
-		defer func() {
-			// 셧다운 시 ctx cancel 되어도 락 해제 보장 + trace ID 등 메타데이터 보존.
-			releaseCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 5*time.Second)
-			defer cancel()
-			if releaseErr := w.procLock.Release(releaseCtx, procKey); releaseErr != nil {
-				log.WithFields(map[string]interface{}{
-					"job_id": pm.ID,
-					"ref_id": ref.ID,
-				}).WithError(releaseErr).Warn("failed to release validator processing lock")
-			}
-		}()
+		defer release()
 	}
 
 	// DB에서 Content 조회 (content_bodies, content_meta 포함)

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -255,20 +255,31 @@ func LoadValidate(envFiles ...string) (ValidateConfig, error) {
 	return cfg, nil
 }
 
-// StageGateConfig 는 stage 별 StageGate 의 동시 처리 슬롯 상한을 나타냅니다 (이슈 #355).
+// StageGateConfig 는 stage 별 StageGate 의 동시 처리 슬롯 상한을 나타냅니다 (이슈 #353/#355/#356).
 //
 // 각 stage 의 Semaphore capacity 는 worker_count/2 를 넘지 않아야 함 — 이슈 #353 설계 제약.
 // 환경변수로 명시적 cap 을 받아 worker_count/2 와 비교 후 작은 값을 채택.
 type StageGateConfig struct {
+	// FetcherMaxConcurrentPerStage: fetcher stage 의 Semaphore capacity 상한.
+	// 0 이하면 worker_count/2 (floor) 사용. 양수면 min(value, worker_count/2) 채택.
+	// fetcher 는 priority pool (high/normal/low) 별 worker 수가 다르므로 pool 별로 동일 cap 적용.
+	FetcherMaxConcurrentPerStage int
+
 	// ParserMaxConcurrentPerStage: parser stage 의 Semaphore capacity 상한.
 	// 0 이하면 worker_count/2 (floor) 사용. 양수면 min(value, worker_count/2) 채택.
 	ParserMaxConcurrentPerStage int
+
+	// ValidateMaxConcurrentPerStage: validate stage 의 Semaphore capacity 상한.
+	// 0 이하면 worker_count/2 (floor) 사용. 양수면 min(value, worker_count/2) 채택.
+	ValidateMaxConcurrentPerStage int
 }
 
-// DefaultStageGateConfig 는 0 (worker_count/2 자동) 기본값을 반환합니다.
+// DefaultStageGateConfig 는 모든 stage 가 0 (worker_count/2 자동) 인 기본값을 반환합니다.
 func DefaultStageGateConfig() StageGateConfig {
 	return StageGateConfig{
-		ParserMaxConcurrentPerStage: 0,
+		FetcherMaxConcurrentPerStage:  0,
+		ParserMaxConcurrentPerStage:   0,
+		ValidateMaxConcurrentPerStage: 0,
 	}
 }
 
@@ -282,12 +293,24 @@ func LoadStageGate(envFiles ...string) (StageGateConfig, error) {
 	}
 
 	cfg := DefaultStageGateConfig()
-	if v := os.Getenv("PARSER_MAX_CONCURRENT_PER_STAGE"); v != "" {
-		n, err := strconv.Atoi(v)
-		if err != nil {
-			return StageGateConfig{}, fmt.Errorf("parse PARSER_MAX_CONCURRENT_PER_STAGE %q: %w", v, err)
+	parseInt := func(key string, dest *int) error {
+		if v := os.Getenv(key); v != "" {
+			n, err := strconv.Atoi(v)
+			if err != nil {
+				return fmt.Errorf("parse %s %q: %w", key, v, err)
+			}
+			*dest = n
 		}
-		cfg.ParserMaxConcurrentPerStage = n
+		return nil
+	}
+	for _, op := range []error{
+		parseInt("FETCHER_MAX_CONCURRENT_PER_STAGE", &cfg.FetcherMaxConcurrentPerStage),
+		parseInt("PARSER_MAX_CONCURRENT_PER_STAGE", &cfg.ParserMaxConcurrentPerStage),
+		parseInt("VALIDATE_MAX_CONCURRENT_PER_STAGE", &cfg.ValidateMaxConcurrentPerStage),
+	} {
+		if op != nil {
+			return StageGateConfig{}, op
+		}
 	}
 	return cfg, nil
 }

--- a/test/internal/locks/stage_gate_test.go
+++ b/test/internal/locks/stage_gate_test.go
@@ -346,3 +346,53 @@ func TestNewStageGate_PanicsOnInvalidArgs(t *testing.T) {
 	assert.Panics(t, func() { locks.NewStageGate(locks.StageFetcher, sem, typedNilLock, log) },
 		"typed-nil ProcessingLock 도 constructor 에서 panic 으로 감지")
 }
+
+// ─────────────────────────────────────────────────────────────────────────────
+// BuildStageGate (이슈 #356 — wiring 헬퍼)
+// ─────────────────────────────────────────────────────────────────────────────
+
+func TestBuildStageGate_NilProcLock_ReturnsNoop(t *testing.T) {
+	log := logger.New(logger.DefaultConfig())
+	gate := locks.BuildStageGate(locks.StageFetcher, 3, nil, log)
+	require.NotNil(t, gate)
+
+	// Noop 는 항상 (release, true, nil) 반환 + release 안전.
+	release, acquired, err := gate.Acquire(context.Background(), "https://example.com")
+	assert.NoError(t, err)
+	assert.True(t, acquired)
+	require.NotNil(t, release)
+	release() // panic 없어야 함
+}
+
+func TestBuildStageGate_ValidProcLock_ReturnsRealGate(t *testing.T) {
+	log := logger.New(logger.DefaultConfig())
+	lock := newStubLock(true)
+	gate := locks.BuildStageGate(locks.StageParser, 2, lock, log)
+	require.NotNil(t, gate)
+
+	release, acquired, err := gate.Acquire(context.Background(), "https://example.com")
+	assert.NoError(t, err)
+	assert.True(t, acquired)
+	require.NotNil(t, release)
+
+	// stub lock 의 Acquire 가 1회 호출됐는지 확인.
+	acq, _ := lock.callCounts()
+	assert.Equal(t, 1, acq)
+
+	release()
+	_, rel := lock.callCounts()
+	assert.Equal(t, 1, rel)
+}
+
+func TestBuildStageGate_CapacityFloor(t *testing.T) {
+	log := logger.New(logger.DefaultConfig())
+	lock := newStubLock(true)
+
+	// capacity < 1 → 내부에서 1 로 보정 (semaphore.NewSemaphore 의 panic 회피)
+	gate := locks.BuildStageGate(locks.StageValidator, 0, lock, log)
+	require.NotNil(t, gate)
+	release, acquired, err := gate.Acquire(context.Background(), "https://example.com")
+	assert.NoError(t, err)
+	assert.True(t, acquired)
+	release()
+}

--- a/test/internal/locks/stage_gate_test.go
+++ b/test/internal/locks/stage_gate_test.go
@@ -384,6 +384,23 @@ func TestBuildStageGate_ValidProcLock_ReturnsRealGate(t *testing.T) {
 	assert.Equal(t, 1, rel)
 }
 
+func TestBuildStageGate_TypedNilProcLock_ReturnsNoop(t *testing.T) {
+	// typed-nil 가드 (gemini 반영 PR #359) — NewStageGate 가 typed-nil 에 panic 하므로
+	// BuildStageGate 는 graceful degrade 로 NoopStageGate 반환 보장.
+	log := logger.New(logger.DefaultConfig())
+	var typedNilLock *locks.RedisProcessingLock // typed-nil
+
+	gate := locks.BuildStageGate(locks.StageFetcher, 3, typedNilLock, log)
+	require.NotNil(t, gate)
+
+	// Noop 동작 검증
+	release, acquired, err := gate.Acquire(context.Background(), "https://example.com")
+	assert.NoError(t, err)
+	assert.True(t, acquired)
+	require.NotNil(t, release)
+	release()
+}
+
 func TestBuildStageGate_CapacityFloor(t *testing.T) {
 	log := logger.New(logger.DefaultConfig())
 	lock := newStubLock(true)

--- a/test/internal/processor/fetcher/worker/processing_lock_pool_test.go
+++ b/test/internal/processor/fetcher/worker/processing_lock_pool_test.go
@@ -3,9 +3,11 @@ package worker_test
 import (
 	"context"
 	"errors"
+	"sync/atomic"
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 
 	"issuetracker/internal/locks"
@@ -15,23 +17,31 @@ import (
 )
 
 // ─────────────────────────────────────────────────────────────────────────────
-// Mock ProcessingLock — 본 파일 안에서만 사용 (test/internal/locks 의 동일명 mock 와 분리).
-// 단위 테스트 (NoopProcessingLock / ProcessingKey) 는 test/internal/locks 에 있음.
+// Mock StageGate — fetcher pool 의 StageGate 분기 (acquire / skip / release) 검증용.
+// 이슈 #356 — fetcher 가 ProcessingLock 직접 호출 대신 StageGate 합성 사용으로 변경됨에 따라
+// 본 mock 는 StageGate 인터페이스를 구현. ProcessingLock 자체 단위 테스트는 test/internal/locks 참조.
 // ─────────────────────────────────────────────────────────────────────────────
 
-type mockProcessingLock struct{ mock.Mock }
-
-func (m *mockProcessingLock) Acquire(ctx context.Context, key string) (bool, error) {
-	args := m.Called(ctx, key)
-	return args.Bool(0), args.Error(1)
+type mockStageGate struct {
+	mock.Mock
+	releaseCalls atomic.Int32
 }
 
-func (m *mockProcessingLock) Release(ctx context.Context, key string) error {
-	args := m.Called(ctx, key)
-	return args.Error(0)
+func (m *mockStageGate) Acquire(ctx context.Context, url string) (func(), bool, error) {
+	args := m.Called(ctx, url)
+	if err := args.Error(2); err != nil {
+		return nil, false, err
+	}
+	acquired := args.Bool(1)
+	if !acquired {
+		return nil, false, nil
+	}
+	return func() { m.releaseCalls.Add(1) }, true, nil
 }
 
-func runPoolWithLocker(t *testing.T, consumer *mockConsumer, pool *worker.KafkaConsumerPool, msg *queue.Message) {
+func (m *mockStageGate) ReleaseCalls() int32 { return m.releaseCalls.Load() }
+
+func runPoolWithGate(t *testing.T, consumer *mockConsumer, pool *worker.KafkaConsumerPool, msg *queue.Message) {
 	t.Helper()
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -50,62 +60,59 @@ func runPoolWithLocker(t *testing.T, consumer *mockConsumer, pool *worker.KafkaC
 	_ = pool.Stop(stopCtx)
 }
 
-// TestKafkaConsumerPool_ProcessingLock_AlreadyAcquired_SkipsWithoutCommit 는
-// 다른 worker 가 이미 락을 보유 중일 때 처리와 commit 을 모두 건너뛰는지 검증합니다.
-// 메시지 유실 방지: 락 보유 워커가 처리 도중 장애로 종료되어도 해당 워커가 commit 하지
+// TestKafkaConsumerPool_StageGate_AlreadyAcquired_SkipsWithoutCommit 는
+// 다른 worker 가 이미 lock 을 보유 중일 때 처리와 commit 을 모두 건너뛰는지 검증합니다.
+// 메시지 유실 방지: lock 보유 worker 가 처리 도중 장애로 종료되어도 해당 worker 가 commit 하지
 // 않았다면 Kafka 가 메시지를 재전달하여 재처리가 보장됩니다.
-func TestKafkaConsumerPool_ProcessingLock_AlreadyAcquired_SkipsWithoutCommit(t *testing.T) {
+func TestKafkaConsumerPool_StageGate_AlreadyAcquired_SkipsWithoutCommit(t *testing.T) {
 	consumer := new(mockConsumer)
 	producer := new(mockProducer)
 	handler := new(mockJobHandler)
 	contentSvc := new(mockContentService)
-	locker := new(mockProcessingLock)
+	gate := new(mockStageGate)
 
 	pool := worker.NewKafkaConsumerPoolWithOptions(
 		consumer, producer, handler, contentSvc, 1,
 		worker.NewCircuitBreakerRegistry(worker.DefaultCircuitBreakerConfig, nil),
-		locker,
+		gate,
 	)
 
 	job := newTestJob()
 	msg := marshaledJobMsg(t, job)
-	wantKey := locks.ProcessingKey(locks.StageFetcher, job.Target.URL)
 
-	// 이미 다른 worker 가 락을 보유 중
-	locker.On("Acquire", mock.Anything, wantKey).Return(false, nil)
+	// 이미 다른 worker 가 lock 을 보유 중 (acquired=false, err=nil)
+	gate.On("Acquire", mock.Anything, job.Target.URL).Return(nil, false, nil)
 
-	runPoolWithLocker(t, consumer, pool, msg)
+	runPoolWithGate(t, consumer, pool, msg)
 
 	// handler, producer, commit 모두 미호출 검증
 	handler.AssertNotCalled(t, "Handle", mock.Anything, mock.Anything)
 	producer.AssertNotCalled(t, "Publish", mock.Anything, mock.Anything)
 	consumer.AssertNotCalled(t, "CommitMessages", mock.Anything, mock.Anything)
-	locker.AssertExpectations(t)
+	gate.AssertExpectations(t)
+	assert.Equal(t, int32(0), gate.ReleaseCalls(), "skip 시 release 호출 X")
 }
 
-// TestKafkaConsumerPool_ProcessingLock_Acquired_ReleasedAfterProcessing 는
-// 락 획득 후 처리 완료 시 Release 가 호출되는지 검증합니다.
-func TestKafkaConsumerPool_ProcessingLock_Acquired_ReleasedAfterProcessing(t *testing.T) {
+// TestKafkaConsumerPool_StageGate_Acquired_ReleasedAfterProcessing 는
+// gate 획득 후 처리 완료 시 release 가 호출되는지 검증합니다.
+func TestKafkaConsumerPool_StageGate_Acquired_ReleasedAfterProcessing(t *testing.T) {
 	consumer := new(mockConsumer)
 	producer := new(mockProducer)
 	handler := new(mockJobHandler)
 	contentSvc := new(mockContentService)
-	locker := new(mockProcessingLock)
+	gate := new(mockStageGate)
 
 	pool := worker.NewKafkaConsumerPoolWithOptions(
 		consumer, producer, handler, contentSvc, 1,
 		worker.NewCircuitBreakerRegistry(worker.DefaultCircuitBreakerConfig, nil),
-		locker,
+		gate,
 	)
 
 	job := newTestJob()
 	content := newTestContent()
 	msg := marshaledJobMsg(t, job)
-	wantKey := locks.ProcessingKey(locks.StageFetcher, job.Target.URL)
 
-	locker.On("Acquire", mock.Anything, wantKey).Return(true, nil)
-	locker.On("Release", mock.Anything, wantKey).Return(nil)
-
+	gate.On("Acquire", mock.Anything, job.Target.URL).Return(nil, true, nil)
 	handler.On("Handle", mock.Anything, job).Return([]*core.Content{content}, nil)
 	contentSvc.On("Store", mock.Anything, content).Return(content.ID, false, nil)
 	producer.On("Publish", mock.Anything, mock.MatchedBy(func(m queue.Message) bool {
@@ -113,47 +120,73 @@ func TestKafkaConsumerPool_ProcessingLock_Acquired_ReleasedAfterProcessing(t *te
 	})).Return(nil)
 	consumer.On("CommitMessages", mock.Anything, mock.Anything).Return(nil)
 
-	runPoolWithLocker(t, consumer, pool, msg)
+	runPoolWithGate(t, consumer, pool, msg)
 
-	locker.AssertCalled(t, "Release", mock.Anything, wantKey)
+	assert.Equal(t, int32(1), gate.ReleaseCalls(), "성공 처리 후 release 1회 호출")
 	handler.AssertExpectations(t)
 }
 
-// TestKafkaConsumerPool_ProcessingLock_AcquireError_ProceedsWithoutLock 는
-// 락 획득 오류 시 처리를 중단하지 않고 경고 후 계속 진행하는지 검증합니다.
-func TestKafkaConsumerPool_ProcessingLock_AcquireError_ProceedsWithoutLock(t *testing.T) {
+// TestKafkaConsumerPool_StageGate_AcquireError_ProceedsWithoutGate 는
+// gate 획득 오류 (ctx 정상 상태에서) 시 처리를 중단하지 않고 경고 후 계속 진행하는지 검증합니다.
+// ctx cancel 케이스는 fetcher 내부에서 별도 분기로 처리 (return err) — 본 테스트는 인프라 오류 경로만.
+//
+// 결정성 (determinism): cancel 시점을 Publish.Once 직후로 동기화 — 첫 msg 의 fail-open 경로가
+// 완료된 후에만 polling 의 두 번째 FetchMessage 가 cancel + ctx.Canceled 반환. 이로써 ctx
+// race 가 사라져 dispatch site 의 `if ctx.Err() != nil { return err }` 분기가 우회됨.
+func TestKafkaConsumerPool_StageGate_AcquireError_ProceedsWithoutGate(t *testing.T) {
 	consumer := new(mockConsumer)
 	producer := new(mockProducer)
 	handler := new(mockJobHandler)
 	contentSvc := new(mockContentService)
-	locker := new(mockProcessingLock)
+	gate := new(mockStageGate)
 
 	pool := worker.NewKafkaConsumerPoolWithOptions(
 		consumer, producer, handler, contentSvc, 1,
 		worker.NewCircuitBreakerRegistry(worker.DefaultCircuitBreakerConfig, nil),
-		locker,
+		gate,
 	)
 
 	job := newTestJob()
 	content := newTestContent()
 	msg := marshaledJobMsg(t, job)
-	wantKey := locks.ProcessingKey(locks.StageFetcher, job.Target.URL)
 
-	// 락 획득 오류 — Redis 장애 시뮬레이션
-	locker.On("Acquire", mock.Anything, wantKey).Return(false, errors.New("redis unavailable"))
+	// gate 획득 오류 — Redis 장애 시뮬레이션. ctx 는 정상 상태.
+	gate.On("Acquire", mock.Anything, job.Target.URL).Return(nil, false, errors.New("redis unavailable"))
 
-	// 락 오류에도 처리는 계속 진행되어야 합니다
+	// gate 오류에도 처리는 계속 진행 (graceful degrade)
+	published := make(chan struct{}, 1)
 	handler.On("Handle", mock.Anything, job).Return([]*core.Content{content}, nil)
 	contentSvc.On("Store", mock.Anything, content).Return(content.ID, false, nil)
 	producer.On("Publish", mock.Anything, mock.MatchedBy(func(m queue.Message) bool {
 		return m.Topic == queue.TopicNormalized
-	})).Return(nil)
+	})).
+		Run(func(_ mock.Arguments) { published <- struct{}{} }).
+		Return(nil)
 	consumer.On("CommitMessages", mock.Anything, mock.Anything).Return(nil)
 
-	runPoolWithLocker(t, consumer, pool, msg)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	consumer.On("FetchMessage", mock.Anything).Return(msg, nil).Once()
+	consumer.On("FetchMessage", mock.Anything).
+		Run(func(_ mock.Arguments) {
+			// 첫 메시지의 fail-open 처리가 Publish 까지 도달한 뒤 cancel.
+			<-published
+			cancel()
+		}).
+		Return(nil, context.Canceled)
+	consumer.On("Close").Return(nil)
+
+	pool.Start(ctx)
+	<-ctx.Done()
+	stopCtx, stopCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer stopCancel()
+	_ = pool.Stop(stopCtx)
 
 	handler.AssertExpectations(t)
 	producer.AssertExpectations(t)
-	// 락 오류 시 Release 는 호출되지 않아야 합니다
-	locker.AssertNotCalled(t, "Release", mock.Anything, mock.Anything)
+	assert.Equal(t, int32(0), gate.ReleaseCalls(), "gate 오류 시 release 호출 X")
 }
+
+// 컴파일 타임 contract — locks.StageGate 인터페이스 만족 확인.
+var _ locks.StageGate = (*mockStageGate)(nil)

--- a/test/internal/processor/validate/worker_test.go
+++ b/test/internal/processor/validate/worker_test.go
@@ -155,7 +155,7 @@ func makeProcessingMessage(content *core.Content, retryCount int) *queue.Message
 }
 
 func newWorker(consumer queue.Consumer, producer queue.Producer, contentSvc service.ContentService) *validate.Worker {
-	return validate.NewWorker(consumer, producer, contentSvc, locks.NoopProcessingLock{}, 1, config.DefaultValidateConfig())
+	return validate.NewWorker(consumer, producer, contentSvc, locks.NewNoopStageGate(), 1, config.DefaultValidateConfig())
 }
 
 func runWorker(t *testing.T, consumer *mockConsumer, w *validate.Worker, msg *queue.Message) {

--- a/test/pkg/config/stage_gate_test.go
+++ b/test/pkg/config/stage_gate_test.go
@@ -9,21 +9,41 @@ import (
 )
 
 func TestLoadStageGate_DefaultValues(t *testing.T) {
+	t.Setenv("FETCHER_MAX_CONCURRENT_PER_STAGE", "")
 	t.Setenv("PARSER_MAX_CONCURRENT_PER_STAGE", "")
+	t.Setenv("VALIDATE_MAX_CONCURRENT_PER_STAGE", "")
 	cfg, err := config.LoadStageGate("/tmp/nonexistent-env-file.env")
 	require.NoError(t, err)
+	require.Equal(t, 0, cfg.FetcherMaxConcurrentPerStage)
 	require.Equal(t, 0, cfg.ParserMaxConcurrentPerStage)
+	require.Equal(t, 0, cfg.ValidateMaxConcurrentPerStage)
 }
 
 func TestLoadStageGate_EnvOverride(t *testing.T) {
+	t.Setenv("FETCHER_MAX_CONCURRENT_PER_STAGE", "2")
 	t.Setenv("PARSER_MAX_CONCURRENT_PER_STAGE", "4")
+	t.Setenv("VALIDATE_MAX_CONCURRENT_PER_STAGE", "5")
 	cfg, err := config.LoadStageGate("/tmp/nonexistent-env-file.env")
 	require.NoError(t, err)
+	require.Equal(t, 2, cfg.FetcherMaxConcurrentPerStage)
 	require.Equal(t, 4, cfg.ParserMaxConcurrentPerStage)
+	require.Equal(t, 5, cfg.ValidateMaxConcurrentPerStage)
 }
 
 func TestLoadStageGate_InvalidValue(t *testing.T) {
 	t.Setenv("PARSER_MAX_CONCURRENT_PER_STAGE", "not-a-number")
+	_, err := config.LoadStageGate("/tmp/nonexistent-env-file.env")
+	require.Error(t, err)
+}
+
+func TestLoadStageGate_InvalidFetcherValue(t *testing.T) {
+	t.Setenv("FETCHER_MAX_CONCURRENT_PER_STAGE", "abc")
+	_, err := config.LoadStageGate("/tmp/nonexistent-env-file.env")
+	require.Error(t, err)
+}
+
+func TestLoadStageGate_InvalidValidateValue(t *testing.T) {
+	t.Setenv("VALIDATE_MAX_CONCURRENT_PER_STAGE", "xyz")
 	_, err := config.LoadStageGate("/tmp/nonexistent-env-file.env")
 	require.Error(t, err)
 }


### PR DESCRIPTION
## 연관 이슈
- Closes #356
- Closes #353

마지막 sub-issue 머지 — 메인 #353 (parser/fetcher/validator 의 StageGate 합성) 통합 완료.

<br>

## 구현 내용
이슈 #353 의 phase 3 — fetcher / validate worker 도 parser (PR #358) 와 동일한 StageGate 패턴으로 마이그레이션. 모든 stage 가 단일 패턴 사용으로 운영·디버깅 일관성 확보.

### 변경 사항

**`internal/processor/fetcher/worker/`**
- `pool.go`: `procLock locks.ProcessingLock` → `stageGate locks.StageGate`. dispatch site 가 `gate.Acquire(ctx, url)` 단일 호출로 stage 진입 검증 + slot 점유 + URL lock 모두 수행.
- ctx cancel/deadline 시 wrapped err 반환 → commit skip + Kafka redeliver (PR #358 gemini/Copilot 패턴).
- ManagerConfig 에 `MaxConcurrentPerStage int` 추가, per-pool (high/normal/low/chromedp) cap = WorkerCount/2.

**`internal/processor/validate/worker.go`**
- 동일 패턴 마이그레이션. `procLock` → `gate`. dispatch site 정리 + ctx-aware abort.

**`internal/locks/stage_gate.go`**
- `BuildStageGate(stage, capacity, procLock, log)` wiring 헬퍼 추가. procLock nil 시 NoopStageGate fallback. parser/validate/fetcher 가 모두 동일 헬퍼 사용 (DRY).

**`pkg/config/config.go`**
- `StageGateConfig` 에 `FetcherMaxConcurrentPerStage`, `ValidateMaxConcurrentPerStage` 추가.
- `LoadStageGate` 가 3개 env 모두 파싱.

**`cmd/issuetracker/main.go`**
- `stageGateCfg` 를 fetcher managerCfg 직전에 로드 (parser/validate 도 재사용).
- parser gate / validate gate 도 `BuildStageGate` 사용으로 코드 정리.

**`cmd/processor/main.go`**
- standalone validator 의 NewWorker 호출이 `NewNoopStageGate()` 받도록 갱신.

**`.env.example`**
- `FETCHER_MAX_CONCURRENT_PER_STAGE` / `PARSER_MAX_CONCURRENT_PER_STAGE` / `VALIDATE_MAX_CONCURRENT_PER_STAGE` 통합 안내.

### 테스트
- `test/internal/locks/stage_gate_test.go`: BuildStageGate (nil procLock / valid / capacity floor) 3건.
- `test/pkg/config/stage_gate_test.go`: 새 env 2건의 default / override / invalid 분기.
- `test/internal/processor/fetcher/worker/processing_lock_pool_test.go`: 기존 mockProcessingLock → mockStageGate 마이그레이션. AcquireError 케이스는 `Publish.Once` 동기화로 ctx race 제거.
- `test/internal/processor/validate/worker_test.go`: NoopStageGate 주입으로 갱신.

<br>

## CI / 머지 게이트 점검

### 변경 영향 범위
- 영향 패키지/모듈: `internal/processor/fetcher/worker`, `internal/processor/validate`, `internal/locks`, `pkg/config`, `cmd/issuetracker`, `cmd/processor`
- 위험도(택1): **Medium** — fetcher worker 가 cap 도입으로 명목 throughput 절반 (pool 별 worker_count/2). 실측은 외부 의존 latency 가 dominant. Redis 부재 시 NoopStageGate 로 즉시 fallback — degrade 안전.

### Required Status Checks
- 통과 확인 대상 (PR Checks 탭에서 확인):
  - [ ] `Commit Lint`
  - [ ] `PR Title Lint`
  - [ ] `Linked Issue Check`
  - [ ] `Format Check`
  - [ ] `Build`
  - [ ] `Test`
  - [ ] `Lint`

### 롤백 계획
- `FETCHER_MAX_CONCURRENT_PER_STAGE=999` (큰 값) → cap 이 worker_count/2 로 자동 제한되므로 의미 없음. 진정한 롤백은 PR revert.
- Redis 부재 시 자동 NoopStageGate → dedup + cap 비활성으로 기존 동작 회귀.

🤖 Generated with [Claude Code](https://claude.com/claude-code)