### PR TITLE
[FEAT#352] claudegen ClaudeWorkerPool — N replica round-robin

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -114,6 +114,10 @@ CLAUDE_CODE_TIMEOUT=120s
 # CLAUDE_CODE_AUTH_DIR=/root/.claude
 # 컨테이너 내 인증 디렉토리 마운트 경로 (기본: /root/.claude — root user 컨테이너 기준)
 # CLAUDE_CODE_CONTAINER_AUTH_PATH=/root/.claude
+# ClaudeWorker pool 크기 (이슈 #352) — 동시 Extract 처리량 N배. 기본 2, 상한 16.
+# 0/음수/parse 실패 시 default(2). LLM rule generation throughput 병목 시 늘림.
+# 자원 사용: docker 컨테이너 N개 동시 기동 + claude API 호출량 N배 — quota 고려.
+CLAUDE_CODE_WORKER_COUNT=2
 
 # PathInfer 휴리스틱 설정 (이슈 #173)
 # URL 패턴 추론에 필요한 최소 샘플 URL 수 (1 이상)

--- a/cmd/issuetracker/main.go
+++ b/cmd/issuetracker/main.go
@@ -653,7 +653,9 @@ func main() {
 	// 미지정 / gemini (기본) 일 때는 buildLLMGenerator 가 설정한 기본 LLM provider 추출.
 	// Start 실패 시 Gemini 경로로 graceful fallback (fatal 아님).
 	// 종료 시 stages.Stop 이후 worker.Stop 호출 — llmGen.Stop 으로 in-flight Extract 완료 보장 후 컨테이너 정리.
-	var claudegenWorker *claudegen.ClaudeWorker
+	// 이슈 #352 — 단일 worker → ClaudeWorkerPool (N replica, default 2) 로 throughput 향상.
+	// CLAUDE_CODE_WORKER_COUNT 로 운영자 조정 가능. 기존 단일 worker 동작은 N=1 로 동등 재현 가능.
+	var claudegenPool *claudegen.ClaudeWorkerPool
 	llmExtractor := os.Getenv("LLM_EXTRACTOR")
 	switch {
 	case llmExtractor != "claude-code":
@@ -664,15 +666,17 @@ func main() {
 	case promptLoader == nil:
 		log.Warn("LLM_EXTRACTOR=claude-code requested but prompt loader is disabled; claudegen extractor not registered")
 	default:
-		worker, werr := claudegen.NewFromEnv(promptLoader, log)
-		if werr != nil {
-			log.WithError(werr).Warn("claudegen worker construction failed, falling back to default extractor")
-		} else if serr := worker.Start(ctx); serr != nil {
-			log.WithError(serr).Warn("claudegen worker start failed, falling back to default extractor")
+		pool, perr := claudegen.NewPoolFromEnv(promptLoader, log)
+		if perr != nil {
+			log.WithError(perr).Warn("claudegen pool construction failed, falling back to default extractor")
+		} else if serr := pool.Start(ctx); serr != nil {
+			log.WithError(serr).Warn("claudegen pool start failed, falling back to default extractor")
 		} else {
-			llmGen.SetExtractor(worker)
-			claudegenWorker = worker
-			log.Info("llmgen: Claude Code 웜 컨테이너 추출기 활성화")
+			llmGen.SetExtractor(pool)
+			claudegenPool = pool
+			log.WithFields(map[string]interface{}{
+				"worker_count": pool.WorkerCount(),
+			}).Info("llmgen: Claude Code 웜 컨테이너 pool 활성화")
 		}
 	}
 
@@ -886,13 +890,13 @@ func main() {
 	// shutdownCtx 가 stages.Stop 에서 timeout 으로 cancel 되더라도 docker rm -f 자체는 반드시 시도되어야
 	// 컨테이너 누수가 발생하지 않으므로, 별도의 cleanupCtx 를 사용.
 	// WithoutCancel(ctx) 로 ctx values 보존.
-	if claudegenWorker != nil {
+	if claudegenPool != nil {
 		cleanupCtx, cleanupCancel := context.WithTimeout(context.WithoutCancel(ctx), shutdownCfg.ClaudegenTimeout)
 		cleanupCtx = log.ToContext(cleanupCtx)
-		if err := claudegenWorker.Stop(cleanupCtx); err != nil {
-			log.WithError(err).Error("claudegen worker stop failed")
+		if err := claudegenPool.Stop(cleanupCtx); err != nil {
+			log.WithError(err).Error("claudegen pool stop failed")
 		} else {
-			log.Info("claudegen worker stopped")
+			log.Info("claudegen pool stopped")
 		}
 		cleanupCancel()
 	}

--- a/internal/processor/parser/rule/claudegen/pool.go
+++ b/internal/processor/parser/rule/claudegen/pool.go
@@ -1,0 +1,249 @@
+package claudegen
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"strconv"
+	"sync"
+	"sync/atomic"
+
+	"issuetracker/internal/processor/parser/rule/llmgen"
+	"issuetracker/internal/storage"
+	"issuetracker/pkg/llm/prompt"
+	"issuetracker/pkg/logger"
+)
+
+// 이슈 #352 — claudegen ClaudeWorker pool.
+//
+// 라이브 분석 (2026-05-11 22:39~) 6시간 누적 검증 실패율 88% 중 핵심 사유는 published_at
+// selector 부재 (1174건 / 83%). LLM rule generator throughput 을 높여 stale/missing selector
+// 의 자동 학습 + 정밀화 속도를 끌어올리는 것이 본 이슈의 목적.
+//
+// 본 파일은 ClaudeWorker 를 N replica pool 로 확장 — concurrent Extract 호출을 round-robin
+// 분배하여 단일 컨테이너 직렬화 병목 해소.
+
+const (
+	// envWorkerCount: pool size 환경변수. 0 / 미설정 → defaultWorkerCount.
+	envWorkerCount     = "CLAUDE_CODE_WORKER_COUNT"
+	defaultWorkerCount = 2
+	// maxWorkerCount: docker 컨테이너 누수 / claude API quota 폭발 방지용 상한.
+	// 운영자가 강제로 더 큰 값을 지정하면 maxWorkerCount 로 clamp.
+	maxWorkerCount = 16
+)
+
+// ClaudeWorkerPool 은 ClaudeWorker N replica 를 round-robin 분배로 사용하는 풀입니다.
+//
+// 모든 worker 가 동일한 환경 (image / model / authDir / timeout) 을 공유하므로 외부에서
+// 본 풀은 단일 SelectorExtractor / EnrichedExtractor 처럼 보입니다 — interface 호환을 통해
+// llmgen.Generator.SetExtractor 가 그대로 사용 가능.
+//
+// 분배 정책: round-robin (atomic.Uint64 의 modulo). 단순성 우선 — idle-first 분배는 운영
+// 검증 후 별도 이슈에서 도입.
+//
+// goroutine-safe: nextIdx 가 atomic, 각 worker 가 자체 mu/wg 로 동시 호출 safe.
+type ClaudeWorkerPool struct {
+	workers []*ClaudeWorker
+	nextIdx atomic.Uint64
+	log     *logger.Logger
+}
+
+// NewPool 은 주어진 worker slice 로 ClaudeWorkerPool 을 생성합니다 (DI 용).
+//
+// workers 빈 slice 시 error. log nil 시 error.
+// 모든 worker 가 동일한 model 사용을 가정 — ModelName() 은 workers[0].ModelName() 반환.
+func NewPool(workers []*ClaudeWorker, log *logger.Logger) (*ClaudeWorkerPool, error) {
+	if log == nil {
+		return nil, errors.New("claudegen: NewPool requires non-nil logger")
+	}
+	if len(workers) == 0 {
+		return nil, errors.New("claudegen: NewPool requires at least 1 worker")
+	}
+	for i, w := range workers {
+		if w == nil {
+			return nil, fmt.Errorf("claudegen: NewPool workers[%d] is nil", i)
+		}
+	}
+	return &ClaudeWorkerPool{workers: workers, log: log}, nil
+}
+
+// NewPoolFromEnv 는 CLAUDE_CODE_WORKER_COUNT 환경변수 기준으로 pool 을 구성합니다.
+//
+// 기본값: defaultWorkerCount (2). 상한: maxWorkerCount (16) — 운영자 입력값이 더 크면 clamp.
+// 0 / 음수 / parse 실패 시 default 적용 (WARN 로그).
+// 각 worker 는 동일 환경변수 set (image / model / authDir / timeout) 으로 구성.
+func NewPoolFromEnv(loader prompt.Loader, log *logger.Logger) (*ClaudeWorkerPool, error) {
+	if log == nil {
+		return nil, errors.New("claudegen: NewPoolFromEnv requires non-nil logger")
+	}
+	if loader == nil {
+		return nil, errors.New("claudegen: NewPoolFromEnv requires non-nil prompt loader")
+	}
+	count := resolveWorkerCount(log)
+	workers := make([]*ClaudeWorker, 0, count)
+	for i := 0; i < count; i++ {
+		w, err := NewFromEnv(loader, log)
+		if err != nil {
+			return nil, fmt.Errorf("claudegen: NewPoolFromEnv worker[%d]: %w", i, err)
+		}
+		workers = append(workers, w)
+	}
+	pool, err := NewPool(workers, log)
+	if err != nil {
+		return nil, err
+	}
+	log.WithFields(map[string]interface{}{
+		"worker_count": count,
+	}).Info("claudegen worker pool constructed (warm containers)")
+	return pool, nil
+}
+
+// resolveWorkerCount 는 CLAUDE_CODE_WORKER_COUNT 를 파싱하고 [1, maxWorkerCount] 로 clamp 합니다.
+func resolveWorkerCount(log *logger.Logger) int {
+	raw := os.Getenv(envWorkerCount)
+	if raw == "" {
+		return defaultWorkerCount
+	}
+	n, err := strconv.Atoi(raw)
+	if err != nil {
+		log.WithFields(map[string]interface{}{
+			"value": raw,
+		}).WithError(err).Warn("CLAUDE_CODE_WORKER_COUNT parse failed, using default")
+		return defaultWorkerCount
+	}
+	if n <= 0 {
+		log.WithFields(map[string]interface{}{
+			"value": n,
+		}).Warn("CLAUDE_CODE_WORKER_COUNT must be positive, using default")
+		return defaultWorkerCount
+	}
+	if n > maxWorkerCount {
+		log.WithFields(map[string]interface{}{
+			"value": n,
+			"cap":   maxWorkerCount,
+		}).Warn("CLAUDE_CODE_WORKER_COUNT exceeds upper bound, clamping")
+		return maxWorkerCount
+	}
+	return n
+}
+
+// ModelName 은 pool 의 첫 worker 모델 ID 를 반환합니다 — 모든 worker 가 동일 환경 가정.
+func (p *ClaudeWorkerPool) ModelName() string {
+	return p.workers[0].ModelName()
+}
+
+// WorkerCount 는 pool 크기를 반환합니다 — 운영 진단용.
+func (p *ClaudeWorkerPool) WorkerCount() int {
+	return len(p.workers)
+}
+
+// Start 는 모든 worker 컨테이너를 병렬로 기동합니다.
+//
+// 일부 worker 실패 시: 이미 성공한 worker 들을 best-effort 로 Stop 후 첫 에러 반환.
+// 운영자가 부분 기동 상태를 보지 않도록 — 전부 가동 또는 전부 종료의 두 상태만 노출.
+func (p *ClaudeWorkerPool) Start(ctx context.Context) error {
+	var wg sync.WaitGroup
+	errs := make([]error, len(p.workers))
+	for i, w := range p.workers {
+		wg.Add(1)
+		go func(idx int, worker *ClaudeWorker) {
+			defer wg.Done()
+			errs[idx] = worker.Start(ctx)
+		}(i, w)
+	}
+	wg.Wait()
+
+	// 부분 실패 시 cleanup
+	var firstErr error
+	failedAny := false
+	for i, err := range errs {
+		if err != nil && firstErr == nil {
+			firstErr = fmt.Errorf("claudegen: pool worker[%d] start failed: %w", i, err)
+		}
+		if err != nil {
+			failedAny = true
+		}
+	}
+	if failedAny {
+		// 이미 성공한 워커들을 best-effort 로 Stop (cleanup ctx 새로 만들어 부모 ctx cancel 영향 회피).
+		cleanupCtx, cleanupCancel := context.WithTimeout(context.WithoutCancel(ctx), defaultSessionTimeout)
+		defer cleanupCancel()
+		for i, w := range p.workers {
+			if errs[i] == nil {
+				if stopErr := w.Stop(cleanupCtx); stopErr != nil {
+					p.log.WithFields(map[string]interface{}{
+						"worker_idx": i,
+					}).WithError(stopErr).Warn("partial-start cleanup: worker stop failed")
+				}
+			}
+		}
+		return firstErr
+	}
+	p.log.WithFields(map[string]interface{}{
+		"worker_count": len(p.workers),
+	}).Info("claudegen worker pool started")
+	return nil
+}
+
+// Stop 은 모든 worker 컨테이너를 병렬로 정리합니다.
+//
+// 각 worker.Stop 이 자체 wg.Wait 으로 in-flight Extract 완료를 보장. 일부 실패는 첫 에러
+// 반환 + 나머지는 best-effort 시도.
+func (p *ClaudeWorkerPool) Stop(ctx context.Context) error {
+	var wg sync.WaitGroup
+	errs := make([]error, len(p.workers))
+	for i, w := range p.workers {
+		wg.Add(1)
+		go func(idx int, worker *ClaudeWorker) {
+			defer wg.Done()
+			errs[idx] = worker.Stop(ctx)
+		}(i, w)
+	}
+	wg.Wait()
+
+	var firstErr error
+	for i, err := range errs {
+		if err != nil {
+			p.log.WithFields(map[string]interface{}{
+				"worker_idx": i,
+			}).WithError(err).Warn("claudegen pool worker stop failed")
+			if firstErr == nil {
+				firstErr = fmt.Errorf("claudegen: pool worker[%d] stop failed: %w", i, err)
+			}
+		}
+	}
+	if firstErr == nil {
+		p.log.Info("claudegen worker pool stopped")
+	}
+	return firstErr
+}
+
+// Extract 는 round-robin 으로 worker 를 선택해 Extract 위임합니다.
+//
+// SelectorExtractor 인터페이스 호환 — llmgen.Generator.SetExtractor 가 본 메소드를 호출.
+func (p *ClaudeWorkerPool) Extract(ctx context.Context, host string, targetType storage.TargetType, html string) (storage.SelectorMap, error) {
+	return p.pick().Extract(ctx, host, targetType, html)
+}
+
+// ExtractEnriched 는 round-robin 으로 worker 를 선택해 ExtractEnriched 위임합니다.
+//
+// EnrichedExtractor 인터페이스 호환 — llmgen.Generator 가 type assertion 으로 자동 분기.
+func (p *ClaudeWorkerPool) ExtractEnriched(ctx context.Context, host string, targetType storage.TargetType, html string) (*llmgen.ExtractResult, error) {
+	return p.pick().ExtractEnriched(ctx, host, targetType, html)
+}
+
+// pick 는 round-robin 분배로 다음 worker 를 선택합니다.
+//
+// atomic.Uint64 의 ADD-AND-MODULO 패턴 — lock-free + counter wrap-around 시 modulo 정상 동작.
+// 분배 균등성은 worker 수가 2^N 일 때 가장 좋고 그 외에도 bias 가 최소.
+func (p *ClaudeWorkerPool) pick() *ClaudeWorker {
+	idx := p.nextIdx.Add(1) - 1 // Add 가 갱신 후 값 반환 — 0-base index 로 -1
+	return p.workers[idx%uint64(len(p.workers))]
+}
+
+// 컴파일 타임 contract — pool 이 두 인터페이스 모두 구현하는지 검증.
+var (
+	_ llmgen.SelectorExtractor = (*ClaudeWorkerPool)(nil)
+	_ llmgen.EnrichedExtractor = (*ClaudeWorkerPool)(nil)
+)

--- a/internal/processor/parser/rule/claudegen/pool.go
+++ b/internal/processor/parser/rule/claudegen/pool.go
@@ -93,9 +93,10 @@ func NewPoolFromEnv(loader prompt.Loader, log *logger.Logger) (*ClaudeWorkerPool
 	if err != nil {
 		return nil, err
 	}
+	// 생성 시점 — 아직 컨테이너 기동 전. Start() 가 성공해야 warm container 상태가 됨.
 	log.WithFields(map[string]interface{}{
 		"worker_count": count,
-	}).Info("claudegen worker pool constructed (warm containers)")
+	}).Info("claudegen worker pool constructed (containers not started yet)")
 	return pool, nil
 }
 
@@ -166,23 +167,31 @@ func (p *ClaudeWorkerPool) Start(ctx context.Context) error {
 		}
 	}
 	if failedAny {
-		// 이미 성공한 워커들을 best-effort 로 Stop (cleanup ctx 새로 만들어 부모 ctx cancel 영향 회피).
-		cleanupCtx, cleanupCancel := context.WithTimeout(context.WithoutCancel(ctx), defaultSessionTimeout)
-		defer cleanupCancel()
+		// 이미 성공한 워커들을 병렬 best-effort 로 Stop — 직렬 cleanup 시 앞 worker 의 timeout 이
+		// 단일 cleanupCtx 를 소진하여 뒤 worker cleanup 이 ctx.Done 으로 실패하는 누수 회피 (Copilot 반영).
+		// worker 별로 독립 timeout 부여.
+		var cwg sync.WaitGroup
 		for i, w := range p.workers {
 			if errs[i] == nil {
-				if stopErr := w.Stop(cleanupCtx); stopErr != nil {
-					p.log.WithFields(map[string]interface{}{
-						"worker_idx": i,
-					}).WithError(stopErr).Warn("partial-start cleanup: worker stop failed")
-				}
+				cwg.Add(1)
+				go func(idx int, worker *ClaudeWorker) {
+					defer cwg.Done()
+					cleanupCtx, cleanupCancel := context.WithTimeout(context.WithoutCancel(ctx), defaultSessionTimeout)
+					defer cleanupCancel()
+					if stopErr := worker.Stop(cleanupCtx); stopErr != nil {
+						p.log.WithFields(map[string]interface{}{
+							"worker_idx": idx,
+						}).WithError(stopErr).Warn("partial-start cleanup: worker stop failed")
+					}
+				}(i, w)
 			}
 		}
+		cwg.Wait()
 		return firstErr
 	}
 	p.log.WithFields(map[string]interface{}{
 		"worker_count": len(p.workers),
-	}).Info("claudegen worker pool started")
+	}).Info("claudegen worker pool started (warm containers)")
 	return nil
 }
 

