### PR TITLE
[FEAT#364] validate → parser 재학습 트리거 인프라 (#363 Sub A)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -124,6 +124,14 @@ CLAUDE_CODE_WORKER_COUNT=2
 PATHINFER_MIN_SAMPLES=3
 
 # Content 검증 임계값 설정 (pkg/config/config.go LoadValidate 참조)
+
+# validator → parser 재학습 트리거 (이슈 #363/#364)
+# true 시 selector 보강으로 해결 가능한 validation 실패 (PublishedAt required / Title-Body
+# min_length) 발생 시 새 CrawlJob 을 발행해 fetcher 재fetch + parser LLM 학습 트리거.
+# 동일 URL retry max = 2 (core.MaxValidateReparseCount). 초과 시 영구 DLQ.
+# default false — Sub C (#366) wiring 머지 후 true 권장.
+VALIDATE_REPARSE_ENABLED=false
+
 # 뉴스 소스 검증
 VALIDATE_NEWS_TITLE_MIN_LEN=10
 VALIDATE_NEWS_TITLE_MAX_LEN=500

--- a/internal/processor/fetcher/core/headers.go
+++ b/internal/processor/fetcher/core/headers.go
@@ -1,0 +1,33 @@
+package core
+
+// Kafka 메시지 헤더 키 — stage 간 (fetcher → parser → validate) 시그널 전파에 사용.
+//
+// 헤더 채택 이유: payload (CrawlJob / RawContentRef / ContentRef) 스키마 변경 없이 메타데이터
+// 만 전달. JSON 마이그레이션 비용 회피 + 헤더는 wire-level 에서 항상 접근 가능.
+const (
+	// HeaderTargetType: 처리 대상 타입 — "list" / "page" / "search".
+	// fetcher 가 host 별 chain handler 분기 + parser 가 ParseLinks vs ParsePage 분기.
+	HeaderTargetType = "target_type"
+
+	// HeaderCrawler: source crawler 식별자 (예: "naver", "cnn"). 로깅 + 재큐 시 보존용.
+	HeaderCrawler = "crawler"
+
+	// HeaderTimeoutMs: fetch / parse 단계의 timeout (ms). scheduler 가 entry 별로 다른 값 부여 가능.
+	HeaderTimeoutMs = "timeout_ms"
+
+	// HeaderValidateReparseCount: validator → parser 재학습 cycle 회차 (이슈 #363/#364).
+	// "0" 또는 미설정 = 일반 fetch / 첫 시도. "1".."MaxValidateReparseCount" = N번째 reparse.
+	// validate worker 가 reject 시 본 count 를 +1 한 새 CrawlJob 을 publish.
+	HeaderValidateReparseCount = "validate_reparse_count"
+
+	// HeaderValidateReparseReason: validate worker 가 reject 한 사유 문자열 (이슈 #363/#365).
+	// claudegen 의 LLM prompt 에 컨텍스트로 주입되어 multi-turn agent 가 selector 보강 또는
+	// validity=blacklist 결정에 활용. 헤더 부재 = reparse 가 아닌 일반 처리 경로.
+	HeaderValidateReparseReason = "validate_reparse_reason"
+)
+
+// MaxValidateReparseCount: validate → parser 재학습 cycle 최대 횟수 (이슈 #364).
+//
+// count 도달 후에도 validate 가 실패하면 영구 DLQ + content delete. 무한 루프 차단.
+// 값 2 의 의미: 원본 fetch 1회 + 재학습 reparse 2회 = 총 fetch 3회 / URL.
+const MaxValidateReparseCount = 2

--- a/internal/processor/fetcher/core/headers.go
+++ b/internal/processor/fetcher/core/headers.go
@@ -5,8 +5,9 @@ package core
 // 헤더 채택 이유: payload (CrawlJob / RawContentRef / ContentRef) 스키마 변경 없이 메타데이터
 // 만 전달. JSON 마이그레이션 비용 회피 + 헤더는 wire-level 에서 항상 접근 가능.
 const (
-	// HeaderTargetType: 처리 대상 타입 — "list" / "page" / "search".
-	// fetcher 가 host 별 chain handler 분기 + parser 가 ParseLinks vs ParsePage 분기.
+	// HeaderTargetType: 처리 대상 타입 — core.TargetType 문자열 ("article"/"category"/"search"/"sitemap").
+	// fetcher 의 chain handler 가 본 헤더로 분기 (예: domain/general/chain_handler.go).
+	// storage 의 TargetType 은 별도 분류 ("list"/"page") — fetcher wire 포맷과 다름 (parser 단에서 변환).
 	HeaderTargetType = "target_type"
 
 	// HeaderCrawler: source crawler 식별자 (예: "naver", "cnn"). 로깅 + 재큐 시 보존용.

--- a/internal/processor/validate/reparse.go
+++ b/internal/processor/validate/reparse.go
@@ -1,0 +1,58 @@
+package validate
+
+// reparse.go — validate 실패 시 parser 재학습 트리거 정책 (이슈 #364).
+//
+// validate 실패 사유 중 selector 보강으로 해결 가능한 케이스만 재학습 대상으로 분류:
+//   - VAL_001 (PublishedAt required) — parsing_rule 에 published_at selector 부재 시
+//   - VAL_003 (Title/Body min_length, min_word_count) — selector 가 잘못된 element 추출
+//
+// 다음 케이스는 재학습 대상 아님 — selector 변경으로 해결 불가:
+//   - VAL_002 (format) / VAL_004 (max_length) / VAL_005 (quality) / VAL_006 (spam)
+//
+// claudegen 의 multi-turn agent 는 reason 컨텍스트 받고 validity=blacklist 판정 가능
+// (예: PublishedAt 이 영원히 없는 메타/index 페이지). 본 모듈은 단순 코드 분류만 수행.
+
+import (
+	"errors"
+	"strconv"
+
+	"issuetracker/internal/processor/fetcher/core"
+	"issuetracker/pkg/queue"
+)
+
+// reparseEligibleCodes 는 selector 재학습으로 해결 가능한 validation 에러 코드 집합입니다.
+var reparseEligibleCodes = map[string]struct{}{
+	core.CodeValMissingField: {}, // VAL_001 — 필수 필드 누락 (PublishedAt 등)
+	core.CodeValContentShort: {}, // VAL_003 — 텍스트 필드 최소 길이 미달 (Title/Body)
+}
+
+// readReparseCount 는 msg 의 validate_reparse_count 헤더를 정수로 파싱합니다.
+//
+// 헤더 부재 / 파싱 실패 시 0 (첫 시도) 반환 — 첫 진입이면 첫 reparse cycle 이 1 이 되도록.
+func readReparseCount(msg *queue.Message) int {
+	raw, ok := msg.Headers[core.HeaderValidateReparseCount]
+	if !ok || raw == "" {
+		return 0
+	}
+	n, err := strconv.Atoi(raw)
+	if err != nil || n < 0 {
+		return 0
+	}
+	return n
+}
+
+// IsReparseEligible 은 err 가 selector 재학습 (parser → LLM 학습) 트리거 대상인지 판정합니다.
+//
+// 분류 기준 (이슈 #364):
+//   - core.CrawlerError 가 아니면 false
+//   - Code 가 reparseEligibleCodes 에 포함된 경우만 true
+//
+// 호출자는 본 true 결과 + reparse_count < MaxValidateReparseCount 일 때 새 CrawlJob 발행.
+func IsReparseEligible(err error) bool {
+	var cerr *core.CrawlerError
+	if !errors.As(err, &cerr) {
+		return false
+	}
+	_, ok := reparseEligibleCodes[cerr.Code]
+	return ok
+}

--- a/internal/processor/validate/worker.go
+++ b/internal/processor/validate/worker.go
@@ -262,26 +262,30 @@ func (w *Worker) process(ctx context.Context, msg *queue.Message) error {
 					"max":           core.MaxValidateReparseCount,
 				}).WithError(err).Info("content validation failed, triggering parser reparse (LLM rule relearn)")
 
-				// reparse cycle 시작 — 기존 contents row 정리 후 새 CrawlJob 발행.
-				// reject 사유 기록은 reparse 의 메타데이터로 충분 — DB 컬럼 갱신 skip 으로 단순화.
+				// reparse cycle 시작 — 발행 성공 후 contents row 정리 (순서 중요, gemini 반영).
+				// Delete 가 republish 보다 먼저면 Delete 성공 + republish 실패 시 Kafka 재처리에서
+				// GetByID 가 ErrNotFound 로 본 분기 자체를 못 타고 idempotent skip 되어 trigger 누락.
+				// → republish 성공 후에만 Delete 호출 → republish 실패해도 Kafka 재처리 시 재시도 가능.
+				if rpErr := w.republishForReparse(ctx, content, reparseCount, err, msg); rpErr != nil {
+					return fmt.Errorf("republish reparse: %w", rpErr)
+				}
 				if delErr := w.contentSvc.Delete(ctx, ref.ID); delErr != nil {
 					log.WithFields(map[string]interface{}{
 						"job_id": pm.ID,
 						"ref_id": ref.ID,
-					}).WithError(delErr).Warn("failed to delete content before reparse (non-fatal — reparse will overwrite)")
+					}).WithError(delErr).Warn("failed to delete content after reparse publish (non-fatal — reparse cycle will overwrite)")
 				}
