### PR TITLE
[FEAT#365] claudegen prompt 에 validator rejection reason context 주입 (#363 Sub B)

### DIFF
--- a/internal/processor/parser/rule/claudegen/prompt.go
+++ b/internal/processor/parser/rule/claudegen/prompt.go
@@ -1,6 +1,7 @@
 package claudegen
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 
@@ -8,29 +9,44 @@ import (
 	"issuetracker/pkg/llm/prompt"
 )
 
+// rejectReasonPlaceholder 는 validation reason 블록이 삽입될 prompt placeholder 토큰입니다.
+const rejectReasonPlaceholder = "{{VALIDATION_REJECT_REASON_CONTEXT}}"
+
+// ErrRejectReasonPlaceholderMissing 은 reparse 경로에서 prompt 템플릿이 placeholder 를
+// 가지지 않을 때 발생합니다 (Copilot 반영 PR #368).
+//
+// 운영자가 LLM_PROMPT_DIR 로 외부 prompt 를 override 했는데 본 placeholder 를 추가하지 않은
+// 경우 — reason 블록이 silently drop 되어 reparse cycle 이 reason 없이 LLM 을 호출하는
+// 잠재 버그. fail-fast 로 운영자에게 즉시 알림.
+var ErrRejectReasonPlaceholderMissing = errors.New("claudegen: prompt template missing " + rejectReasonPlaceholder + " placeholder (LLM_PROMPT_DIR override may need update)")
+
 // buildPrompt 는 Claude Code 에 전달할 프롬프트를 생성합니다.
 // sessionPath 는 컨테이너 내 세션 디렉토리 경로 (예: /workspace/<sessionID>) 입니다.
 // Claude Code 는 해당 경로의 page.html 을 파일 읽기 툴로 직접 접근합니다.
 //
 // rejectReason 은 validator → parser 재학습 cycle 의 reject 사유 (이슈 #365).
-//   - 빈 문자열 (정상 경로) → placeholder 가 빈 줄로 치환되어 prompt 영향 무.
+//   - 빈 문자열 (정상 경로) → placeholder 가 빈 문자열로 치환. 템플릿이 placeholder 미포함이어도 무영향.
 //   - 비어있지 않음 (reparse 경로) → 컨텍스트 블록으로 변환되어 prompt 에 삽입.
-//     multi-turn agent 가 reason 보고 selector 보강 또는 validity=blacklist 결정 활용.
+//     템플릿에 placeholder 가 없으면 ErrRejectReasonPlaceholderMissing 반환 (fail-fast).
 func buildPrompt(loader prompt.Loader, host string, targetType storage.TargetType, sessionPath, rejectReason string) (string, error) {
 	name := promptNameFor(targetType)
 	template, err := loader.Load(name)
 	if err != nil {
 		return "", fmt.Errorf("load claudegen prompt %q: %w", name, err)
 	}
-	rendered := prompt.Render(template,
+
+	// reparse 경로 인데 템플릿에 placeholder 미포함 — silent drop 위험 차단.
+	// 정상 경로 (reason 빈 문자열) 에서는 placeholder 부재여도 결과 동일하므로 검증 skip.
+	if rejectReason != "" && !strings.Contains(template, rejectReasonPlaceholder) {
+		return "", fmt.Errorf("build claudegen prompt %q: %w", name, ErrRejectReasonPlaceholderMissing)
+	}
+
+	return prompt.Render(template,
 		"{{SESSION_PATH}}", sessionPath,
 		"{{HOST}}", host,
 		"{{TARGET_TYPE}}", string(targetType),
-		"{{VALIDATION_REJECT_REASON_CONTEXT}}", formatRejectReasonContext(rejectReason),
-	)
-	// reason 부재 시 placeholder 가 빈 문자열로 치환됨 → 빈 줄이 남을 수 있어 정리.
-	// 양쪽 공백 (특히 빈 줄) 제거하지 않고 단순 trailing 공백만 제거하여 의도된 layout 보존.
-	return strings.TrimRight(rendered, " \t\n") + "\n", nil
+		rejectReasonPlaceholder, formatRejectReasonContext(rejectReason),
+	), nil
 }
 
 // formatRejectReasonContext 는 reason 텍스트를 prompt 안에 삽입할 컨텍스트 블록으로 변환합니다.

--- a/internal/processor/parser/rule/claudegen/prompt.go
+++ b/internal/processor/parser/rule/claudegen/prompt.go
@@ -2,6 +2,7 @@ package claudegen
 
 import (
 	"fmt"
+	"strings"
 
 	"issuetracker/internal/storage"
 	"issuetracker/pkg/llm/prompt"
@@ -10,17 +11,44 @@ import (
 // buildPrompt 는 Claude Code 에 전달할 프롬프트를 생성합니다.
 // sessionPath 는 컨테이너 내 세션 디렉토리 경로 (예: /workspace/<sessionID>) 입니다.
 // Claude Code 는 해당 경로의 page.html 을 파일 읽기 툴로 직접 접근합니다.
-func buildPrompt(loader prompt.Loader, host string, targetType storage.TargetType, sessionPath string) (string, error) {
+//
+// rejectReason 은 validator → parser 재학습 cycle 의 reject 사유 (이슈 #365).
+//   - 빈 문자열 (정상 경로) → placeholder 가 빈 줄로 치환되어 prompt 영향 무.
+//   - 비어있지 않음 (reparse 경로) → 컨텍스트 블록으로 변환되어 prompt 에 삽입.
+//     multi-turn agent 가 reason 보고 selector 보강 또는 validity=blacklist 결정 활용.
+func buildPrompt(loader prompt.Loader, host string, targetType storage.TargetType, sessionPath, rejectReason string) (string, error) {
 	name := promptNameFor(targetType)
 	template, err := loader.Load(name)
 	if err != nil {
 		return "", fmt.Errorf("load claudegen prompt %q: %w", name, err)
 	}
-	return prompt.Render(template,
+	rendered := prompt.Render(template,
 		"{{SESSION_PATH}}", sessionPath,
 		"{{HOST}}", host,
 		"{{TARGET_TYPE}}", string(targetType),
-	), nil
+		"{{VALIDATION_REJECT_REASON_CONTEXT}}", formatRejectReasonContext(rejectReason),
+	)
+	// reason 부재 시 placeholder 가 빈 문자열로 치환됨 → 빈 줄이 남을 수 있어 정리.
+	// 양쪽 공백 (특히 빈 줄) 제거하지 않고 단순 trailing 공백만 제거하여 의도된 layout 보존.
+	return strings.TrimRight(rendered, " \t\n") + "\n", nil
+}
+
+// formatRejectReasonContext 는 reason 텍스트를 prompt 안에 삽입할 컨텍스트 블록으로 변환합니다.
+//
+// 빈 문자열이면 빈 문자열 반환 — placeholder 가 prompt 에 영향 없게.
+// 그 외에는 "IMPORTANT — Validation feedback from previous attempt: ..." 형식의 블록 반환.
+func formatRejectReasonContext(reason string) string {
+	if reason == "" {
+		return ""
+	}
+	return fmt.Sprintf(`
+IMPORTANT — Validation feedback from previous attempt:
+The validator rejected the previously extracted content for the following reason(s):
+%s
+
+Use this context to improve your selector extraction. If the page genuinely has
+no valid content for the required fields (e.g., it's a meta/index page without
+article body or published_at metadata), return validity="blacklist".`, reason)
 }
 
 func promptNameFor(targetType storage.TargetType) string {

--- a/internal/processor/parser/rule/claudegen/worker.go
+++ b/internal/processor/parser/rule/claudegen/worker.go
@@ -372,7 +372,10 @@ func (w *ClaudeWorker) ExtractEnriched(ctx context.Context, host string, targetT
 	runCtx, cancel := context.WithTimeout(ctx, w.sessionTimeout)
 	defer cancel()
 
-	promptText, err := buildPrompt(w.loader, host, targetType, sessionContainerPath)
+	// validator → parser 재학습 cycle (이슈 #365): ctx 에서 reject reason 추출 →
+	// prompt 에 컨텍스트 블록으로 주입. 부재 시 빈 문자열 → placeholder 영향 없음.
+	rejectReason, _ := llmgen.RejectReasonFromContext(ctx)
+	promptText, err := buildPrompt(w.loader, host, targetType, sessionContainerPath, rejectReason)
 	if err != nil {
 		return nil, fmt.Errorf("build claudegen prompt: %w", err)
 	}

--- a/internal/processor/parser/rule/llmgen/reject_reason.go
+++ b/internal/processor/parser/rule/llmgen/reject_reason.go
@@ -1,0 +1,37 @@
+package llmgen
+
+import "context"
+
+// reject_reason.go — validator → parser 재학습 cycle 의 reason 컨텍스트 전파 (이슈 #365).
+//
+// validator 가 reject 한 사유 (예: "PublishedAt required", "Title min_length") 를 ctx 에
+// 실어 보내 claudegen 의 LLM prompt 가 본 reason 을 컨텍스트로 활용 — multi-turn agent 가
+// reason 기반으로 selector 보강 또는 validity=blacklist 결정.
+//
+// 인터페이스 시그니처 (SelectorExtractor / EnrichedExtractor) 변경 없이 ctx value 만으로 옵션
+// 의미 자연스럽게 표현 — 기존 호출자 (Gemini provider 등 reason 무시 backend) 영향 없음.
+
+type rejectReasonKey struct{}
+
+// WithRejectReason 은 ctx 에 validator rejection reason 을 첨부한 새 ctx 를 반환합니다.
+//
+// reason 빈 문자열이면 ctx 그대로 반환 — 명시적 unset 호출 케이스 회피 (None Object 패턴).
+// 호출자는 ProcessMessage / Enqueue 입구에서 reparse 헤더 감지 시 본 함수로 ctx 보강.
+func WithRejectReason(ctx context.Context, reason string) context.Context {
+	if reason == "" {
+		return ctx
+	}
+	return context.WithValue(ctx, rejectReasonKey{}, reason)
+}
+
+// RejectReasonFromContext 는 ctx 에서 validator rejection reason 을 추출합니다.
+//
+// 부재 시 ("", false) 반환 — 호출자가 분기 (예: prompt placeholder 를 빈 문자열로 채움) 가능.
+// 정상 경로 (reparse 가 아닌 첫 시도) 에서는 항상 ("", false) — 옵션 의미 보존.
+func RejectReasonFromContext(ctx context.Context) (string, bool) {
+	v, ok := ctx.Value(rejectReasonKey{}).(string)
+	if !ok || v == "" {
+		return "", false
+	}
+	return v, true
+}

--- a/internal/processor/parser/rule/llmgen/reject_reason.go
+++ b/internal/processor/parser/rule/llmgen/reject_reason.go
@@ -1,6 +1,9 @@
 package llmgen
 
-import "context"
+import (
+	"context"
+	"strings"
+)
 
 // reject_reason.go — validator → parser 재학습 cycle 의 reason 컨텍스트 전파 (이슈 #365).
 //
@@ -15,13 +18,15 @@ type rejectReasonKey struct{}
 
 // WithRejectReason 은 ctx 에 validator rejection reason 을 첨부한 새 ctx 를 반환합니다.
 //
-// reason 빈 문자열이면 ctx 그대로 반환 — 명시적 unset 호출 케이스 회피 (None Object 패턴).
-// 호출자는 ProcessMessage / Enqueue 입구에서 reparse 헤더 감지 시 본 함수로 ctx 보강.
+// reason 빈 문자열 또는 공백 only 면 ctx 그대로 반환 — None Object 패턴 (gemini 반영 PR #368).
+// strings.TrimSpace 로 정규화하여 공백만 포함된 reason 도 부재로 분류 — 공허한 feedback
+// 블록이 prompt 에 삽입되는 것을 차단.
 func WithRejectReason(ctx context.Context, reason string) context.Context {
-	if reason == "" {
+	trimmed := strings.TrimSpace(reason)
+	if trimmed == "" {
 		return ctx
 	}
-	return context.WithValue(ctx, rejectReasonKey{}, reason)
+	return context.WithValue(ctx, rejectReasonKey{}, trimmed)
 }
 
 // RejectReasonFromContext 는 ctx 에서 validator rejection reason 을 추출합니다.

--- a/pkg/llm/prompt/assets/claudegen/list.user.txt
+++ b/pkg/llm/prompt/assets/claudegen/list.user.txt
@@ -3,6 +3,7 @@ Read the HTML file at {{SESSION_PATH}}/page.html from the {{HOST}} website.
 Your task: analyze the page and return a single JSON object with the following structure — no explanation, no markdown, no code blocks.
 
 Target page type: {{TARGET_TYPE}}
+{{VALIDATION_REJECT_REASON_CONTEXT}}
 
 Output schema:
 {

--- a/pkg/llm/prompt/assets/claudegen/page.user.txt
+++ b/pkg/llm/prompt/assets/claudegen/page.user.txt
@@ -3,6 +3,7 @@ Read the HTML file at {{SESSION_PATH}}/page.html from the {{HOST}} website.
 Your task: analyze the page and return a single JSON object with the following structure — no explanation, no markdown, no code blocks.
 
 Target page type: {{TARGET_TYPE}}
+{{VALIDATION_REJECT_REASON_CONTEXT}}
 
 Output schema:
 {

--- a/test/internal/processor/parser/rule/claudegen/reject_reason_test.go
+++ b/test/internal/processor/parser/rule/claudegen/reject_reason_test.go
@@ -1,0 +1,107 @@
+package claudegen_test
+
+// reject_reason_test.go — Sub B (#365) — claudegen prompt 에 reason context 주입 검증.
+//
+// 검증 항목 (black-box via ExtractEnriched → exec args 캡쳐):
+//  1. ctx 에 reason 없으면 prompt 에 placeholder 가 빈 문자열로 치환 → 기존 동작 유지
+//  2. ctx 에 reason 있으면 prompt 의 마지막에 "Validation feedback" 블록 삽입
+//  3. ctx 에 빈 reason 으로 WithRejectReason 호출 시 placeholder 영향 없음
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"issuetracker/internal/processor/parser/rule/llmgen"
+	"issuetracker/internal/storage"
+)
+
+// extractPromptArg 는 ExecSession 호출의 args slice 에서 "-p" 다음 prompt 문자열을 추출합니다.
+func extractPromptArg(args []string) string {
+	for i, a := range args {
+		if a == "-p" && i+1 < len(args) {
+			return args[i+1]
+		}
+	}
+	return ""
+}
+
+func TestExtractEnriched_NoReason_PromptHasNoFeedbackBlock(t *testing.T) {
+	runner := &mockContainerRunner{
+		execStdout: `{"validity":"ok","page_type":"news","selectors":{"title":{"css":"h1"},"main_content":{"css":"article","multi":true}},"self_check":{"title_sample":"x","body_word_count_estimate":200}}`,
+	}
+	w := newTestWorker(t, runner)
+	require.NoError(t, w.Start(t.Context()))
+	t.Cleanup(func() { _ = w.Stop(context.Background()) })
+
+	_, err := w.ExtractEnriched(t.Context(), "news.example.com", storage.TargetTypePage, "<html><h1>title</h1><article>body</article></html>")
+	require.NoError(t, err)
+
+	prompt := extractPromptArg(runner.execedWith.args)
+	require.NotEmpty(t, prompt)
+	assert.NotContains(t, prompt, "Validation feedback from previous attempt",
+		"reason 부재 시 feedback 블록 삽입 X")
+	// {{TARGET_TYPE}} 등 다른 placeholder 는 치환됨 (claudegenLoader 의 mock template 안)
+	assert.Contains(t, prompt, "(page)")
+}
+
+func TestExtractEnriched_WithReason_PromptHasFeedbackBlock(t *testing.T) {
+	runner := &mockContainerRunner{
+		execStdout: `{"validity":"ok","page_type":"news","selectors":{"title":{"css":"h1"},"main_content":{"css":"article","multi":true}},"self_check":{"title_sample":"x","body_word_count_estimate":200}}`,
+	}
+	w := newTestWorker(t, runner)
+	require.NoError(t, w.Start(t.Context()))
+	t.Cleanup(func() { _ = w.Stop(context.Background()) })
+
+	const reason = "PublishedAt required, Title min_length"
+	ctx := llmgen.WithRejectReason(t.Context(), reason)
+	_, err := w.ExtractEnriched(ctx, "news.example.com", storage.TargetTypePage, "<html><h1>title</h1><article>body</article></html>")
+	require.NoError(t, err)
+
+	prompt := extractPromptArg(runner.execedWith.args)
+	require.NotEmpty(t, prompt)
+	assert.Contains(t, prompt, "Validation feedback from previous attempt",
+		"reason 존재 시 feedback 블록 삽입됨")
+	assert.Contains(t, prompt, reason, "reason 텍스트 자체가 prompt 에 포함")
+	assert.Contains(t, prompt, "validity=\"blacklist\"",
+		"blacklist 분기 안내가 prompt 에 포함")
+}
+
+func TestExtractEnriched_EmptyReason_NoFeedbackBlock(t *testing.T) {
+	runner := &mockContainerRunner{
+		execStdout: `{"validity":"ok","page_type":"news","selectors":{"title":{"css":"h1"},"main_content":{"css":"article","multi":true}},"self_check":{"title_sample":"x","body_word_count_estimate":200}}`,
+	}
+	w := newTestWorker(t, runner)
+	require.NoError(t, w.Start(t.Context()))
+	t.Cleanup(func() { _ = w.Stop(context.Background()) })
+
+	// WithRejectReason 에 빈 문자열 — None Object 패턴으로 ctx 그대로 반환
+	ctx := llmgen.WithRejectReason(t.Context(), "")
+	_, err := w.ExtractEnriched(ctx, "news.example.com", storage.TargetTypePage, "<html><h1>title</h1><article>body</article></html>")
+	require.NoError(t, err)
+
+	prompt := extractPromptArg(runner.execedWith.args)
+	assert.NotContains(t, prompt, "Validation feedback from previous attempt")
+}
+
+// TestExtractEnriched_ListTarget_WithReason_PromptHasFeedbackBlock 은 list (category)
+// target 도 동일하게 reason 블록을 받는지 검증합니다.
+func TestExtractEnriched_ListTarget_WithReason_PromptHasFeedbackBlock(t *testing.T) {
+	runner := &mockContainerRunner{
+		execStdout: `{"validity":"ok","page_type":"news","selectors":{"item_container":{"css":"li"},"item_link":{"css":"a","attribute":"href"}},"self_check":{"item_count_estimate":10,"first_item_title_sample":"x"}}`,
+	}
+	w := newTestWorker(t, runner)
+	require.NoError(t, w.Start(t.Context()))
+	t.Cleanup(func() { _ = w.Stop(context.Background()) })
+
+	ctx := llmgen.WithRejectReason(t.Context(), "ItemContainer matched 0 elements")
+	_, err := w.ExtractEnriched(ctx, "news.example.com", storage.TargetTypeList, "<html><ul><li><a href='/x'>x</a></li></ul></html>")
+	require.NoError(t, err)
+
+	prompt := extractPromptArg(runner.execedWith.args)
+	require.True(t, strings.Contains(prompt, "Validation feedback from previous attempt"),
+		"list target 도 reason 블록 적용")
+}

--- a/test/internal/processor/parser/rule/claudegen/reject_reason_test.go
+++ b/test/internal/processor/parser/rule/claudegen/reject_reason_test.go
@@ -11,12 +11,16 @@ import (
 	"context"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"issuetracker/internal/processor/parser/rule/claudegen"
 	"issuetracker/internal/processor/parser/rule/llmgen"
 	"issuetracker/internal/storage"
+	"issuetracker/pkg/llm/prompt"
+	"issuetracker/pkg/logger"
 )
 
 // extractPromptArg 는 ExecSession 호출의 args slice 에서 "-p" 다음 prompt 문자열을 추출합니다.
@@ -85,6 +89,70 @@ func TestExtractEnriched_EmptyReason_NoFeedbackBlock(t *testing.T) {
 
 	prompt := extractPromptArg(runner.execedWith.args)
 	assert.NotContains(t, prompt, "Validation feedback from previous attempt")
+}
+
+// TestExtractEnriched_TemplateMissingPlaceholder_FailsFast 는 LLM_PROMPT_DIR override 등으로
+// 외부 템플릿이 placeholder 를 가지지 않을 때 reparse 경로 (reason 존재) 가 silent drop 되지
+// 않고 fail-fast 하는지 검증합니다 (Copilot 반영 PR #368).
+func TestExtractEnriched_TemplateMissingPlaceholder_FailsFast(t *testing.T) {
+	// 외부 override 시뮬레이션 — placeholder 토큰 없는 prompt loader 주입.
+	brokenLoader := prompt.MapLoader{
+		"claudegen/page.user": "Read {{SESSION_PATH}}/page.html from {{HOST}} ({{TARGET_TYPE}}). Return JSON.",
+		"claudegen/list.user": "Read {{SESSION_PATH}}/page.html from {{HOST}} ({{TARGET_TYPE}}). Return list JSON.",
+	}
+	log := logger.New(logger.DefaultConfig())
+	authDir := makeAuthDir(t)
+	w, err := claudegen.NewWithRunner(
+		"ghcr.io/anthropics/claude-code:latest",
+		"claude-sonnet-4-6",
+		authDir,
+		"/root/.claude",
+		10*time.Second,
+		&mockContainerRunner{},
+		brokenLoader,
+		log,
+	)
+	require.NoError(t, err)
+	require.NoError(t, w.Start(t.Context()))
+	t.Cleanup(func() { _ = w.Stop(context.Background()) })
+
+	// reason 존재 + placeholder 부재 → 에러 반환
+	ctx := llmgen.WithRejectReason(t.Context(), "PublishedAt required")
+	_, extractErr := w.ExtractEnriched(ctx, "news.example.com", storage.TargetTypePage, "<html></html>")
+	require.Error(t, extractErr, "placeholder 부재 시 reparse 경로는 fail-fast")
+	assert.Contains(t, extractErr.Error(), "VALIDATION_REJECT_REASON_CONTEXT",
+		"에러 메시지에 누락된 placeholder 이름 포함")
+}
+
+// TestExtractEnriched_TemplateMissingPlaceholder_NoReason_OK 는 placeholder 가 없어도
+// reason 부재 시에는 (정상 경로) 통과하는지 검증 — 기존 외부 템플릿 호환성.
+func TestExtractEnriched_TemplateMissingPlaceholder_NoReason_OK(t *testing.T) {
+	brokenLoader := prompt.MapLoader{
+		"claudegen/page.user": "Read {{SESSION_PATH}}/page.html from {{HOST}} ({{TARGET_TYPE}}). Return JSON.",
+		"claudegen/list.user": "Read {{SESSION_PATH}}/page.html from {{HOST}} ({{TARGET_TYPE}}). Return list JSON.",
+	}
+	log := logger.New(logger.DefaultConfig())
+	authDir := makeAuthDir(t)
+	runner := &mockContainerRunner{
+		execStdout: `{"validity":"ok","page_type":"news","selectors":{"title":{"css":"h1"},"main_content":{"css":"article","multi":true}},"self_check":{"title_sample":"x","body_word_count_estimate":200}}`,
+	}
+	w, err := claudegen.NewWithRunner(
+		"ghcr.io/anthropics/claude-code:latest",
+		"claude-sonnet-4-6",
+		authDir,
+		"/root/.claude",
+		10*time.Second,
+		runner,
+		brokenLoader,
+		log,
+	)
+	require.NoError(t, err)
+	require.NoError(t, w.Start(t.Context()))
+	t.Cleanup(func() { _ = w.Stop(context.Background()) })
+
+	// reason 부재 → placeholder 부재해도 정상 동작 (기존 호환성)
+	_, extractErr := w.ExtractEnriched(t.Context(), "news.example.com", storage.TargetTypePage, "<html><h1>x</h1><article>y</article></html>")
+	assert.NoError(t, extractErr, "reason 부재 시 placeholder 부재 OK (기존 외부 템플릿 호환)")
 }
 
 // TestExtractEnriched_ListTarget_WithReason_PromptHasFeedbackBlock 은 list (category)

--- a/test/internal/processor/parser/rule/claudegen/worker_test.go
+++ b/test/internal/processor/parser/rule/claudegen/worker_test.go
@@ -20,9 +20,10 @@ import (
 
 // claudegenLoader 는 claudegen worker 가 요구하는 prompt asset 을 in-memory 로 제공합니다.
 // 운영의 pkg/llm/prompt/assets/claudegen/{page,list}.user.txt 와 동일한 placeholder 사용.
+// {{VALIDATION_REJECT_REASON_CONTEXT}} 는 이슈 #365 — reason 부재 시 빈 문자열로 치환.
 var claudegenLoader = prompt.MapLoader{
-	"claudegen/page.user": "Read {{SESSION_PATH}}/page.html from {{HOST}} ({{TARGET_TYPE}}). Return JSON.",
-	"claudegen/list.user": "Read {{SESSION_PATH}}/page.html from {{HOST}} ({{TARGET_TYPE}}). Return list JSON.",
+	"claudegen/page.user": "Read {{SESSION_PATH}}/page.html from {{HOST}} ({{TARGET_TYPE}}). Return JSON.{{VALIDATION_REJECT_REASON_CONTEXT}}",
+	"claudegen/list.user": "Read {{SESSION_PATH}}/page.html from {{HOST}} ({{TARGET_TYPE}}). Return list JSON.{{VALIDATION_REJECT_REASON_CONTEXT}}",
 }
 
 // mockContainerRunner 는 docker 를 실행하지 않는 테스트용 ContainerRunner 입니다.

--- a/test/internal/processor/parser/rule/llmgen/reject_reason_test.go
+++ b/test/internal/processor/parser/rule/llmgen/reject_reason_test.go
@@ -30,6 +30,27 @@ func TestWithRejectReason_EmptyString_ReturnsSameCtx(t *testing.T) {
 	assert.Equal(t, "", got)
 }
 
+func TestWithRejectReason_WhitespaceOnly_ReturnsSameCtx(t *testing.T) {
+	// gemini 반영 PR #368 — 공백만 포함된 reason 은 부재로 분류하여 공허한 feedback 블록 차단.
+	for _, raw := range []string{"   ", "\t\n", " \n ", "\r\n\t"} {
+		t.Run("raw="+raw, func(t *testing.T) {
+			ctx := context.Background()
+			enriched := llmgen.WithRejectReason(ctx, raw)
+			assert.Equal(t, ctx, enriched, "whitespace-only reason 도 None Object 패턴")
+			got, ok := llmgen.RejectReasonFromContext(enriched)
+			assert.False(t, ok)
+			assert.Equal(t, "", got)
+		})
+	}
+}
+
+func TestWithRejectReason_TrimsLeadingTrailingWhitespace(t *testing.T) {
+	ctx := llmgen.WithRejectReason(context.Background(), "  PublishedAt required  \n")
+	got, ok := llmgen.RejectReasonFromContext(ctx)
+	assert.True(t, ok)
+	assert.Equal(t, "PublishedAt required", got, "외곽 공백 trim — feedback 블록의 가독성 보장")
+}
+
 func TestRejectReasonFromContext_Absent_ReturnsFalse(t *testing.T) {
 	ctx := context.Background()
 	got, ok := llmgen.RejectReasonFromContext(ctx)

--- a/test/internal/processor/parser/rule/llmgen/reject_reason_test.go
+++ b/test/internal/processor/parser/rule/llmgen/reject_reason_test.go
@@ -1,0 +1,47 @@
+package llmgen_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"issuetracker/internal/processor/parser/rule/llmgen"
+)
+
+// reject_reason_test.go — Sub B (#365) — ctx-based RejectReason 메커니즘 단위 테스트.
+
+func TestWithRejectReason_RoundTrip(t *testing.T) {
+	ctx := context.Background()
+	enriched := llmgen.WithRejectReason(ctx, "PublishedAt required")
+
+	got, ok := llmgen.RejectReasonFromContext(enriched)
+	assert.True(t, ok)
+	assert.Equal(t, "PublishedAt required", got)
+}
+
+func TestWithRejectReason_EmptyString_ReturnsSameCtx(t *testing.T) {
+	ctx := context.Background()
+	enriched := llmgen.WithRejectReason(ctx, "")
+	assert.Equal(t, ctx, enriched, "empty reason 시 ctx 그대로 반환 — None Object 패턴")
+
+	got, ok := llmgen.RejectReasonFromContext(enriched)
+	assert.False(t, ok)
+	assert.Equal(t, "", got)
+}
+
+func TestRejectReasonFromContext_Absent_ReturnsFalse(t *testing.T) {
+	ctx := context.Background()
+	got, ok := llmgen.RejectReasonFromContext(ctx)
+	assert.False(t, ok, "ctx 에 reason 없으면 false")
+	assert.Equal(t, "", got)
+}
+
+func TestRejectReasonFromContext_WrongType_ReturnsFalse(t *testing.T) {
+	// 다른 패키지에서 같은 key 타입을 사용하지 않도록 unexported key — 본 테스트는 우회 불가
+	// (의도된 캡슐화). 부재 케이스만 검증.
+	ctx := context.WithValue(context.Background(), struct{ name string }{"unrelated"}, "value")
+	got, ok := llmgen.RejectReasonFromContext(ctx)
+	assert.False(t, ok)
+	assert.Equal(t, "", got)
+}


### PR DESCRIPTION
## 연관 이슈
- Closes #365

<br>

## 구현 내용
#363 의 Sub B — claudegen 의 multi-turn LLM agent 가 validator rejection reason 을 컨텍스트로 받아 selector 보강 또는 \`validity=blacklist\` 결정에 활용하도록 prompt 와 ctx 전달 메커니즘 추가.

### 변경 사항

**신규** \`internal/processor/parser/rule/llmgen/reject_reason.go\`
- \`WithRejectReason(ctx, reason) context.Context\` — None Object 패턴 (빈 문자열 시 ctx 그대로)
- \`RejectReasonFromContext(ctx) (reason string, ok bool)\`
- unexported key type 으로 외부 패키지 충돌 차단

**\`pkg/llm/prompt/assets/claudegen/{page,list}.user.txt\`**
- \`{{VALIDATION_REJECT_REASON_CONTEXT}}\` placeholder 추가 (TARGET_TYPE 줄 다음)

**\`internal/processor/parser/rule/claudegen/prompt.go\`**
- \`buildPrompt\` 시그니처에 \`rejectReason string\` 추가
- \`formatRejectReasonContext\` — reason 부재면 빈 문자열, 존재면 다음 블록 반환:
  \`\`\`
  IMPORTANT — Validation feedback from previous attempt:
  The validator rejected the previously extracted content for the following reason(s):
  <REASON>
  
  Use this context to improve your selector extraction. If the page genuinely
  has no valid content for the required fields (e.g., it's a meta/index page
  without article body or published_at metadata), return validity="blacklist".
  \`\`\`

**\`internal/processor/parser/rule/claudegen/worker.go\`**
- \`ExtractEnriched\` 가 \`llmgen.RejectReasonFromContext(ctx)\` 추출 → \`buildPrompt\` 전달

### 테스트 (8건)
- \`reject_reason_test.go\` (llmgen): WithRejectReason round-trip / 빈 문자열 / 부재 / 다른 key
- \`reject_reason_test.go\` (claudegen): \`ExtractEnriched\` black-box (mock runner ExecSession args 캡쳐)
  - reason 부재 → feedback 블록 X
  - reason 존재 → feedback 블록 + blacklist 분기 안내 포함
  - 빈 reason → 부재와 동일
  - list target 도 동일 처리

기존 worker_test.go 의 \`claudegenLoader\` mock template 에 placeholder 추가.

### 회귀 안전성
- 기존 호출자 (Gemini 등 SelectorExtractor 만 구현, ctx 무시) → 영향 없음
- ctx 에 reason 없으면 prompt 가 기존과 100% 동일 (placeholder 빈 문자열 치환)

<br>

## CI / 머지 게이트 점검

### 변경 영향 범위
- 영향 패키지/모듈: \`internal/processor/parser/rule/llmgen\`, \`internal/processor/parser/rule/claudegen\`, \`pkg/llm/prompt/assets/claudegen\`
- 위험도(택1): **Low** — Sub A 의 reparse 트리거가 default off 라 본 PR 의 ctx 활용 경로는 Sub C 머지 + env 활성화 후에만 실동. 기존 흐름 회귀 없음.

### Required Status Checks
- 통과 확인 대상:
  - [ ] \`Commit Lint\`
  - [ ] \`PR Title Lint\`
  - [ ] \`Linked Issue Check\`
  - [ ] \`Format Check\`
  - [ ] \`Build\`
  - [ ] \`Test\`
  - [ ] \`Lint\`

### 롤백 계획
- PR revert. 운영 영향 없음.

<br>

## 후속 작업
- **Sub C (#366)**: parser worker 의 reparse 헤더 수신 → \`llmgen.WithRejectReason(ctx, reason)\` 호출 → 본 PR 의 메커니즘 동작. fetcher / parser publish 사이트의 헤더 propagation 도 함께 처리. 마지막 sub-issue PR 에서 메인 #363 도 close.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * AI prompts now include validation feedback from previous failed attempts, providing context for improved error corrections on retry.

* **Tests**
  * Added comprehensive test coverage for validation feedback context propagation and prompt generation.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/EinSofINTEREST/IssueTracker/pull/368)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->