--- a/test/internal/processor/parser/rule/claudegen/pool_test.go
+++ b/test/internal/processor/parser/rule/claudegen/pool_test.go
@@ -1,0 +1,280 @@
+package claudegen_test
+
+// pool_test.go — 이슈 #352 ClaudeWorkerPool 단위 테스트.
+//
+// 검증 항목:
+//  1. Start: 모든 worker 컨테이너 기동 + 부분 실패 시 cleanup
+//  2. Stop:  모든 worker 컨테이너 정리 + 일부 실패 → first error 반환
+//  3. Extract round-robin: N concurrent 호출이 N worker 에 분배됨
+//  4. WorkerCount / ModelName 메타 메소드
+//  5. 잘못된 입력 (nil worker / 빈 slice 등)
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"issuetracker/internal/processor/parser/rule/claudegen"
+	"issuetracker/internal/storage"
+	"issuetracker/pkg/logger"
+)
+
+// poolMockRunner 는 ExecSession 호출 시 호출된 containerID 를 기록 + 호출 횟수를 추적합니다.
+// pool 의 round-robin 분배를 검증하기 위해 worker 간 구분이 가능한 containerID 가 필요.
+type poolMockRunner struct {
+	id         string
+	startErr   error
+	execStdout string
+	execStderr string
+	execErr    error
+	execDelay  time.Duration // ExecSession 내부 인위적 지연 — concurrent 분배 검증용
+	execCalls  atomic.Int64
+	stopCalls  atomic.Int64
+	startCalls atomic.Int64
+}
+
+func (m *poolMockRunner) StartContainer(_ context.Context, _, _, _, _ string) (string, error) {
+	m.startCalls.Add(1)
+	if m.startErr != nil {
+		return "", m.startErr
+	}
+	return m.id, nil
+}
+
+func (m *poolMockRunner) ExecSession(_ context.Context, _ string, _ []string) (string, string, error) {
+	m.execCalls.Add(1)
+	if m.execDelay > 0 {
+		time.Sleep(m.execDelay)
+	}
+	return m.execStdout, m.execStderr, m.execErr
+}
+
+func (m *poolMockRunner) StopContainer(_ context.Context, _ string) error {
+	m.stopCalls.Add(1)
+	return nil
+}
+
+// newTestPoolWorker 는 ID 가 다른 runner 와 함께 ClaudeWorker 를 생성하는 헬퍼.
+func newTestPoolWorker(t *testing.T, runner *poolMockRunner) *claudegen.ClaudeWorker {
+	t.Helper()
+	log := logger.New(logger.DefaultConfig())
+	authDir := makeAuthDir(t)
+	w, err := claudegen.NewWithRunner(
+		"ghcr.io/anthropics/claude-code:latest",
+		"claude-sonnet-4-6",
+		authDir,
+		"/root/.claude",
+		10*time.Second,
+		runner,
+		claudegenLoader,
+		log,
+	)
+	require.NoError(t, err)
+	return w
+}
+
+// successStdout — 정상 selector 추출 JSON (worker_test.go 와 동일 형식).
+const successStdout = `{"title":{"css":"h1.article-title"},"main_content":{"css":"div.article-body","multi":true},"published_at":{"css":"time","attribute":"datetime"}}`
+
+// TestPool_NewPool_NilLogger 는 nil logger 입력 시 error 반환.
+func TestPool_NewPool_NilLogger(t *testing.T) {
+	_, err := claudegen.NewPool([]*claudegen.ClaudeWorker{nil}, nil)
+	require.Error(t, err)
+}
+
+// TestPool_NewPool_EmptyWorkers 는 빈 slice 입력 시 error 반환.
+func TestPool_NewPool_EmptyWorkers(t *testing.T) {
+	log := logger.New(logger.DefaultConfig())
+	_, err := claudegen.NewPool([]*claudegen.ClaudeWorker{}, log)
+	require.Error(t, err)
+}
+
+// TestPool_NewPool_NilWorker 는 nil 포함 slice 입력 시 error 반환.
+func TestPool_NewPool_NilWorker(t *testing.T) {
+	log := logger.New(logger.DefaultConfig())
+	r := &poolMockRunner{id: "c1", execStdout: successStdout}
+	w := newTestPoolWorker(t, r)
+	_, err := claudegen.NewPool([]*claudegen.ClaudeWorker{w, nil}, log)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "workers[1] is nil")
+}
+
+// TestPool_StartStop_AllContainers 는 N worker pool 의 Start/Stop 이 N 컨테이너 모두 다루는지 검증.
+func TestPool_StartStop_AllContainers(t *testing.T) {
+	log := logger.New(logger.DefaultConfig())
+	r1 := &poolMockRunner{id: "c1", execStdout: successStdout}
+	r2 := &poolMockRunner{id: "c2", execStdout: successStdout}
+	r3 := &poolMockRunner{id: "c3", execStdout: successStdout}
+	workers := []*claudegen.ClaudeWorker{
+		newTestPoolWorker(t, r1),
+		newTestPoolWorker(t, r2),
+		newTestPoolWorker(t, r3),
+	}
+	pool, err := claudegen.NewPool(workers, log)
+	require.NoError(t, err)
+
+	require.NoError(t, pool.Start(context.Background()))
+	assert.Equal(t, int64(1), r1.startCalls.Load())
+	assert.Equal(t, int64(1), r2.startCalls.Load())
+	assert.Equal(t, int64(1), r3.startCalls.Load())
+	assert.Equal(t, 3, pool.WorkerCount())
+
+	require.NoError(t, pool.Stop(context.Background()))
+	assert.Equal(t, int64(1), r1.stopCalls.Load())
+	assert.Equal(t, int64(1), r2.stopCalls.Load())
+	assert.Equal(t, int64(1), r3.stopCalls.Load())
+}
+
+// TestPool_Start_PartialFailure_CleansUpStarted 는 일부 worker 실패 시 이미 성공한
+// worker 가 cleanup 되는지 검증.
+func TestPool_Start_PartialFailure_CleansUpStarted(t *testing.T) {
+	log := logger.New(logger.DefaultConfig())
+	r1 := &poolMockRunner{id: "c1"}
+	r2 := &poolMockRunner{id: "c2", startErr: errors.New("docker daemon down")}
+	r3 := &poolMockRunner{id: "c3"}
+	workers := []*claudegen.ClaudeWorker{
+		newTestPoolWorker(t, r1),
+		newTestPoolWorker(t, r2),
+		newTestPoolWorker(t, r3),
+	}
+	pool, err := claudegen.NewPool(workers, log)
+	require.NoError(t, err)
+
+	err = pool.Start(context.Background())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "docker daemon down")
+
+	// 성공한 r1, r3 는 Stop 이 호출되어야 함 (cleanup), 실패한 r2 는 호출 안 됨.
+	assert.Equal(t, int64(1), r1.stopCalls.Load(), "started worker must be stopped on partial failure")
+	assert.Equal(t, int64(0), r2.stopCalls.Load(), "failed worker has no container to stop")
+	assert.Equal(t, int64(1), r3.stopCalls.Load(), "started worker must be stopped on partial failure")
+}
+
+// TestPool_Extract_RoundRobin 은 concurrent Extract 호출이 N worker 에 균등 분배되는지 검증.
+func TestPool_Extract_RoundRobin(t *testing.T) {
+	log := logger.New(logger.DefaultConfig())
+	const poolSize = 3
+	const callCount = 9 // 3 worker × 3 call
+	runners := make([]*poolMockRunner, poolSize)
+	workers := make([]*claudegen.ClaudeWorker, poolSize)
+	for i := 0; i < poolSize; i++ {
+		runners[i] = &poolMockRunner{
+			id:         "c" + string(rune('1'+i)),
+			execStdout: successStdout,
+			execDelay:  10 * time.Millisecond, // 모든 worker 가 동시에 busy 가 되도록
+		}
+		workers[i] = newTestPoolWorker(t, runners[i])
+	}
+	pool, err := claudegen.NewPool(workers, log)
+	require.NoError(t, err)
+	require.NoError(t, pool.Start(context.Background()))
+	t.Cleanup(func() { _ = pool.Stop(context.Background()) })
+
+	// concurrent Extract 호출
+	var wg sync.WaitGroup
+	for i := 0; i < callCount; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_, _ = pool.Extract(context.Background(), "example.com", storage.TargetTypePage, "<html></html>")
+		}()
+	}
+	wg.Wait()
+
+	// 각 worker 가 정확히 callCount/poolSize = 3 번 호출 (round-robin 균등 분배).
+	for i, r := range runners {
+		assert.Equal(t, int64(callCount/poolSize), r.execCalls.Load(),
+			"worker[%d] should be called %d times under round-robin", i, callCount/poolSize)
+	}
+}
+
+// TestPool_Extract_SequentialDistributesRoundRobin 은 순차 호출도 round-robin 패턴을 따르는지 검증.
+func TestPool_Extract_SequentialDistributesRoundRobin(t *testing.T) {
+	log := logger.New(logger.DefaultConfig())
+	r1 := &poolMockRunner{id: "c1", execStdout: successStdout}
+	r2 := &poolMockRunner{id: "c2", execStdout: successStdout}
+	workers := []*claudegen.ClaudeWorker{
+		newTestPoolWorker(t, r1),
+		newTestPoolWorker(t, r2),
+	}
+	pool, err := claudegen.NewPool(workers, log)
+	require.NoError(t, err)
+	require.NoError(t, pool.Start(context.Background()))
+	t.Cleanup(func() { _ = pool.Stop(context.Background()) })
+
+	for i := 0; i < 4; i++ {
+		_, _ = pool.Extract(context.Background(), "example.com", storage.TargetTypePage, "<html></html>")
+	}
+
+	// 정확히 2회씩 분배.
+	assert.Equal(t, int64(2), r1.execCalls.Load())
+	assert.Equal(t, int64(2), r2.execCalls.Load())
+}
+
+// TestPool_ModelName 은 pool 의 ModelName 이 첫 worker 의 model 을 반환하는지 검증.
+func TestPool_ModelName(t *testing.T) {
+	log := logger.New(logger.DefaultConfig())
+	r := &poolMockRunner{id: "c1"}
+	workers := []*claudegen.ClaudeWorker{newTestPoolWorker(t, r)}
+	pool, err := claudegen.NewPool(workers, log)
+	require.NoError(t, err)
+	assert.Equal(t, "claude-sonnet-4-6", pool.ModelName())
+}
+
+// TestPool_NewPoolFromEnv_DefaultCount 는 환경변수 미설정 시 기본 worker 수 (2) 가 적용되는지 검증.
+// 본 테스트는 실제 docker 호출은 하지 않으며 (validateAuthDir 만 통과), Start 는 호출하지 않음.
+func TestPool_NewPoolFromEnv_DefaultCount(t *testing.T) {
+	log := logger.New(logger.DefaultConfig())
+	// 환경변수 unset 보장
+	t.Setenv("CLAUDE_CODE_WORKER_COUNT", "")
+	t.Setenv("CLAUDE_CODE_AUTH_DIR", makeAuthDir(t))
+
+	pool, err := claudegen.NewPoolFromEnv(claudegenLoader, log)
+	require.NoError(t, err)
+	assert.Equal(t, 2, pool.WorkerCount(), "default worker count must be 2")
+}
+
+// TestPool_NewPoolFromEnv_EnvOverride 는 환경변수로 worker 수 조정이 반영되는지 검증.
+func TestPool_NewPoolFromEnv_EnvOverride(t *testing.T) {
+	log := logger.New(logger.DefaultConfig())
+	t.Setenv("CLAUDE_CODE_WORKER_COUNT", "4")
+	t.Setenv("CLAUDE_CODE_AUTH_DIR", makeAuthDir(t))
+
+	pool, err := claudegen.NewPoolFromEnv(claudegenLoader, log)
+	require.NoError(t, err)
+	assert.Equal(t, 4, pool.WorkerCount())
+}
+
+// TestPool_NewPoolFromEnv_InvalidValueFallsBack 은 잘못된 값 (parse 실패 / 음수 / 0) 시
+// default 로 fallback 되는지 검증.
+func TestPool_NewPoolFromEnv_InvalidValueFallsBack(t *testing.T) {
+	log := logger.New(logger.DefaultConfig())
+	t.Setenv("CLAUDE_CODE_AUTH_DIR", makeAuthDir(t))
+
+	for _, raw := range []string{"abc", "-1", "0"} {
+		t.Run("raw="+raw, func(t *testing.T) {
+			t.Setenv("CLAUDE_CODE_WORKER_COUNT", raw)
+			pool, err := claudegen.NewPoolFromEnv(claudegenLoader, log)
+			require.NoError(t, err)
+			assert.Equal(t, 2, pool.WorkerCount(), "invalid input must fallback to default 2")
+		})
+	}
+}
+
+// TestPool_NewPoolFromEnv_ExceedsMax_ClampsToCap 은 매우 큰 값 입력 시 maxWorkerCount 로
+// clamp 되는지 검증 (docker 누수 / API quota 폭발 방지).
+func TestPool_NewPoolFromEnv_ExceedsMax_ClampsToCap(t *testing.T) {
+	log := logger.New(logger.DefaultConfig())
+	t.Setenv("CLAUDE_CODE_WORKER_COUNT", "999")
+	t.Setenv("CLAUDE_CODE_AUTH_DIR", makeAuthDir(t))
+
+	pool, err := claudegen.NewPoolFromEnv(claudegenLoader, log)
+	require.NoError(t, err)
+	assert.LessOrEqual(t, pool.WorkerCount(), 16, "must be clamped to maxWorkerCount")
+}