-				if rpErr := w.republishForReparse(ctx, content, reparseCount, err); rpErr != nil {
-					return fmt.Errorf("republish reparse: %w", rpErr)
-				}
-				return w.commit(ctx, msg)
+				// commit 은 shutdown 시 ctx cancel 영향 회피 — context.WithoutCancel 로 metadata 보존 (gemini 반영).
+				return w.commit(context.WithoutCancel(ctx), msg)
 			}
-			// max 도달 — 기존 DLQ 경로로 폴스루 (info 로그로 사유 명시)
+			// max 도달 — 기존 DLQ/requeue 흐름으로 폴스루. pm.RetryCount/maxRetries 에 따라
+			// DLQ 또는 requeue 가 결정되므로 "permanent DLQ" 단정 금지 (Copilot 반영).
 			log.WithFields(map[string]interface{}{
 				"job_id":        pm.ID,
 				"ref_id":        ref.ID,
 				"reparse_count": reparseCount,
 				"max":           core.MaxValidateReparseCount,
-			}).Info("reparse count reached max, falling through to permanent DLQ")
+			}).Info("reparse count reached max, falling through to existing DLQ/requeue flow")
 		}
 
 		// 검증 실패: contents에서 삭제 후 DLQ 또는 재큐잉
@@ -512,19 +516,40 @@ func (w *Worker) requeue(ctx context.Context, msg *queue.Message, pm *core.Proce
 	return nil
 }
 
+// reparseJobTimeoutDefault 는 원본 timeout_ms 헤더 부재 시 사용할 reparse CrawlJob timeout.
+const reparseJobTimeoutDefault = 30 * time.Second
+
 // republishForReparse 는 validate 실패 시 parser 재학습 트리거용 새 CrawlJob 을
 // TopicCrawlNormal 에 발행합니다 (이슈 #364).
 //
