### PR TITLE
[FIX#361] make start 의 wsURL 캡쳐 오염 차단 — sub-make directory 메시지 누설

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -105,7 +105,7 @@ run-processor: build ## Validate processor 실행
 	./$(PROCESSOR_BINARY)
 
 run-issuetracker: build ## Crawler + Processor 통합 실행 (chrome 실제 포트 자동 매핑 — 이슈 #348)
-	@urls=$$($(MAKE) -s chrome-remote-urls 2>/tmp/chrome-urls.err); \
+	@raw=$$($(MAKE) --no-print-directory -s chrome-remote-urls 2>/tmp/chrome-urls.err); \
 	rc=$$?; \
 	if [ $$rc -ne 0 ]; then \
 	  echo "ERROR: chrome-remote-urls failed (rc=$$rc):" >&2; \
@@ -114,6 +114,7 @@ run-issuetracker: build ## Crawler + Processor 통합 실행 (chrome 실제 포�
 	  exit $$rc; \
 	fi; \
 	rm -f /tmp/chrome-urls.err; \
+	urls=$$(printf '%s' "$$raw" | grep -oE 'ws://[^,[:space:]]+(,ws://[^,[:space:]]+)*' | tail -1); \
 	if [ -z "$$urls" ]; then \
 	  echo "No chrome compose containers running — falling back to .env FETCHER_CHROMEDP_REMOTE_URLS"; \
 	  echo "Running issuetracker (crawler + processor)..."; \


### PR DESCRIPTION
## 연관 이슈
- Closes #361

<br>

## 구현 내용
\`make start > debug.log 2>&1\` 라이브 실행 시 모든 chromedp fetch 가 \`[network:CDP_002] failed to modify wsURL: invalid control character in URL\` 로 실패하던 버그를 수정.

### 원인
\`make start\` → \`\$(MAKE) run-issuetracker\` → \`\$(MAKE) -s chrome-remote-urls\` 의 transitive sub-make 호출에서 \`-s\` (silent) 가 recipe 출력은 막지만 GNU make 의 \`Entering directory\` / \`Leaving directory\` 트래킹 메시지는 별도 \`--no-print-directory\` 옵션으로 제어해야 함. 결과적으로 \`\$urls\` 변수에 다음 형식이 캡쳐됨:

\`\`\`
make[2]: Entering directory '/home/.../IssueTracker'
ws://localhost:9226,ws://localhost:9227
make[2]: Leaving directory '/home/.../IssueTracker'
\`\`\`

이 오염된 값이 \`FETCHER_CHROMEDP_REMOTE_URLS\` env var 로 전달되어 chromedp 가 \`ws://localhost:9227\\nmake[2]: Leaving...\` 를 wsURL 로 해석 → 모든 fetch 실패.

### 변경 (Makefile)
1. **root cause**: \`\$(MAKE) -s chrome-remote-urls\` → \`\$(MAKE) --no-print-directory -s chrome-remote-urls\`
2. **defensive**: 캡쳐 결과를 \`grep -oE 'ws://[^,[:space:]]+(,ws://[^,[:space:]]+)*' | tail -1\` 로 정화 — 향후 다른 출력 누설에도 안전.

### 검증
\`make start > /tmp/start4.out 2>&1\` 25s 후 로그:
\`\`\`
Discovered chrome remote URLs (2): ws://localhost:9226,ws://localhost:9227
Running issuetracker (crawler + processor)...
\`\`\`
CDP_002 에러 0건.

<br>

## CI / 머지 게이트 점검

### 변경 영향 범위
- 영향: \`Makefile\` 단일 파일 (\`run-issuetracker\` 타겟). 운영자가 직접 \`make run-issuetracker\` 호출 시에도 동일하게 정상 동작 (sub-make 1단계만 발생하여 원래도 문제 없었지만 defensive filter 가 회귀 보호).
- 위험도(택1): **Low** — 환경변수 캡쳐 정화만 추가, 정상 흐름 변화 없음.

### Required Status Checks
- 통과 확인 대상 (PR Checks 탭에서 확인):
  - [ ] \`Commit Lint\`
  - [ ] \`PR Title Lint\`
  - [ ] \`Linked Issue Check\`
  - [ ] \`Format Check\`
  - [ ] \`Build\`
  - [ ] \`Test\`
  - [ ] \`Lint\`

### 롤백 계획
- Makefile revert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)