--- a/test/internal/processor/parser/rule/claudegen/pool_test.go
+++ b/test/internal/processor/parser/rule/claudegen/pool_test.go
@@ -176,16 +176,28 @@ func TestPool_Extract_RoundRobin(t *testing.T) {
 	require.NoError(t, pool.Start(context.Background()))
 	t.Cleanup(func() { _ = pool.Stop(context.Background()) })
 
-	// concurrent Extract 호출
+	// concurrent Extract 호출 — 각 호출 결과 / err 도 검증하여 실패 silent skip 회피 (Copilot 반영).
 	var wg sync.WaitGroup
+	errCh := make(chan error, callCount)
+	resCh := make(chan storage.SelectorMap, callCount)
 	for i := 0; i < callCount; i++ {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			_, _ = pool.Extract(context.Background(), "example.com", storage.TargetTypePage, "<html></html>")
+			sm, err := pool.Extract(context.Background(), "example.com", storage.TargetTypePage, "<html></html>")
+			errCh <- err
+			resCh <- sm
 		}()
 	}
 	wg.Wait()
+	close(errCh)
+	close(resCh)
+	for err := range errCh {
+		require.NoError(t, err, "concurrent Extract must succeed")
+	}
+	for sm := range resCh {
+		require.NotNil(t, sm.Title, "Extract result must include parsed selectors")
+	}
 
 	// 각 worker 가 정확히 callCount/poolSize = 3 번 호출 (round-robin 균등 분배).
 	for i, r := range runners {
@@ -209,7 +221,9 @@ func TestPool_Extract_SequentialDistributesRoundRobin(t *testing.T) {
 	t.Cleanup(func() { _ = pool.Stop(context.Background()) })
 
 	for i := 0; i < 4; i++ {
-		_, _ = pool.Extract(context.Background(), "example.com", storage.TargetTypePage, "<html></html>")
+		sm, err := pool.Extract(context.Background(), "example.com", storage.TargetTypePage, "<html></html>")
+		require.NoError(t, err, "sequential Extract must succeed (call %d)", i)
+		require.NotNil(t, sm.Title, "Extract result must include parsed selectors (call %d)", i)
 	}
 
 	// 정확히 2회씩 분배.


### PR DESCRIPTION
## 연관 이슈
- Closes #352

<br>

## 구현 내용
라이브 분석 6시간 누적 검증 실패율 88% — 핵심 사유는 published_at selector 부재 (83%). LLM rule generator throughput 을 끌어올려 stale/missing selector 자동 학습 + 정밀화 속도를 향상시키는 것이 본 PR 의 목적.

### 변경 사항

**`internal/processor/parser/rule/claudegen/pool.go` (신규)**
- `ClaudeWorkerPool` — N replica round-robin (atomic.Uint64 modulo, lock-free)
- `NewPool(workers, log)` (DI) + `NewPoolFromEnv(loader, log)` (env)
- `Start(ctx)`: 병렬 기동 + 부분 실패 시 이미 성공한 worker cleanup (전부-가동/전부-종료 두 상태만 노출)
- `Stop(ctx)`: 병렬 정리, first error 반환 + 나머지 best-effort
- `Extract(ctx, ...)` / `ExtractEnriched(ctx, ...)`: round-robin 위임
- `ModelName()` / `WorkerCount()` 메타 메소드
- `SelectorExtractor` + `EnrichedExtractor` 인터페이스 모두 구현 — wiring 시 단일 worker 와 동등 호환

**`cmd/issuetracker/main.go`**
- 단일 `claudegenWorker` → `claudegenPool` 로 교체
- shutdown 시 `pool.Stop(cleanupCtx)` 호출, `ClaudegenTimeout` 그대로 적용

**`.env.example`**
- `CLAUDE_CODE_WORKER_COUNT` (default 2, max 16, 0/음수/parse 실패 시 default fallback) 안내

### 테스트 (11건)
- NewPool — nil logger / 빈 slice / nil worker 검증
- StartStop — N 컨테이너 모두 다루는지 확인
- Start partial failure — 성공한 worker cleanup, 실패한 worker 는 stop 호출 없음
- Round-robin concurrent (9 호출 × 3 worker = 균등 3회씩)
- Round-robin sequential (4 호출 × 2 worker = 균등 2회씩)
- ModelName 위임
- NewPoolFromEnv default count / env override / invalid (abc/-1/0) / max clamp

<br>

## CI / 머지 게이트 점검

### 변경 영향 범위
- 영향 패키지/모듈: `internal/processor/parser/rule/claudegen`, `cmd/issuetracker`
- 위험도(택1): **Medium** — LLM rule generator 동작 자체는 동일 (interface 호환 유지). 자원 사용은 N=2 기본값에서 docker 컨테이너 2개 + claude API 호출량 2배. 운영 시 `CLAUDE_CODE_WORKER_COUNT=1` 로 단일 worker 회귀 가능.

### Required Status Checks
- 통과 확인 대상 (PR Checks 탭에서 확인):
  - [ ] `Commit Lint`
  - [ ] `PR Title Lint`
  - [ ] `Linked Issue Check`
  - [ ] `Format Check`
  - [ ] `Build`
  - [ ] `Test`
  - [ ] `Lint`

### 롤백 계획
- `CLAUDE_CODE_WORKER_COUNT=1` 로 단일 worker 동작 회귀 — 변경 전과 동등.
- 추가 문제 시 PR revert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Claude Code extraction now supports multiple concurrent workers. Worker count is configurable via the new `CLAUDE_CODE_WORKER_COUNT` environment variable (default: 1). This allows operators to customize worker count based on deployment requirements.

* **Tests**
  * Added comprehensive test suite for the worker pool functionality.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/EinSofINTEREST/IssueTracker/pull/360)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->