-// 헤더에 validate_reparse_count (현재 + 1) 와 validate_reparse_reason (err.Error())
-// 을 설정 — Sub C 의 parser worker 가 본 헤더 보고 LLM 호출 시 reason context 주입.
+// 헤더 정책:
+//   - 원본 메시지 (orig) 의 모든 헤더를 base 로 복사 후 reparse 전용 키만 덮어쓰기 —
+//     timeout_ms / trace ID / 기타 observability 메타데이터 보존 (gemini 반영)
+//   - validate_reparse_count = currentCount + 1
+//   - validate_reparse_reason = err.Error()
+//   - target_type = string(TargetTypeArticle) — fetcher chain handler 가 article 분기 사용
+//     (Copilot 반영 — wire 포맷은 core.TargetType 문자열 "article" 이지 "page" 아님)
+//   - crawler = content.SourceID (없으면 base 유지)
+//
+// Kafka key 는 job.ID — 기존 crawl 토픽 발행 패턴과 일관 (scheduler/emitter.go, fetcher/rule/upgrader.go).
+//
+// timeout 은 원본 timeout_ms 헤더 계승 (gemini 반영). 부재 시 reparseJobTimeoutDefault.
 //
 // 호출 사전 조건 (호출자가 보장):
 //   - cfg.ReparseEnabled == true
 //   - IsReparseEligible(err) == true
 //   - currentCount < core.MaxValidateReparseCount
