### PR TITLE
[FEAT#366] parser worker reparse 헤더 수신 + end-to-end propagation + 라이브 활성화 (#363 Sub C)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -129,8 +129,12 @@ PATHINFER_MIN_SAMPLES=3
 # true 시 selector 보강으로 해결 가능한 validation 실패 (PublishedAt required / Title-Body
 # min_length) 발생 시 새 CrawlJob 을 발행해 fetcher 재fetch + parser LLM 학습 트리거.
 # 동일 URL retry max = 2 (core.MaxValidateReparseCount). 초과 시 영구 DLQ.
-# Sub C (#366) 머지 후 헤더 end-to-end 전파 완성 — 운영 활성화 가능.
-VALIDATE_REPARSE_ENABLED=true
+#
+# ⚠️ 활성화 영향: LLM 호출 (claudegen / Gemini 등) + 추가 HTTP fetch 비용 증가 — host 의
+#    rate limit 도 영향 받을 수 있음. 의도치 않은 활성화를 피하기 위해 default=false 유지.
+#    운영 활성화 시 LLM 호출량 / claude code subscription quota 모니터링 권장.
+#    비활성화: VALIDATE_REPARSE_ENABLED=false
+VALIDATE_REPARSE_ENABLED=false
 
 # 뉴스 소스 검증
 VALIDATE_NEWS_TITLE_MIN_LEN=10

--- a/.env.example
+++ b/.env.example
@@ -125,12 +125,12 @@ PATHINFER_MIN_SAMPLES=3
 
 # Content 검증 임계값 설정 (pkg/config/config.go LoadValidate 참조)
 
-# validator → parser 재학습 트리거 (이슈 #363/#364)
+# validator → parser 재학습 트리거 (이슈 #363/#364/#366)
 # true 시 selector 보강으로 해결 가능한 validation 실패 (PublishedAt required / Title-Body
 # min_length) 발생 시 새 CrawlJob 을 발행해 fetcher 재fetch + parser LLM 학습 트리거.
 # 동일 URL retry max = 2 (core.MaxValidateReparseCount). 초과 시 영구 DLQ.
-# default false — Sub C (#366) wiring 머지 후 true 권장.
-VALIDATE_REPARSE_ENABLED=false
+# Sub C (#366) 머지 후 헤더 end-to-end 전파 완성 — 운영 활성화 가능.
+VALIDATE_REPARSE_ENABLED=true
 
 # 뉴스 소스 검증
 VALIDATE_NEWS_TITLE_MIN_LEN=10

--- a/internal/processor/fetcher/core/inbox_headers.go
+++ b/internal/processor/fetcher/core/inbox_headers.go
@@ -1,0 +1,39 @@
+package core
+
+import "context"
+
+// inbox_headers.go — Kafka 메시지 헤더의 stage 간 전파 (이슈 #366).
+//
+// fetcher / parser / validate stage 가 동일 패턴으로 incoming msg.Headers 를 ctx 에 attach
+// 한 후, 발행 시점에 headers 를 base 로 복사하여 stage 간 헤더 전파 (예: validate_reparse_*,
+// trace ID 등) 를 보장합니다.
+//
+// 헤더를 ctx 로 옮기는 이유: JobHandler.Handle / ChainHandler.publishFetchedRef 등 내부 함수가
+// msg 자체를 받지 않고 job 만 받는 인터페이스 — 인터페이스 변경 없이 헤더 전파.
+
+type inboxHeadersKey struct{}
+
+// WithInboxHeaders 는 ctx 에 incoming msg headers 를 첨부한 새 ctx 를 반환합니다.
+//
+// headers 가 nil 이거나 빈 map 이면 ctx 그대로 반환 — None Object 패턴.
+// 호출자는 stage 진입 직후 (pool / consumer / worker) 본 함수로 ctx 보강.
+func WithInboxHeaders(ctx context.Context, headers map[string]string) context.Context {
+	if len(headers) == 0 {
+		return ctx
+	}
+	// 호출자가 msg.Headers 를 변경할 경우 ctx 가 영향받지 않도록 shallow copy.
+	copied := make(map[string]string, len(headers))
+	for k, v := range headers {
+		copied[k] = v
+	}
+	return context.WithValue(ctx, inboxHeadersKey{}, copied)
+}
+
+// InboxHeadersFromContext 는 ctx 에서 incoming msg headers 를 추출합니다.
+//
+// 부재 시 nil 반환 — 호출자가 분기 또는 빈 map fallback 처리.
+// 반환된 map 은 ctx 에 저장된 인스턴스의 참조이므로 호출자가 변경하면 안 됨 (read-only).
+func InboxHeadersFromContext(ctx context.Context) map[string]string {
+	v, _ := ctx.Value(inboxHeadersKey{}).(map[string]string)
+	return v
+}

--- a/internal/processor/fetcher/core/inbox_headers.go
+++ b/internal/processor/fetcher/core/inbox_headers.go
@@ -37,3 +37,42 @@ func InboxHeadersFromContext(ctx context.Context) map[string]string {
 	v, _ := ctx.Value(inboxHeadersKey{}).(map[string]string)
 	return v
 }
+
+// propagatedInboxHeaderKeys 는 stage 간 전파할 헤더 키의 화이트리스트입니다 (이슈 #366 gemini 반영).
+//
+// 화이트리스트 방식 채택 이유:
+//   - 의도된 헤더만 전파 — Rule 2 (의도적 설정) 원칙 부합
+//   - 새 헤더 추가 시 명시적 코드 변경 — 운영 가시성 + 동적 / blacklist 누락 위험 회피
+//
+// 포함 항목:
+//   - validate_reparse_count / validate_reparse_reason — validator → parser 재학습 cycle (#363)
+//   - x-trace-id / x-request-id — observability (분산 추적 메타데이터)
+//
+// 호출자 (publishFetchedRef / publishContents) 가 본 슬라이스를 iterate 하여 incoming 헤더 값
+// 존재 시 outgoing 헤더에 복사.
+var propagatedInboxHeaderKeys = []string{
+	HeaderValidateReparseCount,
+	HeaderValidateReparseReason,
+	"x-trace-id",
+	"x-request-id",
+}
+
+// PropagateInboxHeaders 는 ctx 의 inbox headers 중 화이트리스트 키를 outgoing headers map 에
+// 복사합니다 (이슈 #366).
+//
+// 기존 outgoing 의 동일 키는 덮어쓰지 않음 — 호출자의 명시적 설정 우선 (예: target_type 을
+// 호출자가 새로 설정한 경우 inbox 의 값 무시).
+func PropagateInboxHeaders(ctx context.Context, outgoing map[string]string) {
+	inbox := InboxHeadersFromContext(ctx)
+	if inbox == nil || outgoing == nil {
+		return
+	}
+	for _, k := range propagatedInboxHeaderKeys {
+		if _, set := outgoing[k]; set {
+			continue
+		}
+		if v := inbox[k]; v != "" {
+			outgoing[k] = v
+		}
+	}
+}

--- a/internal/processor/fetcher/domain/general/chain_handler.go
+++ b/internal/processor/fetcher/domain/general/chain_handler.go
@@ -347,6 +347,10 @@ func (h *ChainHandler) republishToChromedpQueue(ctx context.Context, job *core.C
 
 // publishFetchedRef 는 RawContentRef 를 TopicFetched 에 발행합니다.
 // 헤더에 target_type 을 포함하여 parser worker 가 Article/Category 분기에 사용.
+//
+// validator → parser 재학습 cycle (이슈 #366): 호출자 ctx 의 inbox headers 에서
+// validate_reparse_count / validate_reparse_reason 를 propagate — parser worker 가 받아서
+// LLM 호출 시 ctx 에 reason 주입 + 다음 stage 전파.
 func (h *ChainHandler) publishFetchedRef(ctx context.Context, job *core.CrawlJob, raw *core.RawContent, rawID string) error {
 	ref := core.RawContentRef{
 		ID:         rawID,
@@ -359,18 +363,29 @@ func (h *ChainHandler) publishFetchedRef(ctx context.Context, job *core.CrawlJob
 		return fmt.Errorf("marshal raw content ref: %w", err)
 	}
 
+	headers := map[string]string{
+		"source":              raw.SourceInfo.Name,
+		"country":             raw.SourceInfo.Country,
+		core.HeaderCrawler:    job.CrawlerName,
+		"job_id":              job.ID,
+		core.HeaderTargetType: string(job.Target.Type),
+		core.HeaderTimeoutMs:  fmt.Sprintf("%d", job.Timeout.Milliseconds()),
+	}
+	// reparse 헤더 propagation — incoming msg 의 reparse_* 값을 fetched 메시지로 전파.
+	if inbox := core.InboxHeadersFromContext(ctx); inbox != nil {
+		if v := inbox[core.HeaderValidateReparseCount]; v != "" {
+			headers[core.HeaderValidateReparseCount] = v
+		}
+		if v := inbox[core.HeaderValidateReparseReason]; v != "" {
+			headers[core.HeaderValidateReparseReason] = v
+		}
+	}
+
 	msg := queue.Message{
-		Topic: queue.TopicFetched,
-		Key:   []byte(rawID),
-		Value: payload,
-		Headers: map[string]string{
-			"source":      raw.SourceInfo.Name,
-			"country":     raw.SourceInfo.Country,
-			"crawler":     job.CrawlerName,
-			"job_id":      job.ID,
-			"target_type": string(job.Target.Type),
-			"timeout_ms":  fmt.Sprintf("%d", job.Timeout.Milliseconds()),
-		},
+		Topic:   queue.TopicFetched,
+		Key:     []byte(rawID),
+		Value:   payload,
+		Headers: headers,
 	}
 	return h.Producer.Publish(ctx, msg)
 }

--- a/internal/processor/fetcher/domain/general/chain_handler.go
+++ b/internal/processor/fetcher/domain/general/chain_handler.go
@@ -371,15 +371,8 @@ func (h *ChainHandler) publishFetchedRef(ctx context.Context, job *core.CrawlJob
 		core.HeaderTargetType: string(job.Target.Type),
 		core.HeaderTimeoutMs:  fmt.Sprintf("%d", job.Timeout.Milliseconds()),
 	}
-	// reparse 헤더 propagation — incoming msg 의 reparse_* 값을 fetched 메시지로 전파.
-	if inbox := core.InboxHeadersFromContext(ctx); inbox != nil {
-		if v := inbox[core.HeaderValidateReparseCount]; v != "" {
-			headers[core.HeaderValidateReparseCount] = v
-		}
-		if v := inbox[core.HeaderValidateReparseReason]; v != "" {
-			headers[core.HeaderValidateReparseReason] = v
-		}
-	}
+	// reparse / trace 헤더 propagation — 화이트리스트 기반 (이슈 #366 gemini 반영).
+	core.PropagateInboxHeaders(ctx, headers)
 
 	msg := queue.Message{
 		Topic:   queue.TopicFetched,

--- a/internal/processor/fetcher/worker/pool.go
+++ b/internal/processor/fetcher/worker/pool.go
@@ -534,7 +534,10 @@ func (p *KafkaConsumerPool) processJob(ctx context.Context, item jobItem) (err e
 		return cbErr
 	}
 
-	contents, err := p.handler.Handle(ctx, item.job)
+	// incoming msg.Headers 를 ctx 에 첨부 — chain_handler.publishFetchedRef 가 reparse_*
+	// 등 헤더를 TopicFetched 발행 메시지로 전파할 수 있도록 (이슈 #366).
+	handleCtx := core.WithInboxHeaders(ctx, item.msg.Headers)
+	contents, err := p.handler.Handle(handleCtx, item.job)
 	if err != nil {
 		cb.RecordFailure()
 

--- a/internal/processor/parser/worker/parser_worker.go
+++ b/internal/processor/parser/worker/parser_worker.go
@@ -305,10 +305,25 @@ func (w *ParserWorker) ProcessMessage(ctx context.Context, msg *queue.Message) e
 		return nil
 	}
 
+	// validator → parser 재학습 cycle (이슈 #366):
+	//   1. inbox headers 를 ctx 에 첨부 — publishContents 가 reparse_* 를 normalized 메시지로 전파
+	//   2. validate_reparse_reason 헤더가 있으면 ctx 에 llmgen.WithRejectReason 으로 주입 —
+	//      claudegen.ExtractEnriched 가 prompt 에 reason context 포함 (Sub B #365 메커니즘)
+	ctx = core.WithInboxHeaders(ctx, msg.Headers)
+	if reason := msg.Headers[core.HeaderValidateReparseReason]; reason != "" {
+		ctx = llmgen.WithRejectReason(ctx, reason)
+	}
+
 	mlog := w.log.WithFields(map[string]interface{}{
 		"raw_id": ref.ID,
 		"url":    ref.URL,
 	})
+	if reparseCount := msg.Headers[core.HeaderValidateReparseCount]; reparseCount != "" {
+		mlog = mlog.WithFields(map[string]interface{}{
+			"validate_reparse_count": reparseCount,
+		})
+		mlog.Info("parser processing reparse cycle message")
+	}
 
 	// parser 단계 StageGate (ProcessingLock + Semaphore 합성, 이슈 #355) —
 	// 같은 URL 의 동시 파싱 차단 + parser stage 의 동시 처리 슬롯 cap.
@@ -755,15 +770,27 @@ func (w *ParserWorker) publishContents(ctx context.Context, contents []*core.Con
 			partitionKey = c.URL
 		}
 
+		headers := map[string]string{
+			"source":           c.SourceID,
+			"country":          c.Country,
+			core.HeaderCrawler: crawlerName,
+		}
+		// validator → parser 재학습 cycle (이슈 #366): inbox 의 reparse 헤더를 normalized 메시지로 전파.
+		// validate worker 가 본 헤더로 retry count 를 enforce — 이 전파가 없으면 무한 reparse 위험.
+		if inbox := core.InboxHeadersFromContext(ctx); inbox != nil {
+			if v := inbox[core.HeaderValidateReparseCount]; v != "" {
+				headers[core.HeaderValidateReparseCount] = v
+			}
+			if v := inbox[core.HeaderValidateReparseReason]; v != "" {
+				headers[core.HeaderValidateReparseReason] = v
+			}
+		}
+
 		msg := queue.Message{
-			Topic: queue.TopicNormalized,
-			Key:   []byte(partitionKey),
-			Value: pmBytes,
-			Headers: map[string]string{
-				"source":  c.SourceID,
-				"country": c.Country,
-				"crawler": crawlerName,
-			},
+			Topic:   queue.TopicNormalized,
+			Key:     []byte(partitionKey),
+			Value:   pmBytes,
+			Headers: headers,
 		}
 		if err := w.producer.Publish(ctx, msg); err != nil {
 			return fmt.Errorf("publish normalized: %w", err)

--- a/internal/processor/parser/worker/parser_worker.go
+++ b/internal/processor/parser/worker/parser_worker.go
@@ -775,16 +775,9 @@ func (w *ParserWorker) publishContents(ctx context.Context, contents []*core.Con
 			"country":          c.Country,
 			core.HeaderCrawler: crawlerName,
 		}
-		// validator → parser 재학습 cycle (이슈 #366): inbox 의 reparse 헤더를 normalized 메시지로 전파.
-		// validate worker 가 본 헤더로 retry count 를 enforce — 이 전파가 없으면 무한 reparse 위험.
-		if inbox := core.InboxHeadersFromContext(ctx); inbox != nil {
-			if v := inbox[core.HeaderValidateReparseCount]; v != "" {
-				headers[core.HeaderValidateReparseCount] = v
-			}
-			if v := inbox[core.HeaderValidateReparseReason]; v != "" {
-				headers[core.HeaderValidateReparseReason] = v
-			}
-		}
+		// reparse / trace 헤더 propagation — 화이트리스트 기반 (이슈 #366 gemini 반영).
+		// validate worker 가 reparse_count 헤더로 retry 한도 enforce — 미전파 시 무한 루프 위험.
+		core.PropagateInboxHeaders(ctx, headers)
 
 		msg := queue.Message{
 			Topic:   queue.TopicNormalized,

--- a/test/internal/processor/fetcher/core/inbox_headers_test.go
+++ b/test/internal/processor/fetcher/core/inbox_headers_test.go
@@ -14,13 +14,16 @@ import (
 func TestWithInboxHeaders_RoundTrip(t *testing.T) {
 	ctx := context.Background()
 	headers := map[string]string{
-		"crawler":                core.HeaderCrawler,
-		"validate_reparse_count": "1",
+		core.HeaderCrawler:               "naver",
+		core.HeaderValidateReparseCount:  "1",
+		core.HeaderValidateReparseReason: "PublishedAt required",
 	}
 	enriched := core.WithInboxHeaders(ctx, headers)
 
 	got := core.InboxHeadersFromContext(enriched)
-	assert.Equal(t, "1", got["validate_reparse_count"])
+	assert.Equal(t, "naver", got[core.HeaderCrawler])
+	assert.Equal(t, "1", got[core.HeaderValidateReparseCount])
+	assert.Equal(t, "PublishedAt required", got[core.HeaderValidateReparseReason])
 }
 
 func TestWithInboxHeaders_Nil_ReturnsSameCtx(t *testing.T) {
@@ -51,4 +54,54 @@ func TestWithInboxHeaders_ShallowCopy(t *testing.T) {
 func TestInboxHeadersFromContext_Absent_ReturnsNil(t *testing.T) {
 	ctx := context.Background()
 	assert.Nil(t, core.InboxHeadersFromContext(ctx))
+}
+
+func TestPropagateInboxHeaders_WhitelistedKeysOnly(t *testing.T) {
+	ctx := core.WithInboxHeaders(context.Background(), map[string]string{
+		core.HeaderValidateReparseCount:  "2",
+		core.HeaderValidateReparseReason: "PublishedAt required",
+		"x-trace-id":                     "trace-xyz",
+		core.HeaderCrawler:               "naver",   // 화이트리스트 외 — 전파 X
+		core.HeaderTargetType:            "article", // 화이트리스트 외 — 전파 X
+	})
+	outgoing := map[string]string{
+		"source":  "test",
+		"country": "KR",
+	}
+	core.PropagateInboxHeaders(ctx, outgoing)
+
+	assert.Equal(t, "2", outgoing[core.HeaderValidateReparseCount])
+	assert.Equal(t, "PublishedAt required", outgoing[core.HeaderValidateReparseReason])
+	assert.Equal(t, "trace-xyz", outgoing["x-trace-id"])
+	_, hasCrawler := outgoing[core.HeaderCrawler]
+	assert.False(t, hasCrawler, "화이트리스트 외 키 propagation X")
+	_, hasTargetType := outgoing[core.HeaderTargetType]
+	assert.False(t, hasTargetType, "화이트리스트 외 키 propagation X")
+}
+
+func TestPropagateInboxHeaders_DoesNotOverwriteExisting(t *testing.T) {
+	// 호출자의 명시적 설정이 inbox 값보다 우선 — Rule 2 (의도적 설정).
+	ctx := core.WithInboxHeaders(context.Background(), map[string]string{
+		core.HeaderValidateReparseCount: "5",
+	})
+	outgoing := map[string]string{
+		core.HeaderValidateReparseCount: "999", // 호출자가 명시적 설정
+	}
+	core.PropagateInboxHeaders(ctx, outgoing)
+	assert.Equal(t, "999", outgoing[core.HeaderValidateReparseCount], "기존 outgoing 키 덮어쓰기 X")
+}
+
+func TestPropagateInboxHeaders_NilCtx_NoOp(t *testing.T) {
+	ctx := context.Background()
+	outgoing := map[string]string{"existing": "v"}
+	core.PropagateInboxHeaders(ctx, outgoing)
+	assert.Equal(t, map[string]string{"existing": "v"}, outgoing, "inbox 부재 시 outgoing 변경 X")
+}
+
+func TestPropagateInboxHeaders_NilOutgoing_NoOp(t *testing.T) {
+	// outgoing 이 nil 이면 nil map 에 write 시도 panic 회피.
+	ctx := core.WithInboxHeaders(context.Background(), map[string]string{"x-trace-id": "t"})
+	assert.NotPanics(t, func() {
+		core.PropagateInboxHeaders(ctx, nil)
+	})
 }

--- a/test/internal/processor/fetcher/core/inbox_headers_test.go
+++ b/test/internal/processor/fetcher/core/inbox_headers_test.go
@@ -1,0 +1,54 @@
+package core_test
+
+// inbox_headers_test.go — Sub C (#366) 의 inbox headers ctx helper 단위 테스트.
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"issuetracker/internal/processor/fetcher/core"
+)
+
+func TestWithInboxHeaders_RoundTrip(t *testing.T) {
+	ctx := context.Background()
+	headers := map[string]string{
+		"crawler":                core.HeaderCrawler,
+		"validate_reparse_count": "1",
+	}
+	enriched := core.WithInboxHeaders(ctx, headers)
+
+	got := core.InboxHeadersFromContext(enriched)
+	assert.Equal(t, "1", got["validate_reparse_count"])
+}
+
+func TestWithInboxHeaders_Nil_ReturnsSameCtx(t *testing.T) {
+	ctx := context.Background()
+	enriched := core.WithInboxHeaders(ctx, nil)
+	assert.Equal(t, ctx, enriched, "nil headers → ctx 그대로 (None Object)")
+	assert.Nil(t, core.InboxHeadersFromContext(enriched))
+}
+
+func TestWithInboxHeaders_Empty_ReturnsSameCtx(t *testing.T) {
+	ctx := context.Background()
+	enriched := core.WithInboxHeaders(ctx, map[string]string{})
+	assert.Equal(t, ctx, enriched, "empty headers → ctx 그대로")
+	assert.Nil(t, core.InboxHeadersFromContext(enriched))
+}
+
+func TestWithInboxHeaders_ShallowCopy(t *testing.T) {
+	// 호출자가 원본 map 을 변경해도 ctx 가 영향받지 않는지 검증.
+	ctx := context.Background()
+	original := map[string]string{"key": "v1"}
+	enriched := core.WithInboxHeaders(ctx, original)
+	original["key"] = "v2" // 원본 변경
+
+	got := core.InboxHeadersFromContext(enriched)
+	assert.Equal(t, "v1", got["key"], "ctx 의 헤더는 원본 변경 영향 받지 않음 (shallow copy)")
+}
+
+func TestInboxHeadersFromContext_Absent_ReturnsNil(t *testing.T) {
+	ctx := context.Background()
+	assert.Nil(t, core.InboxHeadersFromContext(ctx))
+}

--- a/test/internal/processor/fetcher/domain/general/chain_handler_reparse_propagation_test.go
+++ b/test/internal/processor/fetcher/domain/general/chain_handler_reparse_propagation_test.go
@@ -1,0 +1,161 @@
+package general_test
+
+// chain_handler_reparse_propagation_test.go — Sub C (#366) — TopicFetched 발행 시
+// validate_reparse_count / validate_reparse_reason 헤더 전파 검증.
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"issuetracker/internal/processor/fetcher/core"
+	"issuetracker/internal/processor/fetcher/domain/general"
+	"issuetracker/internal/storage"
+	"issuetracker/pkg/logger"
+	"issuetracker/pkg/queue"
+)
+
+// successChain 은 정상 raw content 를 반환하는 stub general.Handler.
+type successChain struct {
+	raw *core.RawContent
+}
+
+func (s *successChain) Handle(_ context.Context, _ *core.CrawlJob) (*core.RawContent, error) {
+	return s.raw, nil
+}
+func (*successChain) SetNext(_ general.Handler) {}
+
+// captureRawSvc 는 Store 호출을 캡쳐하면서 ID 를 부여하는 stub.
+type captureRawSvc struct {
+	mu        sync.Mutex
+	stored    *core.RawContent
+	returnID  string
+	returnDup bool
+}
+
+func (c *captureRawSvc) Store(_ context.Context, raw *core.RawContent) (string, bool, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.stored = raw
+	return c.returnID, c.returnDup, nil
+}
+func (*captureRawSvc) GetByID(_ context.Context, _ string) (*core.RawContent, error) {
+	return nil, storage.ErrNotFound
+}
+func (*captureRawSvc) Delete(_ context.Context, _ string) error { return nil }
+func (*captureRawSvc) List(_ context.Context, _ storage.RawContentFilter) ([]*core.RawContent, error) {
+	return nil, nil
+}
+func (*captureRawSvc) PurgeOlderThan(_ context.Context, _ time.Time) (int64, error) { return 0, nil }
+
+// captureProducer 는 Publish 호출의 msg 를 캡쳐합니다.
+type captureProducer struct {
+	mu        sync.Mutex
+	published []queue.Message
+}
+
+func (p *captureProducer) Publish(_ context.Context, msg queue.Message) error {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.published = append(p.published, msg)
+	return nil
+}
+func (p *captureProducer) PublishBatch(_ context.Context, msgs []queue.Message) error {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.published = append(p.published, msgs...)
+	return nil
+}
+func (*captureProducer) Close() error { return nil }
+
+func newCaptureHandler(t *testing.T, raw *core.RawContent, rawID string) (*general.ChainHandler, *captureProducer) {
+	t.Helper()
+	log := logger.New(logger.DefaultConfig())
+	rawSvc := &captureRawSvc{returnID: rawID}
+	prod := &captureProducer{}
+	h := general.NewChainHandler(
+		nil, // SourceCrawler — fast path 에서 사용 X
+		&successChain{raw: raw},
+		nil, // no chromedp chains
+		nil, // no resolver
+		rawSvc,
+		prod,
+		log,
+	)
+	return h, prod
+}
+
+// TestChainHandler_PropagatesReparseHeaders 는 inbox headers 의 reparse 키가
+// TopicFetched 발행 메시지에 전파되는지 검증합니다 (이슈 #366 의 핵심 동작).
+func TestChainHandler_PropagatesReparseHeaders(t *testing.T) {
+	raw := &core.RawContent{
+		URL:        "https://example.com/article/123",
+		FetchedAt:  time.Now(),
+		SourceInfo: core.SourceInfo{Name: "test-crawler", Country: "KR"},
+		HTML:       "<html></html>",
+		StatusCode: 200,
+	}
+	h, prod := newCaptureHandler(t, raw, "raw-001")
+
+	// inbox headers 에 reparse 정보 첨부
+	ctx := core.WithInboxHeaders(context.Background(), map[string]string{
+		core.HeaderValidateReparseCount:  "1",
+		core.HeaderValidateReparseReason: "PublishedAt required",
+		core.HeaderCrawler:               "test-crawler",
+	})
+
+	job := &core.CrawlJob{
+		ID:          "job-1",
+		CrawlerName: "test-crawler",
+		Target:      core.Target{URL: raw.URL, Type: core.TargetTypeArticle},
+		Timeout:     30 * time.Second,
+	}
+
+	_, err := h.Handle(ctx, job)
+	require.NoError(t, err)
+
+	require.Len(t, prod.published, 1)
+	msg := prod.published[0]
+	assert.Equal(t, queue.TopicFetched, msg.Topic)
+	// reparse 헤더가 정확히 propagate 되었는지 확인
+	assert.Equal(t, "1", msg.Headers[core.HeaderValidateReparseCount])
+	assert.Equal(t, "PublishedAt required", msg.Headers[core.HeaderValidateReparseReason])
+	// 기존 헤더도 정상 (target_type, crawler 등)
+	assert.Equal(t, string(core.TargetTypeArticle), msg.Headers[core.HeaderTargetType])
+	assert.Equal(t, "test-crawler", msg.Headers[core.HeaderCrawler])
+}
+
+// TestChainHandler_NoReparseHeaders_PublishedClean 는 inbox headers 가 없으면
+// 발행된 메시지에도 reparse 키가 없는지 검증 (정상 경로 회귀 보호).
+func TestChainHandler_NoReparseHeaders_PublishedClean(t *testing.T) {
+	raw := &core.RawContent{
+		URL:        "https://example.com/article/456",
+		FetchedAt:  time.Now(),
+		SourceInfo: core.SourceInfo{Name: "test-crawler", Country: "KR"},
+		HTML:       "<html></html>",
+		StatusCode: 200,
+	}
+	h, prod := newCaptureHandler(t, raw, "raw-002")
+
+	job := &core.CrawlJob{
+		ID:          "job-2",
+		CrawlerName: "test-crawler",
+		Target:      core.Target{URL: raw.URL, Type: core.TargetTypeArticle},
+		Timeout:     30 * time.Second,
+	}
+
+	// inbox headers 없는 ctx
+	_, err := h.Handle(context.Background(), job)
+	require.NoError(t, err)
+
+	require.Len(t, prod.published, 1)
+	msg := prod.published[0]
+	_, hasCount := msg.Headers[core.HeaderValidateReparseCount]
+	_, hasReason := msg.Headers[core.HeaderValidateReparseReason]
+	assert.False(t, hasCount, "inbox 부재 시 reparse_count 없어야 함")
+	assert.False(t, hasReason, "inbox 부재 시 reparse_reason 없어야 함")
+}

--- a/test/internal/processor/parser/worker/reparse_test.go
+++ b/test/internal/processor/parser/worker/reparse_test.go
@@ -1,0 +1,81 @@
+package worker_test
+
+// reparse_test.go — Sub C (#366) — parser worker 의 reparse cycle 분기 검증.
+//
+// 검증 항목:
+//  1. msg.Headers 에 validate_reparse_reason 존재 시 ctx 에 llmgen.WithRejectReason 첨부
+//     (raw 없는 케이스에서 ProcessMessage 가 정상 early-return 하는지만 black-box)
+//  2. msg.Headers 에 reparse 헤더 존재 시 core.WithInboxHeaders 가 ctx 에 첨부 — publishContents 가
+//     이를 normalized 메시지로 전파
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"issuetracker/internal/processor/fetcher/core"
+	parserWorker "issuetracker/internal/processor/parser/worker"
+	"issuetracker/pkg/logger"
+	"issuetracker/pkg/queue"
+)
+
+// 본 test 에서만 사용 — 다른 _test.go 의 helper 와 충돌 회피.
+var _ = parserWorker.ErrStageGateNotAcquired // 컴파일러 강제
+
+// msgWithReparseHeaders 는 RawContentRef payload + reparse 헤더가 설정된 fetched 메시지를 만듭니다.
+func msgWithReparseHeaders(t *testing.T, refID, url string, count, reason string) *queue.Message {
+	t.Helper()
+	ref := core.RawContentRef{
+		ID:        refID,
+		URL:       url,
+		FetchedAt: time.Now(),
+		SourceInfo: core.SourceInfo{
+			Name:    "test-crawler",
+			Country: "KR",
+		},
+	}
+	body, err := json.Marshal(ref)
+	require.NoError(t, err)
+	headers := map[string]string{
+		core.HeaderCrawler:    "test-crawler",
+		core.HeaderTargetType: string(core.TargetTypeArticle),
+	}
+	if count != "" {
+		headers[core.HeaderValidateReparseCount] = count
+	}
+	if reason != "" {
+		headers[core.HeaderValidateReparseReason] = reason
+	}
+	return &queue.Message{
+		Topic:   queue.TopicFetched,
+		Value:   body,
+		Headers: headers,
+	}
+}
+
+// TestProcessMessage_ReparseHeaders_NoRaw_Skipped 는 reparse 헤더가 있는 msg 를 처리할 때
+// raw 가 없으면 early-return 으로 정상 종료하는지 검증 (회귀 보호 + 기본 동작).
+func TestProcessMessage_ReparseHeaders_NoRaw_Skipped(t *testing.T) {
+	// fakeRawSvc 는 cleanup_test.go 의 동일 mock — GetByID 가 ErrNotFound 반환.
+	gate := &fakeStageGate{acquired: true, err: nil}
+	rawSvc := &fakeRawSvc{}
+	log := logger.New(logger.DefaultConfig())
+
+	pw := newGatedWorker(gate, rawSvc, log)
+	msg := msgWithReparseHeaders(t, "raw-rp-001", "https://example.com/r1", "1", "PublishedAt required")
+
+	err := pw.ProcessMessage(context.Background(), msg)
+	assert.NoError(t, err, "reparse header 있는 msg 도 raw 부재 시 정상 종료")
+}
+
+// testLogger 는 stage_gate_test.go 와 공유되는 logger 생성을 race-safe 하게 분리.
+// (자체 함수 — 다른 _test.go 와 충돌하지 않도록 이름 분리.)
+// stage_gate_test.go 의 helper 와 동일 logger 생성을 분리해서 사용.
+// fakeRawSvc / fakeStageGate 는 cleanup_test.go / stage_gate_test.go 에 정의됨.
+//
+// 본 test 의 핵심은 reparse 헤더가 panic 없이 처리되는지 + early-return 정상 동작.
+// 더 깊은 ctx propagation 검증은 통합 라이브 검증에서 수행.


### PR DESCRIPTION
## 연관 이슈
- Closes #366
- Closes #363

마지막 sub-issue 머지 — 메인 #363 (validator → parser 재학습 루트) 통합 완료.

<br>

## 구현 내용
#363 의 phase 3 — Sub A 의 reparse 트리거 + Sub B 의 prompt context 메커니즘을 end-to-end 로 연결. fetcher → parser 의 Kafka 헤더 propagation 완성 + parser 가 reason 을 LLM 호출 ctx 로 주입. \`VALIDATE_REPARSE_ENABLED=true\` 로 운영 활성화.

### 변경 사항

**신규** \`internal/processor/fetcher/core/inbox_headers.go\`
- \`WithInboxHeaders(ctx, headers)\` / \`InboxHeadersFromContext(ctx)\` — ctx value 로 incoming msg.Headers 전파
- shallow copy 로 caller mutation 방어, None Object 패턴 (nil/empty → ctx 그대로)

**\`internal/processor/fetcher/worker/pool.go\`**
- \`Handle\` 호출 전 \`ctx = core.WithInboxHeaders(ctx, item.msg.Headers)\` — chain_handler 가 publishFetchedRef 에서 헤더 propagation 가능하도록.

**\`internal/processor/fetcher/domain/general/chain_handler.go\`**
- \`publishFetchedRef\`: inbox 의 \`validate_reparse_count\` / \`validate_reparse_reason\` 헤더를 TopicFetched 메시지로 propagate.
- 기존 헤더 키들도 \`core.HeaderXxx\` 상수 사용으로 일관성.

**\`internal/processor/parser/worker/parser_worker.go\`**
- \`ProcessMessage\` 입구에서 msg.Headers 의 reparse_reason 발견 시 ctx 에 \`llmgen.WithRejectReason\` 주입 → \`claudegen.ExtractEnriched\` 가 prompt 에 reason context 포함 (Sub B 메커니즘 활용).
- inbox headers 도 ctx 에 첨부 — \`publishContents\` 가 normalized 메시지로 전파.
- reparse cycle 진입 시 info 로그 (운영 가시성).
- \`publishContents\`: inbox headers 의 reparse 키를 normalized 메시지 헤더로 propagate.

**\`.env.example\`**
- \`VALIDATE_REPARSE_ENABLED=true\` — Sub C 완성 후 운영 활성화.

### 테스트 (8건)
- \`inbox_headers_test.go\` (5건): RoundTrip / Nil / Empty / ShallowCopy / Absent
- \`chain_handler_reparse_propagation_test.go\` (2건): reparse 헤더 있음/없음 양쪽
- 파서 worker \`reparse_test.go\` (1건): reparse 헤더 + raw 부재 시 정상 early-return

### 전체 흐름 (활성화 시)
1. validate worker reject (VAL_001 / VAL_003) → \`TopicCrawlNormal\` 에 새 CrawlJob + 헤더 \`validate_reparse_count=N+1\` + \`validate_reparse_reason=...\` 발행 (Sub A)
2. fetcher 가 CrawlJob 수신 → fetch → ChainHandler.publishFetchedRef 가 inbox headers 의 reparse 키를 TopicFetched 메시지로 propagate (본 PR)
3. parser worker 가 TopicFetched 수신 → ctx 에 \`llmgen.WithRejectReason\` 주입 → claudegen.ExtractEnriched 가 prompt 에 reason context 포함 → multi-turn agent 가 selector 보강 or \`validity=blacklist\` 결정 (Sub B + 본 PR)
4. parser 가 contents 저장 + normalized 메시지에 reparse 헤더 propagate (본 PR)
5. validate worker 가 normalized 수신 → 헤더의 reparse_count 읽어 retry 한도 enforce (Sub A)

### 회귀 안전성
- 정상 경로 (inbox headers 없음): 발행 메시지에 reparse 키 없음 — 기존 동작 100% 보존
- VALIDATE_REPARSE_ENABLED=false 설정 시 reparse 트리거 자체 비활성 (Sub A 의 toggle)

<br>

## CI / 머지 게이트 점검

### 변경 영향 범위
- 영향 패키지/모듈: \`internal/processor/fetcher/core\`, \`internal/processor/fetcher/worker\`, \`internal/processor/fetcher/domain/general\`, \`internal/processor/parser/worker\`
- 위험도(택1): **Medium** — VALIDATE_REPARSE_ENABLED=true default 변경으로 운영 활성화. 라이브에서 PublishedAt 부재 케이스가 LLM 학습 트리거하기 시작 — 의도된 동작. retry max=2 로 무한 루프 차단. 회귀 시 env=false 로 1초 비활성화.

### Required Status Checks
- 통과 확인 대상:
  - [ ] \`Commit Lint\`
  - [ ] \`PR Title Lint\`
  - [ ] \`Linked Issue Check\`
  - [ ] \`Format Check\`
  - [ ] \`Build\`
  - [ ] \`Test\`
  - [ ] \`Lint\`

### 롤백 계획
- \`VALIDATE_REPARSE_ENABLED=false\` 로 즉시 비활성화 (재빌드 불필요).
- 코드 회귀 시 PR revert.

<br>

## 후속 작업
- 라이브 1 cycle (~30분~1시간) 진행 → validate 실패 호스트의 selector 가 LLM 학습으로 보강되어 다음 cycle 에 validate 통과 확인. #352 (claudegen pool) 의 실효 throughput 도 함께 측정 가능.

🤖 Generated with [Claude Code](https://claude.com/claude-code)