### PR TITLE
[REFAC#372] DB 테이블 명 통일 — parsing_* → parser_* (Phase 1: schema + Go SQL)

### DIFF
--- a/cmd/issuetracker/main.go
+++ b/cmd/issuetracker/main.go
@@ -124,14 +124,14 @@ func main() {
 
 	jobPublisher := publisher.New(crawlerProducer, resolver, log)
 
-	// rule.Parser: parsing_rules 테이블 기반 단일 파서 엔진.
+	// rule.Parser: parser_rules 테이블 기반 단일 파서 엔진.
 	// 사이트별 NaverParser/CNNParser/... 를 대체 — 모든 사이트가 본 단일 인스턴스를 공유.
 	parsingRuleRepo := pgstore.NewParsingRuleRepository(pool, log)
 	ruleResolver, err := rule.NewResolver(parsingRuleRepo)
 	if err != nil {
 		log.WithError(err).Fatal("failed to construct rule resolver")
 	}
-	// parsing_rules mutation → cache invalidate 자동 결합 (decorator 패턴).
+	// parser_rules mutation → cache invalidate 자동 결합 (decorator 패턴).
 	// 호출처가 명시적 Invalidate 를 까먹어도 stale cache 발생 X — single source of truth.
 	parsingRuleRepo = storage.WrapWithInvalidator(parsingRuleRepo, ruleResolver)
 	ruleParser, err := rule.NewParser(ruleResolver)
@@ -158,16 +158,16 @@ func main() {
 		// invalidatingBlacklistRepo decorator: claudegen 자동 INSERT (#326) 시 Matcher cache flush.
 		blacklistRepo = storage.WrapBlacklistWithInvalidator(repo, bm)
 		blacklistMatcher = bm
-		log.Info("page-parse blacklist enabled (parsing_blacklist DB-backed)")
+		log.Info("page-parse blacklist enabled (parser_blacklist DB-backed)")
 	} else {
 		log.Info("page-parse blacklist disabled (BLACKLIST_ENABLED=false)")
 	}
 
-	// Readiness check: 사이트 등록 전 parsing_rules 가 seed 됐는지 검증.
+	// Readiness check: 사이트 등록 전 parser_rules 가 seed 됐는지 검증.
 	// 부재 시 fail-fast — 실행 중 모든 ParsePage/ParseLinks 가 ErrNoRule 로 죽는 것보다 즉시 종료.
 	// migration 007 (또는 동등한 운영자 seed) 가 적용되어야 통과.
 	if err := rule.VerifySeeded(ctx, ruleResolver); err != nil {
-		log.WithError(err).Fatal("parsing_rules seed missing — apply migration 007 before deploy")
+		log.WithError(err).Fatal("parser_rules seed missing — apply migration 007 before deploy")
 	}
 
 	// raw_contents 서비스 — fetcher 측 Claim Check 저장 + parser 측 로드/삭제.

--- a/cmd/rule-validator/main.go
+++ b/cmd/rule-validator/main.go
@@ -1,4 +1,4 @@
-// rule-validator 는 parsing_rules 의 특정 row 를 의미 검증하는 수동 운영 CLI 입니다.
+// rule-validator 는 parser_rules 의 특정 row 를 의미 검증하는 수동 운영 CLI 입니다.
 //
 // 사용법:
 //

--- a/internal/processor/fetcher/domain/general/types.go
+++ b/internal/processor/fetcher/domain/general/types.go
@@ -7,7 +7,7 @@
 // 의 단일 DB 규칙 기반 엔진이 처리합니다.
 //
 // Source-specific parsers (NaverParser/CNNParser/...) 는 더 이상 존재하지 않습니다.
-// 새 사이트 지원 = parsing_rules 테이블에 row 추가.
+// 새 사이트 지원 = parser_rules 테이블에 row 추가.
 package general
 
 import (

--- a/internal/processor/parser/rule/claudegen/worker.go
+++ b/internal/processor/parser/rule/claudegen/worker.go
@@ -337,7 +337,7 @@ func (w *ClaudeWorker) Extract(ctx context.Context, host string, targetType stor
 //  5. 세션 디렉토리 정리 (defer)
 //
 // validity == "blacklist" 면 ExtractResult.Blacklist 비-nil — 호출자가 셀렉터 INSERT skip
-// + parsing_blacklist Upsert 분기. Selectors / PageType 은 의미 없음.
+// + parser_blacklist Upsert 분기. Selectors / PageType 은 의미 없음.
 func (w *ClaudeWorker) ExtractEnriched(ctx context.Context, host string, targetType storage.TargetType, html string) (*llmgen.ExtractResult, error) {
 	// wg.Add 를 락 획득보다 먼저 수행 — Stop() 의 wg.Wait() 이 이 Extract 호출을 놓치지 않도록 함.
 	w.wg.Add(1)
@@ -559,7 +559,7 @@ func truncate(s string, n int) string {
 // knownPageTypes 는 prompt schema 에 명시된 valid page_type 집합입니다 (CodeRabbit Major 반영).
 //
 // LLM 응답이 prompt 명세를 벗어나면 (예: "News" 대문자, "news_article" 등 변종) silent 하게
-// parsing_rules.page_type 에 들어가 분류 통계가 오염될 수 있어 정규화 + 허용 set 검증.
+// parser_rules.page_type 에 들어가 분류 통계가 오염될 수 있어 정규화 + 허용 set 검증.
 //
 // 동의어 매핑: 잘 알려진 변종은 표준 PageType 으로 매핑. 모르는 값은 빈 문자열 (Unspecified)
 // 로 fall-back — rule INSERT 자체는 막지 않음 (selector 가 정상이면 분류만 미상태로 저장).

--- a/internal/processor/parser/rule/llmgen/extractor.go
+++ b/internal/processor/parser/rule/llmgen/extractor.go
@@ -27,11 +27,11 @@ const (
 
 // BlacklistDecision 은 LLM 이 페이지를 \"파싱에 부적합\" 으로 판단했을 때의 결정입니다.
 //
-// 호출자 (Generator) 가 본 결정을 받으면 셀렉터 INSERT 를 skip 하고 parsing_blacklist 에
+// 호출자 (Generator) 가 본 결정을 받으면 셀렉터 INSERT 를 skip 하고 parser_blacklist 에
 // source='auto' 로 등록 — 동일 host+path 가 다음 사이클에서 fetch / parse 되지 않음.
 type BlacklistDecision struct {
 	// Reason 은 운영자가 사후 분류 / 검증할 수 있도록 한국어로 작성된 사유.
-	// parsing_blacklist.reason 컬럼에 그대로 저장.
+	// parser_blacklist.reason 컬럼에 그대로 저장.
 	Reason string
 }
 

--- a/internal/processor/parser/rule/llmgen/generator.go
+++ b/internal/processor/parser/rule/llmgen/generator.go
@@ -1,6 +1,6 @@
 // Package llmgen 은 LLM 으로 parsing rule 을 자동 생성하는 컴포넌트입니다.
 //
-// Package llmgen automatically generates parsing_rules entries via LLM when a host
+// Package llmgen automatically generates parser_rules entries via LLM when a host
 // has no rule registered (rule.ErrNoRule fallback path).
 //
 // 흐름:
@@ -755,7 +755,7 @@ func selectorMatches(doc *goquery.Document, fs *storage.FieldSelector) bool {
 // handleBlacklistDecision 은 EnrichedExtractor 가 페이지를 blacklist 로 판정했을 때 호출됩니다.
 //
 // blacklistRepo 가 비-nil 이면 sampleURL 의 path 를 정확 일치 regex (escape + ^/$ anchor) 로
-// parsing_blacklist 에 INSERT — 동일 URL 만 차단, 같은 host 의 다른 path 는 영향 없음.
+// parser_blacklist 에 INSERT — 동일 URL 만 차단, 같은 host 의 다른 path 는 영향 없음.
 // 운영자가 후속으로 host-level catch-all 등 정책 widening 가능.
 //
 // 모든 실패 (blacklistRepo nil / Insert 에러 / ErrDuplicate) 는 non-fatal — 호출자는
@@ -803,7 +803,7 @@ func (g *Generator) handleBlacklistDecision(ctx context.Context, host, sampleURL
 }
 
 // pathPatternFromURL 은 sampleURL 의 path 부분을 RE2 regex 로 escape 한 anchor pattern 을
-// 반환합니다. parsing_blacklist 의 path_pattern 컬럼에 사용 — 정확히 동일한 URL 만 매칭.
+// 반환합니다. parser_blacklist 의 path_pattern 컬럼에 사용 — 정확히 동일한 URL 만 매칭.
 //
 // 정책 (CodeRabbit Major 반영):
 //   - URL parse 실패 → "" 반환 (호출자가 insert skip)

--- a/internal/processor/parser/rule/parser.go
+++ b/internal/processor/parser/rule/parser.go
@@ -25,7 +25,7 @@ const resolveTimeout = 5 * time.Second
 //
 // Parser implements both parser.ContentParser and parser.LinkListParser, driven by
 // storage.ParsingRuleRecord resolved per request via Resolver. 사이트별 hardcode 파서
-// (NaverParser/DaumParser/...) 를 대체 — 새 사이트 지원 = parsing_rules row 추가.
+// (NaverParser/DaumParser/...) 를 대체 — 새 사이트 지원 = parser_rules row 추가.
 //
 // 도메인 중립 — 뉴스 / 블로그 / 제품 페이지 / 일반 문서 모두 동일 engine 으로 처리.
 // 호출자가 도메인-specific 모델로 변환 (예: Page → news.NewsArticle) 하면 됨.

--- a/internal/processor/parser/rule/seeded.go
+++ b/internal/processor/parser/rule/seeded.go
@@ -7,7 +7,7 @@ import (
 	"issuetracker/internal/storage"
 )
 
-// seededHostTargets 는 IssueTracker 가 부팅 시 parsing_rules 테이블에 활성 row 로 존재해야 하는
+// seededHostTargets 는 IssueTracker 가 부팅 시 parser_rules 테이블에 활성 row 로 존재해야 하는
 // (host, target_type) 페어 목록입니다. migration 007 이 등록하는 seed rules 와 1:1 대응.
 //
 // 신규 사이트 추가 시: migration 또는 별도 seed 입력 후 본 슬라이스에 항목 추가.
@@ -25,7 +25,7 @@ var seededHostTargets = []struct {
 	{"edition.cnn.com", storage.TargetTypeList},
 }
 
-// VerifySeeded 는 seededHostTargets 의 모든 (host, target_type) 페어가 parsing_rules 테이블에
+// VerifySeeded 는 seededHostTargets 의 모든 (host, target_type) 페어가 parser_rules 테이블에
 // 활성 row 로 존재하는지 확인합니다.
 //
 // 부재 시 ErrNoRule 등 진단 에러를 그대로 반환 — 호출자가 Fatal 로 부팅 차단.

--- a/internal/storage/blacklist.go
+++ b/internal/storage/blacklist.go
@@ -35,7 +35,7 @@ const (
 	BlacklistModeExtractLinksOnly BlacklistMode = "extract_links_only"
 )
 
-// BlacklistRecord 는 parsing_blacklist 테이블의 단일 행입니다.
+// BlacklistRecord 는 parser_blacklist 테이블의 단일 행입니다.
 //
 // page-parse 차단 정책 — 매칭 URL 은 article job 발행 단계에서 drop:
 //   - HostPattern : URL host 매칭 (정확 일치, 호출자가 normalize)
@@ -65,7 +65,7 @@ type BlacklistFilter struct {
 	Offset      int
 }
 
-// BlacklistRepository 는 parsing_blacklist 테이블에 대한 데이터 접근 인터페이스입니다.
+// BlacklistRepository 는 parser_blacklist 테이블에 대한 데이터 접근 인터페이스입니다.
 //
 // goroutine-safe: 모든 구현은 동시 호출 안전해야 함.
 type BlacklistRepository interface {
@@ -86,7 +86,7 @@ type BlacklistRepository interface {
 
 	// FindEnabledByHost 는 host_pattern 매칭 enabled=TRUE row 들을 반환합니다 (Matcher 핫패스).
 	//
-	// 정렬: LENGTH(path_pattern) DESC — 더 구체적인 path 가 먼저 평가되도록 (parsing_rules 의
+	// 정렬: LENGTH(path_pattern) DESC — 더 구체적인 path 가 먼저 평가되도록 (parser_rules 의
 	// FindActiveCandidates 와 동일 정책). path_pattern="" (catch-all) 은 가장 마지막.
 	//
 	// 매칭 없으면 빈 슬라이스 + nil error.

--- a/internal/storage/blacklist_invalidating.go
+++ b/internal/storage/blacklist_invalidating.go
@@ -12,7 +12,7 @@ type BlacklistInvalidator interface {
 }
 
 // invalidatingBlacklistRepo 는 BlacklistRepository 를 wrap 하여 mutation 후 자동으로 Matcher 의
-// host cache 를 invalidate 하는 decorator 입니다 (parsing_rules 의 invalidatingRepo 와 동일 패턴).
+// host cache 를 invalidate 하는 decorator 입니다 (parser_rules 의 invalidatingRepo 와 동일 패턴).
 //
 // 적용 정책:
 //   - Insert 성공          → Invalidate (host)

--- a/internal/storage/errors.go
+++ b/internal/storage/errors.go
@@ -11,5 +11,5 @@ var ErrNotFound = errors.New("record not found")
 var ErrDuplicate = errors.New("duplicate record")
 
 // ErrInvalid 는 record 의 형식이 유효하지 않을 때 반환됩니다.
-// 예: parsing_rules.path_pattern 이 RE2 컴파일 실패 — Repository 가 DB write 전 거부.
+// 예: parser_rules.path_pattern 이 RE2 컴파일 실패 — Repository 가 DB write 전 거부.
 var ErrInvalid = errors.New("invalid record")

--- a/internal/storage/parsing_rule.go
+++ b/internal/storage/parsing_rule.go
@@ -125,9 +125,9 @@ type LinkDiscoveryConfig struct {
 	MaxLinksPerPage int `json:"max_links_per_page,omitempty"`
 }
 
-// ParsingRuleRecord 는 parsing_rules 테이블의 단일 행입니다.
+// ParsingRuleRecord 는 parser_rules 테이블의 단일 행입니다.
 //
-// ParsingRuleRecord represents a single row of the parsing_rules table.
+// ParsingRuleRecord represents a single row of the parser_rules table.
 type ParsingRuleRecord struct {
 	ID          int64
 	SourceName  string     // "naver" / "cnn"
@@ -181,9 +181,9 @@ type ParsingRuleFilter struct {
 	Offset      int
 }
 
-// ParsingRuleRepository 는 parsing_rules 테이블에 대한 데이터 접근 인터페이스입니다.
+// ParsingRuleRepository 는 parser_rules 테이블에 대한 데이터 접근 인터페이스입니다.
 //
-// ParsingRuleRepository is the data access interface for parsing_rules.
+// ParsingRuleRepository is the data access interface for parser_rules.
 // All implementations must be goroutine-safe.
 type ParsingRuleRepository interface {
 	// Insert 는 새 규칙을 저장합니다. 자연키 충돌 시 ErrDuplicate 반환.

--- a/internal/storage/postgres/blacklist.go
+++ b/internal/storage/postgres/blacklist.go
@@ -29,14 +29,14 @@ func NewBlacklistRepository(pool *pgxpool.Pool, log *logger.Logger) storage.Blac
 }
 
 const sqlInsertBlacklist = `
-INSERT INTO parsing_blacklist (host_pattern, path_pattern, reason, source, mode, enabled)
+INSERT INTO parser_blacklist (host_pattern, path_pattern, reason, source, mode, enabled)
 VALUES ($1, $2, $3, $4, $5, $6)
 RETURNING id, created_at, updated_at
 `
 
 // Insert 는 새 row 를 저장합니다. 자연키 (host_pattern, path_pattern) 충돌 시 ErrDuplicate.
 //
-// path_pattern 이 비어있지 않으면 RE2 컴파일 검증 — parsing_rules.Insert 와 동일 정책 (DB write
+// path_pattern 이 비어있지 않으면 RE2 컴파일 검증 — parser_rules.Insert 와 동일 정책 (DB write
 // 전 잘못된 regex 거부, 운영 가시성 ↑ + Matcher 가 매 호출마다 negative cache 로 흡수하지 않도록).
 //
 // HostPattern 을 lowercase 로 정규화 — BlacklistMatcher 가 host 를
@@ -68,7 +68,7 @@ func (r *pgBlacklistRepository) Insert(ctx context.Context, rec *storage.Blackli
 }
 
 const sqlUpdateBlacklist = `
-UPDATE parsing_blacklist
+UPDATE parser_blacklist
 SET reason = $2, source = $3, mode = $4, enabled = $5, updated_at = NOW()
 WHERE id = $1
 RETURNING updated_at
@@ -92,7 +92,7 @@ func (r *pgBlacklistRepository) Update(ctx context.Context, rec *storage.Blackli
 	return nil
 }
 
-const sqlDeleteBlacklist = `DELETE FROM parsing_blacklist WHERE id = $1`
+const sqlDeleteBlacklist = `DELETE FROM parser_blacklist WHERE id = $1`
 
 // Delete 는 ID 로 row 를 삭제합니다. 존재하지 않아도 nil 반환 (idempotent).
 func (r *pgBlacklistRepository) Delete(ctx context.Context, id int64) error {
@@ -104,7 +104,7 @@ func (r *pgBlacklistRepository) Delete(ctx context.Context, id int64) error {
 
 const sqlGetBlacklistByID = `
 SELECT id, host_pattern, path_pattern, reason, source, mode, enabled, created_at, updated_at
-FROM parsing_blacklist
+FROM parser_blacklist
 WHERE id = $1
 `
 
@@ -123,14 +123,14 @@ func (r *pgBlacklistRepository) GetByID(ctx context.Context, id int64) (*storage
 
 const sqlFindEnabledBlacklistByHost = `
 SELECT id, host_pattern, path_pattern, reason, source, mode, enabled, created_at, updated_at
-FROM parsing_blacklist
+FROM parser_blacklist
 WHERE host_pattern = $1 AND enabled = TRUE
 ORDER BY LENGTH(path_pattern) DESC, id DESC
 `
 
 // FindEnabledByHost 는 (host) 매칭 enabled=TRUE row 들을 LENGTH(path_pattern) DESC 정렬로 반환합니다.
 //
-// parsing_rules.FindActiveCandidates 와 동일 정책 — 더 구체적인 path 우선 평가, catch-all (path="")
+// parser_rules.FindActiveCandidates 와 동일 정책 — 더 구체적인 path 우선 평가, catch-all (path="")
 // 이 가장 마지막. tie-break 로 id DESC (최근 등록 우선) 사용.
 //
 // host 는 lowercase 로 정규화된 상태 가정 (Matcher 가 lowercase 로 호출). DB 에 저장된 host_pattern
@@ -164,7 +164,7 @@ func (r *pgBlacklistRepository) List(ctx context.Context, f storage.BlacklistFil
 	}
 	q := `
 SELECT id, host_pattern, path_pattern, reason, source, mode, enabled, created_at, updated_at
-FROM parsing_blacklist
+FROM parser_blacklist
 WHERE ($1 = '' OR host_pattern = $1)
   AND ($2 = '' OR source = $2)
   AND (NOT $3 OR enabled = TRUE)

--- a/internal/storage/postgres/parsing_rule.go
+++ b/internal/storage/postgres/parsing_rule.go
@@ -33,7 +33,7 @@ func NewParsingRuleRepository(pool *pgxpool.Pool, log *logger.Logger) storage.Pa
 }
 
 const sqlInsertParsingRule = `
-INSERT INTO parsing_rules (
+INSERT INTO parser_rules (
   source_name, host_pattern, path_pattern, target_type, version, enabled, selectors, confidence, description, page_type
 ) VALUES (
   $1, $2, $3, $4, $5, $6, $7, $8, $9, $10
@@ -81,7 +81,7 @@ func (r *pgParsingRuleRepository) Insert(ctx context.Context, rec *storage.Parsi
 }
 
 const sqlUpdateParsingRule = `
-UPDATE parsing_rules
+UPDATE parser_rules
 SET selectors = $2, confidence = $3, enabled = $4, description = $5
 WHERE id = $1
 RETURNING updated_at
@@ -121,7 +121,7 @@ func (r *pgParsingRuleRepository) Update(ctx context.Context, rec *storage.Parsi
 // 가드 조건이 false 면 `pgx.ErrNoRows` → storage.ErrNotFound 반환 — 호출자 (refiner) 는 이미 ErrNotFound
 // 분기에서 Invalidate / Purge 모두 skip 하므로 stale 변경 사이드이펙트 없음.
 const sqlUpdatePathPattern = `
-UPDATE parsing_rules
+UPDATE parser_rules
 SET path_pattern = $2, description = $3
 WHERE id = $1
   AND source_name = 'llm-auto'
@@ -152,7 +152,7 @@ func (r *pgParsingRuleRepository) UpdatePathPattern(ctx context.Context, id int6
 
 const sqlGetParsingRuleByID = `
 SELECT id, source_name, host_pattern, path_pattern, target_type, version, enabled, selectors, confidence, description, page_type, created_at, updated_at
-FROM parsing_rules
+FROM parser_rules
 WHERE id = $1
 `
 
@@ -171,7 +171,7 @@ func (r *pgParsingRuleRepository) GetByID(ctx context.Context, id int64) (*stora
 
 const sqlFindParsingRuleByNaturalKey = `
 SELECT id, source_name, host_pattern, path_pattern, target_type, version, enabled, selectors, confidence, description, page_type, created_at, updated_at
-FROM parsing_rules
+FROM parser_rules
 WHERE source_name  = $1
   AND host_pattern = $2
   AND path_pattern = $3
@@ -202,7 +202,7 @@ func (r *pgParsingRuleRepository) FindByNaturalKey(ctx context.Context, sourceNa
 
 const sqlMaxVersionByNaturalKey = `
 SELECT COALESCE(MAX(version), 0)
-FROM parsing_rules
+FROM parser_rules
 WHERE source_name = $1
   AND host_pattern = $2
   AND path_pattern = $3
@@ -238,7 +238,7 @@ const sqlHasAnyRule = `
 SELECT
   COUNT(*) > 0                        AS exists_any,
   COALESCE(bool_or(enabled), FALSE)   AS has_enabled
-FROM parsing_rules
+FROM parser_rules
 WHERE host_pattern=$1 AND target_type=$2
 `
 
@@ -262,7 +262,7 @@ func (r *pgParsingRuleRepository) HasAnyRule(ctx context.Context, hostPattern st
 //   - version DESC             : 같은 패턴 안에서 최신 버전 우선
 const sqlFindActiveCandidates = `
 SELECT id, source_name, host_pattern, path_pattern, target_type, version, enabled, selectors, confidence, description, page_type, created_at, updated_at
-FROM parsing_rules
+FROM parser_rules
 WHERE host_pattern = $1
   AND target_type  = $2
   AND enabled      = TRUE
@@ -319,7 +319,7 @@ func (r *pgParsingRuleRepository) List(ctx context.Context, f storage.ParsingRul
 
 	query := `
 SELECT id, source_name, host_pattern, path_pattern, target_type, version, enabled, selectors, confidence, description, page_type, created_at, updated_at
-FROM parsing_rules
+FROM parser_rules
 WHERE 1=1`
 	args := make([]any, 0, 4)
 	idx := 1
@@ -366,7 +366,7 @@ WHERE 1=1`
 	return out, nil
 }
 
-const sqlDeleteParsingRule = `DELETE FROM parsing_rules WHERE id = $1`
+const sqlDeleteParsingRule = `DELETE FROM parser_rules WHERE id = $1`
 
 // Delete 는 ID 로 규칙을 삭제합니다 (idempotent — 미존재여도 nil).
 func (r *pgParsingRuleRepository) Delete(ctx context.Context, id int64) error {

--- a/internal/storage/postgres/sample_url.go
+++ b/internal/storage/postgres/sample_url.go
@@ -29,12 +29,12 @@ func NewSampleURLRepository(pool *pgxpool.Pool, log *logger.Logger) storage.Samp
 
 const sqlCountSamples = `
 SELECT COUNT(*)
-FROM parsing_rule_sample_urls
+FROM parser_rule_sample_urls
 WHERE rule_id = $1
 `
 
 const sqlInsertSample = `
-INSERT INTO parsing_rule_sample_urls (rule_id, url)
+INSERT INTO parser_rule_sample_urls (rule_id, url)
 VALUES ($1, $2)
 `
 
@@ -77,7 +77,7 @@ func (r *pgSampleURLRepository) Count(ctx context.Context, ruleID int64) (int, e
 
 const sqlListSamples = `
 SELECT id, rule_id, url, observed_at
-FROM parsing_rule_sample_urls
+FROM parser_rule_sample_urls
 WHERE rule_id = $1
 ORDER BY observed_at DESC
 LIMIT $2
@@ -108,7 +108,7 @@ func (r *pgSampleURLRepository) List(ctx context.Context, ruleID int64, limit in
 	return out, nil
 }
 
-const sqlPurgeSamples = `DELETE FROM parsing_rule_sample_urls WHERE rule_id = $1`
+const sqlPurgeSamples = `DELETE FROM parser_rule_sample_urls WHERE rule_id = $1`
 
 // Purge 는 rule_id 의 모든 sample 을 삭제합니다 (정밀화 완료 후 호출, idempotent).
 func (r *pgSampleURLRepository) Purge(ctx context.Context, ruleID int64) error {

--- a/internal/storage/sample_url.go
+++ b/internal/storage/sample_url.go
@@ -5,7 +5,7 @@ import (
 	"time"
 )
 
-// SampleURL 은 parsing_rule_sample_urls 테이블의 단일 행입니다.
+// SampleURL 은 parser_rule_sample_urls 테이블의 단일 행입니다.
 //
 // SampleURL represents a single accumulated sample URL for a parsing rule —
 // used by the progressive refinement workflow (path_pattern 추론).
@@ -22,7 +22,7 @@ type SampleURL struct {
 // trigger 미동작 / LLM_ENABLED=false 등으로 정밀화가 발생하지 않을 때 DB 폭증 방어.
 const SampleCapPerRule = 100
 
-// SampleURLRepository 는 parsing_rule_sample_urls 테이블에 대한 데이터 접근 인터페이스입니다.
+// SampleURLRepository 는 parser_rule_sample_urls 테이블에 대한 데이터 접근 인터페이스입니다.
 //
 // 모든 구현체는 goroutine-safe 해야 합니다.
 type SampleURLRepository interface {

--- a/migrations/down/026_rename_parsing_to_parser.sql
+++ b/migrations/down/026_rename_parsing_to_parser.sql
@@ -25,9 +25,57 @@ BEGIN
   END IF;
 END $$;
 
--- ─── Constraints ─────────────────────────────────────────────────────────────
+-- ─── Constraints (역순) ──────────────────────────────────────────────────────
 DO $$
 BEGIN
+  -- Auto-generated names — up 의 역순
+  IF EXISTS (
+    SELECT 1 FROM pg_constraint c
+    JOIN pg_class t ON c.conrelid = t.oid
+    WHERE t.relname = 'parser_rule_sample_urls' AND c.conname = 'parser_rule_sample_urls_rule_id_fkey'
+  ) THEN
+    ALTER TABLE parser_rule_sample_urls
+      RENAME CONSTRAINT parser_rule_sample_urls_rule_id_fkey TO parsing_rule_sample_urls_rule_id_fkey;
+  END IF;
+
+  IF EXISTS (
+    SELECT 1 FROM pg_constraint c
+    JOIN pg_class t ON c.conrelid = t.oid
+    WHERE t.relname = 'parser_rule_sample_urls' AND c.conname = 'parser_rule_sample_urls_pkey'
+  ) THEN
+    ALTER TABLE parser_rule_sample_urls
+      RENAME CONSTRAINT parser_rule_sample_urls_pkey TO parsing_rule_sample_urls_pkey;
+  END IF;
+
+  IF EXISTS (
+    SELECT 1 FROM pg_constraint c
+    JOIN pg_class t ON c.conrelid = t.oid
+    WHERE t.relname = 'parser_blacklist' AND c.conname = 'parser_blacklist_host_pattern_path_pattern_key'
+  ) THEN
+    ALTER TABLE parser_blacklist
+      RENAME CONSTRAINT parser_blacklist_host_pattern_path_pattern_key
+                     TO parsing_blacklist_host_pattern_path_pattern_key;
+  END IF;
+
+  IF EXISTS (
+    SELECT 1 FROM pg_constraint c
+    JOIN pg_class t ON c.conrelid = t.oid
+    WHERE t.relname = 'parser_blacklist' AND c.conname = 'parser_blacklist_pkey'
+  ) THEN
+    ALTER TABLE parser_blacklist
+      RENAME CONSTRAINT parser_blacklist_pkey TO parsing_blacklist_pkey;
+  END IF;
+
+  IF EXISTS (
+    SELECT 1 FROM pg_constraint c
+    JOIN pg_class t ON c.conrelid = t.oid
+    WHERE t.relname = 'parser_rules' AND c.conname = 'parser_rules_pkey'
+  ) THEN
+    ALTER TABLE parser_rules
+      RENAME CONSTRAINT parser_rules_pkey TO parsing_rules_pkey;
+  END IF;
+
+  -- Named constraints
   IF EXISTS (
     SELECT 1 FROM pg_constraint c
     JOIN pg_class t ON c.conrelid = t.oid

--- a/migrations/down/026_rename_parsing_to_parser.sql
+++ b/migrations/down/026_rename_parsing_to_parser.sql
@@ -1,0 +1,113 @@
+-- 026_rename_parsing_to_parser 롤백 — parser_* → parsing_* 역방향
+--
+-- 모든 RENAME 을 026 up 의 역순으로 수행하여 schema 를 025 시점 상태로 복원한다.
+-- 멱등성 — 이미 원상복귀된 상태에서 재실행해도 무처리.
+
+-- ─── Function + Trigger (역순) ───────────────────────────────────────────────
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1 FROM pg_proc WHERE proname = 'parser_rules_touch_updated_at'
+  ) THEN
+    ALTER FUNCTION parser_rules_touch_updated_at() RENAME TO parsing_rules_touch_updated_at;
+  END IF;
+END $$;
+
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1 FROM pg_trigger tr
+    JOIN pg_class t ON tr.tgrelid = t.oid
+    WHERE t.relname = 'parser_rules' AND tr.tgname = 'parser_rules_touch_updated_at'
+  ) THEN
+    ALTER TRIGGER parser_rules_touch_updated_at ON parser_rules
+      RENAME TO parsing_rules_touch_updated_at;
+  END IF;
+END $$;
+
+-- ─── Constraints ─────────────────────────────────────────────────────────────
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1 FROM pg_constraint c
+    JOIN pg_class t ON c.conrelid = t.oid
+    WHERE t.relname = 'parser_blacklist' AND c.conname = 'parser_blacklist_mode_check'
+  ) THEN
+    ALTER TABLE parser_blacklist
+      RENAME CONSTRAINT parser_blacklist_mode_check TO parsing_blacklist_mode_check;
+  END IF;
+
+  IF EXISTS (
+    SELECT 1 FROM pg_constraint c
+    JOIN pg_class t ON c.conrelid = t.oid
+    WHERE t.relname = 'parser_blacklist' AND c.conname = 'parser_blacklist_source_check'
+  ) THEN
+    ALTER TABLE parser_blacklist
+      RENAME CONSTRAINT parser_blacklist_source_check TO parsing_blacklist_source_check;
+  END IF;
+
+  IF EXISTS (
+    SELECT 1 FROM pg_constraint c
+    JOIN pg_class t ON c.conrelid = t.oid
+    WHERE t.relname = 'parser_rule_sample_urls' AND c.conname = 'parser_rule_sample_urls_unique'
+  ) THEN
+    ALTER TABLE parser_rule_sample_urls
+      RENAME CONSTRAINT parser_rule_sample_urls_unique TO parsing_rule_sample_urls_unique;
+  END IF;
+
+  IF EXISTS (
+    SELECT 1 FROM pg_constraint c
+    JOIN pg_class t ON c.conrelid = t.oid
+    WHERE t.relname = 'parser_rules' AND c.conname = 'parser_rules_lookup_key_unique'
+  ) THEN
+    ALTER TABLE parser_rules
+      RENAME CONSTRAINT parser_rules_lookup_key_unique TO parsing_rules_lookup_key_unique;
+  END IF;
+
+  IF EXISTS (
+    SELECT 1 FROM pg_constraint c
+    JOIN pg_class t ON c.conrelid = t.oid
+    WHERE t.relname = 'parser_rules' AND c.conname = 'parser_rules_version_positive'
+  ) THEN
+    ALTER TABLE parser_rules
+      RENAME CONSTRAINT parser_rules_version_positive TO parsing_rules_version_positive;
+  END IF;
+
+  IF EXISTS (
+    SELECT 1 FROM pg_constraint c
+    JOIN pg_class t ON c.conrelid = t.oid
+    WHERE t.relname = 'parser_rules' AND c.conname = 'parser_rules_target_type_check'
+  ) THEN
+    ALTER TABLE parser_rules
+      RENAME CONSTRAINT parser_rules_target_type_check TO parsing_rules_target_type_check;
+  END IF;
+END $$;
+
+-- ─── Indexes ─────────────────────────────────────────────────────────────────
+ALTER INDEX IF EXISTS idx_parser_rule_sample_urls_lookup
+  RENAME TO idx_parsing_rule_sample_urls_lookup;
+
+ALTER INDEX IF EXISTS idx_parser_blacklist_host_enabled
+  RENAME TO idx_parsing_blacklist_host_enabled;
+
+ALTER INDEX IF EXISTS idx_parser_rules_source_enabled
+  RENAME TO idx_parsing_rules_source_enabled;
+
+ALTER INDEX IF EXISTS idx_parser_rules_lookup
+  RENAME TO idx_parsing_rules_lookup;
+
+-- ─── Tables ──────────────────────────────────────────────────────────────────
+DO $$
+BEGIN
+  IF EXISTS (SELECT 1 FROM pg_tables WHERE tablename = 'parser_rule_sample_urls') THEN
+    ALTER TABLE parser_rule_sample_urls RENAME TO parsing_rule_sample_urls;
+  END IF;
+
+  IF EXISTS (SELECT 1 FROM pg_tables WHERE tablename = 'parser_blacklist') THEN
+    ALTER TABLE parser_blacklist RENAME TO parsing_blacklist;
+  END IF;
+
+  IF EXISTS (SELECT 1 FROM pg_tables WHERE tablename = 'parser_rules') THEN
+    ALTER TABLE parser_rules RENAME TO parsing_rules;
+  END IF;
+END $$;

--- a/migrations/down/026_rename_parsing_to_parser.sql
+++ b/migrations/down/026_rename_parsing_to_parser.sql
@@ -1,15 +1,15 @@
 -- 026_rename_parsing_to_parser 롤백 — parser_* → parsing_* 역방향
 --
--- 모든 RENAME 을 026 up 의 역순으로 수행하여 schema 를 025 시점 상태로 복원한다.
+-- up 의 모든 변경을 역순으로 수행하여 schema 를 025 시점 상태로 복원.
 -- 멱등성 — 이미 원상복귀된 상태에서 재실행해도 무처리.
+-- 모든 존재 확인은 schema-qualified (`to_regclass` / `to_regprocedure`) — up 과 동일 패턴.
 
 -- ─── Function + Trigger (역순) ───────────────────────────────────────────────
 DO $$
 BEGIN
-  IF EXISTS (
-    SELECT 1 FROM pg_proc WHERE proname = 'parser_rules_touch_updated_at'
-  ) THEN
-    ALTER FUNCTION parser_rules_touch_updated_at() RENAME TO parsing_rules_touch_updated_at;
+  IF to_regprocedure('public.parser_rules_touch_updated_at()') IS NOT NULL THEN
+    ALTER FUNCTION public.parser_rules_touch_updated_at()
+      RENAME TO parsing_rules_touch_updated_at;
   END IF;
 END $$;
 
@@ -18,144 +18,84 @@ BEGIN
   IF EXISTS (
     SELECT 1 FROM pg_trigger tr
     JOIN pg_class t ON tr.tgrelid = t.oid
-    WHERE t.relname = 'parser_rules' AND tr.tgname = 'parser_rules_touch_updated_at'
+    JOIN pg_namespace n ON t.relnamespace = n.oid
+    WHERE n.nspname = 'public'
+      AND t.relname = 'parser_rules'
+      AND tr.tgname = 'parser_rules_touch_updated_at'
   ) THEN
-    ALTER TRIGGER parser_rules_touch_updated_at ON parser_rules
+    ALTER TRIGGER parser_rules_touch_updated_at ON public.parser_rules
       RENAME TO parsing_rules_touch_updated_at;
   END IF;
 END $$;
 
 -- ─── Constraints (역순) ──────────────────────────────────────────────────────
 DO $$
+DECLARE
+  rec record;
 BEGIN
-  -- Auto-generated names — up 의 역순
-  IF EXISTS (
-    SELECT 1 FROM pg_constraint c
-    JOIN pg_class t ON c.conrelid = t.oid
-    WHERE t.relname = 'parser_rule_sample_urls' AND c.conname = 'parser_rule_sample_urls_rule_id_fkey'
-  ) THEN
-    ALTER TABLE parser_rule_sample_urls
-      RENAME CONSTRAINT parser_rule_sample_urls_rule_id_fkey TO parsing_rule_sample_urls_rule_id_fkey;
-  END IF;
-
-  IF EXISTS (
-    SELECT 1 FROM pg_constraint c
-    JOIN pg_class t ON c.conrelid = t.oid
-    WHERE t.relname = 'parser_rule_sample_urls' AND c.conname = 'parser_rule_sample_urls_pkey'
-  ) THEN
-    ALTER TABLE parser_rule_sample_urls
-      RENAME CONSTRAINT parser_rule_sample_urls_pkey TO parsing_rule_sample_urls_pkey;
-  END IF;
-
-  IF EXISTS (
-    SELECT 1 FROM pg_constraint c
-    JOIN pg_class t ON c.conrelid = t.oid
-    WHERE t.relname = 'parser_blacklist' AND c.conname = 'parser_blacklist_host_pattern_path_pattern_key'
-  ) THEN
-    ALTER TABLE parser_blacklist
-      RENAME CONSTRAINT parser_blacklist_host_pattern_path_pattern_key
-                     TO parsing_blacklist_host_pattern_path_pattern_key;
-  END IF;
-
-  IF EXISTS (
-    SELECT 1 FROM pg_constraint c
-    JOIN pg_class t ON c.conrelid = t.oid
-    WHERE t.relname = 'parser_blacklist' AND c.conname = 'parser_blacklist_pkey'
-  ) THEN
-    ALTER TABLE parser_blacklist
-      RENAME CONSTRAINT parser_blacklist_pkey TO parsing_blacklist_pkey;
-  END IF;
-
-  IF EXISTS (
-    SELECT 1 FROM pg_constraint c
-    JOIN pg_class t ON c.conrelid = t.oid
-    WHERE t.relname = 'parser_rules' AND c.conname = 'parser_rules_pkey'
-  ) THEN
-    ALTER TABLE parser_rules
-      RENAME CONSTRAINT parser_rules_pkey TO parsing_rules_pkey;
-  END IF;
-
-  -- Named constraints
-  IF EXISTS (
-    SELECT 1 FROM pg_constraint c
-    JOIN pg_class t ON c.conrelid = t.oid
-    WHERE t.relname = 'parser_blacklist' AND c.conname = 'parser_blacklist_mode_check'
-  ) THEN
-    ALTER TABLE parser_blacklist
-      RENAME CONSTRAINT parser_blacklist_mode_check TO parsing_blacklist_mode_check;
-  END IF;
-
-  IF EXISTS (
-    SELECT 1 FROM pg_constraint c
-    JOIN pg_class t ON c.conrelid = t.oid
-    WHERE t.relname = 'parser_blacklist' AND c.conname = 'parser_blacklist_source_check'
-  ) THEN
-    ALTER TABLE parser_blacklist
-      RENAME CONSTRAINT parser_blacklist_source_check TO parsing_blacklist_source_check;
-  END IF;
-
-  IF EXISTS (
-    SELECT 1 FROM pg_constraint c
-    JOIN pg_class t ON c.conrelid = t.oid
-    WHERE t.relname = 'parser_rule_sample_urls' AND c.conname = 'parser_rule_sample_urls_unique'
-  ) THEN
-    ALTER TABLE parser_rule_sample_urls
-      RENAME CONSTRAINT parser_rule_sample_urls_unique TO parsing_rule_sample_urls_unique;
-  END IF;
-
-  IF EXISTS (
-    SELECT 1 FROM pg_constraint c
-    JOIN pg_class t ON c.conrelid = t.oid
-    WHERE t.relname = 'parser_rules' AND c.conname = 'parser_rules_lookup_key_unique'
-  ) THEN
-    ALTER TABLE parser_rules
-      RENAME CONSTRAINT parser_rules_lookup_key_unique TO parsing_rules_lookup_key_unique;
-  END IF;
-
-  IF EXISTS (
-    SELECT 1 FROM pg_constraint c
-    JOIN pg_class t ON c.conrelid = t.oid
-    WHERE t.relname = 'parser_rules' AND c.conname = 'parser_rules_version_positive'
-  ) THEN
-    ALTER TABLE parser_rules
-      RENAME CONSTRAINT parser_rules_version_positive TO parsing_rules_version_positive;
-  END IF;
-
-  IF EXISTS (
-    SELECT 1 FROM pg_constraint c
-    JOIN pg_class t ON c.conrelid = t.oid
-    WHERE t.relname = 'parser_rules' AND c.conname = 'parser_rules_target_type_check'
-  ) THEN
-    ALTER TABLE parser_rules
-      RENAME CONSTRAINT parser_rules_target_type_check TO parsing_rules_target_type_check;
-  END IF;
+  FOR rec IN
+    SELECT * FROM (VALUES
+      -- up 의 역순 (FK → PK → UNIQUE → anonymous CHECK → named)
+      ('parser_rule_sample_urls', 'parser_rule_sample_urls_rule_id_fkey',            'parsing_rule_sample_urls_rule_id_fkey'),
+      ('parser_rule_sample_urls', 'parser_rule_sample_urls_pkey',                    'parsing_rule_sample_urls_pkey'),
+      ('parser_rule_sample_urls', 'parser_rule_sample_urls_unique',                  'parsing_rule_sample_urls_unique'),
+      ('parser_blacklist',        'parser_blacklist_host_pattern_path_pattern_key',  'parsing_blacklist_host_pattern_path_pattern_key'),
+      ('parser_blacklist',        'parser_blacklist_pkey',                           'parsing_blacklist_pkey'),
+      ('parser_blacklist',        'parser_blacklist_mode_check',                     'parsing_blacklist_mode_check'),
+      ('parser_blacklist',        'parser_blacklist_source_check',                   'parsing_blacklist_source_check'),
+      ('parser_rules',            'parser_rules_pkey',                               'parsing_rules_pkey'),
+      ('parser_rules',            'parser_rules_lookup_key_unique',                  'parsing_rules_lookup_key_unique'),
+      ('parser_rules',            'parser_rules_version_positive',                   'parsing_rules_version_positive'),
+      ('parser_rules',            'parser_rules_target_type_check',                  'parsing_rules_target_type_check')
+    ) AS v(tbl, old_name, new_name)
+  LOOP
+    IF EXISTS (
+      SELECT 1 FROM pg_constraint c
+      JOIN pg_class t ON c.conrelid = t.oid
+      JOIN pg_namespace n ON t.relnamespace = n.oid
+      WHERE n.nspname = 'public' AND t.relname = rec.tbl AND c.conname = rec.old_name
+    ) THEN
+      EXECUTE format('ALTER TABLE public.%I RENAME CONSTRAINT %I TO %I',
+                     rec.tbl, rec.old_name, rec.new_name);
+    END IF;
+  END LOOP;
 END $$;
 
--- ─── Indexes ─────────────────────────────────────────────────────────────────
-ALTER INDEX IF EXISTS idx_parser_rule_sample_urls_lookup
+-- ─── Sequences (역순) ────────────────────────────────────────────────────────
+ALTER SEQUENCE IF EXISTS public.parser_rule_sample_urls_id_seq
+  RENAME TO parsing_rule_sample_urls_id_seq;
+
+ALTER SEQUENCE IF EXISTS public.parser_blacklist_id_seq
+  RENAME TO parsing_blacklist_id_seq;
+
+ALTER SEQUENCE IF EXISTS public.parser_rules_id_seq
+  RENAME TO parsing_rules_id_seq;
+
+-- ─── Indexes (역순) ──────────────────────────────────────────────────────────
+ALTER INDEX IF EXISTS public.idx_parser_rule_sample_urls_lookup
   RENAME TO idx_parsing_rule_sample_urls_lookup;
 
-ALTER INDEX IF EXISTS idx_parser_blacklist_host_enabled
+ALTER INDEX IF EXISTS public.idx_parser_blacklist_host_enabled
   RENAME TO idx_parsing_blacklist_host_enabled;
 
-ALTER INDEX IF EXISTS idx_parser_rules_source_enabled
+ALTER INDEX IF EXISTS public.idx_parser_rules_source_enabled
   RENAME TO idx_parsing_rules_source_enabled;
 
-ALTER INDEX IF EXISTS idx_parser_rules_lookup
+ALTER INDEX IF EXISTS public.idx_parser_rules_lookup
   RENAME TO idx_parsing_rules_lookup;
 
--- ─── Tables ──────────────────────────────────────────────────────────────────
+-- ─── Tables (역순) ───────────────────────────────────────────────────────────
 DO $$
 BEGIN
-  IF EXISTS (SELECT 1 FROM pg_tables WHERE tablename = 'parser_rule_sample_urls') THEN
-    ALTER TABLE parser_rule_sample_urls RENAME TO parsing_rule_sample_urls;
+  IF to_regclass('public.parser_rule_sample_urls') IS NOT NULL THEN
+    ALTER TABLE public.parser_rule_sample_urls RENAME TO parsing_rule_sample_urls;
   END IF;
 
-  IF EXISTS (SELECT 1 FROM pg_tables WHERE tablename = 'parser_blacklist') THEN
-    ALTER TABLE parser_blacklist RENAME TO parsing_blacklist;
+  IF to_regclass('public.parser_blacklist') IS NOT NULL THEN
+    ALTER TABLE public.parser_blacklist RENAME TO parsing_blacklist;
   END IF;
 
-  IF EXISTS (SELECT 1 FROM pg_tables WHERE tablename = 'parser_rules') THEN
-    ALTER TABLE parser_rules RENAME TO parsing_rules;
+  IF to_regclass('public.parser_rules') IS NOT NULL THEN
+    ALTER TABLE public.parser_rules RENAME TO parsing_rules;
   END IF;
 END $$;

--- a/migrations/up/026_rename_parsing_to_parser.sql
+++ b/migrations/up/026_rename_parsing_to_parser.sql
@@ -1,0 +1,152 @@
+-- 026_rename_parsing_to_parser: DB 명칭을 다른 stage 의 명명 규칙과 정합 (이슈 #372)
+--
+-- 배경:
+--   fetcher / scheduler 등 다른 stage 는 stage 명을 그대로 prefix 로 사용 (fetcher_rules,
+--   scheduler_entries). 반면 parser stage 만 gerund 형 `parsing_*` 를 사용하여 일관성 결여.
+--   본 마이그레이션은 schema 레벨 명칭을 `parser_*` 로 통일.
+--
+-- Phase 1 (본 migration) — schema 명칭 + Go SQL 문자열 동시 갱신
+-- Phase 2 (후속 이슈) — Go 식별자 (ParsingRule → ParserRule 등) 정리
+--
+-- 변경 항목:
+--   Tables (3):
+--     parsing_rules → parser_rules
+--     parsing_blacklist → parser_blacklist
+--     parsing_rule_sample_urls → parser_rule_sample_urls
+--   Indexes (4):
+--     idx_parsing_rules_lookup, idx_parsing_rules_source_enabled,
+--     idx_parsing_blacklist_host_enabled, idx_parsing_rule_sample_urls_lookup
+--   Named constraints (4):
+--     parsing_rules_target_type_check, parsing_rules_version_positive,
+--     parsing_rules_lookup_key_unique, parsing_rule_sample_urls_unique
+--   Anonymous CHECK constraints (PG auto-named `<table>_<col>_check`, 2):
+--     parsing_blacklist_source_check, parsing_blacklist_mode_check
+--   Trigger + Function:
+--     parsing_rules_touch_updated_at
+--
+-- 멱등성:
+--   - ALTER TABLE/INDEX/TRIGGER/FUNCTION 은 IF EXISTS 미지원 (PG 16 기준 인덱스만 지원)
+--     → DO $$ BEGIN ... END $$ 블록으로 존재 여부 체크 후 RENAME 수행
+--   - 이미 RENAME 된 상태에서 재실행해도 무처리 (catalog 조회로 분기)
+--
+-- 운영 영향:
+--   - ALTER TABLE RENAME 은 ACCESS EXCLUSIVE lock — in-flight 쿼리 ERROR
+--   - 배포 순서 강제: migration up 적용 → app 재기동 (구 코드가 `parsing_*` 참조 시 실패)
+--   - 롤백은 026_rename_parsing_to_parser down 으로 복귀
+
+-- ─── Tables ──────────────────────────────────────────────────────────────────
+DO $$
+BEGIN
+  IF EXISTS (SELECT 1 FROM pg_tables WHERE tablename = 'parsing_rules') THEN
+    ALTER TABLE parsing_rules RENAME TO parser_rules;
+  END IF;
+
+  IF EXISTS (SELECT 1 FROM pg_tables WHERE tablename = 'parsing_blacklist') THEN
+    ALTER TABLE parsing_blacklist RENAME TO parser_blacklist;
+  END IF;
+
+  IF EXISTS (SELECT 1 FROM pg_tables WHERE tablename = 'parsing_rule_sample_urls') THEN
+    ALTER TABLE parsing_rule_sample_urls RENAME TO parser_rule_sample_urls;
+  END IF;
+END $$;
+
+-- ─── Indexes ─────────────────────────────────────────────────────────────────
+ALTER INDEX IF EXISTS idx_parsing_rules_lookup
+  RENAME TO idx_parser_rules_lookup;
+
+ALTER INDEX IF EXISTS idx_parsing_rules_source_enabled
+  RENAME TO idx_parser_rules_source_enabled;
+
+ALTER INDEX IF EXISTS idx_parsing_blacklist_host_enabled
+  RENAME TO idx_parser_blacklist_host_enabled;
+
+ALTER INDEX IF EXISTS idx_parsing_rule_sample_urls_lookup
+  RENAME TO idx_parser_rule_sample_urls_lookup;
+
+-- ─── Named constraints ───────────────────────────────────────────────────────
+DO $$
+BEGIN
+  -- parser_rules constraints
+  IF EXISTS (
+    SELECT 1 FROM pg_constraint c
+    JOIN pg_class t ON c.conrelid = t.oid
+    WHERE t.relname = 'parser_rules' AND c.conname = 'parsing_rules_target_type_check'
+  ) THEN
+    ALTER TABLE parser_rules
+      RENAME CONSTRAINT parsing_rules_target_type_check TO parser_rules_target_type_check;
+  END IF;
+
+  IF EXISTS (
+    SELECT 1 FROM pg_constraint c
+    JOIN pg_class t ON c.conrelid = t.oid
+    WHERE t.relname = 'parser_rules' AND c.conname = 'parsing_rules_version_positive'
+  ) THEN
+    ALTER TABLE parser_rules
+      RENAME CONSTRAINT parsing_rules_version_positive TO parser_rules_version_positive;
+  END IF;
+
+  IF EXISTS (
+    SELECT 1 FROM pg_constraint c
+    JOIN pg_class t ON c.conrelid = t.oid
+    WHERE t.relname = 'parser_rules' AND c.conname = 'parsing_rules_lookup_key_unique'
+  ) THEN
+    ALTER TABLE parser_rules
+      RENAME CONSTRAINT parsing_rules_lookup_key_unique TO parser_rules_lookup_key_unique;
+  END IF;
+
+  -- parser_rule_sample_urls constraints
+  IF EXISTS (
+    SELECT 1 FROM pg_constraint c
+    JOIN pg_class t ON c.conrelid = t.oid
+    WHERE t.relname = 'parser_rule_sample_urls' AND c.conname = 'parsing_rule_sample_urls_unique'
+  ) THEN
+    ALTER TABLE parser_rule_sample_urls
+      RENAME CONSTRAINT parsing_rule_sample_urls_unique TO parser_rule_sample_urls_unique;
+  END IF;
+
+  -- parser_blacklist anonymous CHECK constraints (PG auto-named)
+  IF EXISTS (
+    SELECT 1 FROM pg_constraint c
+    JOIN pg_class t ON c.conrelid = t.oid
+    WHERE t.relname = 'parser_blacklist' AND c.conname = 'parsing_blacklist_source_check'
+  ) THEN
+    ALTER TABLE parser_blacklist
+      RENAME CONSTRAINT parsing_blacklist_source_check TO parser_blacklist_source_check;
+  END IF;
+
+  IF EXISTS (
+    SELECT 1 FROM pg_constraint c
+    JOIN pg_class t ON c.conrelid = t.oid
+    WHERE t.relname = 'parser_blacklist' AND c.conname = 'parsing_blacklist_mode_check'
+  ) THEN
+    ALTER TABLE parser_blacklist
+      RENAME CONSTRAINT parsing_blacklist_mode_check TO parser_blacklist_mode_check;
+  END IF;
+END $$;
+
+-- ─── Trigger + Function ──────────────────────────────────────────────────────
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1 FROM pg_trigger tr
+    JOIN pg_class t ON tr.tgrelid = t.oid
+    WHERE t.relname = 'parser_rules' AND tr.tgname = 'parsing_rules_touch_updated_at'
+  ) THEN
+    ALTER TRIGGER parsing_rules_touch_updated_at ON parser_rules
+      RENAME TO parser_rules_touch_updated_at;
+  END IF;
+END $$;
+
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1 FROM pg_proc WHERE proname = 'parsing_rules_touch_updated_at'
+  ) THEN
+    ALTER FUNCTION parsing_rules_touch_updated_at() RENAME TO parser_rules_touch_updated_at;
+  END IF;
+END $$;
+
+-- ─── Comments — 본문에 참조된 테이블 명 갱신 ──────────────────────────────────
+-- (016 에서 설정한 parsing_blacklist 관련 COMMENT 는 catalog 상 자동 follow — 별도 처리 불필요)
+COMMENT ON TABLE parser_blacklist IS
+  'page-parse 블랙리스트 (이슈 #295) — 매칭 URL 은 article job 발행 단계에서 drop.';

--- a/migrations/up/026_rename_parsing_to_parser.sql
+++ b/migrations/up/026_rename_parsing_to_parser.sql
@@ -122,7 +122,62 @@ BEGIN
     ALTER TABLE parser_blacklist
       RENAME CONSTRAINT parsing_blacklist_mode_check TO parser_blacklist_mode_check;
   END IF;
+
+  -- PG auto-generated constraint names: <orig_table>_pkey / <orig_table>_<cols>_key /
+  -- <orig_table>_<col>_fkey. RENAME TABLE 은 이 이름을 자동 갱신하지 않음 → 명시 처리.
+  -- parser_rules
+  IF EXISTS (
+    SELECT 1 FROM pg_constraint c
+    JOIN pg_class t ON c.conrelid = t.oid
+    WHERE t.relname = 'parser_rules' AND c.conname = 'parsing_rules_pkey'
+  ) THEN
+    ALTER TABLE parser_rules
+      RENAME CONSTRAINT parsing_rules_pkey TO parser_rules_pkey;
+  END IF;
+
+  -- parser_blacklist auto-generated PK + UNIQUE
+  IF EXISTS (
+    SELECT 1 FROM pg_constraint c
+    JOIN pg_class t ON c.conrelid = t.oid
+    WHERE t.relname = 'parser_blacklist' AND c.conname = 'parsing_blacklist_pkey'
+  ) THEN
+    ALTER TABLE parser_blacklist
+      RENAME CONSTRAINT parsing_blacklist_pkey TO parser_blacklist_pkey;
+  END IF;
+
+  IF EXISTS (
+    SELECT 1 FROM pg_constraint c
+    JOIN pg_class t ON c.conrelid = t.oid
+    WHERE t.relname = 'parser_blacklist' AND c.conname = 'parsing_blacklist_host_pattern_path_pattern_key'
+  ) THEN
+    ALTER TABLE parser_blacklist
+      RENAME CONSTRAINT parsing_blacklist_host_pattern_path_pattern_key
+                     TO parser_blacklist_host_pattern_path_pattern_key;
+  END IF;
+
+  -- parser_rule_sample_urls auto-generated PK + FK
+  IF EXISTS (
+    SELECT 1 FROM pg_constraint c
+    JOIN pg_class t ON c.conrelid = t.oid
+    WHERE t.relname = 'parser_rule_sample_urls' AND c.conname = 'parsing_rule_sample_urls_pkey'
+  ) THEN
+    ALTER TABLE parser_rule_sample_urls
+      RENAME CONSTRAINT parsing_rule_sample_urls_pkey TO parser_rule_sample_urls_pkey;
+  END IF;
+
+  IF EXISTS (
+    SELECT 1 FROM pg_constraint c
+    JOIN pg_class t ON c.conrelid = t.oid
+    WHERE t.relname = 'parser_rule_sample_urls' AND c.conname = 'parsing_rule_sample_urls_rule_id_fkey'
+  ) THEN
+    ALTER TABLE parser_rule_sample_urls
+      RENAME CONSTRAINT parsing_rule_sample_urls_rule_id_fkey TO parser_rule_sample_urls_rule_id_fkey;
+  END IF;
 END $$;
+
+-- 명명된 인덱스가 PG 카탈로그에 자동으로 같이 따라오므로 UNIQUE / PK 의 backing 인덱스 명도
+-- constraint 명과 동기화 — PG 는 constraint rename 시 backing 인덱스도 함께 rename 한다
+-- (catalog 시맨틱), 따라서 별도 ALTER INDEX 불필요.
 
 -- ─── Trigger + Function ──────────────────────────────────────────────────────
 DO $$

--- a/migrations/up/026_rename_parsing_to_parser.sql
+++ b/migrations/up/026_rename_parsing_to_parser.sql
@@ -8,26 +8,23 @@
 -- Phase 1 (본 migration) — schema 명칭 + Go SQL 문자열 동시 갱신
 -- Phase 2 (후속 이슈) — Go 식별자 (ParsingRule → ParserRule 등) 정리
 --
--- 변경 항목:
---   Tables (3):
---     parsing_rules → parser_rules
---     parsing_blacklist → parser_blacklist
---     parsing_rule_sample_urls → parser_rule_sample_urls
---   Indexes (4):
---     idx_parsing_rules_lookup, idx_parsing_rules_source_enabled,
---     idx_parsing_blacklist_host_enabled, idx_parsing_rule_sample_urls_lookup
---   Named constraints (4):
---     parsing_rules_target_type_check, parsing_rules_version_positive,
---     parsing_rules_lookup_key_unique, parsing_rule_sample_urls_unique
---   Anonymous CHECK constraints (PG auto-named `<table>_<col>_check`, 2):
---     parsing_blacklist_source_check, parsing_blacklist_mode_check
---   Trigger + Function:
---     parsing_rules_touch_updated_at
+-- 변경 항목 (총 23 catalog 객체):
+--   Tables (3): parsing_rules / parsing_blacklist / parsing_rule_sample_urls
+--   Indexes (4): idx_parsing_rules_*, idx_parsing_blacklist_*, idx_parsing_rule_sample_urls_*
+--   Named constraints (4): parsing_rules_target_type_check, _version_positive,
+--                          _lookup_key_unique, parsing_rule_sample_urls_unique
+--   Anonymous CHECK (2): parsing_blacklist_source_check, parsing_blacklist_mode_check
+--   Auto-generated PK/FK/UNIQUE (5): *_pkey 3, _key 1, _fkey 1
+--   Sequences (3): parsing_*_id_seq (BIGSERIAL backing)
+--   Trigger + Function (2): parsing_rules_touch_updated_at
 --
--- 멱등성:
---   - ALTER TABLE/INDEX/TRIGGER/FUNCTION 은 IF EXISTS 미지원 (PG 16 기준 인덱스만 지원)
---     → DO $$ BEGIN ... END $$ 블록으로 존재 여부 체크 후 RENAME 수행
---   - 이미 RENAME 된 상태에서 재실행해도 무처리 (catalog 조회로 분기)
+-- 멱등성 + 안전성:
+--   - 모든 존재 확인은 `to_regclass('public.<obj>')` / `to_regprocedure('public.<func>(...)')`
+--     로 schema-qualified 처리 — search_path 변동 / 동명 객체 다른 schema 위험 회피
+--     (Copilot / gemini PR #373 피드백)
+--   - 모든 DDL 도 `public.<obj>` 로 schema 명시
+--   - constraint / trigger 는 (table, conname/tgname) 단위라 pg_class + pg_namespace JOIN
+--   - 이미 RENAME 된 상태에서 재실행해도 무처리
 --
 -- 운영 영향:
 --   - ALTER TABLE RENAME 은 ACCESS EXCLUSIVE lock — in-flight 쿼리 ERROR
@@ -37,147 +34,75 @@
 -- ─── Tables ──────────────────────────────────────────────────────────────────
 DO $$
 BEGIN
-  IF EXISTS (SELECT 1 FROM pg_tables WHERE tablename = 'parsing_rules') THEN
-    ALTER TABLE parsing_rules RENAME TO parser_rules;
+  IF to_regclass('public.parsing_rules') IS NOT NULL THEN
+    ALTER TABLE public.parsing_rules RENAME TO parser_rules;
   END IF;
 
-  IF EXISTS (SELECT 1 FROM pg_tables WHERE tablename = 'parsing_blacklist') THEN
-    ALTER TABLE parsing_blacklist RENAME TO parser_blacklist;
+  IF to_regclass('public.parsing_blacklist') IS NOT NULL THEN
+    ALTER TABLE public.parsing_blacklist RENAME TO parser_blacklist;
   END IF;
 
-  IF EXISTS (SELECT 1 FROM pg_tables WHERE tablename = 'parsing_rule_sample_urls') THEN
-    ALTER TABLE parsing_rule_sample_urls RENAME TO parser_rule_sample_urls;
+  IF to_regclass('public.parsing_rule_sample_urls') IS NOT NULL THEN
+    ALTER TABLE public.parsing_rule_sample_urls RENAME TO parser_rule_sample_urls;
   END IF;
 END $$;
 
 -- ─── Indexes ─────────────────────────────────────────────────────────────────
-ALTER INDEX IF EXISTS idx_parsing_rules_lookup
+ALTER INDEX IF EXISTS public.idx_parsing_rules_lookup
   RENAME TO idx_parser_rules_lookup;
 
-ALTER INDEX IF EXISTS idx_parsing_rules_source_enabled
+ALTER INDEX IF EXISTS public.idx_parsing_rules_source_enabled
   RENAME TO idx_parser_rules_source_enabled;
 
-ALTER INDEX IF EXISTS idx_parsing_blacklist_host_enabled
+ALTER INDEX IF EXISTS public.idx_parsing_blacklist_host_enabled
   RENAME TO idx_parser_blacklist_host_enabled;
 
-ALTER INDEX IF EXISTS idx_parsing_rule_sample_urls_lookup
+ALTER INDEX IF EXISTS public.idx_parsing_rule_sample_urls_lookup
   RENAME TO idx_parser_rule_sample_urls_lookup;
 
--- ─── Named constraints ───────────────────────────────────────────────────────
+-- ─── Sequences ───────────────────────────────────────────────────────────────
+-- BIGSERIAL 컬럼이 자동 생성한 sequence — RENAME TABLE 은 sequence 명을 자동 갱신하지 않음.
+ALTER SEQUENCE IF EXISTS public.parsing_rules_id_seq
+  RENAME TO parser_rules_id_seq;
+
+ALTER SEQUENCE IF EXISTS public.parsing_blacklist_id_seq
+  RENAME TO parser_blacklist_id_seq;
+
+ALTER SEQUENCE IF EXISTS public.parsing_rule_sample_urls_id_seq
+  RENAME TO parser_rule_sample_urls_id_seq;
+
+-- ─── Constraints (named + anonymous + auto-generated PK/FK) ──────────────────
+-- constraint / trigger 는 (table, name) 단위라 schema 는 pg_namespace JOIN 으로 확인.
 DO $$
+DECLARE
+  rec record;
 BEGIN
-  -- parser_rules constraints
-  IF EXISTS (
-    SELECT 1 FROM pg_constraint c
-    JOIN pg_class t ON c.conrelid = t.oid
-    WHERE t.relname = 'parser_rules' AND c.conname = 'parsing_rules_target_type_check'
-  ) THEN
-    ALTER TABLE parser_rules
-      RENAME CONSTRAINT parsing_rules_target_type_check TO parser_rules_target_type_check;
-  END IF;
-
-  IF EXISTS (
-    SELECT 1 FROM pg_constraint c
-    JOIN pg_class t ON c.conrelid = t.oid
-    WHERE t.relname = 'parser_rules' AND c.conname = 'parsing_rules_version_positive'
-  ) THEN
-    ALTER TABLE parser_rules
-      RENAME CONSTRAINT parsing_rules_version_positive TO parser_rules_version_positive;
-  END IF;
-
-  IF EXISTS (
-    SELECT 1 FROM pg_constraint c
-    JOIN pg_class t ON c.conrelid = t.oid
-    WHERE t.relname = 'parser_rules' AND c.conname = 'parsing_rules_lookup_key_unique'
-  ) THEN
-    ALTER TABLE parser_rules
-      RENAME CONSTRAINT parsing_rules_lookup_key_unique TO parser_rules_lookup_key_unique;
-  END IF;
-
-  -- parser_rule_sample_urls constraints
-  IF EXISTS (
-    SELECT 1 FROM pg_constraint c
-    JOIN pg_class t ON c.conrelid = t.oid
-    WHERE t.relname = 'parser_rule_sample_urls' AND c.conname = 'parsing_rule_sample_urls_unique'
-  ) THEN
-    ALTER TABLE parser_rule_sample_urls
-      RENAME CONSTRAINT parsing_rule_sample_urls_unique TO parser_rule_sample_urls_unique;
-  END IF;
-
-  -- parser_blacklist anonymous CHECK constraints (PG auto-named)
-  IF EXISTS (
-    SELECT 1 FROM pg_constraint c
-    JOIN pg_class t ON c.conrelid = t.oid
-    WHERE t.relname = 'parser_blacklist' AND c.conname = 'parsing_blacklist_source_check'
-  ) THEN
-    ALTER TABLE parser_blacklist
-      RENAME CONSTRAINT parsing_blacklist_source_check TO parser_blacklist_source_check;
-  END IF;
-
-  IF EXISTS (
-    SELECT 1 FROM pg_constraint c
-    JOIN pg_class t ON c.conrelid = t.oid
-    WHERE t.relname = 'parser_blacklist' AND c.conname = 'parsing_blacklist_mode_check'
-  ) THEN
-    ALTER TABLE parser_blacklist
-      RENAME CONSTRAINT parsing_blacklist_mode_check TO parser_blacklist_mode_check;
-  END IF;
-
-  -- PG auto-generated constraint names: <orig_table>_pkey / <orig_table>_<cols>_key /
-  -- <orig_table>_<col>_fkey. RENAME TABLE 은 이 이름을 자동 갱신하지 않음 → 명시 처리.
-  -- parser_rules
-  IF EXISTS (
-    SELECT 1 FROM pg_constraint c
-    JOIN pg_class t ON c.conrelid = t.oid
-    WHERE t.relname = 'parser_rules' AND c.conname = 'parsing_rules_pkey'
-  ) THEN
-    ALTER TABLE parser_rules
-      RENAME CONSTRAINT parsing_rules_pkey TO parser_rules_pkey;
-  END IF;
-
-  -- parser_blacklist auto-generated PK + UNIQUE
-  IF EXISTS (
-    SELECT 1 FROM pg_constraint c
-    JOIN pg_class t ON c.conrelid = t.oid
-    WHERE t.relname = 'parser_blacklist' AND c.conname = 'parsing_blacklist_pkey'
-  ) THEN
-    ALTER TABLE parser_blacklist
-      RENAME CONSTRAINT parsing_blacklist_pkey TO parser_blacklist_pkey;
-  END IF;
-
-  IF EXISTS (
-    SELECT 1 FROM pg_constraint c
-    JOIN pg_class t ON c.conrelid = t.oid
-    WHERE t.relname = 'parser_blacklist' AND c.conname = 'parsing_blacklist_host_pattern_path_pattern_key'
-  ) THEN
-    ALTER TABLE parser_blacklist
-      RENAME CONSTRAINT parsing_blacklist_host_pattern_path_pattern_key
-                     TO parser_blacklist_host_pattern_path_pattern_key;
-  END IF;
-
-  -- parser_rule_sample_urls auto-generated PK + FK
-  IF EXISTS (
-    SELECT 1 FROM pg_constraint c
-    JOIN pg_class t ON c.conrelid = t.oid
-    WHERE t.relname = 'parser_rule_sample_urls' AND c.conname = 'parsing_rule_sample_urls_pkey'
-  ) THEN
-    ALTER TABLE parser_rule_sample_urls
-      RENAME CONSTRAINT parsing_rule_sample_urls_pkey TO parser_rule_sample_urls_pkey;
-  END IF;
-
-  IF EXISTS (
-    SELECT 1 FROM pg_constraint c
-    JOIN pg_class t ON c.conrelid = t.oid
-    WHERE t.relname = 'parser_rule_sample_urls' AND c.conname = 'parsing_rule_sample_urls_rule_id_fkey'
-  ) THEN
-    ALTER TABLE parser_rule_sample_urls
-      RENAME CONSTRAINT parsing_rule_sample_urls_rule_id_fkey TO parser_rule_sample_urls_rule_id_fkey;
-  END IF;
+  FOR rec IN
+    SELECT * FROM (VALUES
+      ('parser_rules',            'parsing_rules_target_type_check',                  'parser_rules_target_type_check'),
+      ('parser_rules',            'parsing_rules_version_positive',                   'parser_rules_version_positive'),
+      ('parser_rules',            'parsing_rules_lookup_key_unique',                  'parser_rules_lookup_key_unique'),
+      ('parser_rules',            'parsing_rules_pkey',                               'parser_rules_pkey'),
+      ('parser_blacklist',        'parsing_blacklist_source_check',                   'parser_blacklist_source_check'),
+      ('parser_blacklist',        'parsing_blacklist_mode_check',                     'parser_blacklist_mode_check'),
+      ('parser_blacklist',        'parsing_blacklist_pkey',                           'parser_blacklist_pkey'),
+      ('parser_blacklist',        'parsing_blacklist_host_pattern_path_pattern_key',  'parser_blacklist_host_pattern_path_pattern_key'),
+      ('parser_rule_sample_urls', 'parsing_rule_sample_urls_unique',                  'parser_rule_sample_urls_unique'),
+      ('parser_rule_sample_urls', 'parsing_rule_sample_urls_pkey',                    'parser_rule_sample_urls_pkey'),
+      ('parser_rule_sample_urls', 'parsing_rule_sample_urls_rule_id_fkey',            'parser_rule_sample_urls_rule_id_fkey')
+    ) AS v(tbl, old_name, new_name)
+  LOOP
+    IF EXISTS (
+      SELECT 1 FROM pg_constraint c
+      JOIN pg_class t ON c.conrelid = t.oid
+      JOIN pg_namespace n ON t.relnamespace = n.oid
+      WHERE n.nspname = 'public' AND t.relname = rec.tbl AND c.conname = rec.old_name
+    ) THEN
+      EXECUTE format('ALTER TABLE public.%I RENAME CONSTRAINT %I TO %I',
+                     rec.tbl, rec.old_name, rec.new_name);
+    END IF;
+  END LOOP;
 END $$;
-
--- 명명된 인덱스가 PG 카탈로그에 자동으로 같이 따라오므로 UNIQUE / PK 의 backing 인덱스 명도
--- constraint 명과 동기화 — PG 는 constraint rename 시 backing 인덱스도 함께 rename 한다
--- (catalog 시맨틱), 따라서 별도 ALTER INDEX 불필요.
 
 -- ─── Trigger + Function ──────────────────────────────────────────────────────
 DO $$
@@ -185,23 +110,25 @@ BEGIN
   IF EXISTS (
     SELECT 1 FROM pg_trigger tr
     JOIN pg_class t ON tr.tgrelid = t.oid
-    WHERE t.relname = 'parser_rules' AND tr.tgname = 'parsing_rules_touch_updated_at'
+    JOIN pg_namespace n ON t.relnamespace = n.oid
+    WHERE n.nspname = 'public'
+      AND t.relname = 'parser_rules'
+      AND tr.tgname = 'parsing_rules_touch_updated_at'
   ) THEN
-    ALTER TRIGGER parsing_rules_touch_updated_at ON parser_rules
+    ALTER TRIGGER parsing_rules_touch_updated_at ON public.parser_rules
       RENAME TO parser_rules_touch_updated_at;
   END IF;
 END $$;
 
 DO $$
 BEGIN
-  IF EXISTS (
-    SELECT 1 FROM pg_proc WHERE proname = 'parsing_rules_touch_updated_at'
-  ) THEN
-    ALTER FUNCTION parsing_rules_touch_updated_at() RENAME TO parser_rules_touch_updated_at;
+  -- to_regprocedure 는 schema + signature 까지 명시 — overloading 충돌 방지.
+  IF to_regprocedure('public.parsing_rules_touch_updated_at()') IS NOT NULL THEN
+    ALTER FUNCTION public.parsing_rules_touch_updated_at()
+      RENAME TO parser_rules_touch_updated_at;
   END IF;
 END $$;
 
 -- ─── Comments — 본문에 참조된 테이블 명 갱신 ──────────────────────────────────
--- (016 에서 설정한 parsing_blacklist 관련 COMMENT 는 catalog 상 자동 follow — 별도 처리 불필요)
-COMMENT ON TABLE parser_blacklist IS
+COMMENT ON TABLE public.parser_blacklist IS
   'page-parse 블랙리스트 (이슈 #295) — 매칭 URL 은 article job 발행 단계에서 drop.';


### PR DESCRIPTION
## 연관 이슈
- Closes #372

<br>

## 구현 내용

다른 파이프라인 stage 들이 stage 명을 prefix 로 사용 (\`fetcher_rules\`, \`scheduler_entries\`) 하는 반면 parser stage 만 \`parsing_*\` (gerund) 로 명명되어 불일치. 본 PR 은 schema 명칭을 \`parser_*\` 로 통일.

### Phase 1 — schema + Go SQL (본 PR)
- **migration 026 신규** — 14개 catalog 객체 RENAME:
  - 테이블 3: \`parsing_rules\` / \`parsing_blacklist\` / \`parsing_rule_sample_urls\`
  - 인덱스 4: \`idx_parsing_rules_*\` / \`idx_parsing_blacklist_*\` / \`idx_parsing_rule_sample_urls_*\`
  - Named constraint 4: \`parsing_rules_target_type_check\` / \`parsing_rules_version_positive\` / \`parsing_rules_lookup_key_unique\` / \`parsing_rule_sample_urls_unique\`
  - Anonymous CHECK 2 (PG auto-named): \`parsing_blacklist_source_check\` / \`parsing_blacklist_mode_check\`
  - **Auto-generated PK/FK/UNIQUE 5** (라이브 적용 시 발견 → 보강 commit \`edeb2e6\`): \`*_pkey\` / \`*_*_fkey\` / \`*_*_key\`
  - Trigger + Function: \`parsing_rules_touch_updated_at\`
- **Go 코드 갱신** — 16개 \`.go\` 파일의 SQL 쿼리 문자열 + 주석에서 테이블명 치환
- 모든 RENAME 은 \`DO $$ BEGIN ... END $$\` + \`IF EXISTS\` 로 멱등성 보장

### Phase 2 (후속 이슈 권장) — Go 식별자
- 본 PR scope 외: Go 파일명 (\`parsing_rule.go\` → \`parser_rule.go\`), 타입명 (\`ParsingRule\` → \`ParserRule\`), 함수/변수명 정리
- Phase 1 만으로 schema 명칭 통일 완료 + 코드 빌드 가능 → 안전한 분할

<br>

## CI / 머지 게이트 점검

### 변경 영향 범위
- 영향 패키지/모듈: \`migrations/\`, \`internal/storage/*\`, \`internal/processor/parser/rule/*\`, \`cmd/issuetracker\`, \`cmd/rule-validator\`
- 위험도: **Medium** — schema RENAME 은 ACCESS EXCLUSIVE lock + 배포 순서 강제 필요 (migration up → app 재기동)

### 검증
- 로컬 PostgreSQL 에 migration up 적용 — 91 row \`parser_rules\` SELECT 성공
- 026 멱등 재적용 검증 — schema_migrations 에서 026 제거 후 재실행 시 idempotent OK
- \`go build ./...\` + \`go vet ./...\` + \`go test -race -count=1 ./...\` 전체 통과

### Required Status Checks
- 통과 확인 대상 (PR Checks 탭에서 확인):
  - [ ] \`Commit Lint\`
  - [ ] \`PR Title Lint\`
  - [ ] \`Linked Issue Check\`
  - [ ] \`Format Check\`
  - [ ] \`Build\`
  - [ ] \`Test\`
  - [ ] \`Lint\`

### 롤백 계획
- \`migrations/down/026_rename_parsing_to_parser.sql\` 으로 원상복귀
- 코드는 PR revert (구 SQL 문자열로 복원)
- 배포 순서: code revert → migration down — 동기화 필요

<br>

## TODO
- 머지 후 후속 이슈 생성 권장 — Phase 2 (Go 식별자 정리)

<br>

## 논의 사항
- 라이브 적용 시점 운영 노트: ACCESS EXCLUSIVE lock 로 in-flight 쿼리 ERROR 가능 → off-peak 시간대 권장

🤖 Generated with [Claude Code](https://claude.com/claude-code)