-func (w *Worker) republishForReparse(ctx context.Context, content *core.Content, currentCount int, reason error) error {
+func (w *Worker) republishForReparse(ctx context.Context, content *core.Content, currentCount int, reason error, orig *queue.Message) error {
 	log := logger.FromContext(ctx)
 	nextCount := currentCount + 1
+
+	// timeout — 원본 timeout_ms 헤더 계승, 부재 시 기본.
+	jobTimeout := reparseJobTimeoutDefault
+	if raw := orig.Headers[core.HeaderTimeoutMs]; raw != "" {
+		if ms, perr := strconv.Atoi(raw); perr == nil && ms > 0 {
+			jobTimeout = time.Duration(ms) * time.Millisecond
+		}
+	}
 
 	job := core.CrawlJob{
 		ID:          fmt.Sprintf("reparse-%s-%d", content.ID, nextCount),
@@ -535,7 +560,7 @@ func (w *Worker) republishForReparse(ctx context.Context, content *core.Content,
 		},
 		Priority:    core.PriorityNormal,
 		ScheduledAt: time.Now(),
-		Timeout:     30 * time.Second, // fetcher 기본값 — entrypoint 가 scheduler timeout 헤더 없으면 기본
+		Timeout:     jobTimeout,
 		RetryCount:  0,
 		MaxRetries:  3,
 	}
@@ -544,16 +569,24 @@ func (w *Worker) republishForReparse(ctx context.Context, content *core.Content,
 		return fmt.Errorf("marshal reparse crawl job: %w", err)
 	}
 
+	// 원본 헤더 base 복사 + reparse 전용 키 덮어쓰기 (gemini 반영).
+	headers := make(map[string]string, len(orig.Headers)+4)
+	for k, v := range orig.Headers {
+		headers[k] = v
+	}
+	headers[core.HeaderTargetType] = string(core.TargetTypeArticle) // wire 포맷 (Copilot 반영)
+	if content.SourceID != "" {
+		headers[core.HeaderCrawler] = content.SourceID
+	}
+	headers[core.HeaderTimeoutMs] = strconv.FormatInt(jobTimeout.Milliseconds(), 10)
+	headers[core.HeaderValidateReparseCount] = strconv.Itoa(nextCount)
+	headers[core.HeaderValidateReparseReason] = reason.Error()
+
 	reparseMsg := queue.Message{
-		Topic: queue.TopicCrawlNormal,
-		Key:   []byte(content.URL),
-		Value: payload,
-		Headers: map[string]string{
-			core.HeaderTargetType:            "page",
-			core.HeaderCrawler:               content.SourceID,
-			core.HeaderValidateReparseCount:  strconv.Itoa(nextCount),
-			core.HeaderValidateReparseReason: reason.Error(),
-		},
+		Topic:   queue.TopicCrawlNormal,
+		Key:     []byte(job.ID), // 기존 crawl 토픽 패턴 일관 (Copilot 반영)
+		Value:   payload,
+		Headers: headers,
 	}
 
 	pubErr := w.producer.Publish(ctx, reparseMsg)

--- a/internal/processor/validate/worker.go
+++ b/internal/processor/validate/worker.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"strconv"
 	"sync"
 	"time"
 
@@ -247,6 +248,42 @@ func (w *Worker) process(ctx context.Context, msg *queue.Message) error {
 
 	_, err = RunValidation(ctx, v, content)
 	if err != nil {
+		// validator → parser 재학습 트리거 분기 (이슈 #363/#364) — selector 보강으로 해결
+		// 가능한 에러 (PublishedAt required / Title-Body min_length) 가 trigger 대상.
+		// 본 분기는 cfg.ReparseEnabled + 횟수 < max 일 때만 동작 — 그 외에는 기존 DLQ/requeue 흐름.
+		if w.cfg.ReparseEnabled && IsReparseEligible(err) {
+			reparseCount := readReparseCount(msg)
+			if reparseCount < core.MaxValidateReparseCount {
+				log.WithFields(map[string]interface{}{
+					"job_id":        pm.ID,
+					"ref_id":        ref.ID,
+					"source":        content.SourceID,
+					"reparse_count": reparseCount,
+					"max":           core.MaxValidateReparseCount,
+				}).WithError(err).Info("content validation failed, triggering parser reparse (LLM rule relearn)")
+
+				// reparse cycle 시작 — 기존 contents row 정리 후 새 CrawlJob 발행.
+				// reject 사유 기록은 reparse 의 메타데이터로 충분 — DB 컬럼 갱신 skip 으로 단순화.
+				if delErr := w.contentSvc.Delete(ctx, ref.ID); delErr != nil {
+					log.WithFields(map[string]interface{}{
+						"job_id": pm.ID,
+						"ref_id": ref.ID,
+					}).WithError(delErr).Warn("failed to delete content before reparse (non-fatal — reparse will overwrite)")
+				}
+				if rpErr := w.republishForReparse(ctx, content, reparseCount, err); rpErr != nil {
+					return fmt.Errorf("republish reparse: %w", rpErr)
+				}
+				return w.commit(ctx, msg)
+			}
+			// max 도달 — 기존 DLQ 경로로 폴스루 (info 로그로 사유 명시)
+			log.WithFields(map[string]interface{}{
+				"job_id":        pm.ID,
+				"ref_id":        ref.ID,
+				"reparse_count": reparseCount,
+				"max":           core.MaxValidateReparseCount,
+			}).Info("reparse count reached max, falling through to permanent DLQ")
+		}
+
 		// 검증 실패: contents에서 삭제 후 DLQ 또는 재큐잉
 		if pm.RetryCount >= maxRetries(msg) {
 			log.WithFields(map[string]interface{}{
@@ -472,6 +509,76 @@ func (w *Worker) requeue(ctx context.Context, msg *queue.Message, pm *core.Proce
 		}).WithError(err).Error("failed to requeue processing message for retry")
 		return err
 	}
+	return nil
+}
+
+// republishForReparse 는 validate 실패 시 parser 재학습 트리거용 새 CrawlJob 을
+// TopicCrawlNormal 에 발행합니다 (이슈 #364).
+//
+// 헤더에 validate_reparse_count (현재 + 1) 와 validate_reparse_reason (err.Error())
+// 을 설정 — Sub C 의 parser worker 가 본 헤더 보고 LLM 호출 시 reason context 주입.
+//
+// 호출 사전 조건 (호출자가 보장):
+//   - cfg.ReparseEnabled == true
+//   - IsReparseEligible(err) == true
+//   - currentCount < core.MaxValidateReparseCount
+func (w *Worker) republishForReparse(ctx context.Context, content *core.Content, currentCount int, reason error) error {
+	log := logger.FromContext(ctx)
+	nextCount := currentCount + 1
+
+	job := core.CrawlJob{
+		ID:          fmt.Sprintf("reparse-%s-%d", content.ID, nextCount),
+		CrawlerName: content.SourceID,
+		Target: core.Target{
+			URL:  content.URL,
+			Type: core.TargetTypeArticle, // validate 는 article (page) 단계만 처리
+		},
+		Priority:    core.PriorityNormal,
+		ScheduledAt: time.Now(),
+		Timeout:     30 * time.Second, // fetcher 기본값 — entrypoint 가 scheduler timeout 헤더 없으면 기본
+		RetryCount:  0,
+		MaxRetries:  3,
+	}
+	payload, err := json.Marshal(&job)
+	if err != nil {
+		return fmt.Errorf("marshal reparse crawl job: %w", err)
+	}
+
+	reparseMsg := queue.Message{
+		Topic: queue.TopicCrawlNormal,
+		Key:   []byte(content.URL),
+		Value: payload,
+		Headers: map[string]string{
+			core.HeaderTargetType:            "page",
+			core.HeaderCrawler:               content.SourceID,
+			core.HeaderValidateReparseCount:  strconv.Itoa(nextCount),
+			core.HeaderValidateReparseReason: reason.Error(),
+		},
+	}
+
+	pubErr := w.producer.Publish(ctx, reparseMsg)
+	if pubErr != nil && errors.Is(pubErr, context.Canceled) {
+		drainCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), drainTimeout)
+		defer cancel()
+		pubErr = w.producer.Publish(drainCtx, reparseMsg)
+	}
+	if pubErr != nil {
+		log.WithFields(map[string]interface{}{
+			"content_id":    content.ID,
+			"url":           content.URL,
+			"reparse_count": nextCount,
+		}).WithError(pubErr).Error("failed to publish reparse crawl job")
+		return pubErr
+	}
+
+	log.WithFields(map[string]interface{}{
+		"content_id":    content.ID,
+		"url":           content.URL,
+		"source":        content.SourceID,
+		"reparse_count": nextCount,
+		"max":           core.MaxValidateReparseCount,
+		"reason":        reason.Error(),
+	}).Info("published reparse crawl job for validator-driven rule relearn")
 	return nil
 }
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -173,6 +173,11 @@ type ValidateConfig struct {
 	CommunityQualityThreshold float64 // VALIDATE_COMMUNITY_QUALITY_THRESHOLD (default: 0.4)
 	CommunityMaxRepeatRatio   float64 // VALIDATE_COMMUNITY_MAX_REPEAT_RATIO (default: 0.30)
 	CommunityMinRepeatRun     int     // VALIDATE_COMMUNITY_MIN_REPEAT_RUN (default: 4)
+
+	// ReparseEnabled: validate 실패 시 parser 재학습 트리거 활성화 여부 (이슈 #364).
+	// VALIDATE_REPARSE_ENABLED (default: false — Sub C wiring 완료 후 활성화)
+	// false 면 reparse 트리거 자체가 비활성 — 기존 DLQ 경로 그대로 동작 (회귀 안전).
+	ReparseEnabled bool
 }
 
 // DefaultValidateConfig는 개발 환경 기본 ValidateConfig를 반환합니다.
@@ -193,6 +198,7 @@ func DefaultValidateConfig() ValidateConfig {
 		CommunityQualityThreshold: 0.4,
 		CommunityMaxRepeatRatio:   0.30,
 		CommunityMinRepeatRun:     4,
+		ReparseEnabled:            false, // Sub C 머지 후 활성화 (이슈 #366)
 	}
 }
 
@@ -228,6 +234,14 @@ func LoadValidate(envFiles ...string) (ValidateConfig, error) {
 			*dest = f
 		}
 		return nil
+	}
+
+	if v := os.Getenv("VALIDATE_REPARSE_ENABLED"); v != "" {
+		b, err := strconv.ParseBool(v)
+		if err != nil {
+			return ValidateConfig{}, fmt.Errorf("parse VALIDATE_REPARSE_ENABLED %q: %w", v, err)
+		}
+		cfg.ReparseEnabled = b
 	}
 
 	for _, op := range []error{

--- a/test/internal/processor/validate/reparse_test.go
+++ b/test/internal/processor/validate/reparse_test.go
@@ -150,13 +150,18 @@ func TestWorker_Reparse_FirstAttempt_PublishesCrawlJob(t *testing.T) {
 		"first reparse 의 count 헤더는 1 이어야 함")
 	assert.NotEmpty(t, publishedCrawlJob.Headers[core.HeaderValidateReparseReason],
 		"reason 헤더 비어 있으면 안 됨")
-	assert.Equal(t, "page", publishedCrawlJob.Headers[core.HeaderTargetType])
+	// target_type 헤더는 fetcher chain handler 가 분기에 사용하는 wire 포맷 (core.TargetType 문자열).
+	assert.Equal(t, string(core.TargetTypeArticle), publishedCrawlJob.Headers[core.HeaderTargetType])
 	assert.Equal(t, content.SourceID, publishedCrawlJob.Headers[core.HeaderCrawler])
+	// timeout_ms 헤더 — 원본 부재 시 reparseJobTimeoutDefault (30s = 30000ms)
+	assert.Equal(t, "30000", publishedCrawlJob.Headers[core.HeaderTimeoutMs])
 
 	var job core.CrawlJob
 	require.NoError(t, json.Unmarshal(publishedCrawlJob.Value, &job))
 	assert.Equal(t, content.URL, job.Target.URL)
 	assert.Equal(t, content.SourceID, job.CrawlerName)
+	// Key 는 job.ID 패턴 (기존 crawl 토픽 발행과 일관)
+	assert.Equal(t, []byte(job.ID), publishedCrawlJob.Key)
 
 	// content 가 삭제됐는지 확인 (reparse cycle 의 사전조건)
 	contentSvc.AssertCalled(t, "Delete", mock.Anything, content.ID)
@@ -167,6 +172,44 @@ func TestWorker_Reparse_FirstAttempt_PublishesCrawlJob(t *testing.T) {
 			assert.NotEqual(t, queue.TopicDLQ, m.Topic, "reparse 분기에서 DLQ 발행 X")
 		}
 	}
