### PR TITLE
[REFAC#370] retry scheduler heartbeat 로그 압축 — 매 tick → 주기적 요약

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -35,6 +35,12 @@ REDIS_INGESTION_LOCK_TTL=24h
 # - 정상 흐름은 명시적 Release, 본 TTL 은 worker 충돌 시 fallback
 PIPELINE_GUARD_CATEGORY_TTL=60s
 
+# Redis delayed retry scheduler 의 idle heartbeat 로그 압축 (이슈 #370)
+# - default: 60 — PollInterval=1s 기준 ~1분에 1회 "retry pipeline idle heartbeat" DEBUG
+# - 0: legacy (매 idle tick 마다 1줄, 노이즈 심함)
+# - due 항목 발견 시점 로그는 본 설정 무관하게 항상 즉시 emit
+RETRY_HEARTBEAT_EVERY_N_IDLE_TICKS=60
+
 # Kafka 연결 설정 (pkg/queue/config.go 기본값: localhost:9092)
 # 현재 코드에서 환경변수로 read 하지 않음. 별도 이슈에서 wiring 예정.
 # KAFKA_BROKERS=localhost:9092

--- a/cmd/issuetracker/main.go
+++ b/cmd/issuetracker/main.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"os"
 	"os/signal"
+	"strconv"
 	"syscall"
 	"time"
 
@@ -290,9 +291,16 @@ func main() {
 			// Delayed retry queue: retry 를 Redis ZSET 에 보관하고 별도
 			// goroutine 이 ScheduledAt 도달 시 Kafka 에 발행 — worker 슬롯 점유 회피.
 			// Redis 부재 시 worker 가 lazy 로 KafkaImmediateRetryScheduler 를 사용 (기존 동작).
+			retryCfg := crawlerWorker.DefaultRedisRetrySchedulerConfig()
+			// idle heartbeat 압축 (이슈 #370) — env 로 override. 음수 / 비숫자는 default 유지.
+			if v := os.Getenv("RETRY_HEARTBEAT_EVERY_N_IDLE_TICKS"); v != "" {
+				if n, err := strconv.Atoi(v); err == nil && n >= 0 {
+					retryCfg.HeartbeatEveryNIdleTicks = n
+				}
+			}
 			redisRetry := crawlerWorker.NewRedisDelayedRetryScheduler(
 				redisClient, crawlerProducer,
-				crawlerWorker.DefaultRedisRetrySchedulerConfig(),
+				retryCfg,
 				log,
 			)
 			runCtx, cancelRun := context.WithCancel(ctx)

--- a/cmd/issuetracker/main.go
+++ b/cmd/issuetracker/main.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"os"
 	"os/signal"
-	"strconv"
 	"syscall"
 	"time"
 
@@ -292,12 +291,12 @@ func main() {
 			// goroutine 이 ScheduledAt 도달 시 Kafka 에 발행 — worker 슬롯 점유 회피.
 			// Redis 부재 시 worker 가 lazy 로 KafkaImmediateRetryScheduler 를 사용 (기존 동작).
 			retryCfg := crawlerWorker.DefaultRedisRetrySchedulerConfig()
-			// idle heartbeat 압축 (이슈 #370) — env 로 override. 음수 / 비숫자는 default 유지.
-			if v := os.Getenv("RETRY_HEARTBEAT_EVERY_N_IDLE_TICKS"); v != "" {
-				if n, err := strconv.Atoi(v); err == nil && n >= 0 {
-					retryCfg.HeartbeatEveryNIdleTicks = n
-				}
+			// idle heartbeat 압축 (이슈 #370) — pkg/config 로 env 로드 일관성 유지.
+			retrySchedCfg, retrySchedErr := config.LoadRetryScheduler()
+			if retrySchedErr != nil {
+				log.WithError(retrySchedErr).Fatal("RETRY_HEARTBEAT_EVERY_N_IDLE_TICKS 로드 실패")
 			}
+			retryCfg.HeartbeatEveryNIdleTicks = retrySchedCfg.HeartbeatEveryNIdleTicks
 			redisRetry := crawlerWorker.NewRedisDelayedRetryScheduler(
 				redisClient, crawlerProducer,
 				retryCfg,

--- a/internal/processor/fetcher/worker/retry_scheduler.go
+++ b/internal/processor/fetcher/worker/retry_scheduler.go
@@ -153,7 +153,11 @@ type RedisDelayedRetryScheduler struct {
 }
 
 // NewRedisDelayedRetryScheduler 는 RedisDelayedRetryScheduler 를 생성합니다.
-// cfg 의 0 값 필드는 DefaultRedisRetrySchedulerConfig 로 보정합니다.
+//
+// 보정 규칙:
+//   - PollInterval / BatchSize / RepublishFailureBackoff: 0 또는 음수 → default 적용.
+//   - HeartbeatEveryNIdleTicks: **0 은 legacy (매 tick 로깅) 로 유효한 값** 이므로
+//     음수일 때만 default (60) 로 보정. 따라서 0 을 명시하면 default 가 적용되지 않음.
 func NewRedisDelayedRetryScheduler(client retryQueueClient, producer queue.Producer, cfg RedisRetrySchedulerConfig, log *logger.Logger) *RedisDelayedRetryScheduler {
 	def := DefaultRedisRetrySchedulerConfig()
 	if cfg.PollInterval <= 0 {

--- a/internal/processor/fetcher/worker/retry_scheduler.go
+++ b/internal/processor/fetcher/worker/retry_scheduler.go
@@ -112,14 +112,21 @@ type RedisRetrySchedulerConfig struct {
 	// RepublishFailureBackoff: Kafka publish 실패 시 동일 항목을 재 enqueue 할 지연
 	// (default: 1s). 일시적 Kafka 장애 흡수용 — Redis enqueue 까지 실패하면 데이터 손실
 	RepublishFailureBackoff time.Duration
+
+	// HeartbeatEveryNIdleTicks: idle (due 항목 0) tick 이 연속 N 회 발생할 때마다 1회
+	// "retry pipeline idle heartbeat" DEBUG 로그를 남김 (default: 60 = 1s polling 기준 ~1분).
+	// 0 이면 legacy 동작 (매 idle tick 마다 1줄 — 노이즈 많음).
+	// due 항목 발견 시점 로그는 본 설정 무관하게 항상 즉시 emit.
+	HeartbeatEveryNIdleTicks int
 }
 
 // DefaultRedisRetrySchedulerConfig 는 운영 기본값을 반환합니다.
 func DefaultRedisRetrySchedulerConfig() RedisRetrySchedulerConfig {
 	return RedisRetrySchedulerConfig{
-		PollInterval:            1 * time.Second,
-		BatchSize:               50,
-		RepublishFailureBackoff: 1 * time.Second,
+		PollInterval:             1 * time.Second,
+		BatchSize:                50,
+		RepublishFailureBackoff:  1 * time.Second,
+		HeartbeatEveryNIdleTicks: 60,
 	}
 }
 
@@ -139,6 +146,10 @@ type RedisDelayedRetryScheduler struct {
 	cfg      RedisRetrySchedulerConfig
 	log      *logger.Logger
 	wg       sync.WaitGroup
+
+	// idleTicks: 연속 idle (due 0) tick 수. due 발견 시 0 으로 reset.
+	// pollOnce 만 접근 — goroutine 단일 진입이라 race 없음.
+	idleTicks int
 }
 
 // NewRedisDelayedRetryScheduler 는 RedisDelayedRetryScheduler 를 생성합니다.
@@ -153,6 +164,9 @@ func NewRedisDelayedRetryScheduler(client retryQueueClient, producer queue.Produ
 	}
 	if cfg.RepublishFailureBackoff <= 0 {
 		cfg.RepublishFailureBackoff = def.RepublishFailureBackoff
+	}
+	if cfg.HeartbeatEveryNIdleTicks < 0 {
+		cfg.HeartbeatEveryNIdleTicks = def.HeartbeatEveryNIdleTicks
 	}
 	return &RedisDelayedRetryScheduler{
 		client:   client,
@@ -248,18 +262,26 @@ func (s *RedisDelayedRetryScheduler) pollOnce(ctx context.Context) {
 		return
 	}
 
-	// peek 결과를 항상 DEBUG 로 노출 (count=0 이어도 한 줄).
-	// 운영자가 retry pipeline 이 살아있고 polling 중인지 즉답 가능.
+	// peek 결과를 DEBUG 로 노출 — due 발견 시 즉시, idle 시 주기적 heartbeat.
+	// 운영자가 retry pipeline 이 살아있고 polling 중인지 즉답 가능하면서
+	// 매 tick 1줄 노이즈는 피한다 (이슈 #370).
 	if len(due) > 0 {
 		s.log.WithFields(map[string]interface{}{
-			"due_count":  len(due),
-			"peek_ms":    time.Since(peekStart).Milliseconds(),
-			"batch_size": s.cfg.BatchSize,
+			"due_count":           len(due),
+			"peek_ms":             time.Since(peekStart).Milliseconds(),
+			"batch_size":          s.cfg.BatchSize,
+			"previous_idle_ticks": s.idleTicks,
 		}).Debug("retry peek returned due items")
+		s.idleTicks = 0
 	} else {
-		s.log.WithFields(map[string]interface{}{
-			"peek_ms": time.Since(peekStart).Milliseconds(),
-		}).Debug("retry peek returned no due items")
+		s.idleTicks++
+		every := s.cfg.HeartbeatEveryNIdleTicks
+		if every == 0 || s.idleTicks%every == 0 {
+			s.log.WithFields(map[string]interface{}{
+				"peek_ms":                time.Since(peekStart).Milliseconds(),
+				"consecutive_idle_ticks": s.idleTicks,
+			}).Debug("retry pipeline idle heartbeat")
+		}
 	}
 
 	for _, item := range due {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1461,3 +1461,47 @@ func LoadGoogleCSE(envFiles ...string) (GoogleCSEConfig, error) {
 func (c GoogleCSEConfig) IsConfigured() bool {
 	return c.APIKey != "" && c.CX != ""
 }
+
+// RetrySchedulerConfig 는 RedisDelayedRetryScheduler 의 운영자 노출 설정입니다.
+//
+// 본 struct 는 cmd 가 worker.RedisRetrySchedulerConfig 의 default 를 override 할 때
+// 사용합니다. 다른 필드 (PollInterval / BatchSize / RepublishFailureBackoff) 는
+// 현재 코드 default 가 운영 가치 있음 — 노출 필요 시 본 struct 에 추가하면 됨.
+type RetrySchedulerConfig struct {
+	// HeartbeatEveryNIdleTicks: idle (due 0) tick 이 연속 N 회 발생할 때마다 1회
+	// "retry pipeline idle heartbeat" DEBUG 로그를 남김.
+	// 환경변수 RETRY_HEARTBEAT_EVERY_N_IDLE_TICKS (default 60). 0=legacy (매 tick).
+	HeartbeatEveryNIdleTicks int
+}
+
+// DefaultRetrySchedulerConfig 는 운영 기본값을 반환합니다.
+func DefaultRetrySchedulerConfig() RetrySchedulerConfig {
+	return RetrySchedulerConfig{HeartbeatEveryNIdleTicks: 60}
+}
+
+// LoadRetryScheduler 는 .env 를 로드한 후 환경변수로 RetrySchedulerConfig 를 구성합니다.
+//
+// 지원 환경변수:
+//   - RETRY_HEARTBEAT_EVERY_N_IDLE_TICKS: int >= 0 (default 60)
+//     0 은 legacy 동작 (매 idle tick 마다 1줄). 음수는 invalid.
+func LoadRetryScheduler(envFiles ...string) (RetrySchedulerConfig, error) {
+	if len(envFiles) == 0 {
+		envFiles = []string{".env"}
+	}
+	if err := godotenv.Load(envFiles...); err != nil && !errors.Is(err, os.ErrNotExist) {
+		return RetrySchedulerConfig{}, fmt.Errorf("failed to load env files %v: %w", envFiles, err)
+	}
+
+	cfg := DefaultRetrySchedulerConfig()
+	if v := os.Getenv("RETRY_HEARTBEAT_EVERY_N_IDLE_TICKS"); v != "" {
+		n, err := strconv.Atoi(v)
+		if err != nil {
+			return RetrySchedulerConfig{}, fmt.Errorf("parse RETRY_HEARTBEAT_EVERY_N_IDLE_TICKS %q: %w", v, err)
+		}
+		if n < 0 {
+			return RetrySchedulerConfig{}, fmt.Errorf("invalid RETRY_HEARTBEAT_EVERY_N_IDLE_TICKS %d: must be >= 0", n)
+		}
+		cfg.HeartbeatEveryNIdleTicks = n
+	}
+	return cfg, nil
+}

--- a/test/internal/processor/fetcher/worker/retry_scheduler_test.go
+++ b/test/internal/processor/fetcher/worker/retry_scheduler_test.go
@@ -1,9 +1,11 @@
 package worker_test
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -578,4 +580,142 @@ func TestRedisDelayedRetryScheduler_DefaultConfigBoundary(t *testing.T) {
 	case <-time.After(time.Second):
 		t.Fatal("Run 이 ctx cancel 후 즉시 종료되어야 함")
 	}
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Heartbeat 압축 (이슈 #370) — idle tick 마다 1줄 → N tick 마다 1줄
+// ─────────────────────────────────────────────────────────────────────────────
+
+// safeBuffer 는 bytes.Buffer 에 mutex 를 씌워 concurrent write/read 안전성을 제공한다.
+// retry scheduler 의 Run goroutine 이 로그를 쓰는 동안 테스트가 동시 read 하므로 필요.
+type safeBuffer struct {
+	mu  sync.Mutex
+	buf bytes.Buffer
+}
+
+func (s *safeBuffer) Write(p []byte) (int, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.buf.Write(p)
+}
+
+func (s *safeBuffer) String() string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.buf.String()
+}
+
+// captureDebugLogger 는 DEBUG 레벨 JSON 로그를 buf 에 캡처하는 logger 를 만든다.
+func captureDebugLogger(buf *safeBuffer) *logger.Logger {
+	return logger.New(logger.Config{
+		Level:      logger.LevelDebug,
+		Output:     buf,
+		TimeFormat: time.RFC3339,
+	})
+}
+
+func countLines(buf *safeBuffer, substr string) int {
+	n := 0
+	for _, line := range strings.Split(buf.String(), "\n") {
+		if strings.Contains(line, substr) {
+			n++
+		}
+	}
+	return n
+}
+
+// TestRedisDelayedRetryScheduler_IdleHeartbeat_CompressedEveryN 는
+// HeartbeatEveryNIdleTicks=N 설정 시 N tick 마다 1회만 heartbeat 로그가 나오는지 검증.
+func TestRedisDelayedRetryScheduler_IdleHeartbeat_CompressedEveryN(t *testing.T) {
+	q := newFakeRetryQueue() // 비어있음 — 항상 idle
+	prod := new(mockProducer)
+	buf := &safeBuffer{}
+
+	cfg := worker.DefaultRedisRetrySchedulerConfig()
+	cfg.PollInterval = 10 * time.Millisecond
+	cfg.HeartbeatEveryNIdleTicks = 5
+	sched := worker.NewRedisDelayedRetryScheduler(q, prod, cfg, captureDebugLogger(buf))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() { sched.Run(ctx); close(done) }()
+
+	// ~12 tick 분 폴링 대기 (= heartbeat 2회 기대: tick 5, 10)
+	time.Sleep(125 * time.Millisecond)
+	cancel()
+	<-done
+
+	heartbeats := countLines(buf, "retry pipeline idle heartbeat")
+	// 정확한 횟수는 ticker timing 변동으로 ±1 허용 — 핵심은 매 tick 12회 ≠ heartbeat 12회
+	assert.GreaterOrEqual(t, heartbeats, 1, "heartbeat 가 최소 1회 emit")
+	assert.LessOrEqual(t, heartbeats, 4, "12 tick 동안 heartbeat 가 N=5 압축으로 4회 이하")
+	// 메시지 명 변경 — 구 메시지가 남아있으면 안 됨
+	assert.Equal(t, 0, countLines(buf, "retry peek returned no due items"),
+		"구 메시지는 더 이상 emit 되지 않아야 함")
+}
+
+// TestRedisDelayedRetryScheduler_IdleHeartbeat_LegacyEveryTick 는
+// HeartbeatEveryNIdleTicks=0 시 legacy 동작 (매 tick 1줄) 이 유지되는지 검증.
+func TestRedisDelayedRetryScheduler_IdleHeartbeat_LegacyEveryTick(t *testing.T) {
+	q := newFakeRetryQueue()
+	prod := new(mockProducer)
+	buf := &safeBuffer{}
+
+	cfg := worker.DefaultRedisRetrySchedulerConfig()
+	cfg.PollInterval = 10 * time.Millisecond
+	cfg.HeartbeatEveryNIdleTicks = 0 // legacy
+	sched := worker.NewRedisDelayedRetryScheduler(q, prod, cfg, captureDebugLogger(buf))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() { sched.Run(ctx); close(done) }()
+
+	time.Sleep(105 * time.Millisecond) // ~10 tick
+	cancel()
+	<-done
+
+	heartbeats := countLines(buf, "retry pipeline idle heartbeat")
+	// legacy 는 매 tick → 10 tick 부근. timing 변동으로 5 이상이면 legacy 동작 확인 충분.
+	assert.GreaterOrEqual(t, heartbeats, 5, "legacy 동작 — 매 tick heartbeat (≥5/10 tick)")
+}
+
+// TestRedisDelayedRetryScheduler_IdleTicksResetOnDue 는 due 항목 처리 시 idleTicks 가
+// 0 으로 reset 되고 previous_idle_ticks 필드로 직전 idle 지속이 노출됨을 검증.
+func TestRedisDelayedRetryScheduler_IdleTicksResetOnDue(t *testing.T) {
+	q := newFakeRetryQueue()
+	prod := new(mockProducer)
+	buf := &safeBuffer{}
+
+	cfg := worker.DefaultRedisRetrySchedulerConfig()
+	cfg.PollInterval = 10 * time.Millisecond
+	cfg.HeartbeatEveryNIdleTicks = 100 // 사실상 idle heartbeat 안 찍히도록
+	sched := worker.NewRedisDelayedRetryScheduler(q, prod, cfg, captureDebugLogger(buf))
+
+	prod.On("Publish", mock.Anything, mock.Anything).Return(nil)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() { sched.Run(ctx); close(done) }()
+
+	// idle 상태 ~5 tick
+	time.Sleep(55 * time.Millisecond)
+
+	// due 항목 추가 — 다음 tick 에서 처리
+	job := retryTestJob(core.PriorityNormal)
+	job.ScheduledAt = time.Now().Add(-time.Second)
+	require.NoError(t, sched.Enqueue(context.Background(), job, errors.New("err")))
+
+	// 처리 완료까지 대기
+	require.Eventually(t, func() bool {
+		return countLines(buf, "retry peek returned due items") >= 1
+	}, time.Second, 5*time.Millisecond, "due 항목이 처리되어야 함")
+
+	cancel()
+	<-done
+
+	// due 로그에 previous_idle_ticks 필드가 포함됐는지 확인 — 0 이 아닌 양수값
+	require.Contains(t, buf.String(), "previous_idle_ticks", "due 로그에 previous_idle_ticks 필드 노출")
+	// previous_idle_ticks 가 1 이상 — 직전 idle 이 있었음
+	assert.Regexp(t, `"previous_idle_ticks":[1-9]`, buf.String(),
+		"previous_idle_ticks 가 양수여야 함 (직전 idle window 존재)")
 }

--- a/test/internal/processor/fetcher/worker/retry_scheduler_test.go
+++ b/test/internal/processor/fetcher/worker/retry_scheduler_test.go
@@ -626,6 +626,9 @@ func countLines(buf *safeBuffer, substr string) int {
 
 // TestRedisDelayedRetryScheduler_IdleHeartbeat_CompressedEveryN 는
 // HeartbeatEveryNIdleTicks=N 설정 시 N tick 마다 1회만 heartbeat 로그가 나오는지 검증.
+//
+// CI 부하 / 스케줄링 지연에서도 안정적으로 통과하도록 Eventually 로 최소 heartbeat
+// 도달까지 대기한 뒤 끊는다 (Sleep 으로 tick 수를 '대략' 맞추는 방식은 flaky 위험).
 func TestRedisDelayedRetryScheduler_IdleHeartbeat_CompressedEveryN(t *testing.T) {
 	q := newFakeRetryQueue() // 비어있음 — 항상 idle
 	prod := new(mockProducer)
@@ -639,16 +642,27 @@ func TestRedisDelayedRetryScheduler_IdleHeartbeat_CompressedEveryN(t *testing.T)
 	ctx, cancel := context.WithCancel(context.Background())
 	done := make(chan struct{})
 	go func() { sched.Run(ctx); close(done) }()
+	defer func() {
+		cancel()
+		<-done
+	}()
 
-	// ~12 tick 분 폴링 대기 (= heartbeat 2회 기대: tick 5, 10)
-	time.Sleep(125 * time.Millisecond)
-	cancel()
-	<-done
+	// 최소 2회 heartbeat 가 emit 될 때까지 대기 — CI 지연에도 deterministic.
+	// 부하 환경에서 ticker 가 지연되더라도 결국 heartbeat 가 발생함.
+	require.Eventually(t, func() bool {
+		return countLines(buf, "retry pipeline idle heartbeat") >= 2
+	}, 3*time.Second, 5*time.Millisecond, "최소 2회 heartbeat emit 되어야 함")
 
+	// 핵심 검증: 매 tick 로깅이 아니라는 것 — 압축이 동작하는가.
+	// peek 호출 횟수 대비 heartbeat 횟수가 ~1/N 이어야 함.
+	peekCount := int(q.peekCallCount.Load())
 	heartbeats := countLines(buf, "retry pipeline idle heartbeat")
-	// 정확한 횟수는 ticker timing 변동으로 ±1 허용 — 핵심은 매 tick 12회 ≠ heartbeat 12회
-	assert.GreaterOrEqual(t, heartbeats, 1, "heartbeat 가 최소 1회 emit")
-	assert.LessOrEqual(t, heartbeats, 4, "12 tick 동안 heartbeat 가 N=5 압축으로 4회 이하")
+	require.Greater(t, peekCount, heartbeats,
+		"peek 호출 횟수가 heartbeat 보다 많아야 함 (압축 동작)")
+	// 압축 비율: N=5 기준 heartbeat 는 peek 의 약 1/5 — 여유롭게 1/2 이하만 검증
+	assert.LessOrEqual(t, heartbeats*2, peekCount,
+		"heartbeat 가 peek 의 절반 이하 (N=5 압축 확인) — heartbeats=%d peeks=%d",
+		heartbeats, peekCount)
 	// 메시지 명 변경 — 구 메시지가 남아있으면 안 됨
 	assert.Equal(t, 0, countLines(buf, "retry peek returned no due items"),
 		"구 메시지는 더 이상 emit 되지 않아야 함")
@@ -669,14 +683,23 @@ func TestRedisDelayedRetryScheduler_IdleHeartbeat_LegacyEveryTick(t *testing.T) 
 	ctx, cancel := context.WithCancel(context.Background())
 	done := make(chan struct{})
 	go func() { sched.Run(ctx); close(done) }()
+	defer func() {
+		cancel()
+		<-done
+	}()
 
-	time.Sleep(105 * time.Millisecond) // ~10 tick
-	cancel()
-	<-done
+	// 5 회 heartbeat 도달까지 deterministic 하게 대기 — Sleep 으로 tick 수 추정하지 않음.
+	require.Eventually(t, func() bool {
+		return countLines(buf, "retry pipeline idle heartbeat") >= 5
+	}, 3*time.Second, 5*time.Millisecond, "legacy 모드는 매 tick heartbeat — 5회 도달")
 
+	// legacy 동작: heartbeat 수가 peek 수와 같아야 함 (매 idle peek 마다 emit).
+	// timing race 로 마지막 peek 직후 cancel 되면 ±1 차이 가능.
+	peekCount := int(q.peekCallCount.Load())
 	heartbeats := countLines(buf, "retry pipeline idle heartbeat")
-	// legacy 는 매 tick → 10 tick 부근. timing 변동으로 5 이상이면 legacy 동작 확인 충분.
-	assert.GreaterOrEqual(t, heartbeats, 5, "legacy 동작 — 매 tick heartbeat (≥5/10 tick)")
+	assert.InDelta(t, peekCount, heartbeats, 1,
+		"legacy 모드는 heartbeat 가 peek 와 거의 1:1 — heartbeats=%d peeks=%d",
+		heartbeats, peekCount)
 }
 
 // TestRedisDelayedRetryScheduler_IdleTicksResetOnDue 는 due 항목 처리 시 idleTicks 가
@@ -713,9 +736,9 @@ func TestRedisDelayedRetryScheduler_IdleTicksResetOnDue(t *testing.T) {
 	cancel()
 	<-done
 
-	// due 로그에 previous_idle_ticks 필드가 포함됐는지 확인 — 0 이 아닌 양수값
+	// due 로그에 previous_idle_ticks 필드가 포함됐는지 확인 — 0 이 아닌 양수값.
+	// 정규식 `[1-9][0-9]*` 로 두 자릿수 이상 idle (sleep 오버슈트 시) 도 매칭.
 	require.Contains(t, buf.String(), "previous_idle_ticks", "due 로그에 previous_idle_ticks 필드 노출")
-	// previous_idle_ticks 가 1 이상 — 직전 idle 이 있었음
-	assert.Regexp(t, `"previous_idle_ticks":[1-9]`, buf.String(),
+	assert.Regexp(t, `"previous_idle_ticks":[1-9][0-9]*`, buf.String(),
 		"previous_idle_ticks 가 양수여야 함 (직전 idle window 존재)")
 }

--- a/test/pkg/config/config_test.go
+++ b/test/pkg/config/config_test.go
@@ -833,3 +833,62 @@ func TestLoadPrompt_SetValue(t *testing.T) {
 		t.Errorf("Dir: got %q, want /custom/path", cfg.Dir)
 	}
 }
+
+// ─────────────────────────────────────────────────────────────────────────────
+// RetrySchedulerConfig (이슈 #370)
+// ─────────────────────────────────────────────────────────────────────────────
+
+func TestLoadRetryScheduler_DefaultValues(t *testing.T) {
+	t.Setenv("RETRY_HEARTBEAT_EVERY_N_IDLE_TICKS", "")
+
+	cfg, err := config.LoadRetryScheduler("/tmp/nonexistent-env-file.env")
+	require.NoError(t, err)
+
+	def := config.DefaultRetrySchedulerConfig()
+	if cfg.HeartbeatEveryNIdleTicks != def.HeartbeatEveryNIdleTicks {
+		t.Errorf("HeartbeatEveryNIdleTicks: got %d, want %d (default)",
+			cfg.HeartbeatEveryNIdleTicks, def.HeartbeatEveryNIdleTicks)
+	}
+}
+
+func TestLoadRetryScheduler_EnvOverride(t *testing.T) {
+	tests := []struct {
+		name string
+		env  string
+		want int
+	}{
+		{"explicit 60", "60", 60},
+		{"compressed 120", "120", 120},
+		{"legacy 0", "0", 0}, // 0 = legacy 매 tick 모드, 유효한 값
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("RETRY_HEARTBEAT_EVERY_N_IDLE_TICKS", tt.env)
+
+			cfg, err := config.LoadRetryScheduler("/tmp/nonexistent-env-file.env")
+			require.NoError(t, err)
+			if cfg.HeartbeatEveryNIdleTicks != tt.want {
+				t.Errorf("HeartbeatEveryNIdleTicks: got %d, want %d", cfg.HeartbeatEveryNIdleTicks, tt.want)
+			}
+		})
+	}
+}
+
+func TestLoadRetryScheduler_InvalidValues(t *testing.T) {
+	tests := []struct {
+		name string
+		env  string
+	}{
+		{"negative", "-1"},
+		{"non-numeric", "abc"},
+		{"float", "1.5"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("RETRY_HEARTBEAT_EVERY_N_IDLE_TICKS", tt.env)
+
+			_, err := config.LoadRetryScheduler("/tmp/nonexistent-env-file.env")
+			require.Error(t, err, "%q 는 에러여야 함", tt.env)
+		})
+	}
+}


### PR DESCRIPTION
## 연관 이슈
- Closes #370

<br>

## 구현 내용

라이브 로그 분석 결과 \`retry peek returned no due items\` 가 175분 동안 10,464건 (debug.log 의 24%) emit — heartbeat 의도였으나 매 tick 마다 1줄로 노이즈 큼.

### 변경
- **`RedisRetrySchedulerConfig.HeartbeatEveryNIdleTicks`** 신규 필드 (default `60`)
  - PollInterval 1s 기준 약 1분에 1회 heartbeat
  - `0` → legacy 동작 (매 tick) 보존
- **메시지 명 변경**: `"retry peek returned no due items"` → `"retry pipeline idle heartbeat"` (heartbeat 임을 명시)
- **신규 필드**:
  - heartbeat 로그: `consecutive_idle_ticks` — idle 누적 tick 수
  - due 로그: `previous_idle_ticks` — 얼마나 idle 후 처리됐는지
- **idleTicks 카운터** — due 발견 시 0 으로 reset (단일 goroutine 진입 → race-free)
- **`cmd/issuetracker` 와이어링** + `.env.example` 에 `RETRY_HEARTBEAT_EVERY_N_IDLE_TICKS` 추가

### 테스트
- `TestRedisDelayedRetryScheduler_IdleHeartbeat_CompressedEveryN` — N 압축 동작
- `TestRedisDelayedRetryScheduler_IdleHeartbeat_LegacyEveryTick` — N=0 legacy
- `TestRedisDelayedRetryScheduler_IdleTicksResetOnDue` — due 발견 시 reset + previous_idle_ticks 필드
- `safeBuffer` helper — concurrent log capture race 회피

<br>

## CI / 머지 게이트 점검

### 변경 영향 범위
- 영향 패키지/모듈: \`internal/processor/fetcher/worker\` (retry_scheduler), \`cmd/issuetracker\`, \`.env.example\`
- 위험도: **Low** — 로그 가시성 변경만, 실제 retry 처리 로직 불변

### Required Status Checks
- 통과 확인 대상 (PR Checks 탭에서 확인):
  - [ ] \`Commit Lint\`
  - [ ] \`PR Title Lint\`
  - [ ] \`Linked Issue Check\`
  - [ ] \`Format Check\`
  - [ ] \`Build\`
  - [ ] \`Test\`
  - [ ] \`Lint\`

### 롤백 계획
- 운영 즉시 회귀 필요 시: \`.env\` 에 \`RETRY_HEARTBEAT_EVERY_N_IDLE_TICKS=0\` 설정 → legacy 매 tick 로깅 복원 (재배포 불필요)

<br>

## TODO
- (없음) 단발 변경 — 이슈 #370 의 모든 완료 조건 충족

<br>

## 논의 사항
- default 60 (~1분) 이 적절한지 — 너무 길면 polling alive 확인이 느려질 수 있으나 \`consecutive_idle_ticks\` 필드로 보완 가능

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable environment variable to control retry scheduler debug logging frequency during idle polling periods, reducing log volume with tunable intervals.

* **Tests**
  * Added comprehensive test coverage for idle heartbeat logging behavior across different configuration scenarios.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/EinSofINTEREST/IssueTracker/pull/371)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->