+}
+
+// TestWorker_Reparse_PropagatesOriginalHeaders 는 원본 메시지의 timeout_ms 등 trace 헤더가
+// reparse CrawlJob 에 propagate 되는지 검증합니다 (gemini 반영).
+func TestWorker_Reparse_PropagatesOriginalHeaders(t *testing.T) {
+	consumer := new(mockConsumer)
+	producer := new(mockProducer)
+	contentSvc := new(mockContentService)
+	content := invalidNewsContent()
+	contentSvc.On("GetByID", mock.Anything, content.ID).Return(content, nil)
+	contentSvc.On("Delete", mock.Anything, content.ID).Return(nil)
+
+	cfg := config.DefaultValidateConfig()
+	cfg.ReparseEnabled = true
+
+	var publishedCrawlJob queue.Message
+	producer.On("Publish", mock.Anything, mock.MatchedBy(func(m queue.Message) bool {
+		return m.Topic == queue.TopicCrawlNormal
+	})).Run(func(args mock.Arguments) {
+		publishedCrawlJob = args.Get(1).(queue.Message)
+	}).Return(nil)
+
+	msg := makeContentMsgWithReparseHeader(t, content, 0)
+	msg.Headers[core.HeaderTimeoutMs] = "60000" // 60s — 원본 timeout
+	msg.Headers["x-trace-id"] = "trace-abc-123"
+
+	w := validate.NewWorker(consumer, producer, contentSvc, locks.NewNoopStageGate(), 1, cfg)
+	runProcessOnce(t, consumer, w, msg)
+
+	// 원본 timeout_ms 가 그대로 reparse 메시지에 계승됨
+	assert.Equal(t, "60000", publishedCrawlJob.Headers[core.HeaderTimeoutMs])
+	// 임의 trace 헤더도 보존됨 (observability)
+	assert.Equal(t, "trace-abc-123", publishedCrawlJob.Headers["x-trace-id"])
+
+	// CrawlJob.Timeout 도 60s 로 설정됨
+	var job core.CrawlJob
+	require.NoError(t, json.Unmarshal(publishedCrawlJob.Value, &job))
+	assert.Equal(t, 60*time.Second, job.Timeout)
 }
 
 // TestWorker_Reparse_MaxCount_NoCrawlJob 은 count == max 도달 시 reparse cycle 자체가

--- a/test/internal/processor/validate/reparse_test.go
+++ b/test/internal/processor/validate/reparse_test.go
@@ -1,0 +1,230 @@
+package validate_test
+
+// reparse_test.go — Sub A (#364) 의 단위 테스트.
+//
+// 검증 항목:
+//  1. IsReparseEligible — VAL_001, VAL_003 만 true, 그 외 (VAL_002/004/005/006) false
+//  2. readReparseCount — 헤더 부재 / 빈 / 잘못된 값 / 정상 값
+//  3. validate worker process — cfg.ReparseEnabled + 적격 에러 + count<max 시
+//     TopicCrawlNormal 에 reparse CrawlJob 발행 (헤더에 count+1 + reason)
+//  4. validate worker — count == max 도달 시 reparse 안 하고 기존 DLQ 경로 사용
+//  5. validate worker — cfg.ReparseEnabled=false 시 reparse 자체 비활성
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	"issuetracker/internal/locks"
+	"issuetracker/internal/processor/fetcher/core"
+	"issuetracker/internal/processor/validate"
+	"issuetracker/internal/storage"
+	"issuetracker/internal/storage/service"
+	"issuetracker/pkg/config"
+	"issuetracker/pkg/queue"
+)
+
+func TestIsReparseEligible(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"VAL_001 PublishedAt required → eligible", core.NewValidationError(core.CodeValMissingField, "x", nil), true},
+		{"VAL_003 Title min_length → eligible", core.NewValidationError(core.CodeValContentShort, "x", nil), true},
+		{"VAL_002 format → NOT eligible", core.NewValidationError(core.CodeValInvalidFormat, "x", nil), false},
+		{"VAL_004 max_length → NOT eligible", core.NewValidationError(core.CodeValContentLong, "x", nil), false},
+		{"VAL_005 quality_low → NOT eligible", core.NewValidationError(core.CodeValQualityLow, "x", nil), false},
+		{"VAL_006 spam → NOT eligible", core.NewValidationError(core.CodeValSpam, "x", nil), false},
+		{"non-CrawlerError → NOT eligible", errors.New("plain error"), false},
+		{"nil → NOT eligible", nil, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, validate.IsReparseEligible(tt.err))
+		})
+	}
+}
+
+// 본 헬퍼는 외부 테스트 패키지에서 readReparseCount 가 unexported 라 직접 접근 불가.
+// 따라서 validate worker process 의 동작 (publish 시 헤더 값) 으로 간접 검증.
+
+// makeContentMsgWithReparseHeader 는 reparse count 헤더가 설정된 normalized 메시지를 생성합니다.
+func makeContentMsgWithReparseHeader(t *testing.T, content *core.Content, reparseCount int) *queue.Message {
+	t.Helper()
+	ref := core.ContentRef{
+		ID:         content.ID,
+		URL:        content.URL,
+		Country:    content.Country,
+		SourceInfo: core.SourceInfo{Name: content.SourceID, Country: content.Country},
+	}
+	refBytes, _ := json.Marshal(ref)
+	pm := core.ProcessingMessage{
+		ID:        "job-test",
+		Timestamp: time.Now(),
+		Country:   content.Country,
+		Stage:     "normalized",
+		Data:      refBytes,
+	}
+	pmBytes, _ := json.Marshal(pm)
+
+	headers := map[string]string{}
+	if reparseCount > 0 {
+		headers[core.HeaderValidateReparseCount] = strconv.Itoa(reparseCount)
+	}
+	return &queue.Message{
+		Topic:   queue.TopicNormalized,
+		Key:     []byte(content.URL),
+		Value:   pmBytes,
+		Headers: headers,
+	}
+}
+
+// invalidNewsContent 는 PublishedAt 부재로 VAL_001 을 일으키는 news content 입니다.
+func invalidNewsContent() *core.Content {
+	return &core.Content{
+		ID:    "ref-001",
+		URL:   "https://news.example.com/article/123",
+		Title: "Sample news article title is long enough",
+		Body: "This is a sample news article body that has enough length to pass the body min_length check. " +
+			"It contains multiple sentences with various words to also satisfy min_word_count. " +
+			"The validator should reject only on PublishedAt required. Some more filler text here. " +
+			"And yet more filler. And more. And yet more. Enough. Surely enough words now.",
+		SourceID:    "naver",
+		SourceType:  "news",
+		Country:     "KR",
+		Language:    "ko",
+		PublishedAt: time.Time{}, // zero → VAL_001
+	}
+}
+
+// runProcessOnce 는 ConsumerPool 의 consumer→processor→commit loop 1회를 trigger 합니다.
+func runProcessOnce(t *testing.T, consumer *mockConsumer, w *validate.Worker, msg *queue.Message) {
+	t.Helper()
+	ctx, cancel := context.WithCancel(context.Background())
+	consumer.On("FetchMessage", mock.Anything).Return(msg, nil).Once()
+	consumer.On("FetchMessage", mock.Anything).
+		Run(func(_ mock.Arguments) { cancel() }).
+		Return(nil, context.Canceled)
+	consumer.On("Close").Return(nil)
+	consumer.On("CommitMessages", mock.Anything, mock.Anything).Return(nil)
+	w.Start(ctx)
+	<-ctx.Done()
+	stopCtx, stopCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer stopCancel()
+	_ = w.Stop(stopCtx)
+}
+
+// TestWorker_Reparse_FirstAttempt_PublishesCrawlJob 는 reparse-eligible 에러 + count 0 일 때
+// TopicCrawlNormal 에 reparse CrawlJob 이 발행되는지 검증합니다.
+func TestWorker_Reparse_FirstAttempt_PublishesCrawlJob(t *testing.T) {
+	consumer := new(mockConsumer)
+	producer := new(mockProducer)
+	contentSvc := new(mockContentService)
+	content := invalidNewsContent()
+	contentSvc.On("GetByID", mock.Anything, content.ID).Return(content, nil)
+	contentSvc.On("Delete", mock.Anything, content.ID).Return(nil)
+
+	cfg := config.DefaultValidateConfig()
+	cfg.ReparseEnabled = true
+
+	var publishedCrawlJob queue.Message
+	producer.On("Publish", mock.Anything, mock.MatchedBy(func(m queue.Message) bool {
+		return m.Topic == queue.TopicCrawlNormal
+	})).Run(func(args mock.Arguments) {
+		publishedCrawlJob = args.Get(1).(queue.Message)
+	}).Return(nil)
+
+	w := validate.NewWorker(consumer, producer, contentSvc, locks.NewNoopStageGate(), 1, cfg)
+	runProcessOnce(t, consumer, w, makeContentMsgWithReparseHeader(t, content, 0))
+
+	require.Equal(t, queue.TopicCrawlNormal, publishedCrawlJob.Topic)
+	assert.Equal(t, "1", publishedCrawlJob.Headers[core.HeaderValidateReparseCount],
+		"first reparse 의 count 헤더는 1 이어야 함")
+	assert.NotEmpty(t, publishedCrawlJob.Headers[core.HeaderValidateReparseReason],
+		"reason 헤더 비어 있으면 안 됨")
+	assert.Equal(t, "page", publishedCrawlJob.Headers[core.HeaderTargetType])
+	assert.Equal(t, content.SourceID, publishedCrawlJob.Headers[core.HeaderCrawler])
+
+	var job core.CrawlJob
+	require.NoError(t, json.Unmarshal(publishedCrawlJob.Value, &job))
+	assert.Equal(t, content.URL, job.Target.URL)
+	assert.Equal(t, content.SourceID, job.CrawlerName)
+
+	// content 가 삭제됐는지 확인 (reparse cycle 의 사전조건)
+	contentSvc.AssertCalled(t, "Delete", mock.Anything, content.ID)
+	// DLQ 발행은 일어나지 않아야 함
+	for _, c := range producer.Calls {
+		if c.Method == "Publish" {
+			m := c.Arguments.Get(1).(queue.Message)
+			assert.NotEqual(t, queue.TopicDLQ, m.Topic, "reparse 분기에서 DLQ 발행 X")
+		}
+	}
+}
+
+// TestWorker_Reparse_MaxCount_NoCrawlJob 은 count == max 도달 시 reparse cycle 자체가
+// 일어나지 않음을 검증합니다 (기존 DLQ/requeue 경로로 폴스루).
+func TestWorker_Reparse_MaxCount_NoCrawlJob(t *testing.T) {
+	consumer := new(mockConsumer)
+	producer := new(mockProducer)
+	contentSvc := new(mockContentService)
+	content := invalidNewsContent()
+	contentSvc.On("GetByID", mock.Anything, content.ID).Return(content, nil)
+	contentSvc.On("UpdateValidationStatus", mock.Anything, content.ID, mock.Anything, mock.Anything).Return(nil)
+
+	cfg := config.DefaultValidateConfig()
+	cfg.ReparseEnabled = true
+
+	crawlPublished := false
+	producer.On("Publish", mock.Anything, mock.MatchedBy(func(m queue.Message) bool {
+		if m.Topic == queue.TopicCrawlNormal {
+			crawlPublished = true
+		}
+		return true
+	})).Return(nil)
+
+	w := validate.NewWorker(consumer, producer, contentSvc, locks.NewNoopStageGate(), 1, cfg)
+	runProcessOnce(t, consumer, w, makeContentMsgWithReparseHeader(t, content, core.MaxValidateReparseCount))
+
+	assert.False(t, crawlPublished, "max 도달 시 reparse CrawlJob 발행 X (기존 DLQ/requeue 흐름으로 폴스루)")
+}
+
+// TestWorker_Reparse_Disabled_NoCrawlJob 는 cfg.ReparseEnabled=false 일 때 reparse 자체가
+// 비활성되는지 검증합니다.
+func TestWorker_Reparse_Disabled_NoCrawlJob(t *testing.T) {
+	consumer := new(mockConsumer)
+	producer := new(mockProducer)
+	contentSvc := new(mockContentService)
+	content := invalidNewsContent()
+	contentSvc.On("GetByID", mock.Anything, content.ID).Return(content, nil)
+	contentSvc.On("UpdateValidationStatus", mock.Anything, content.ID, mock.Anything, mock.Anything).Return(nil)
+
+	cfg := config.DefaultValidateConfig()
+	cfg.ReparseEnabled = false // 비활성
+
+	crawlPublished := false
+	producer.On("Publish", mock.Anything, mock.MatchedBy(func(m queue.Message) bool {
+		if m.Topic == queue.TopicCrawlNormal {
+			crawlPublished = true
+		}
+		return true
+	})).Return(nil)
+
+	w := validate.NewWorker(consumer, producer, contentSvc, locks.NewNoopStageGate(), 1, cfg)
+	runProcessOnce(t, consumer, w, makeContentMsgWithReparseHeader(t, content, 0))
+
+	assert.False(t, crawlPublished, "ReparseEnabled=false 시 reparse CrawlJob 발행 X")
+}
+
+// 컴파일 타임 contract 보증 — storage.ErrNotFound 사용 검증용.
+var _ = storage.ErrNotFound
+
+// service 패키지 의존성 강제 — content service mock 가 인터페이스 구현 검증.
+var _ service.ContentService = (*mockContentService)(nil)

--- a/test/pkg/config/stage_gate_test.go
+++ b/test/pkg/config/stage_gate_test.go
@@ -48,6 +48,26 @@ func TestLoadStageGate_InvalidValidateValue(t *testing.T) {
 	require.Error(t, err)
 }
 
+func TestLoadValidate_ReparseEnabled_DefaultFalse(t *testing.T) {
+	t.Setenv("VALIDATE_REPARSE_ENABLED", "")
+	cfg, err := config.LoadValidate("/tmp/nonexistent-env-file.env")
+	require.NoError(t, err)
+	require.False(t, cfg.ReparseEnabled, "default 는 false (Sub C 머지 후 활성화)")
+}
+
+func TestLoadValidate_ReparseEnabled_True(t *testing.T) {
+	t.Setenv("VALIDATE_REPARSE_ENABLED", "true")
+	cfg, err := config.LoadValidate("/tmp/nonexistent-env-file.env")
+	require.NoError(t, err)
+	require.True(t, cfg.ReparseEnabled)
+}
+
+func TestLoadValidate_ReparseEnabled_InvalidValue(t *testing.T) {
+	t.Setenv("VALIDATE_REPARSE_ENABLED", "not-a-bool")
+	_, err := config.LoadValidate("/tmp/nonexistent-env-file.env")
+	require.Error(t, err)
+}
+
 func TestCapPerStage(t *testing.T) {
 	tests := []struct {
 		name        string


### PR DESCRIPTION
## 연관 이슈
- Closes #364

<br>

## 구현 내용
#363 의 Sub A — validator → parser 재학습 루트의 인프라 신설. validate 실패 시 selector 보강으로 해결 가능한 에러 (VAL_001 PublishedAt / VAL_003 min_length) 발생 시 새 \`CrawlJob\` 을 \`TopicCrawlNormal\` 에 발행. 무한 루프는 retry max=2 로 차단.

본 PR 자체는 \`VALIDATE_REPARSE_ENABLED=false\` (default) 라 즉시 동작 변경 없음 — Sub C (#366) 의 parser wiring 완료 후 \`true\` 로 활성화.

### 변경 사항

**신규** \`internal/processor/fetcher/core/headers.go\`
- Kafka header 상수 (target_type / crawler / timeout_ms — 기존 사용 문자열 상수화 + 신규 reparse_count / reparse_reason)
- \`MaxValidateReparseCount = 2\` 상수

**신규** \`internal/processor/validate/reparse.go\`
- \`IsReparseEligible(err)\` — VAL_001 / VAL_003 만 true
- \`readReparseCount(msg)\` — 헤더 파싱 헬퍼

**\`internal/processor/validate/worker.go\`**
- \`process()\` 에 reparse 분기 삽입 — \`cfg.ReparseEnabled + IsReparseEligible + count<max\` 조건 충족 시 \`republishForReparse\` 호출, content delete 후 commit.
- count==max 도달 시 기존 DLQ/requeue 흐름으로 폴스루 (info 로그로 사유 명시).
- \`republishForReparse(ctx, content, currentCount, reason)\` — \`TopicCrawlNormal\` 에 새 \`CrawlJob\` 발행. 헤더에 \`validate_reparse_count=N+1\` + \`validate_reparse_reason=err.Error()\` + 기본 (\`target_type=page\`, \`crawler\`) propagate.

**\`pkg/config/config.go\`**
- \`ValidateConfig\` 에 \`ReparseEnabled bool\` 추가. \`VALIDATE_REPARSE_ENABLED\` env 파싱. default false.

**\`.env.example\`**
- \`VALIDATE_REPARSE_ENABLED\` 안내 추가.

### 테스트 (3개 파일)
- \`reparse_test.go\` (신규): \`IsReparseEligible\` 8 cases + worker integration 3 cases (first attempt publishes / max → no publish / disabled → no publish).
- \`stage_gate_test.go\` (확장): \`LoadValidate.ReparseEnabled\` 파싱 default/true/invalid 3건.

<br>

## CI / 머지 게이트 점검

### 변경 영향 범위
- 영향 패키지/모듈: \`internal/processor/fetcher/core\`, \`internal/processor/validate\`, \`pkg/config\`
- 위험도(택1): **Low** — \`VALIDATE_REPARSE_ENABLED\` default false 이므로 본 PR 머지 시 운영 동작 무변경. Sub C wiring 까지 완료 후 운영 활성화 가능.

### Required Status Checks
- 통과 확인 대상 (PR Checks 탭에서 확인):
  - [ ] \`Commit Lint\`
  - [ ] \`PR Title Lint\`
  - [ ] \`Linked Issue Check\`
  - [ ] \`Format Check\`
  - [ ] \`Build\`
  - [ ] \`Test\`
  - [ ] \`Lint\`

### 롤백 계획
- \`VALIDATE_REPARSE_ENABLED=false\` (default) 로 운영 무영향. 코드 회귀 시 PR revert.

<br>

## 후속 작업
- **Sub B (#365)**: claudegen prompt placeholder + \`ExtractEnriched\` reason context
- **Sub C (#366)**: parser worker header 수신 + 통합 라이브 검증 — 마지막 sub-issue PR 에서 메인 #363 도 close

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic revalidation mechanism triggered when validation fails on specific error types (missing required fields, insufficient content length).

* **Configuration**
  * New environment variable to enable/disable automatic revalidation (default: disabled; recommended after upcoming system update).
  * Maximum retry limit set to 2 attempts per URL.

* **Tests**
  * Added comprehensive test coverage for revalidation logic and configuration parsing.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/EinSofINTEREST/IssueTracker/pull/367)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->