### PR TITLE
[REFAC#374] Go 식별자/파일명 정합 — Parsing* → Parser* (#372 Phase 2)

### DIFF
--- a/cmd/issuetracker/main.go
+++ b/cmd/issuetracker/main.go
@@ -126,7 +126,7 @@ func main() {
 
 	// rule.Parser: parser_rules 테이블 기반 단일 파서 엔진.
 	// 사이트별 NaverParser/CNNParser/... 를 대체 — 모든 사이트가 본 단일 인스턴스를 공유.
-	parserRuleRepo := pgstore.NewParsingRuleRepository(pool, log)
+	parserRuleRepo := pgstore.NewParserRuleRepository(pool, log)
 	ruleResolver, err := rule.NewResolver(parserRuleRepo)
 	if err != nil {
 		log.WithError(err).Fatal("failed to construct rule resolver")

--- a/cmd/issuetracker/main.go
+++ b/cmd/issuetracker/main.go
@@ -126,14 +126,14 @@ func main() {
 
 	// rule.Parser: parser_rules 테이블 기반 단일 파서 엔진.
 	// 사이트별 NaverParser/CNNParser/... 를 대체 — 모든 사이트가 본 단일 인스턴스를 공유.
-	parsingRuleRepo := pgstore.NewParsingRuleRepository(pool, log)
-	ruleResolver, err := rule.NewResolver(parsingRuleRepo)
+	parserRuleRepo := pgstore.NewParsingRuleRepository(pool, log)
+	ruleResolver, err := rule.NewResolver(parserRuleRepo)
 	if err != nil {
 		log.WithError(err).Fatal("failed to construct rule resolver")
 	}
 	// parser_rules mutation → cache invalidate 자동 결합 (decorator 패턴).
 	// 호출처가 명시적 Invalidate 를 까먹어도 stale cache 발생 X — single source of truth.
-	parsingRuleRepo = storage.WrapWithInvalidator(parsingRuleRepo, ruleResolver)
+	parserRuleRepo = storage.WrapWithInvalidator(parserRuleRepo, ruleResolver)
 	ruleParser, err := rule.NewParser(ruleResolver)
 	if err != nil {
 		log.WithError(err).Fatal("failed to construct rule parser")
@@ -443,7 +443,7 @@ func main() {
 		}).Info("LLM prompt loader enabled (file → embed chain)")
 	}
 
-	llmGen, err := llmgenwiring.Build(llmProvider, parsingRuleRepo, ruleResolver, promptLoader, redisClientShared, log)
+	llmGen, err := llmgenwiring.Build(llmProvider, parserRuleRepo, ruleResolver, promptLoader, redisClientShared, log)
 	if err != nil {
 		log.WithError(err).Fatal("failed to build llmgen generator")
 	}
@@ -699,7 +699,7 @@ func main() {
 	// catch-all + llm-auto rule 의 누적 sample URL 로부터 path_pattern 정밀화.
 	// REFINEMENT_ENABLED=false 또는 config 실패 시 nil — 기존 catch-all rule 그대로 동작.
 	// metricsRegistry 는 nil 허용 — Record* 호출이 noop.
-	pathRefiner, err := refinerwiring.Build(llmProvider, promptLoader, parsingRuleRepo, sampleRepo, ruleResolver, metricsRegistry, log)
+	pathRefiner, err := refinerwiring.Build(llmProvider, promptLoader, parserRuleRepo, sampleRepo, ruleResolver, metricsRegistry, log)
 	if err != nil {
 		log.WithError(err).Fatal("failed to build refiner")
 	}

--- a/cmd/rule-validator/main.go
+++ b/cmd/rule-validator/main.go
@@ -54,7 +54,7 @@ func main() {
 	}
 	defer pool.Close()
 
-	ruleRepo := pgstore.NewParsingRuleRepository(pool, log)
+	ruleRepo := pgstore.NewParserRuleRepository(pool, log)
 
 	// parsing_rule 조회
 	record, err := ruleRepo.GetByID(ctx, *ruleID)

--- a/internal/processor/parser/parser.go
+++ b/internal/processor/parser/parser.go
@@ -3,7 +3,7 @@
 //
 // Package parser defines domain-agnostic interfaces and models for extracting
 // the main content of any web page. 사이트별 hardcode 파서를 대체하여, DB 기반 rule
-// (storage.ParsingRuleRecord) 만 다른 단일 engine 이 모든 웹페이지를 처리합니다.
+// (storage.ParserRuleRecord) 만 다른 단일 engine 이 모든 웹페이지를 처리합니다.
 //
 // 두 핵심 인터페이스:
 //   - ContentParser  : 단일 웹페이지 → Page (핵심 본문 + 메타데이터)

--- a/internal/processor/parser/rule/discovery.go
+++ b/internal/processor/parser/rule/discovery.go
@@ -24,7 +24,7 @@ import (
 // URL dedup / rate limiter 가 흡수합니다.
 //
 // stateless / goroutine-safe — 호출 시마다 regex 컴파일을 회피하기 위해
-// Resolver 가 cache 한 ParsingRuleRecord 를 재사용하는 호출자 측에서 컴파일 결과를
+// Resolver 가 cache 한 ParserRuleRecord 를 재사용하는 호출자 측에서 컴파일 결과를
 // 메모이즈하는 것이 이상적이나, 현재 구현에서는 호출 시 한 번만 컴파일.
 type PageLinkDiscovery struct{}
 

--- a/internal/processor/parser/rule/llmgen/generator.go
+++ b/internal/processor/parser/rule/llmgen/generator.go
@@ -8,7 +8,7 @@
 //  2. Generator goroutine: in-flight dedup 후 LLM 프롬프트 생성 → Provider.Generate 호출
 //  3. 응답 JSON 파싱 → storage.SelectorMap 으로 변환
 //  4. validation: 생성된 selector 로 실제 HTML 매칭 확인 (0건이면 폐기)
-//  5. ParsingRuleRepository.Insert (enabled=true — CSS selector 검증 통과가 품질 게이트)
+//  5. ParserRuleRepository.Insert (enabled=true — CSS selector 검증 통과가 품질 게이트)
 //  6. Resolver.Invalidate 로 negative cache flush — 다음 fetch 부터 새 rule 사용 가능
 //
 // 현재 구현 범위:
@@ -120,7 +120,7 @@ var errBlacklistedNoRule = errors.New("llmgen: page blacklisted, no rule generat
 type Generator struct {
 	provider     llm.Provider
 	extractor    SelectorExtractor // nil 이면 provider 로 fallback
-	repo         storage.ParsingRuleRepository
+	repo         storage.ParserRuleRepository
 	resolver     *rule.Resolver
 	promptLoader prompt.Loader
 	log          *logger.Logger
@@ -209,7 +209,7 @@ func (g *Generator) SetBreaker(b *HostBreaker) {
 //
 // provider / repo / resolver / promptLoader / log 모두 비-nil 필수. 하나라도 nil 이면 error —
 // 호출자 (cmd/main) 가 boot fatal 처리.
-func New(provider llm.Provider, repo storage.ParsingRuleRepository, resolver *rule.Resolver, promptLoader prompt.Loader, log *logger.Logger) (*Generator, error) {
+func New(provider llm.Provider, repo storage.ParserRuleRepository, resolver *rule.Resolver, promptLoader prompt.Loader, log *logger.Logger) (*Generator, error) {
 	if provider == nil {
 		return nil, errors.New("llmgen: New requires non-nil provider")
 	}
@@ -639,7 +639,7 @@ func (g *Generator) runOnce(ctx context.Context, host string, targetType storage
 	confidence := ComputeFieldConfidence(selectors, html)
 	selectors = ApplyConfidenceFilter(selectors, confidence)
 
-	record := &storage.ParsingRuleRecord{
+	record := &storage.ParserRuleRecord{
 		SourceName:  LLMAutoSourceName,
 		HostPattern: host,
 		TargetType:  targetType,

--- a/internal/processor/parser/rule/llmgen/wiring/wiring.go
+++ b/internal/processor/parser/rule/llmgen/wiring/wiring.go
@@ -24,7 +24,7 @@ import (
 // provider 가 nil (LLM 비활성) 이면 (nil, nil) 반환 — parser worker 는 ErrNoRule 시 raw 만 잔존.
 // llmgen.New 자체 실패는 wiring 버그 — 호출자 (main) 에서 Fatal 결정.
 // redisClient 가 nil 이면 in-process memInflightLocker 로 graceful degrade.
-func Build(provider llm.Provider, repo storage.ParsingRuleRepository, resolver *rule.Resolver, promptLoader prompt.Loader, redisClient *redis.Client, log *logger.Logger) (*llmgen.Generator, error) {
+func Build(provider llm.Provider, repo storage.ParserRuleRepository, resolver *rule.Resolver, promptLoader prompt.Loader, redisClient *redis.Client, log *logger.Logger) (*llmgen.Generator, error) {
 	if provider == nil {
 		return nil, nil
 	}

--- a/internal/processor/parser/rule/parser.go
+++ b/internal/processor/parser/rule/parser.go
@@ -24,7 +24,7 @@ const resolveTimeout = 5 * time.Second
 // Parser 는 DB 기반 파싱 규칙으로 동작하는 단일 page parser engine 입니다.
 //
 // Parser implements both parser.ContentParser and parser.LinkListParser, driven by
-// storage.ParsingRuleRecord resolved per request via Resolver. 사이트별 hardcode 파서
+// storage.ParserRuleRecord resolved per request via Resolver. 사이트별 hardcode 파서
 // (NaverParser/DaumParser/...) 를 대체 — 새 사이트 지원 = parser_rules row 추가.
 //
 // 도메인 중립 — 뉴스 / 블로그 / 제품 페이지 / 일반 문서 모두 동일 engine 으로 처리.

--- a/internal/processor/parser/rule/refiner/refiner.go
+++ b/internal/processor/parser/rule/refiner/refiner.go
@@ -2,7 +2,7 @@
 // 추론하여 자동 갱신하는 점진적 정밀화 워크플로를 구현합니다.
 //
 // 흐름 (Run goroutine 1회 cycle):
-//  1. ParsingRuleRepository.List(SourceName='llm-auto', OnlyEnabled=true) 로 후보 rule 조회.
+//  1. ParserRuleRepository.List(SourceName='llm-auto', OnlyEnabled=true) 로 후보 rule 조회.
 //  2. PathPattern == "" (catch-all) 인 rule 만 정밀화 대상으로 선별.
 //  3. 각 대상 rule 마다:
 //     a. SampleURLRepository.Count(rule.ID) >= MinSamples 검사 — 미만이면 skip.
@@ -10,7 +10,7 @@
 //     c. pathinfer.InferHeuristic(samples) 시도 — 성공하면 algorithm 방식 채택.
 //     d. 실패 + LLMClient != nil 이면 pathinfer.InferLLM(samples) 시도 — 성공하면 llm 방식 채택.
 //     e. 결과 regex 가 비어있으면 skip (다음 polling 에서 재시도 — sample 누적 추가 후 재평가).
-//     f. ParsingRuleRepository.InsertNextVersion — 기존 catch-all (v1) 보존 + 정밀 path_pattern 으로
+//     f. ParserRuleRepository.InsertNextVersion — 기존 catch-all (v1) 보존 + 정밀 path_pattern 으로
 //     새 version (v2) INSERT. v2 가 매칭 안 되는 path 는 v1 (catch-all)
 //     로 fallback — 정밀화 적용 범위가 좁아도 silent miss 없음.
 //     g. resolver.Invalidate(host, type) — cache flush (다음 lookup 부터 갱신된 rule 적용).
@@ -59,7 +59,7 @@ const DefaultMinSamples = 5
 //   - Start 두 번 호출은 두 번째가 noop, Stop 후 Start 는 noop (race 안전).
 //   - 테스트 친화 — Run / RunOnce 는 그대로 유지하여 외부에서 단일 cycle 호출 가능.
 type Refiner struct {
-	rules    storage.ParsingRuleRepository
+	rules    storage.ParserRuleRepository
 	samples  storage.SampleURLRepository
 	resolver *rule.Resolver
 	llm      pathinfer.LLMClient // nil 허용
@@ -118,7 +118,7 @@ func WithMetrics(m *Metrics) Option {
 // New 는 Refiner 를 생성합니다. rules / samples / resolver / log 가 nil 이면 error —
 // 호출자 (cmd/main) 가 boot fatal 처리. LLMClient 만 nil 허용 (algorithm-only 동작).
 func New(
-	rules storage.ParsingRuleRepository,
+	rules storage.ParserRuleRepository,
 	samples storage.SampleURLRepository,
 	resolver *rule.Resolver,
 	log *logger.Logger,
@@ -239,7 +239,7 @@ func (r *Refiner) Run(ctx context.Context) {
 // 모든 rule 의 단계별 실패는 cycle 안에서 흡수 (Warn 로그) — 함수는 cycle 자체의 치명적
 // 에러 (rule List 실패) 만 에러 반환. test 친화 — Run 외부에서 단발 호출 가능.
 func (r *Refiner) RunOnce(ctx context.Context) error {
-	candidates, err := r.rules.List(ctx, storage.ParsingRuleFilter{
+	candidates, err := r.rules.List(ctx, storage.ParserRuleFilter{
 		SourceName:  llmgen.LLMAutoSourceName,
 		OnlyEnabled: true,
 		Limit:       1000, // 운영상 llm-auto rule 은 호스트 수 만큼 — 1000 이면 충분.
@@ -260,7 +260,7 @@ func (r *Refiner) RunOnce(ctx context.Context) error {
 
 // refineOne 은 단일 rule 에 대한 정밀화 단계를 수행합니다.
 // 모든 단계 실패는 함수 내에서 Warn 로그 + 조용히 return — 호출자가 다음 rule 로 진행 가능.
-func (r *Refiner) refineOne(ctx context.Context, rec *storage.ParsingRuleRecord) {
+func (r *Refiner) refineOne(ctx context.Context, rec *storage.ParserRuleRecord) {
 	rlog := r.log.WithFields(map[string]interface{}{
 		"rule_id": rec.ID,
 		"host":    rec.HostPattern,
@@ -333,7 +333,7 @@ func (r *Refiner) refineOne(ctx context.Context, rec *storage.ParsingRuleRecord)
 	// 정렬로 v2 를 우선 시도하고 매칭 실패 시 v1 catch-all 로 자연 fallback.
 	//
 	// 새 record 의 selector / confidence / source / host / target / enabled 는 v1 의 값을 그대로 복사.
-	newRec := &storage.ParsingRuleRecord{
+	newRec := &storage.ParserRuleRecord{
 		SourceName:  rec.SourceName,
 		HostPattern: rec.HostPattern,
 		PathPattern: pattern,

--- a/internal/processor/parser/rule/refiner/wiring/wiring.go
+++ b/internal/processor/parser/rule/refiner/wiring/wiring.go
@@ -30,7 +30,7 @@ import (
 func Build(
 	provider llm.Provider,
 	promptLoader prompt.Loader,
-	rules storage.ParsingRuleRepository,
+	rules storage.ParserRuleRepository,
 	samples storage.SampleURLRepository,
 	resolver *rule.Resolver,
 	metricsRegistry *prometheus.Registry,

--- a/internal/processor/parser/rule/resolver.go
+++ b/internal/processor/parser/rule/resolver.go
@@ -33,9 +33,9 @@ const DefaultNegativeCacheTTL = 30 * time.Second
 // 부하 패턴 (소수의 동일 host 반복 lookup) 에는 충분.
 const DefaultMaxCacheEntries = 10_000
 
-// Resolver 는 URL 에서 host 를 추출해 storage.ParsingRuleRecord 를 조회합니다.
+// Resolver 는 URL 에서 host 를 추출해 storage.ParserRuleRecord 를 조회합니다.
 //
-// Resolver maps a URL to its active ParsingRule via host_pattern + target_type.
+// Resolver maps a URL to its active ParserRule via host_pattern + target_type.
 // In-memory cache (TTL based) 로 DB roundtrip 을 줄입니다 — 운영자는 새 rule enabled 후
 // 최대 DefaultCacheTTL 만큼 지연을 감수합니다.
 //
@@ -45,7 +45,7 @@ const DefaultMaxCacheEntries = 10_000
 //
 // goroutine-safe — sync.RWMutex 로 cache 보호. regex compile cache 는 sync.Map.
 type Resolver struct {
-	repo             storage.ParsingRuleRepository
+	repo             storage.ParserRuleRepository
 	cacheTTL         time.Duration
 	negativeCacheTTL time.Duration
 	maxEntries       int
@@ -89,7 +89,7 @@ type cacheKey struct {
 // 후보 슬라이스를 통째로 보관 — application 측 path 매칭은 매 호출마다 실행
 // (cache hit path 안에서 수행). 매칭 비용은 ms 미만 (regex 컴파일은 regexCache 로 분리).
 type cacheEntry struct {
-	candidates []*storage.ParsingRuleRecord // 빈 슬라이스 = negative cache
+	candidates []*storage.ParserRuleRecord // 빈 슬라이스 = negative cache
 	expiresAt  time.Time
 }
 
@@ -116,9 +116,9 @@ func WithMaxCacheEntries(n int) Option {
 	}
 }
 
-// NewResolver 는 ParsingRuleRepository 를 사용하는 Resolver 를 생성합니다.
+// NewResolver 는 ParserRuleRepository 를 사용하는 Resolver 를 생성합니다.
 // repo 가 nil 이면 error — 호출자 (cmd/main) 가 boot fatal 처리.
-func NewResolver(repo storage.ParsingRuleRepository, opts ...Option) (*Resolver, error) {
+func NewResolver(repo storage.ParserRuleRepository, opts ...Option) (*Resolver, error) {
 	if repo == nil {
 		return nil, errors.New("rule: NewResolver requires non-nil repo")
 	}
@@ -151,7 +151,7 @@ func NewResolver(repo storage.ParsingRuleRepository, opts ...Option) (*Resolver,
 //
 // 매칭 없음은 storage.ErrNotFound 가 아닌 rule.ErrNoRule 로 정규화 — 호출자가 errors.Is
 // 로 분기 가능 (예: LLM 자동 생성 fallback 트리거).
-func (r *Resolver) ResolveByURL(ctx context.Context, rawURL string, targetType storage.TargetType) (*storage.ParsingRuleRecord, error) {
+func (r *Resolver) ResolveByURL(ctx context.Context, rawURL string, targetType storage.TargetType) (*storage.ParserRuleRecord, error) {
 	host, path, err := extractHostPath(rawURL)
 	if err != nil {
 		return nil, &Error{Code: ErrInvalidURL, Message: err.Error(), URL: rawURL}
@@ -163,7 +163,7 @@ func (r *Resolver) ResolveByURL(ctx context.Context, rawURL string, targetType s
 //
 // host 는 정규화 (lowercase, 포트 제외) 된 상태로 전달 권장. path 는 URL.Path (rawpath 아님) —
 // 정규화는 호출자 책임.
-func (r *Resolver) Resolve(ctx context.Context, host, path string, targetType storage.TargetType) (*storage.ParsingRuleRecord, error) {
+func (r *Resolver) Resolve(ctx context.Context, host, path string, targetType storage.TargetType) (*storage.ParserRuleRecord, error) {
 	host = strings.ToLower(host)
 	key := cacheKey{host: host, targetType: targetType}
 
@@ -287,7 +287,7 @@ func (r *Resolver) HasAnyRule(ctx context.Context, host string, targetType stora
 
 // lookupCache 는 캐시 조회 결과를 반환합니다.
 // 반환값: (candidates, hit) — hit=true 이면 캐시 적용 (negative cache 는 빈 슬라이스).
-func (r *Resolver) lookupCache(key cacheKey) ([]*storage.ParsingRuleRecord, bool) {
+func (r *Resolver) lookupCache(key cacheKey) ([]*storage.ParserRuleRecord, bool) {
 	r.mu.RLock()
 	entry, ok := r.cache[key]
 	r.mu.RUnlock()
@@ -344,7 +344,7 @@ func (r *Resolver) evictHasAnyExpiringSoon() {
 
 // storeCache 는 후보 슬라이스를 저장합니다.
 // maxEntries 초과 시 evictExpiringSoon 으로 가장 만료 임박 entry 제거 후 저장.
-func (r *Resolver) storeCache(key cacheKey, candidates []*storage.ParsingRuleRecord, ttl time.Duration) {
+func (r *Resolver) storeCache(key cacheKey, candidates []*storage.ParserRuleRecord, ttl time.Duration) {
 	r.mu.Lock()
 	r.evictExpiringSoon()
 	r.cache[key] = cacheEntry{candidates: candidates, expiresAt: r.now().Add(ttl)}

--- a/internal/storage/parser_rule.go
+++ b/internal/storage/parser_rule.go
@@ -125,10 +125,10 @@ type LinkDiscoveryConfig struct {
 	MaxLinksPerPage int `json:"max_links_per_page,omitempty"`
 }
 
-// ParsingRuleRecord 는 parser_rules 테이블의 단일 행입니다.
+// ParserRuleRecord 는 parser_rules 테이블의 단일 행입니다.
 //
-// ParsingRuleRecord represents a single row of the parser_rules table.
-type ParsingRuleRecord struct {
+// ParserRuleRecord represents a single row of the parser_rules table.
+type ParserRuleRecord struct {
 	ID          int64
 	SourceName  string     // "naver" / "cnn"
 	HostPattern string     // URL host 매칭 (예: "n.news.naver.com")
@@ -171,8 +171,8 @@ type FieldConfidence struct {
 	SampleCount int     `json:"sample_count"`
 }
 
-// ParsingRuleFilter 는 List 조회 시 필터 조건입니다.
-type ParsingRuleFilter struct {
+// ParserRuleFilter 는 List 조회 시 필터 조건입니다.
+type ParserRuleFilter struct {
 	SourceName  string     // 빈 문자열이면 전체
 	HostPattern string     // 빈 문자열이면 전체
 	TargetType  TargetType // 빈 문자열이면 전체
@@ -181,18 +181,18 @@ type ParsingRuleFilter struct {
 	Offset      int
 }
 
-// ParsingRuleRepository 는 parser_rules 테이블에 대한 데이터 접근 인터페이스입니다.
+// ParserRuleRepository 는 parser_rules 테이블에 대한 데이터 접근 인터페이스입니다.
 //
-// ParsingRuleRepository is the data access interface for parser_rules.
+// ParserRuleRepository is the data access interface for parser_rules.
 // All implementations must be goroutine-safe.
-type ParsingRuleRepository interface {
+type ParserRuleRepository interface {
 	// Insert 는 새 규칙을 저장합니다. 자연키 충돌 시 ErrDuplicate 반환.
 	// 성공 시 r.ID 가 채워집니다.
-	Insert(ctx context.Context, r *ParsingRuleRecord) error
+	Insert(ctx context.Context, r *ParserRuleRecord) error
 
 	// Update 는 ID 로 규칙을 갱신합니다. 존재하지 않으면 ErrNotFound 반환.
 	// 갱신 가능 필드: Selectors, Enabled, Description (자연키는 변경 불가).
-	Update(ctx context.Context, r *ParsingRuleRecord) error
+	Update(ctx context.Context, r *ParserRuleRecord) error
 
 	// UpdatePathPattern 은 정밀화 워크플로 에서 호출 — path_pattern + description 갱신.
 	//
@@ -206,7 +206,7 @@ type ParsingRuleRepository interface {
 	UpdatePathPattern(ctx context.Context, id int64, pattern, description string) error
 
 	// GetByID 는 ID 로 규칙을 조회합니다.
-	GetByID(ctx context.Context, id int64) (*ParsingRuleRecord, error)
+	GetByID(ctx context.Context, id int64) (*ParserRuleRecord, error)
 
 	// FindActive 는 host + target_type 에 매칭되는 활성 규칙을 반환합니다 (RuleResolver 핫패스).
 	// 같은 (host, type) 에 여러 활성 row 가 있다면 version DESC 순으로 첫 항목 반환.
@@ -215,7 +215,7 @@ type ParsingRuleRepository interface {
 	// Deprecated: path_pattern 도입 후 후보 슬라이스를 한꺼번에 받아 application 측에서
 	// 매칭하는 FindActiveCandidates 사용 권장. 본 메소드는 후방 호환을 위해 유지 — 내부적으로
 	// FindActiveCandidates 의 첫 항목 (length DESC 정렬, '' 포함) 을 반환합니다.
-	FindActive(ctx context.Context, host string, targetType TargetType) (*ParsingRuleRecord, error)
+	FindActive(ctx context.Context, host string, targetType TargetType) (*ParserRuleRecord, error)
 
 	// InsertNextVersion 은 (source_name, host_pattern, path_pattern, target_type) 자연키의 다음
 	// version 으로 rec 을 INSERT 합니다.
@@ -232,7 +232,7 @@ type ParsingRuleRepository interface {
 	//   3. 자연키 충돌 (race window) 시 ErrDuplicate 반환 — 호출자 retry 또는 흡수
 	//
 	// rec.Version 은 입력 무관 (자동 계산). 성공 시 rec.ID / Version / CreatedAt / UpdatedAt 채워짐.
-	InsertNextVersion(ctx context.Context, r *ParsingRuleRecord) error
+	InsertNextVersion(ctx context.Context, r *ParserRuleRecord) error
 
 	// HasAnyRule 은 (host_pattern, target_type) 에 대한 룰 존재 여부를 반환합니다.
 	//
@@ -254,7 +254,7 @@ type ParsingRuleRepository interface {
 	// 회피하는 사전 lookup. Insert 시 ErrDuplicate 위반과 동일한 자연키를 검사합니다.
 	//
 	// 매칭 없으면 ErrNotFound.
-	FindByNaturalKey(ctx context.Context, sourceName, hostPattern, pathPattern string, targetType TargetType, version int) (*ParsingRuleRecord, error)
+	FindByNaturalKey(ctx context.Context, sourceName, hostPattern, pathPattern string, targetType TargetType, version int) (*ParserRuleRecord, error)
 
 	// FindActiveCandidates 는 host + target_type 매칭 활성 rule 들을 LENGTH(path_pattern) DESC,
 	// version DESC 정렬로 반환합니다.
@@ -263,10 +263,10 @@ type ParsingRuleRepository interface {
 	// path_pattern='' 인 row 는 길이 0 으로 가장 마지막에 위치 (catch-all).
 	//
 	// 매칭 없으면 빈 슬라이스 + nil 에러 (ErrNotFound 아님 — 호출자가 빈 슬라이스로 분기).
-	FindActiveCandidates(ctx context.Context, host string, targetType TargetType) ([]*ParsingRuleRecord, error)
+	FindActiveCandidates(ctx context.Context, host string, targetType TargetType) ([]*ParserRuleRecord, error)
 
 	// List 는 필터 조건에 맞는 규칙들을 반환합니다 (운영 대시보드용).
-	List(ctx context.Context, filter ParsingRuleFilter) ([]*ParsingRuleRecord, error)
+	List(ctx context.Context, filter ParserRuleFilter) ([]*ParserRuleRecord, error)
 
 	// Delete 는 ID 로 규칙을 삭제합니다. 존재하지 않아도 nil 반환 (idempotent).
 	Delete(ctx context.Context, id int64) error

--- a/internal/storage/parser_rule_invalidating.go
+++ b/internal/storage/parser_rule_invalidating.go
@@ -43,7 +43,7 @@ type invalidatingRepo struct {
 //
 // 사용 예 (cmd/issuetracker/main.go):
 //
-//	parserRuleRepo := pgstore.NewParsingRuleRepository(pool, log)
+//	parserRuleRepo := pgstore.NewParserRuleRepository(pool, log)
 //	parserRuleRepo = storage.WrapWithInvalidator(parserRuleRepo, ruleResolver)
 //
 // inner 가 nil 이면 panic — wiring 버그 (호출자가 nil 검사 필요).

--- a/internal/storage/parser_rule_invalidating.go
+++ b/internal/storage/parser_rule_invalidating.go
@@ -14,7 +14,7 @@ type CacheInvalidator interface {
 	Invalidate(host string, targetType TargetType)
 }
 
-// invalidatingRepo 는 ParsingRuleRepository 를 wrap 하여 mutation 메소드 호출 후 자동으로
+// invalidatingRepo 는 ParserRuleRepository 를 wrap 하여 mutation 메소드 호출 후 자동으로
 // CacheInvalidator.Invalidate 를 호출하는 decorator 입니다.
 //
 // 의도:
@@ -35,20 +35,20 @@ type CacheInvalidator interface {
 //
 // CacheInvalidator 가 nil 이면 noop wrapper — invalidate 만 skip 하고 inner 호출은 그대로 진행.
 type invalidatingRepo struct {
-	inner ParsingRuleRepository
+	inner ParserRuleRepository
 	inv   CacheInvalidator
 }
 
-// WrapWithInvalidator 는 ParsingRuleRepository 를 invalidatingRepo 로 wrap 합니다.
+// WrapWithInvalidator 는 ParserRuleRepository 를 invalidatingRepo 로 wrap 합니다.
 //
 // 사용 예 (cmd/issuetracker/main.go):
 //
-//	parsingRuleRepo := pgstore.NewParsingRuleRepository(pool, log)
-//	parsingRuleRepo = storage.WrapWithInvalidator(parsingRuleRepo, ruleResolver)
+//	parserRuleRepo := pgstore.NewParsingRuleRepository(pool, log)
+//	parserRuleRepo = storage.WrapWithInvalidator(parserRuleRepo, ruleResolver)
 //
 // inner 가 nil 이면 panic — wiring 버그 (호출자가 nil 검사 필요).
 // inv 가 nil 이면 wrapper 역할만 (invalidate skip, 향후 wiring 단계에서 쉽게 토글).
-func WrapWithInvalidator(inner ParsingRuleRepository, inv CacheInvalidator) ParsingRuleRepository {
+func WrapWithInvalidator(inner ParserRuleRepository, inv CacheInvalidator) ParserRuleRepository {
 	if inner == nil {
 		panic("storage: WrapWithInvalidator requires non-nil inner repository")
 	}
@@ -64,7 +64,7 @@ func (r *invalidatingRepo) invalidate(host string, t TargetType) {
 // InsertNextVersion wraps inner.InsertNextVersion + invalidates on success or ErrDuplicate.
 //
 // 같은 (host, target_type) 에 대한 재학습 시 cache 가 stale 일 수 있으므로 invalidate 보장.
-func (r *invalidatingRepo) InsertNextVersion(ctx context.Context, rec *ParsingRuleRecord) error {
+func (r *invalidatingRepo) InsertNextVersion(ctx context.Context, rec *ParserRuleRecord) error {
 	err := r.inner.InsertNextVersion(ctx, rec)
 	if err == nil || errors.Is(err, ErrDuplicate) {
 		r.invalidate(rec.HostPattern, rec.TargetType)
@@ -76,7 +76,7 @@ func (r *invalidatingRepo) InsertNextVersion(ctx context.Context, rec *ParsingRu
 //
 // ErrDuplicate 시에도 invalidate — INSERT 실패했지만 동일 자연키 row 가 이미 DB 에 존재하므로
 // cache 가 stale 일 가능성 (다른 인스턴스가 INSERT 했거나 운영자 manual).
-func (r *invalidatingRepo) Insert(ctx context.Context, rec *ParsingRuleRecord) error {
+func (r *invalidatingRepo) Insert(ctx context.Context, rec *ParserRuleRecord) error {
 	err := r.inner.Insert(ctx, rec)
 	if err == nil || errors.Is(err, ErrDuplicate) {
 		r.invalidate(rec.HostPattern, rec.TargetType)
@@ -85,7 +85,7 @@ func (r *invalidatingRepo) Insert(ctx context.Context, rec *ParsingRuleRecord) e
 }
 
 // Update wraps inner.Update + invalidates on success.
-func (r *invalidatingRepo) Update(ctx context.Context, rec *ParsingRuleRecord) error {
+func (r *invalidatingRepo) Update(ctx context.Context, rec *ParserRuleRecord) error {
 	err := r.inner.Update(ctx, rec)
 	if err == nil {
 		r.invalidate(rec.HostPattern, rec.TargetType)
@@ -128,15 +128,15 @@ func (r *invalidatingRepo) Delete(ctx context.Context, id int64) error {
 
 // 이하 read-only / find 메소드는 단순 위임 — invalidate 트리거 없음.
 
-func (r *invalidatingRepo) GetByID(ctx context.Context, id int64) (*ParsingRuleRecord, error) {
+func (r *invalidatingRepo) GetByID(ctx context.Context, id int64) (*ParserRuleRecord, error) {
 	return r.inner.GetByID(ctx, id)
 }
 
-func (r *invalidatingRepo) FindActive(ctx context.Context, host string, t TargetType) (*ParsingRuleRecord, error) {
+func (r *invalidatingRepo) FindActive(ctx context.Context, host string, t TargetType) (*ParserRuleRecord, error) {
 	return r.inner.FindActive(ctx, host, t)
 }
 
-func (r *invalidatingRepo) FindActiveCandidates(ctx context.Context, host string, t TargetType) ([]*ParsingRuleRecord, error) {
+func (r *invalidatingRepo) FindActiveCandidates(ctx context.Context, host string, t TargetType) ([]*ParserRuleRecord, error) {
 	return r.inner.FindActiveCandidates(ctx, host, t)
 }
 
@@ -144,13 +144,13 @@ func (r *invalidatingRepo) HasAnyRule(ctx context.Context, host string, t Target
 	return r.inner.HasAnyRule(ctx, host, t)
 }
 
-func (r *invalidatingRepo) FindByNaturalKey(ctx context.Context, sourceName, hostPattern, pathPattern string, t TargetType, version int) (*ParsingRuleRecord, error) {
+func (r *invalidatingRepo) FindByNaturalKey(ctx context.Context, sourceName, hostPattern, pathPattern string, t TargetType, version int) (*ParserRuleRecord, error) {
 	return r.inner.FindByNaturalKey(ctx, sourceName, hostPattern, pathPattern, t, version)
 }
 
-func (r *invalidatingRepo) List(ctx context.Context, f ParsingRuleFilter) ([]*ParsingRuleRecord, error) {
+func (r *invalidatingRepo) List(ctx context.Context, f ParserRuleFilter) ([]*ParserRuleRecord, error) {
 	return r.inner.List(ctx, f)
 }
 
 // 컴파일 타임 인터페이스 만족 검증.
-var _ ParsingRuleRepository = (*invalidatingRepo)(nil)
+var _ ParserRuleRepository = (*invalidatingRepo)(nil)

--- a/internal/storage/postgres/parser_rule.go
+++ b/internal/storage/postgres/parser_rule.go
@@ -17,17 +17,17 @@ import (
 	"issuetracker/pkg/logger"
 )
 
-// pgParsingRuleRepository 는 pgx/v5 기반 ParsingRuleRepository 구현체입니다.
+// pgParsingRuleRepository 는 pgx/v5 기반 ParserRuleRepository 구현체입니다.
 type pgParsingRuleRepository struct {
 	pool *pgxpool.Pool
 }
 
-// NewParsingRuleRepository 는 pgxpool 을 사용하는 ParsingRuleRepository 를 생성합니다.
+// NewParsingRuleRepository 는 pgxpool 을 사용하는 ParserRuleRepository 를 생성합니다.
 //
 // log 인자는 향후 query latency / error log 등 운영 가시성 추가를 대비해 시그니처에 유지하되,
 // 현재 구현에서는 사용하지 않습니다 (Gemini code review #8 — 미사용 필드 정리).
 // 다른 Repository 들 (NewContentRepository 등) 의 시그니처와 일관성을 위해 인자는 보존.
-func NewParsingRuleRepository(pool *pgxpool.Pool, log *logger.Logger) storage.ParsingRuleRepository {
+func NewParsingRuleRepository(pool *pgxpool.Pool, log *logger.Logger) storage.ParserRuleRepository {
 	_ = log
 	return &pgParsingRuleRepository{pool: pool}
 }
@@ -49,7 +49,7 @@ RETURNING id, created_at, updated_at
 // INSERT 시점에 거부하는 것이 운영 가시성 ↑ + DB 에 잘못된 row 진입 차단.
 //
 // 성공 시 r.ID / CreatedAt / UpdatedAt 가 채워집니다.
-func (r *pgParsingRuleRepository) Insert(ctx context.Context, rec *storage.ParsingRuleRecord) error {
+func (r *pgParsingRuleRepository) Insert(ctx context.Context, rec *storage.ParserRuleRecord) error {
 	if rec.PathPattern != "" {
 		if _, reErr := regexp.Compile(rec.PathPattern); reErr != nil {
 			return fmt.Errorf("%w: path_pattern %q is not a valid regex: %v", storage.ErrInvalid, rec.PathPattern, reErr)
@@ -93,7 +93,7 @@ RETURNING updated_at
 // confidence 도 함께 갱신 — selectors 만 바뀌고 confidence 가 stale
 // 로 남으면 하류 validator 가 잘못된 신뢰도로 판단. 호출자는 selectors 변경 시 confidence 도
 // 같이 채워서 전달 (또는 nil/빈 map 으로 reset).
-func (r *pgParsingRuleRepository) Update(ctx context.Context, rec *storage.ParsingRuleRecord) error {
+func (r *pgParsingRuleRepository) Update(ctx context.Context, rec *storage.ParserRuleRecord) error {
 	selectors, err := json.Marshal(rec.Selectors)
 	if err != nil {
 		return fmt.Errorf("marshal selectors: %w", err)
@@ -157,7 +157,7 @@ WHERE id = $1
 `
 
 // GetByID 는 ID 로 규칙을 조회합니다.
-func (r *pgParsingRuleRepository) GetByID(ctx context.Context, id int64) (*storage.ParsingRuleRecord, error) {
+func (r *pgParsingRuleRepository) GetByID(ctx context.Context, id int64) (*storage.ParserRuleRecord, error) {
 	row := r.pool.QueryRow(ctx, sqlGetParsingRuleByID, id)
 	rec, err := scanParsingRule(row)
 	if err != nil {
@@ -186,7 +186,7 @@ WHERE source_name  = $1
 //
 // 용도: llmgen.Generator 가 LLM 호출 전 사전 lookup 으로 사용. 이미 같은 자연키 룰이
 // 존재하면 LLM 호출 (~55s sonnet) 을 회피하여 비용 절감.
-func (r *pgParsingRuleRepository) FindByNaturalKey(ctx context.Context, sourceName, hostPattern, pathPattern string, targetType storage.TargetType, version int) (*storage.ParsingRuleRecord, error) {
+func (r *pgParsingRuleRepository) FindByNaturalKey(ctx context.Context, sourceName, hostPattern, pathPattern string, targetType storage.TargetType, version int) (*storage.ParserRuleRecord, error) {
 	row := r.pool.QueryRow(ctx, sqlFindParsingRuleByNaturalKey,
 		sourceName, hostPattern, pathPattern, string(targetType), version,
 	)
@@ -213,7 +213,7 @@ WHERE source_name = $1
 //
 // race window: MAX 조회와 INSERT 사이에 다른 인스턴스가 같은 version 을 INSERT 할 수 있음.
 // 자연키 unique 제약이 ErrDuplicate 로 반응 — 호출자가 retry 또는 흡수 책임.
-func (r *pgParsingRuleRepository) InsertNextVersion(ctx context.Context, rec *storage.ParsingRuleRecord) error {
+func (r *pgParsingRuleRepository) InsertNextVersion(ctx context.Context, rec *storage.ParserRuleRecord) error {
 	if rec.PathPattern != "" {
 		if _, reErr := regexp.Compile(rec.PathPattern); reErr != nil {
 			return fmt.Errorf("%w: path_pattern %q is not a valid regex: %v", storage.ErrInvalid, rec.PathPattern, reErr)
@@ -274,7 +274,7 @@ ORDER BY LENGTH(path_pattern) DESC, version DESC
 // Deprecated: path_pattern 도입 후 후보 슬라이스를 받아 application 측에서 path 매칭하는
 // FindActiveCandidates 사용 권장. 본 메소드는 호출자 호환을 위해 유지 — 내부적으로 후보 슬라이스의
 // 첫 항목 (가장 구체적 또는 최신) 을 반환. ErrNotFound 시 storage.ErrNotFound.
-func (r *pgParsingRuleRepository) FindActive(ctx context.Context, host string, targetType storage.TargetType) (*storage.ParsingRuleRecord, error) {
+func (r *pgParsingRuleRepository) FindActive(ctx context.Context, host string, targetType storage.TargetType) (*storage.ParserRuleRecord, error) {
 	candidates, err := r.FindActiveCandidates(ctx, host, targetType)
 	if err != nil {
 		return nil, err
@@ -289,14 +289,14 @@ func (r *pgParsingRuleRepository) FindActive(ctx context.Context, host string, t
 // version DESC 정렬로 반환합니다.
 //
 // 매칭 없으면 빈 슬라이스 + nil 에러 (호출자가 빈 슬라이스로 분기).
-func (r *pgParsingRuleRepository) FindActiveCandidates(ctx context.Context, host string, targetType storage.TargetType) ([]*storage.ParsingRuleRecord, error) {
+func (r *pgParsingRuleRepository) FindActiveCandidates(ctx context.Context, host string, targetType storage.TargetType) ([]*storage.ParserRuleRecord, error) {
 	rows, err := r.pool.Query(ctx, sqlFindActiveCandidates, host, string(targetType))
 	if err != nil {
 		return nil, fmt.Errorf("find active candidates (%s, %s): %w", host, targetType, err)
 	}
 	defer rows.Close()
 
-	var out []*storage.ParsingRuleRecord
+	var out []*storage.ParserRuleRecord
 	for rows.Next() {
 		rec, scanErr := scanParsingRule(rows)
 		if scanErr != nil {
@@ -311,7 +311,7 @@ func (r *pgParsingRuleRepository) FindActiveCandidates(ctx context.Context, host
 }
 
 // List 는 필터 조건에 맞는 규칙들을 반환합니다.
-func (r *pgParsingRuleRepository) List(ctx context.Context, f storage.ParsingRuleFilter) ([]*storage.ParsingRuleRecord, error) {
+func (r *pgParsingRuleRepository) List(ctx context.Context, f storage.ParserRuleFilter) ([]*storage.ParserRuleRecord, error) {
 	limit := f.Limit
 	if limit <= 0 {
 		limit = 50
@@ -352,7 +352,7 @@ WHERE 1=1`
 	}
 	defer rows.Close()
 
-	var out []*storage.ParsingRuleRecord
+	var out []*storage.ParserRuleRecord
 	for rows.Next() {
 		rec, err := scanParsingRule(rows)
 		if err != nil {
@@ -376,10 +376,10 @@ func (r *pgParsingRuleRepository) Delete(ctx context.Context, id int64) error {
 	return nil
 }
 
-// scanParsingRule 은 Row/Rows 에서 ParsingRuleRecord 를 스캔합니다.
+// scanParsingRule 은 Row/Rows 에서 ParserRuleRecord 를 스캔합니다.
 // selectors / confidence 는 raw JSONB → application struct 로 unmarshal.
-func scanParsingRule(s scanner) (*storage.ParsingRuleRecord, error) {
-	rec := &storage.ParsingRuleRecord{}
+func scanParsingRule(s scanner) (*storage.ParserRuleRecord, error) {
+	rec := &storage.ParserRuleRecord{}
 	var selectorsRaw, confidenceRaw []byte
 	var targetType string
 	if err := s.Scan(

--- a/internal/storage/postgres/parser_rule.go
+++ b/internal/storage/postgres/parser_rule.go
@@ -17,22 +17,22 @@ import (
 	"issuetracker/pkg/logger"
 )
 
-// pgParsingRuleRepository 는 pgx/v5 기반 ParserRuleRepository 구현체입니다.
-type pgParsingRuleRepository struct {
+// pgParserRuleRepository 는 pgx/v5 기반 ParserRuleRepository 구현체입니다.
+type pgParserRuleRepository struct {
 	pool *pgxpool.Pool
 }
 
-// NewParsingRuleRepository 는 pgxpool 을 사용하는 ParserRuleRepository 를 생성합니다.
+// NewParserRuleRepository 는 pgxpool 을 사용하는 ParserRuleRepository 를 생성합니다.
 //
 // log 인자는 향후 query latency / error log 등 운영 가시성 추가를 대비해 시그니처에 유지하되,
 // 현재 구현에서는 사용하지 않습니다 (Gemini code review #8 — 미사용 필드 정리).
 // 다른 Repository 들 (NewContentRepository 등) 의 시그니처와 일관성을 위해 인자는 보존.
-func NewParsingRuleRepository(pool *pgxpool.Pool, log *logger.Logger) storage.ParserRuleRepository {
+func NewParserRuleRepository(pool *pgxpool.Pool, log *logger.Logger) storage.ParserRuleRepository {
 	_ = log
-	return &pgParsingRuleRepository{pool: pool}
+	return &pgParserRuleRepository{pool: pool}
 }
 
-const sqlInsertParsingRule = `
+const sqlInsertParserRule = `
 INSERT INTO parser_rules (
   source_name, host_pattern, path_pattern, target_type, version, enabled, selectors, confidence, description, page_type
 ) VALUES (
@@ -49,7 +49,7 @@ RETURNING id, created_at, updated_at
 // INSERT 시점에 거부하는 것이 운영 가시성 ↑ + DB 에 잘못된 row 진입 차단.
 //
 // 성공 시 r.ID / CreatedAt / UpdatedAt 가 채워집니다.
-func (r *pgParsingRuleRepository) Insert(ctx context.Context, rec *storage.ParserRuleRecord) error {
+func (r *pgParserRuleRepository) Insert(ctx context.Context, rec *storage.ParserRuleRecord) error {
 	if rec.PathPattern != "" {
 		if _, reErr := regexp.Compile(rec.PathPattern); reErr != nil {
 			return fmt.Errorf("%w: path_pattern %q is not a valid regex: %v", storage.ErrInvalid, rec.PathPattern, reErr)
@@ -66,7 +66,7 @@ func (r *pgParsingRuleRepository) Insert(ctx context.Context, rec *storage.Parse
 	if rec.Version == 0 {
 		rec.Version = 1
 	}
-	row := r.pool.QueryRow(ctx, sqlInsertParsingRule,
+	row := r.pool.QueryRow(ctx, sqlInsertParserRule,
 		rec.SourceName, rec.HostPattern, rec.PathPattern, string(rec.TargetType), rec.Version,
 		rec.Enabled, selectors, confidence, rec.Description, rec.PageType,
 	)
@@ -80,7 +80,7 @@ func (r *pgParsingRuleRepository) Insert(ctx context.Context, rec *storage.Parse
 	return nil
 }
 
-const sqlUpdateParsingRule = `
+const sqlUpdateParserRule = `
 UPDATE parser_rules
 SET selectors = $2, confidence = $3, enabled = $4, description = $5
 WHERE id = $1
@@ -93,7 +93,7 @@ RETURNING updated_at
 // confidence 도 함께 갱신 — selectors 만 바뀌고 confidence 가 stale
 // 로 남으면 하류 validator 가 잘못된 신뢰도로 판단. 호출자는 selectors 변경 시 confidence 도
 // 같이 채워서 전달 (또는 nil/빈 map 으로 reset).
-func (r *pgParsingRuleRepository) Update(ctx context.Context, rec *storage.ParserRuleRecord) error {
+func (r *pgParserRuleRepository) Update(ctx context.Context, rec *storage.ParserRuleRecord) error {
 	selectors, err := json.Marshal(rec.Selectors)
 	if err != nil {
 		return fmt.Errorf("marshal selectors: %w", err)
@@ -102,7 +102,7 @@ func (r *pgParsingRuleRepository) Update(ctx context.Context, rec *storage.Parse
 	if err != nil {
 		return fmt.Errorf("marshal confidence: %w", err)
 	}
-	row := r.pool.QueryRow(ctx, sqlUpdateParsingRule, rec.ID, selectors, confidence, rec.Enabled, rec.Description)
+	row := r.pool.QueryRow(ctx, sqlUpdateParserRule, rec.ID, selectors, confidence, rec.Enabled, rec.Description)
 	if err := row.Scan(&rec.UpdatedAt); err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			return storage.ErrNotFound
@@ -134,7 +134,7 @@ RETURNING updated_at
 //
 // pattern != "" 이면 RE2 컴파일 검증 (Insert 와 동일 정책) — 실패 시 storage.ErrInvalid.
 // rule 이 미존재하거나 catch-all + llm-auto + enabled 상태가 아니면 storage.ErrNotFound.
-func (r *pgParsingRuleRepository) UpdatePathPattern(ctx context.Context, id int64, pattern, description string) error {
+func (r *pgParserRuleRepository) UpdatePathPattern(ctx context.Context, id int64, pattern, description string) error {
 	if pattern != "" {
 		if _, reErr := regexp.Compile(pattern); reErr != nil {
 			return fmt.Errorf("%w: path_pattern %q is not a valid regex: %v", storage.ErrInvalid, pattern, reErr)
@@ -150,16 +150,16 @@ func (r *pgParsingRuleRepository) UpdatePathPattern(ctx context.Context, id int6
 	return nil
 }
 
-const sqlGetParsingRuleByID = `
+const sqlGetParserRuleByID = `
 SELECT id, source_name, host_pattern, path_pattern, target_type, version, enabled, selectors, confidence, description, page_type, created_at, updated_at
 FROM parser_rules
 WHERE id = $1
 `
 
 // GetByID 는 ID 로 규칙을 조회합니다.
-func (r *pgParsingRuleRepository) GetByID(ctx context.Context, id int64) (*storage.ParserRuleRecord, error) {
-	row := r.pool.QueryRow(ctx, sqlGetParsingRuleByID, id)
-	rec, err := scanParsingRule(row)
+func (r *pgParserRuleRepository) GetByID(ctx context.Context, id int64) (*storage.ParserRuleRecord, error) {
+	row := r.pool.QueryRow(ctx, sqlGetParserRuleByID, id)
+	rec, err := scanParserRule(row)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			return nil, storage.ErrNotFound
@@ -169,7 +169,7 @@ func (r *pgParsingRuleRepository) GetByID(ctx context.Context, id int64) (*stora
 	return rec, nil
 }
 
-const sqlFindParsingRuleByNaturalKey = `
+const sqlFindParserRuleByNaturalKey = `
 SELECT id, source_name, host_pattern, path_pattern, target_type, version, enabled, selectors, confidence, description, page_type, created_at, updated_at
 FROM parser_rules
 WHERE source_name  = $1
@@ -186,11 +186,11 @@ WHERE source_name  = $1
 //
 // 용도: llmgen.Generator 가 LLM 호출 전 사전 lookup 으로 사용. 이미 같은 자연키 룰이
 // 존재하면 LLM 호출 (~55s sonnet) 을 회피하여 비용 절감.
-func (r *pgParsingRuleRepository) FindByNaturalKey(ctx context.Context, sourceName, hostPattern, pathPattern string, targetType storage.TargetType, version int) (*storage.ParserRuleRecord, error) {
-	row := r.pool.QueryRow(ctx, sqlFindParsingRuleByNaturalKey,
+func (r *pgParserRuleRepository) FindByNaturalKey(ctx context.Context, sourceName, hostPattern, pathPattern string, targetType storage.TargetType, version int) (*storage.ParserRuleRecord, error) {
+	row := r.pool.QueryRow(ctx, sqlFindParserRuleByNaturalKey,
 		sourceName, hostPattern, pathPattern, string(targetType), version,
 	)
-	rec, err := scanParsingRule(row)
+	rec, err := scanParserRule(row)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			return nil, storage.ErrNotFound
@@ -213,7 +213,7 @@ WHERE source_name = $1
 //
 // race window: MAX 조회와 INSERT 사이에 다른 인스턴스가 같은 version 을 INSERT 할 수 있음.
 // 자연키 unique 제약이 ErrDuplicate 로 반응 — 호출자가 retry 또는 흡수 책임.
-func (r *pgParsingRuleRepository) InsertNextVersion(ctx context.Context, rec *storage.ParserRuleRecord) error {
+func (r *pgParserRuleRepository) InsertNextVersion(ctx context.Context, rec *storage.ParserRuleRecord) error {
 	if rec.PathPattern != "" {
 		if _, reErr := regexp.Compile(rec.PathPattern); reErr != nil {
 			return fmt.Errorf("%w: path_pattern %q is not a valid regex: %v", storage.ErrInvalid, rec.PathPattern, reErr)
@@ -246,7 +246,7 @@ WHERE host_pattern=$1 AND target_type=$2
 //
 // FindActiveCandidates 와 달리 enabled 필터 없음 — disabled 룰도 \"존재함\" 으로 카운트.
 // 결과는 (exists, hasEnabled).
-func (r *pgParsingRuleRepository) HasAnyRule(ctx context.Context, hostPattern string, targetType storage.TargetType) (bool, bool, error) {
+func (r *pgParserRuleRepository) HasAnyRule(ctx context.Context, hostPattern string, targetType storage.TargetType) (bool, bool, error) {
 	row := r.pool.QueryRow(ctx, sqlHasAnyRule, hostPattern, string(targetType))
 	var exists, hasEnabled bool
 	if err := row.Scan(&exists, &hasEnabled); err != nil {
@@ -274,7 +274,7 @@ ORDER BY LENGTH(path_pattern) DESC, version DESC
 // Deprecated: path_pattern 도입 후 후보 슬라이스를 받아 application 측에서 path 매칭하는
 // FindActiveCandidates 사용 권장. 본 메소드는 호출자 호환을 위해 유지 — 내부적으로 후보 슬라이스의
 // 첫 항목 (가장 구체적 또는 최신) 을 반환. ErrNotFound 시 storage.ErrNotFound.
-func (r *pgParsingRuleRepository) FindActive(ctx context.Context, host string, targetType storage.TargetType) (*storage.ParserRuleRecord, error) {
+func (r *pgParserRuleRepository) FindActive(ctx context.Context, host string, targetType storage.TargetType) (*storage.ParserRuleRecord, error) {
 	candidates, err := r.FindActiveCandidates(ctx, host, targetType)
 	if err != nil {
 		return nil, err
@@ -289,7 +289,7 @@ func (r *pgParsingRuleRepository) FindActive(ctx context.Context, host string, t
 // version DESC 정렬로 반환합니다.
 //
 // 매칭 없으면 빈 슬라이스 + nil 에러 (호출자가 빈 슬라이스로 분기).
-func (r *pgParsingRuleRepository) FindActiveCandidates(ctx context.Context, host string, targetType storage.TargetType) ([]*storage.ParserRuleRecord, error) {
+func (r *pgParserRuleRepository) FindActiveCandidates(ctx context.Context, host string, targetType storage.TargetType) ([]*storage.ParserRuleRecord, error) {
 	rows, err := r.pool.Query(ctx, sqlFindActiveCandidates, host, string(targetType))
 	if err != nil {
 		return nil, fmt.Errorf("find active candidates (%s, %s): %w", host, targetType, err)
@@ -298,7 +298,7 @@ func (r *pgParsingRuleRepository) FindActiveCandidates(ctx context.Context, host
 
 	var out []*storage.ParserRuleRecord
 	for rows.Next() {
-		rec, scanErr := scanParsingRule(rows)
+		rec, scanErr := scanParserRule(rows)
 		if scanErr != nil {
 			return nil, fmt.Errorf("scan candidate: %w", scanErr)
 		}
@@ -311,7 +311,7 @@ func (r *pgParsingRuleRepository) FindActiveCandidates(ctx context.Context, host
 }
 
 // List 는 필터 조건에 맞는 규칙들을 반환합니다.
-func (r *pgParsingRuleRepository) List(ctx context.Context, f storage.ParserRuleFilter) ([]*storage.ParserRuleRecord, error) {
+func (r *pgParserRuleRepository) List(ctx context.Context, f storage.ParserRuleFilter) ([]*storage.ParserRuleRecord, error) {
 	limit := f.Limit
 	if limit <= 0 {
 		limit = 50
@@ -354,7 +354,7 @@ WHERE 1=1`
 
 	var out []*storage.ParserRuleRecord
 	for rows.Next() {
-		rec, err := scanParsingRule(rows)
+		rec, err := scanParserRule(rows)
 		if err != nil {
 			return nil, fmt.Errorf("scan parsing rule row: %w", err)
 		}
@@ -366,19 +366,19 @@ WHERE 1=1`
 	return out, nil
 }
 
-const sqlDeleteParsingRule = `DELETE FROM parser_rules WHERE id = $1`
+const sqlDeleteParserRule = `DELETE FROM parser_rules WHERE id = $1`
 
 // Delete 는 ID 로 규칙을 삭제합니다 (idempotent — 미존재여도 nil).
-func (r *pgParsingRuleRepository) Delete(ctx context.Context, id int64) error {
-	if _, err := r.pool.Exec(ctx, sqlDeleteParsingRule, id); err != nil {
+func (r *pgParserRuleRepository) Delete(ctx context.Context, id int64) error {
+	if _, err := r.pool.Exec(ctx, sqlDeleteParserRule, id); err != nil {
 		return fmt.Errorf("delete parsing rule %d: %w", id, err)
 	}
 	return nil
 }
 
-// scanParsingRule 은 Row/Rows 에서 ParserRuleRecord 를 스캔합니다.
+// scanParserRule 은 Row/Rows 에서 ParserRuleRecord 를 스캔합니다.
 // selectors / confidence 는 raw JSONB → application struct 로 unmarshal.
-func scanParsingRule(s scanner) (*storage.ParserRuleRecord, error) {
+func scanParserRule(s scanner) (*storage.ParserRuleRecord, error) {
 	rec := &storage.ParserRuleRecord{}
 	var selectorsRaw, confidenceRaw []byte
 	var targetType string

--- a/internal/storage/postgres/sample_url.go
+++ b/internal/storage/postgres/sample_url.go
@@ -20,7 +20,7 @@ type pgSampleURLRepository struct {
 
 // NewSampleURLRepository 는 pgxpool 을 사용하는 SampleURLRepository 를 생성합니다.
 //
-// log 는 다른 Repository 와 시그니처 일관성을 위해 인자에 유지하지만 현재 미사용 (NewParsingRuleRepository
+// log 는 다른 Repository 와 시그니처 일관성을 위해 인자에 유지하지만 현재 미사용 (NewParserRuleRepository
 // 와 동일 패턴 — Gemini code review #8).
 func NewSampleURLRepository(pool *pgxpool.Pool, log *logger.Logger) storage.SampleURLRepository {
 	_ = log

--- a/test/internal/processor/parser/rule/discovery_test.go
+++ b/test/internal/processor/parser/rule/discovery_test.go
@@ -44,8 +44,8 @@ const fullPageHTML = `
 </body></html>
 `
 
-func discoveryRule(cfg *storage.LinkDiscoveryConfig) *storage.ParsingRuleRecord {
-	return &storage.ParsingRuleRecord{
+func discoveryRule(cfg *storage.LinkDiscoveryConfig) *storage.ParserRuleRecord {
+	return &storage.ParserRuleRecord{
 		ID:          3,
 		SourceName:  "test",
 		HostPattern: "news.example.com",
@@ -418,7 +418,7 @@ func TestParser_ParseLinks_RoutesToDiscoveryWhenPatternSet(t *testing.T) {
 		ArticleURLPattern: `/article/\d{4}/\d{2}/\d{2}/`,
 		SameOriginOnly:    true,
 	}
-	repo := &fakeRepo{rules: []*storage.ParsingRuleRecord{discoveryRule(cfg)}}
+	repo := &fakeRepo{rules: []*storage.ParserRuleRecord{discoveryRule(cfg)}}
 	res, _ := rule.NewResolver(repo)
 	p, _ := rule.NewParser(res)
 
@@ -429,7 +429,7 @@ func TestParser_ParseLinks_RoutesToDiscoveryWhenPatternSet(t *testing.T) {
 
 func TestParser_ParseLinks_FallsBackToItemContainerWhenPatternEmpty(t *testing.T) {
 	// LinkDiscovery 가 nil → 기존 ItemContainer 경로 사용
-	repo := &fakeRepo{rules: []*storage.ParsingRuleRecord{listRule()}}
+	repo := &fakeRepo{rules: []*storage.ParserRuleRecord{listRule()}}
 	res, _ := rule.NewResolver(repo)
 	p, _ := rule.NewParser(res)
 
@@ -453,7 +453,7 @@ func TestParser_ParseLinks_LinkDiscoveryWithEmptyPattern_AllPassDiscovery(t *tes
 	}
 	// ItemContainer 를 매칭 0건 selector 로 변경 — fallback 진입 시 ErrParseFailure 보장
 	r.Selectors.ItemContainer = &storage.FieldSelector{CSS: "div.no-such-class-anywhere"}
-	repo := &fakeRepo{rules: []*storage.ParsingRuleRecord{r}}
+	repo := &fakeRepo{rules: []*storage.ParserRuleRecord{r}}
 	res, _ := rule.NewResolver(repo)
 	p, _ := rule.NewParser(res)
 

--- a/test/internal/processor/parser/rule/llmgen/enriched_extractor_test.go
+++ b/test/internal/processor/parser/rule/llmgen/enriched_extractor_test.go
@@ -113,7 +113,7 @@ func TestGenerator_EnrichedExtractor_BlacklistBranch(t *testing.T) {
 	g.Stop(stopCtx)
 
 	// 셀렉터 INSERT skip 검증.
-	assert.Empty(t, repo.inserts(), "blacklist 분기 시 ParsingRuleRepository.Insert 발생 X")
+	assert.Empty(t, repo.inserts(), "blacklist 분기 시 ParserRuleRepository.Insert 발생 X")
 	assert.Equal(t, 1, extractor.callCount(), "ExtractEnriched 1회 호출")
 
 	// Blacklist Insert 1회 검증 + 페이로드 확인.
@@ -129,7 +129,7 @@ func TestGenerator_EnrichedExtractor_BlacklistBranch(t *testing.T) {
 }
 
 // TestGenerator_EnrichedExtractor_Ok_PageTypeStored 는 validity=ok 분기에서 PageType 이
-// 정상으로 ParsingRuleRecord 에 저장되는지 검증합니다.
+// 정상으로 ParserRuleRecord 에 저장되는지 검증합니다.
 func TestGenerator_EnrichedExtractor_Ok_PageTypeStored(t *testing.T) {
 	provider := &fakeProvider{name: "gemini-flash", response: "{}"}
 	repo := &recordingRepo{}
@@ -155,7 +155,7 @@ func TestGenerator_EnrichedExtractor_Ok_PageTypeStored(t *testing.T) {
 
 	recs := repo.inserts()
 	require.Len(t, recs, 1)
-	assert.Equal(t, "news", recs[0].PageType, "ExtractResult.PageType 가 ParsingRuleRecord.PageType 에 저장")
+	assert.Equal(t, "news", recs[0].PageType, "ExtractResult.PageType 가 ParserRuleRecord.PageType 에 저장")
 }
 
 // TestGenerator_EnrichedExtractor_BlacklistRepoNil_StillSkipsInsert 는 blacklistRepo 가

--- a/test/internal/processor/parser/rule/llmgen/generator_test.go
+++ b/test/internal/processor/parser/rule/llmgen/generator_test.go
@@ -50,14 +50,14 @@ func (p *fakeProvider) callCount() int {
 	return p.calls
 }
 
-// recordingRepo 는 Insert 호출을 기록하는 ParsingRuleRepository 구현입니다.
+// recordingRepo 는 Insert 호출을 기록하는 ParserRuleRepository 구현입니다.
 type recordingRepo struct {
 	mu       sync.Mutex
-	inserted []*storage.ParsingRuleRecord
+	inserted []*storage.ParserRuleRecord
 	insertEr error
 
 	// findByNaturalKeyResult: 사전 lookup 시뮬레이션 (이슈 #274). nil 이면 ErrNotFound.
-	findByNaturalKeyResult *storage.ParsingRuleRecord
+	findByNaturalKeyResult *storage.ParserRuleRecord
 	// findByNaturalKeyErr: 설정 시 result 무시하고 본 에러 반환 (PR #275 리뷰 — DB 장애 시뮬레이션).
 	findByNaturalKeyErr   error
 	findByNaturalKeyCalls int
@@ -68,7 +68,7 @@ type recordingRepo struct {
 	insertNextVersionCalls int
 }
 
-func (r *recordingRepo) Insert(_ context.Context, rec *storage.ParsingRuleRecord) error {
+func (r *recordingRepo) Insert(_ context.Context, rec *storage.ParserRuleRecord) error {
 	if r.insertEr != nil {
 		return r.insertEr
 	}
@@ -80,20 +80,20 @@ func (r *recordingRepo) Insert(_ context.Context, rec *storage.ParsingRuleRecord
 	r.inserted = append(r.inserted, &clone)
 	return nil
 }
-func (r *recordingRepo) Update(_ context.Context, _ *storage.ParsingRuleRecord) error { return nil }
-func (r *recordingRepo) GetByID(_ context.Context, _ int64) (*storage.ParsingRuleRecord, error) {
+func (r *recordingRepo) Update(_ context.Context, _ *storage.ParserRuleRecord) error { return nil }
+func (r *recordingRepo) GetByID(_ context.Context, _ int64) (*storage.ParserRuleRecord, error) {
 	return nil, storage.ErrNotFound
 }
-func (r *recordingRepo) FindActive(_ context.Context, _ string, _ storage.TargetType) (*storage.ParsingRuleRecord, error) {
+func (r *recordingRepo) FindActive(_ context.Context, _ string, _ storage.TargetType) (*storage.ParserRuleRecord, error) {
 	return nil, storage.ErrNotFound
 }
-func (r *recordingRepo) FindActiveCandidates(_ context.Context, _ string, _ storage.TargetType) ([]*storage.ParsingRuleRecord, error) {
+func (r *recordingRepo) FindActiveCandidates(_ context.Context, _ string, _ storage.TargetType) ([]*storage.ParserRuleRecord, error) {
 	return nil, nil
 }
 func (r *recordingRepo) HasAnyRule(_ context.Context, _ string, _ storage.TargetType) (bool, bool, error) {
 	return false, false, nil
 }
-func (r *recordingRepo) InsertNextVersion(ctx context.Context, rec *storage.ParsingRuleRecord) error {
+func (r *recordingRepo) InsertNextVersion(ctx context.Context, rec *storage.ParserRuleRecord) error {
 	r.mu.Lock()
 	r.insertNextVersionCalls++
 	// 자연키 (source, host, path, type) 동일 row 의 MAX(version)+1 시뮬레이션 — postgres 구현과 일치.
@@ -112,7 +112,7 @@ func (r *recordingRepo) InsertNextVersion(ctx context.Context, rec *storage.Pars
 	r.mu.Unlock()
 	return r.Insert(ctx, rec)
 }
-func (r *recordingRepo) FindByNaturalKey(_ context.Context, _, _, _ string, _ storage.TargetType, _ int) (*storage.ParsingRuleRecord, error) {
+func (r *recordingRepo) FindByNaturalKey(_ context.Context, _, _, _ string, _ storage.TargetType, _ int) (*storage.ParserRuleRecord, error) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	r.findByNaturalKeyCalls++
@@ -124,17 +124,17 @@ func (r *recordingRepo) FindByNaturalKey(_ context.Context, _, _, _ string, _ st
 	}
 	return nil, storage.ErrNotFound
 }
-func (r *recordingRepo) List(_ context.Context, _ storage.ParsingRuleFilter) ([]*storage.ParsingRuleRecord, error) {
+func (r *recordingRepo) List(_ context.Context, _ storage.ParserRuleFilter) ([]*storage.ParserRuleRecord, error) {
 	return nil, nil
 }
 func (r *recordingRepo) Delete(_ context.Context, _ int64) error { return nil }
 func (r *recordingRepo) UpdatePathPattern(_ context.Context, _ int64, _, _ string) error {
 	return nil
 }
-func (r *recordingRepo) inserts() []*storage.ParsingRuleRecord {
+func (r *recordingRepo) inserts() []*storage.ParserRuleRecord {
 	r.mu.Lock()
 	defer r.mu.Unlock()
-	out := make([]*storage.ParsingRuleRecord, len(r.inserted))
+	out := make([]*storage.ParserRuleRecord, len(r.inserted))
 	copy(out, r.inserted)
 	return out
 }
@@ -165,7 +165,7 @@ var testPromptLoader = prompt.MapLoader{
 	"llmgen/list.user": "host={{HOST}} type={{TARGET_TYPE}} html={{HTML}}",
 }
 
-func newGenerator(t *testing.T, provider llm.Provider, repo storage.ParsingRuleRepository) (*llmgen.Generator, *rule.Resolver) {
+func newGenerator(t *testing.T, provider llm.Provider, repo storage.ParserRuleRepository) (*llmgen.Generator, *rule.Resolver) {
 	t.Helper()
 	resolver, _ := rule.NewResolver(&noopFindRepo{}, rule.WithCacheTTL(time.Minute))
 	g, err := llmgen.New(provider, repo, resolver, testPromptLoader, logger.New(logger.DefaultConfig()))
@@ -173,30 +173,30 @@ func newGenerator(t *testing.T, provider llm.Provider, repo storage.ParsingRuleR
 	return g, resolver
 }
 
-// noopFindRepo: Resolver 가 요구하는 ParsingRuleRepository 인터페이스를 만족하는 stub.
+// noopFindRepo: Resolver 가 요구하는 ParserRuleRepository 인터페이스를 만족하는 stub.
 type noopFindRepo struct{}
 
-func (noopFindRepo) Insert(_ context.Context, _ *storage.ParsingRuleRecord) error { return nil }
-func (noopFindRepo) Update(_ context.Context, _ *storage.ParsingRuleRecord) error { return nil }
-func (noopFindRepo) GetByID(_ context.Context, _ int64) (*storage.ParsingRuleRecord, error) {
+func (noopFindRepo) Insert(_ context.Context, _ *storage.ParserRuleRecord) error { return nil }
+func (noopFindRepo) Update(_ context.Context, _ *storage.ParserRuleRecord) error { return nil }
+func (noopFindRepo) GetByID(_ context.Context, _ int64) (*storage.ParserRuleRecord, error) {
 	return nil, storage.ErrNotFound
 }
-func (noopFindRepo) FindActive(_ context.Context, _ string, _ storage.TargetType) (*storage.ParsingRuleRecord, error) {
+func (noopFindRepo) FindActive(_ context.Context, _ string, _ storage.TargetType) (*storage.ParserRuleRecord, error) {
 	return nil, storage.ErrNotFound
 }
-func (noopFindRepo) FindActiveCandidates(_ context.Context, _ string, _ storage.TargetType) ([]*storage.ParsingRuleRecord, error) {
+func (noopFindRepo) FindActiveCandidates(_ context.Context, _ string, _ storage.TargetType) ([]*storage.ParserRuleRecord, error) {
 	return nil, nil
 }
 func (noopFindRepo) HasAnyRule(_ context.Context, _ string, _ storage.TargetType) (bool, bool, error) {
 	return false, false, nil
 }
-func (noopFindRepo) InsertNextVersion(_ context.Context, _ *storage.ParsingRuleRecord) error {
+func (noopFindRepo) InsertNextVersion(_ context.Context, _ *storage.ParserRuleRecord) error {
 	return nil
 }
-func (noopFindRepo) FindByNaturalKey(_ context.Context, _, _, _ string, _ storage.TargetType, _ int) (*storage.ParsingRuleRecord, error) {
+func (noopFindRepo) FindByNaturalKey(_ context.Context, _, _, _ string, _ storage.TargetType, _ int) (*storage.ParserRuleRecord, error) {
 	return nil, storage.ErrNotFound
 }
-func (noopFindRepo) List(_ context.Context, _ storage.ParsingRuleFilter) ([]*storage.ParsingRuleRecord, error) {
+func (noopFindRepo) List(_ context.Context, _ storage.ParserRuleFilter) ([]*storage.ParserRuleRecord, error) {
 	return nil, nil
 }
 func (noopFindRepo) Delete(_ context.Context, _ int64) error { return nil }
@@ -687,7 +687,7 @@ func TestGenerator_DuplicateInsert_AbsorbedAsSuccess(t *testing.T) {
 func TestGenerator_PreCheckHit_SkipsLLMCall(t *testing.T) {
 	provider := &fakeProvider{name: "fake", response: `{"title":{"css":"h1"}}`}
 	repo := &recordingRepo{
-		findByNaturalKeyResult: &storage.ParsingRuleRecord{
+		findByNaturalKeyResult: &storage.ParserRuleRecord{
 			ID:          42,
 			SourceName:  llmgen.LLMAutoSourceName,
 			HostPattern: "example.com",
@@ -745,7 +745,7 @@ func TestGenerator_PreCheckMiss_ProceedsToLLM(t *testing.T) {
 func TestGenerator_PreCheckHit_DisabledRule_SkipsLLM(t *testing.T) {
 	provider := &fakeProvider{name: "fake", response: `{"title":{"css":"h1"}}`}
 	repo := &recordingRepo{
-		findByNaturalKeyResult: &storage.ParsingRuleRecord{
+		findByNaturalKeyResult: &storage.ParserRuleRecord{
 			ID:          99,
 			SourceName:  llmgen.LLMAutoSourceName,
 			HostPattern: "example.com",
@@ -837,7 +837,7 @@ func TestGenerator_EnqueueStale_BypassesEnabledPreCheck(t *testing.T) {
 	// 사전 lookup 결과 — enabled=true 룰 잔존 (정상적으로 fresh Enqueue 면 skip 대상).
 	// 동일 자연키 row 를 inserted 에 미리 시딩하여 InsertNextVersion 의 MAX(version)+1 동작이
 	// v=2 를 산출하도록 — postgres 의 실제 자연키 충돌 회피 동작과 일치.
-	existingV1 := &storage.ParsingRuleRecord{
+	existingV1 := &storage.ParserRuleRecord{
 		ID:          1,
 		SourceName:  llmgen.LLMAutoSourceName,
 		HostPattern: "stale.example.com",
@@ -847,7 +847,7 @@ func TestGenerator_EnqueueStale_BypassesEnabledPreCheck(t *testing.T) {
 		Enabled:     true,
 	}
 	repo := &recordingRepo{
-		inserted:               []*storage.ParsingRuleRecord{existingV1},
+		inserted:               []*storage.ParserRuleRecord{existingV1},
 		findByNaturalKeyResult: existingV1,
 	}
 	g, _ := newGenerator(t, provider, repo)

--- a/test/internal/processor/parser/rule/parser_test.go
+++ b/test/internal/processor/parser/rule/parser_test.go
@@ -53,8 +53,8 @@ const listHTML = `
 </body></html>
 `
 
-func pageRule() *storage.ParsingRuleRecord {
-	return &storage.ParsingRuleRecord{
+func pageRule() *storage.ParserRuleRecord {
+	return &storage.ParserRuleRecord{
 		ID:          1,
 		SourceName:  "test",
 		HostPattern: "news.example.com",
@@ -73,8 +73,8 @@ func pageRule() *storage.ParsingRuleRecord {
 	}
 }
 
-func listRule() *storage.ParsingRuleRecord {
-	return &storage.ParsingRuleRecord{
+func listRule() *storage.ParserRuleRecord {
+	return &storage.ParserRuleRecord{
 		ID:          2,
 		SourceName:  "test",
 		HostPattern: "news.example.com",
@@ -99,7 +99,7 @@ func makeRaw(url, html string) *core.RawContent {
 // ─────────────────────────────────────────────────────────────────────────────
 
 func TestParser_ParsePage_Success(t *testing.T) {
-	repo := &fakeRepo{rules: []*storage.ParsingRuleRecord{pageRule()}}
+	repo := &fakeRepo{rules: []*storage.ParserRuleRecord{pageRule()}}
 	res, _ := rule.NewResolver(repo)
 	p, _ := rule.NewParser(res)
 
@@ -130,7 +130,7 @@ func TestParser_ParsePage_NoRule_ReturnsErrNoRule(t *testing.T) {
 func TestParser_ParsePage_MissingTitleSelector_EmptySelector(t *testing.T) {
 	r := pageRule()
 	r.Selectors.Title = nil
-	repo := &fakeRepo{rules: []*storage.ParsingRuleRecord{r}}
+	repo := &fakeRepo{rules: []*storage.ParserRuleRecord{r}}
 	res, _ := rule.NewResolver(repo)
 	p, _ := rule.NewParser(res)
 
@@ -144,7 +144,7 @@ func TestParser_ParsePage_MissingTitleSelector_EmptySelector(t *testing.T) {
 func TestParser_ParsePage_MainContentMatchesNothing_ParseFailure(t *testing.T) {
 	r := pageRule()
 	r.Selectors.MainContent = &storage.FieldSelector{CSS: "div.no-such-class", Multi: true}
-	repo := &fakeRepo{rules: []*storage.ParsingRuleRecord{r}}
+	repo := &fakeRepo{rules: []*storage.ParserRuleRecord{r}}
 	res, _ := rule.NewResolver(repo)
 	p, _ := rule.NewParser(res)
 
@@ -156,7 +156,7 @@ func TestParser_ParsePage_MainContentMatchesNothing_ParseFailure(t *testing.T) {
 }
 
 func TestParser_ParsePage_EmptyRaw_ParseFailure(t *testing.T) {
-	repo := &fakeRepo{rules: []*storage.ParsingRuleRecord{pageRule()}}
+	repo := &fakeRepo{rules: []*storage.ParserRuleRecord{pageRule()}}
 	res, _ := rule.NewResolver(repo)
 	p, _ := rule.NewParser(res)
 
@@ -172,7 +172,7 @@ func TestParser_ParsePage_EmptyRaw_ParseFailure(t *testing.T) {
 // ─────────────────────────────────────────────────────────────────────────────
 
 func TestParser_ParseLinks_Success_AbsolutizesURLs(t *testing.T) {
-	repo := &fakeRepo{rules: []*storage.ParsingRuleRecord{listRule()}}
+	repo := &fakeRepo{rules: []*storage.ParserRuleRecord{listRule()}}
 	res, _ := rule.NewResolver(repo)
 	p, _ := rule.NewParser(res)
 
@@ -191,7 +191,7 @@ func TestParser_ParseLinks_Success_AbsolutizesURLs(t *testing.T) {
 func TestParser_ParseLinks_MissingItemContainer_EmptySelector(t *testing.T) {
 	r := listRule()
 	r.Selectors.ItemContainer = nil
-	repo := &fakeRepo{rules: []*storage.ParsingRuleRecord{r}}
+	repo := &fakeRepo{rules: []*storage.ParserRuleRecord{r}}
 	res, _ := rule.NewResolver(repo)
 	p, _ := rule.NewParser(res)
 
@@ -205,7 +205,7 @@ func TestParser_ParseLinks_MissingItemContainer_EmptySelector(t *testing.T) {
 func TestParser_ParseLinks_MissingItemLink_EmptySelector(t *testing.T) {
 	r := listRule()
 	r.Selectors.ItemLink = nil
-	repo := &fakeRepo{rules: []*storage.ParsingRuleRecord{r}}
+	repo := &fakeRepo{rules: []*storage.ParserRuleRecord{r}}
 	res, _ := rule.NewResolver(repo)
 	p, _ := rule.NewParser(res)
 

--- a/test/internal/processor/parser/rule/refiner/refiner_test.go
+++ b/test/internal/processor/parser/rule/refiner/refiner_test.go
@@ -33,11 +33,11 @@ var pathinferLoader = prompt.MapLoader{
 // In-memory mocks
 // ─────────────────────────────────────────────────────────────────────────────
 
-// fakeRulesRepo 는 ParsingRuleRepository 의 in-memory 구현입니다.
+// fakeRulesRepo 는 ParserRuleRepository 의 in-memory 구현입니다.
 // List / InsertNextVersion / FindActiveCandidates 만 사용 — 나머지는 zero stub.
 type fakeRulesRepo struct {
 	mu       sync.Mutex
-	records  []*storage.ParsingRuleRecord
+	records  []*storage.ParserRuleRecord
 	inserts  []insertCall // 이슈 #282 Phase 2: 새 InsertNextVersion 추적
 	listErr  error
 	insErr   error // InsertNextVersion 강제 에러
@@ -52,15 +52,15 @@ type insertCall struct {
 	description string
 }
 
-func (r *fakeRulesRepo) Insert(_ context.Context, _ *storage.ParsingRuleRecord) error { return nil }
-func (r *fakeRulesRepo) Update(_ context.Context, _ *storage.ParsingRuleRecord) error { return nil }
-func (r *fakeRulesRepo) GetByID(_ context.Context, _ int64) (*storage.ParsingRuleRecord, error) {
+func (r *fakeRulesRepo) Insert(_ context.Context, _ *storage.ParserRuleRecord) error { return nil }
+func (r *fakeRulesRepo) Update(_ context.Context, _ *storage.ParserRuleRecord) error { return nil }
+func (r *fakeRulesRepo) GetByID(_ context.Context, _ int64) (*storage.ParserRuleRecord, error) {
 	return nil, storage.ErrNotFound
 }
-func (r *fakeRulesRepo) FindActive(_ context.Context, _ string, _ storage.TargetType) (*storage.ParsingRuleRecord, error) {
+func (r *fakeRulesRepo) FindActive(_ context.Context, _ string, _ storage.TargetType) (*storage.ParserRuleRecord, error) {
 	return nil, storage.ErrNotFound
 }
-func (r *fakeRulesRepo) FindActiveCandidates(_ context.Context, _ string, _ storage.TargetType) ([]*storage.ParsingRuleRecord, error) {
+func (r *fakeRulesRepo) FindActiveCandidates(_ context.Context, _ string, _ storage.TargetType) ([]*storage.ParserRuleRecord, error) {
 	return nil, nil
 }
 func (r *fakeRulesRepo) HasAnyRule(_ context.Context, _ string, _ storage.TargetType) (bool, bool, error) {
@@ -68,7 +68,7 @@ func (r *fakeRulesRepo) HasAnyRule(_ context.Context, _ string, _ storage.Target
 }
 
 // InsertNextVersion 은 자연키의 MAX(version)+1 로 새 record 를 기록하고 sequential ID 를 할당합니다 (이슈 #282).
-func (r *fakeRulesRepo) InsertNextVersion(_ context.Context, rec *storage.ParsingRuleRecord) error {
+func (r *fakeRulesRepo) InsertNextVersion(_ context.Context, rec *storage.ParserRuleRecord) error {
 	if r.insErr != nil {
 		return r.insErr
 	}
@@ -104,16 +104,16 @@ func (r *fakeRulesRepo) InsertNextVersion(_ context.Context, rec *storage.Parsin
 	return nil
 }
 
-func (r *fakeRulesRepo) FindByNaturalKey(_ context.Context, _, _, _ string, _ storage.TargetType, _ int) (*storage.ParsingRuleRecord, error) {
+func (r *fakeRulesRepo) FindByNaturalKey(_ context.Context, _, _, _ string, _ storage.TargetType, _ int) (*storage.ParserRuleRecord, error) {
 	return nil, storage.ErrNotFound
 }
-func (r *fakeRulesRepo) List(_ context.Context, f storage.ParsingRuleFilter) ([]*storage.ParsingRuleRecord, error) {
+func (r *fakeRulesRepo) List(_ context.Context, f storage.ParserRuleFilter) ([]*storage.ParserRuleRecord, error) {
 	if r.listErr != nil {
 		return nil, r.listErr
 	}
 	r.mu.Lock()
 	defer r.mu.Unlock()
-	out := make([]*storage.ParsingRuleRecord, 0)
+	out := make([]*storage.ParserRuleRecord, 0)
 	for _, rec := range r.records {
 		if f.SourceName != "" && rec.SourceName != f.SourceName {
 			continue
@@ -127,7 +127,7 @@ func (r *fakeRulesRepo) List(_ context.Context, f storage.ParsingRuleFilter) ([]
 }
 func (r *fakeRulesRepo) Delete(_ context.Context, _ int64) error { return nil }
 
-// UpdatePathPattern 은 ParsingRuleRepository 인터페이스 충족용 stub — 이슈 #282 Phase 2 이후
+// UpdatePathPattern 은 ParserRuleRepository 인터페이스 충족용 stub — 이슈 #282 Phase 2 이후
 // refiner 는 본 메소드를 호출하지 않음 (InsertNextVersion 으로 전환). 호출 시 단순 ErrNotFound.
 func (r *fakeRulesRepo) UpdatePathPattern(_ context.Context, _ int64, _, _ string) error {
 	return storage.ErrNotFound
@@ -215,8 +215,8 @@ func (f *fakeLLM) Generate(_ context.Context, _ string, _ string) (string, error
 // Helpers
 // ─────────────────────────────────────────────────────────────────────────────
 
-func newCatchAllRule(id int64, host string) *storage.ParsingRuleRecord {
-	return &storage.ParsingRuleRecord{
+func newCatchAllRule(id int64, host string) *storage.ParserRuleRecord {
+	return &storage.ParserRuleRecord{
 		ID:          id,
 		SourceName:  llmgen.LLMAutoSourceName,
 		HostPattern: host,
@@ -227,7 +227,7 @@ func newCatchAllRule(id int64, host string) *storage.ParsingRuleRecord {
 	}
 }
 
-func newRefiner(t *testing.T, rules storage.ParsingRuleRepository, samples storage.SampleURLRepository, opts ...refiner.Option) *refiner.Refiner {
+func newRefiner(t *testing.T, rules storage.ParserRuleRepository, samples storage.SampleURLRepository, opts ...refiner.Option) *refiner.Refiner {
 	t.Helper()
 	resolver, _ := rule.NewResolver(rules)
 	log := logger.New(logger.DefaultConfig())
@@ -245,7 +245,7 @@ func newRefiner(t *testing.T, rules storage.ParsingRuleRepository, samples stora
 
 func TestRunOnce_AlgorithmSuccess_InsertsNextVersion(t *testing.T) {
 	rec := newCatchAllRule(1, "news.example.com")
-	rules := &fakeRulesRepo{records: []*storage.ParsingRuleRecord{rec}, nextID: 1}
+	rules := &fakeRulesRepo{records: []*storage.ParserRuleRecord{rec}, nextID: 1}
 	samples := newFakeSamplesRepo()
 
 	// numeric ID 패턴 — InferHeuristic 이 ^/article/(\d+)$ 추론.
@@ -287,7 +287,7 @@ func TestRunOnce_AlgorithmSuccess_InsertsNextVersion(t *testing.T) {
 
 func TestRunOnce_BelowThreshold_NoUpdate(t *testing.T) {
 	rec := newCatchAllRule(1, "news.example.com")
-	rules := &fakeRulesRepo{records: []*storage.ParsingRuleRecord{rec}}
+	rules := &fakeRulesRepo{records: []*storage.ParserRuleRecord{rec}}
 	samples := newFakeSamplesRepo()
 
 	// 2 sample — minSamples 3 미만.
@@ -305,7 +305,7 @@ func TestRunOnce_AlreadyRefined_Skipped(t *testing.T) {
 	// PathPattern != "" → 정밀화 대상 아님.
 	rec := newCatchAllRule(1, "news.example.com")
 	rec.PathPattern = `^/news/(\d+)$`
-	rules := &fakeRulesRepo{records: []*storage.ParsingRuleRecord{rec}}
+	rules := &fakeRulesRepo{records: []*storage.ParserRuleRecord{rec}}
 	samples := newFakeSamplesRepo()
 	for i := 0; i < 5; i++ {
 		require.NoError(t, samples.Insert(context.Background(), 1, "https://news.example.com/news/1"))
@@ -319,7 +319,7 @@ func TestRunOnce_AlreadyRefined_Skipped(t *testing.T) {
 
 func TestRunOnce_AlgorithmFails_LLMFallback(t *testing.T) {
 	rec := newCatchAllRule(1, "news.example.com")
-	rules := &fakeRulesRepo{records: []*storage.ParsingRuleRecord{rec}}
+	rules := &fakeRulesRepo{records: []*storage.ParserRuleRecord{rec}}
 	samples := newFakeSamplesRepo()
 
 	// segment 길이가 다른 sample — InferHeuristic 실패 케이스.
@@ -346,7 +346,7 @@ func TestRunOnce_AlgorithmFails_LLMFallback(t *testing.T) {
 
 func TestRunOnce_AlgorithmFails_NoLLM_Skipped(t *testing.T) {
 	rec := newCatchAllRule(1, "news.example.com")
-	rules := &fakeRulesRepo{records: []*storage.ParsingRuleRecord{rec}}
+	rules := &fakeRulesRepo{records: []*storage.ParserRuleRecord{rec}}
 	samples := newFakeSamplesRepo()
 	// segment 길이가 다른 sample — InferHeuristic 실패.
 	for _, u := range []string{
@@ -366,7 +366,7 @@ func TestRunOnce_AlgorithmFails_NoLLM_Skipped(t *testing.T) {
 
 func TestRunOnce_LLMError_NoUpdate(t *testing.T) {
 	rec := newCatchAllRule(1, "news.example.com")
-	rules := &fakeRulesRepo{records: []*storage.ParsingRuleRecord{rec}}
+	rules := &fakeRulesRepo{records: []*storage.ParserRuleRecord{rec}}
 	samples := newFakeSamplesRepo()
 	// algorithm 실패 케이스.
 	for _, u := range []string{
@@ -389,7 +389,7 @@ func TestRunOnce_NonAutoRule_Skipped(t *testing.T) {
 	// SourceName != "llm-auto" → List filter 가 거름.
 	rec := newCatchAllRule(1, "news.example.com")
 	rec.SourceName = "operator-tuned"
-	rules := &fakeRulesRepo{records: []*storage.ParsingRuleRecord{rec}}
+	rules := &fakeRulesRepo{records: []*storage.ParserRuleRecord{rec}}
 	samples := newFakeSamplesRepo()
 	for i := 0; i < 5; i++ {
 		require.NoError(t, samples.Insert(context.Background(), 1, "https://news.example.com/article/1"))
@@ -404,7 +404,7 @@ func TestRunOnce_NonAutoRule_Skipped(t *testing.T) {
 func TestRunOnce_DisabledRule_Skipped(t *testing.T) {
 	rec := newCatchAllRule(1, "news.example.com")
 	rec.Enabled = false
-	rules := &fakeRulesRepo{records: []*storage.ParsingRuleRecord{rec}}
+	rules := &fakeRulesRepo{records: []*storage.ParserRuleRecord{rec}}
 	samples := newFakeSamplesRepo()
 	for i := 0; i < 5; i++ {
 		require.NoError(t, samples.Insert(context.Background(), 1, "https://news.example.com/article/1"))
@@ -430,7 +430,7 @@ func TestRunOnce_ListError_Returned(t *testing.T) {
 func TestRunOnce_InsertError_NoPurge(t *testing.T) {
 	rec := newCatchAllRule(1, "news.example.com")
 	rules := &fakeRulesRepo{
-		records: []*storage.ParsingRuleRecord{rec},
+		records: []*storage.ParserRuleRecord{rec},
 		insErr:  errors.New("insert failed"),
 	}
 	samples := newFakeSamplesRepo()
@@ -453,7 +453,7 @@ func TestRunOnce_InsertError_NoPurge(t *testing.T) {
 func TestRunOnce_InsertDuplicate_Skipped(t *testing.T) {
 	rec := newCatchAllRule(1, "news.example.com")
 	rules := &fakeRulesRepo{
-		records:  []*storage.ParsingRuleRecord{rec},
+		records:  []*storage.ParserRuleRecord{rec},
 		insIsDup: true,
 	}
 	samples := newFakeSamplesRepo()
@@ -531,7 +531,7 @@ func TestRunOnce_RecordsMetrics(t *testing.T) {
 
 	// (1) success / algorithm — numeric ID 패턴.
 	rec1 := newCatchAllRule(1, "news.example.com")
-	rules := &fakeRulesRepo{records: []*storage.ParsingRuleRecord{rec1}}
+	rules := &fakeRulesRepo{records: []*storage.ParserRuleRecord{rec1}}
 	samples := newFakeSamplesRepo()
 	for _, u := range []string{
 		"https://news.example.com/article/100",

--- a/test/internal/processor/parser/rule/resolver_test.go
+++ b/test/internal/processor/parser/rule/resolver_test.go
@@ -15,11 +15,11 @@ import (
 	"issuetracker/internal/storage"
 )
 
-// fakeRepo 는 in-memory ParsingRuleRepository 구현입니다.
+// fakeRepo 는 in-memory ParserRuleRepository 구현입니다.
 // FindActiveCandidates 호출 횟수를 atomic 으로 추적하여 cache 동작을 검증합니다.
 type fakeRepo struct {
-	rules           []*storage.ParsingRuleRecord // FindActiveCandidates 매칭 후보
-	notFound        bool                         // true 면 항상 빈 슬라이스 (negative cache 시뮬레이션)
+	rules           []*storage.ParserRuleRecord // FindActiveCandidates 매칭 후보
+	notFound        bool                        // true 면 항상 빈 슬라이스 (negative cache 시뮬레이션)
 	findActiveCalls int64
 
 	// hasAnyRule 시뮬레이션 (이슈 #287)
@@ -30,12 +30,12 @@ type fakeRepo struct {
 	hasAnyRuleAllRows bool // true: rules 슬라이스 기반 동적 결과 (HostPattern/TargetType 매칭)
 }
 
-func (r *fakeRepo) Insert(_ context.Context, _ *storage.ParsingRuleRecord) error { return nil }
-func (r *fakeRepo) Update(_ context.Context, _ *storage.ParsingRuleRecord) error { return nil }
-func (r *fakeRepo) GetByID(_ context.Context, _ int64) (*storage.ParsingRuleRecord, error) {
+func (r *fakeRepo) Insert(_ context.Context, _ *storage.ParserRuleRecord) error { return nil }
+func (r *fakeRepo) Update(_ context.Context, _ *storage.ParserRuleRecord) error { return nil }
+func (r *fakeRepo) GetByID(_ context.Context, _ int64) (*storage.ParserRuleRecord, error) {
 	return nil, storage.ErrNotFound
 }
-func (r *fakeRepo) List(_ context.Context, _ storage.ParsingRuleFilter) ([]*storage.ParsingRuleRecord, error) {
+func (r *fakeRepo) List(_ context.Context, _ storage.ParserRuleFilter) ([]*storage.ParserRuleRecord, error) {
 	return nil, nil
 }
 func (r *fakeRepo) Delete(_ context.Context, _ int64) error { return nil }
@@ -44,7 +44,7 @@ func (r *fakeRepo) UpdatePathPattern(_ context.Context, _ int64, _, _ string) er
 }
 
 // FindActive 는 FindActiveCandidates 의 첫 항목을 반환 (이슈 #173 후방 호환).
-func (r *fakeRepo) FindActive(ctx context.Context, host string, t storage.TargetType) (*storage.ParsingRuleRecord, error) {
+func (r *fakeRepo) FindActive(ctx context.Context, host string, t storage.TargetType) (*storage.ParserRuleRecord, error) {
 	candidates, err := r.FindActiveCandidates(ctx, host, t)
 	if err != nil {
 		return nil, err
@@ -56,12 +56,12 @@ func (r *fakeRepo) FindActive(ctx context.Context, host string, t storage.Target
 }
 
 // FindActiveCandidates 는 host + target_type 매칭 슬라이스 반환. LENGTH(path_pattern) DESC 정렬 시뮬레이션.
-func (r *fakeRepo) FindActiveCandidates(_ context.Context, host string, t storage.TargetType) ([]*storage.ParsingRuleRecord, error) {
+func (r *fakeRepo) FindActiveCandidates(_ context.Context, host string, t storage.TargetType) ([]*storage.ParserRuleRecord, error) {
 	atomic.AddInt64(&r.findActiveCalls, 1)
 	if r.notFound {
 		return nil, nil
 	}
-	out := make([]*storage.ParsingRuleRecord, 0)
+	out := make([]*storage.ParserRuleRecord, 0)
 	for _, rec := range r.rules {
 		if rec.HostPattern == host && rec.TargetType == t && rec.Enabled {
 			out = append(out, rec)
@@ -95,17 +95,17 @@ func (r *fakeRepo) HasAnyRule(_ context.Context, host string, t storage.TargetTy
 	return r.hasAnyExists, r.hasAnyEnabled, nil
 }
 func (r *fakeRepo) hasAnyCalls() int { return int(atomic.LoadInt64(&r.hasAnyRuleCalls)) }
-func (r *fakeRepo) InsertNextVersion(_ context.Context, _ *storage.ParsingRuleRecord) error {
+func (r *fakeRepo) InsertNextVersion(_ context.Context, _ *storage.ParserRuleRecord) error {
 	return nil
 }
 
-func (r *fakeRepo) FindByNaturalKey(_ context.Context, _, _, _ string, _ storage.TargetType, _ int) (*storage.ParsingRuleRecord, error) {
+func (r *fakeRepo) FindByNaturalKey(_ context.Context, _, _, _ string, _ storage.TargetType, _ int) (*storage.ParserRuleRecord, error) {
 	return nil, storage.ErrNotFound
 }
 
 // sortByPathPatternLengthDesc 는 LENGTH(path_pattern) DESC, version DESC 정렬을 수행합니다.
 // postgres 의 ORDER BY LENGTH(path_pattern) DESC, version DESC 와 동일 동작 (PR #181 gemini 피드백).
-func sortByPathPatternLengthDesc(s []*storage.ParsingRuleRecord) {
+func sortByPathPatternLengthDesc(s []*storage.ParserRuleRecord) {
 	sort.SliceStable(s, func(i, j int) bool {
 		if len(s[i].PathPattern) != len(s[j].PathPattern) {
 			return len(s[i].PathPattern) > len(s[j].PathPattern)
@@ -114,8 +114,8 @@ func sortByPathPatternLengthDesc(s []*storage.ParsingRuleRecord) {
 	})
 }
 
-func samplePageRule(host string) *storage.ParsingRuleRecord {
-	return &storage.ParsingRuleRecord{
+func samplePageRule(host string) *storage.ParserRuleRecord {
+	return &storage.ParserRuleRecord{
 		ID:          1,
 		SourceName:  "test",
 		HostPattern: host,
@@ -134,7 +134,7 @@ func samplePageRule(host string) *storage.ParsingRuleRecord {
 // ─────────────────────────────────────────────────────────────────────────────
 
 func TestResolver_ResolveByURL_Success(t *testing.T) {
-	repo := &fakeRepo{rules: []*storage.ParsingRuleRecord{samplePageRule("news.example.com")}}
+	repo := &fakeRepo{rules: []*storage.ParserRuleRecord{samplePageRule("news.example.com")}}
 	r, _ := rule.NewResolver(repo)
 
 	got, err := r.ResolveByURL(context.Background(), "https://news.example.com/article/1", storage.TargetTypePage)
@@ -144,7 +144,7 @@ func TestResolver_ResolveByURL_Success(t *testing.T) {
 }
 
 func TestResolver_ResolveByURL_HostUppercaseNormalized(t *testing.T) {
-	repo := &fakeRepo{rules: []*storage.ParsingRuleRecord{samplePageRule("news.example.com")}}
+	repo := &fakeRepo{rules: []*storage.ParserRuleRecord{samplePageRule("news.example.com")}}
 	r, _ := rule.NewResolver(repo)
 
 	// URL host 가 대문자여도 lookup 은 lowercase 로 정규화되어 매칭
@@ -178,7 +178,7 @@ func TestResolver_NoMatch_ReturnsErrNoRule(t *testing.T) {
 // ─────────────────────────────────────────────────────────────────────────────
 
 func TestResolver_Cache_HitsAvoidRepoCall(t *testing.T) {
-	repo := &fakeRepo{rules: []*storage.ParsingRuleRecord{samplePageRule("news.example.com")}}
+	repo := &fakeRepo{rules: []*storage.ParserRuleRecord{samplePageRule("news.example.com")}}
 	r, _ := rule.NewResolver(repo)
 
 	// 첫 호출 → repo 1
@@ -206,7 +206,7 @@ func TestResolver_NegativeCache_AvoidRepoCallForMissingHost(t *testing.T) {
 }
 
 func TestResolver_Invalidate_ForcesRepoCall(t *testing.T) {
-	repo := &fakeRepo{rules: []*storage.ParsingRuleRecord{samplePageRule("news.example.com")}}
+	repo := &fakeRepo{rules: []*storage.ParserRuleRecord{samplePageRule("news.example.com")}}
 	r, _ := rule.NewResolver(repo)
 
 	_, err := r.Resolve(context.Background(), "news.example.com", "/", storage.TargetTypePage)
@@ -223,7 +223,7 @@ func TestResolver_Invalidate_ForcesRepoCall(t *testing.T) {
 }
 
 func TestResolver_InvalidateAll_ClearsAllEntries(t *testing.T) {
-	repo := &fakeRepo{rules: []*storage.ParsingRuleRecord{
+	repo := &fakeRepo{rules: []*storage.ParserRuleRecord{
 		samplePageRule("a.example.com"),
 		samplePageRule("b.example.com"),
 	}}
@@ -245,7 +245,7 @@ func TestResolver_InvalidateAll_ClearsAllEntries(t *testing.T) {
 }
 
 func TestResolver_CacheTTL_ExpiresAfterDuration(t *testing.T) {
-	repo := &fakeRepo{rules: []*storage.ParsingRuleRecord{samplePageRule("news.example.com")}}
+	repo := &fakeRepo{rules: []*storage.ParserRuleRecord{samplePageRule("news.example.com")}}
 	// TTL 50ms — 테스트 친화적 짧은 시간
 	r, _ := rule.NewResolver(repo, rule.WithCacheTTL(50*time.Millisecond))
 
@@ -273,7 +273,7 @@ func TestNewResolver_NilRepo_ReturnsError(t *testing.T) {
 
 // path_pattern=” (catch-all) rule 만 있을 때 어떤 path 든 매칭됨 — 기존 동작 보존.
 func TestResolver_PathPattern_EmptyMatchesAnyPath(t *testing.T) {
-	repo := &fakeRepo{rules: []*storage.ParsingRuleRecord{samplePageRule("news.example.com")}}
+	repo := &fakeRepo{rules: []*storage.ParserRuleRecord{samplePageRule("news.example.com")}}
 	r, _ := rule.NewResolver(repo)
 
 	for _, path := range []string{"/", "/article/1", "/sports/breaking-news", "/about"} {
@@ -294,7 +294,7 @@ func TestResolver_PathPattern_LongerPatternWinsOverCatchAll(t *testing.T) {
 	catchAll := samplePageRule("news.example.com") // PathPattern="" 기본
 	catchAll.Selectors.Title = &storage.FieldSelector{CSS: "h1.default"}
 
-	repo := &fakeRepo{rules: []*storage.ParsingRuleRecord{specific, catchAll}}
+	repo := &fakeRepo{rules: []*storage.ParserRuleRecord{specific, catchAll}}
 	r, _ := rule.NewResolver(repo)
 
 	// /sports/* path 는 specific rule 매칭 (LENGTH DESC 정렬상 우선)
@@ -324,7 +324,7 @@ func TestResolver_PathPattern_HigherVersionWinsForSamePattern(t *testing.T) {
 	v2.PathPattern = "^/article/(\\d+)$" // 동일 path_pattern (stale relearn 결과)
 	v2.Selectors.Title = &storage.FieldSelector{CSS: "h1.new"}
 
-	repo := &fakeRepo{rules: []*storage.ParsingRuleRecord{v1, v2}}
+	repo := &fakeRepo{rules: []*storage.ParserRuleRecord{v1, v2}}
 	r, _ := rule.NewResolver(repo)
 
 	got, err := r.Resolve(context.Background(), "news.example.com", "/article/123", storage.TargetTypePage)
@@ -353,7 +353,7 @@ func TestResolver_PathPattern_RefinedAndCatchAll_FallbackForNonMatching(t *testi
 	refined.PathPattern = `^/article/(\d+)$`
 	refined.Selectors.Title = &storage.FieldSelector{CSS: "h1.refined"}
 
-	repo := &fakeRepo{rules: []*storage.ParsingRuleRecord{catchAll, refined}}
+	repo := &fakeRepo{rules: []*storage.ParserRuleRecord{catchAll, refined}}
 	r, _ := rule.NewResolver(repo)
 
 	// 매칭 path → refined 채택
@@ -372,7 +372,7 @@ func TestResolver_PathPattern_NoMatchReturnsErrNoRule(t *testing.T) {
 	specific := samplePageRule("news.example.com")
 	specific.PathPattern = "^/sports/.*$"
 
-	repo := &fakeRepo{rules: []*storage.ParsingRuleRecord{specific}}
+	repo := &fakeRepo{rules: []*storage.ParserRuleRecord{specific}}
 	r, _ := rule.NewResolver(repo)
 
 	_, err := r.Resolve(context.Background(), "news.example.com", "/about", storage.TargetTypePage)
@@ -391,7 +391,7 @@ func TestResolver_PathPattern_InvalidRegexFallsThrough(t *testing.T) {
 	catchAll := samplePageRule("news.example.com") // PathPattern=""
 	catchAll.Selectors.Title = &storage.FieldSelector{CSS: "h1.default"}
 
-	repo := &fakeRepo{rules: []*storage.ParsingRuleRecord{bad, catchAll}}
+	repo := &fakeRepo{rules: []*storage.ParserRuleRecord{bad, catchAll}}
 	r, _ := rule.NewResolver(repo)
 
 	got, err := r.Resolve(context.Background(), "news.example.com", "/article/1", storage.TargetTypePage)
@@ -409,7 +409,7 @@ func TestResolver_PathPattern_RegexCacheReuseAcrossHosts(t *testing.T) {
 	b := samplePageRule("b.example.com")
 	b.PathPattern = pattern
 
-	repo := &fakeRepo{rules: []*storage.ParsingRuleRecord{a, b}}
+	repo := &fakeRepo{rules: []*storage.ParserRuleRecord{a, b}}
 	r, _ := rule.NewResolver(repo)
 
 	got, err := r.Resolve(context.Background(), "a.example.com", "/news/123", storage.TargetTypePage)
@@ -427,7 +427,7 @@ func TestResolver_ResolveByURL_PathPatternMatching(t *testing.T) {
 	specific.PathPattern = "^/article/[0-9]+$"
 	specific.Selectors.Title = &storage.FieldSelector{CSS: "h1.article"}
 
-	repo := &fakeRepo{rules: []*storage.ParsingRuleRecord{specific}}
+	repo := &fakeRepo{rules: []*storage.ParserRuleRecord{specific}}
 	r, _ := rule.NewResolver(repo)
 
 	got, err := r.ResolveByURL(context.Background(), "https://news.example.com/article/12345?utm=x", storage.TargetTypePage)

--- a/test/internal/storage/parser_rule_invalidating_test.go
+++ b/test/internal/storage/parser_rule_invalidating_test.go
@@ -49,7 +49,7 @@ type recordingRepo struct {
 	insertErr     error
 	updateErr     error
 	updatePathErr error
-	getByIDResult *storage.ParsingRuleRecord
+	getByIDResult *storage.ParserRuleRecord
 	getByIDErr    error
 
 	insertCalls            int
@@ -60,18 +60,18 @@ type recordingRepo struct {
 	getByIDCalls           int
 }
 
-func (r *recordingRepo) Insert(_ context.Context, _ *storage.ParsingRuleRecord) error {
+func (r *recordingRepo) Insert(_ context.Context, _ *storage.ParserRuleRecord) error {
 	r.insertCalls++
 	return r.insertErr
 }
-func (r *recordingRepo) InsertNextVersion(_ context.Context, rec *storage.ParsingRuleRecord) error {
+func (r *recordingRepo) InsertNextVersion(_ context.Context, rec *storage.ParserRuleRecord) error {
 	r.insertNextVersionCalls++
 	if rec.Version == 0 {
 		rec.Version = 1
 	}
 	return r.insertErr
 }
-func (r *recordingRepo) Update(_ context.Context, _ *storage.ParsingRuleRecord) error {
+func (r *recordingRepo) Update(_ context.Context, _ *storage.ParserRuleRecord) error {
 	r.updateCalls++
 	return r.updateErr
 }
@@ -83,23 +83,23 @@ func (r *recordingRepo) Delete(_ context.Context, _ int64) error {
 	r.deleteCalls++
 	return nil
 }
-func (r *recordingRepo) GetByID(_ context.Context, _ int64) (*storage.ParsingRuleRecord, error) {
+func (r *recordingRepo) GetByID(_ context.Context, _ int64) (*storage.ParserRuleRecord, error) {
 	r.getByIDCalls++
 	return r.getByIDResult, r.getByIDErr
 }
-func (r *recordingRepo) FindActive(_ context.Context, _ string, _ storage.TargetType) (*storage.ParsingRuleRecord, error) {
+func (r *recordingRepo) FindActive(_ context.Context, _ string, _ storage.TargetType) (*storage.ParserRuleRecord, error) {
 	return nil, storage.ErrNotFound
 }
-func (r *recordingRepo) FindActiveCandidates(_ context.Context, _ string, _ storage.TargetType) ([]*storage.ParsingRuleRecord, error) {
+func (r *recordingRepo) FindActiveCandidates(_ context.Context, _ string, _ storage.TargetType) ([]*storage.ParserRuleRecord, error) {
 	return nil, nil
 }
 func (r *recordingRepo) HasAnyRule(_ context.Context, _ string, _ storage.TargetType) (bool, bool, error) {
 	return false, false, nil
 }
-func (r *recordingRepo) FindByNaturalKey(_ context.Context, _, _, _ string, _ storage.TargetType, _ int) (*storage.ParsingRuleRecord, error) {
+func (r *recordingRepo) FindByNaturalKey(_ context.Context, _, _, _ string, _ storage.TargetType, _ int) (*storage.ParserRuleRecord, error) {
 	return nil, storage.ErrNotFound
 }
-func (r *recordingRepo) List(_ context.Context, _ storage.ParsingRuleFilter) ([]*storage.ParsingRuleRecord, error) {
+func (r *recordingRepo) List(_ context.Context, _ storage.ParserRuleFilter) ([]*storage.ParserRuleRecord, error) {
 	return nil, nil
 }
 
@@ -112,7 +112,7 @@ func TestInvalidatingRepo_Insert_Success_TriggersInvalidate(t *testing.T) {
 	inv := &recordingInvalidator{}
 	repo := storage.WrapWithInvalidator(inner, inv)
 
-	rec := &storage.ParsingRuleRecord{HostPattern: "example.com", TargetType: storage.TargetTypePage}
+	rec := &storage.ParserRuleRecord{HostPattern: "example.com", TargetType: storage.TargetTypePage}
 	err := repo.Insert(context.Background(), rec)
 	require.NoError(t, err)
 	assert.Equal(t, 1, inv.callCount(), "Insert 성공 시 Invalidate 호출")
@@ -124,7 +124,7 @@ func TestInvalidatingRepo_Insert_ErrDuplicate_TriggersInvalidate(t *testing.T) {
 	inv := &recordingInvalidator{}
 	repo := storage.WrapWithInvalidator(inner, inv)
 
-	rec := &storage.ParsingRuleRecord{HostPattern: "example.com", TargetType: storage.TargetTypePage}
+	rec := &storage.ParserRuleRecord{HostPattern: "example.com", TargetType: storage.TargetTypePage}
 	err := repo.Insert(context.Background(), rec)
 	require.ErrorIs(t, err, storage.ErrDuplicate)
 	assert.Equal(t, 1, inv.callCount(), "ErrDuplicate 도 invalidate — cache 가 stale 일 가능성")
@@ -139,7 +139,7 @@ func TestInvalidatingRepo_InsertNextVersion_Success_TriggersInvalidate(t *testin
 	inv := &recordingInvalidator{}
 	repo := storage.WrapWithInvalidator(inner, inv)
 
-	rec := &storage.ParsingRuleRecord{HostPattern: "stale.example.com", TargetType: storage.TargetTypePage}
+	rec := &storage.ParserRuleRecord{HostPattern: "stale.example.com", TargetType: storage.TargetTypePage}
 	err := repo.InsertNextVersion(context.Background(), rec)
 	require.NoError(t, err)
 	assert.Equal(t, 1, inner.insertNextVersionCalls)
@@ -152,7 +152,7 @@ func TestInvalidatingRepo_InsertNextVersion_ErrDuplicate_TriggersInvalidate(t *t
 	inv := &recordingInvalidator{}
 	repo := storage.WrapWithInvalidator(inner, inv)
 
-	err := repo.InsertNextVersion(context.Background(), &storage.ParsingRuleRecord{HostPattern: "x", TargetType: storage.TargetTypePage})
+	err := repo.InsertNextVersion(context.Background(), &storage.ParserRuleRecord{HostPattern: "x", TargetType: storage.TargetTypePage})
 	require.ErrorIs(t, err, storage.ErrDuplicate)
 	assert.Equal(t, 1, inv.callCount(), "ErrDuplicate (race window) 도 invalidate")
 }
@@ -162,7 +162,7 @@ func TestInvalidatingRepo_Insert_OtherError_NoInvalidate(t *testing.T) {
 	inv := &recordingInvalidator{}
 	repo := storage.WrapWithInvalidator(inner, inv)
 
-	rec := &storage.ParsingRuleRecord{HostPattern: "example.com", TargetType: storage.TargetTypePage}
+	rec := &storage.ParserRuleRecord{HostPattern: "example.com", TargetType: storage.TargetTypePage}
 	err := repo.Insert(context.Background(), rec)
 	require.Error(t, err)
 	assert.Equal(t, 0, inv.callCount(), "기타 에러 (DB 장애 등) 시 invalidate 안 함 — cache 보존")
@@ -177,7 +177,7 @@ func TestInvalidatingRepo_Update_Success_TriggersInvalidate(t *testing.T) {
 	inv := &recordingInvalidator{}
 	repo := storage.WrapWithInvalidator(inner, inv)
 
-	rec := &storage.ParsingRuleRecord{HostPattern: "example.com", TargetType: storage.TargetTypeList}
+	rec := &storage.ParserRuleRecord{HostPattern: "example.com", TargetType: storage.TargetTypeList}
 	err := repo.Update(context.Background(), rec)
 	require.NoError(t, err)
 	assert.Equal(t, 1, inv.callCount())
@@ -189,7 +189,7 @@ func TestInvalidatingRepo_Update_Error_NoInvalidate(t *testing.T) {
 	inv := &recordingInvalidator{}
 	repo := storage.WrapWithInvalidator(inner, inv)
 
-	err := repo.Update(context.Background(), &storage.ParsingRuleRecord{})
+	err := repo.Update(context.Background(), &storage.ParserRuleRecord{})
 	require.Error(t, err)
 	assert.Equal(t, 0, inv.callCount())
 }
@@ -200,7 +200,7 @@ func TestInvalidatingRepo_Update_Error_NoInvalidate(t *testing.T) {
 
 func TestInvalidatingRepo_UpdatePathPattern_Success_PrefetchesAndInvalidates(t *testing.T) {
 	inner := &recordingRepo{
-		getByIDResult: &storage.ParsingRuleRecord{
+		getByIDResult: &storage.ParserRuleRecord{
 			ID: 42, HostPattern: "yna.co.kr", TargetType: storage.TargetTypePage,
 		},
 	}
@@ -217,7 +217,7 @@ func TestInvalidatingRepo_UpdatePathPattern_Success_PrefetchesAndInvalidates(t *
 
 func TestInvalidatingRepo_UpdatePathPattern_Error_NoInvalidate(t *testing.T) {
 	inner := &recordingRepo{
-		getByIDResult: &storage.ParsingRuleRecord{HostPattern: "x.com", TargetType: storage.TargetTypePage},
+		getByIDResult: &storage.ParserRuleRecord{HostPattern: "x.com", TargetType: storage.TargetTypePage},
 		updatePathErr: errors.New("not found"),
 	}
 	inv := &recordingInvalidator{}
@@ -247,7 +247,7 @@ func TestInvalidatingRepo_UpdatePathPattern_PrefetchFails_NoInvalidate(t *testin
 
 func TestInvalidatingRepo_Delete_Success_PrefetchesAndInvalidates(t *testing.T) {
 	inner := &recordingRepo{
-		getByIDResult: &storage.ParsingRuleRecord{
+		getByIDResult: &storage.ParserRuleRecord{
 			ID: 99, HostPattern: "delete.example.com", TargetType: storage.TargetTypePage,
 		},
 	}
@@ -284,7 +284,7 @@ func TestInvalidatingRepo_NilInvalidator_NoOp(t *testing.T) {
 	inner := &recordingRepo{}
 	repo := storage.WrapWithInvalidator(inner, nil)
 
-	err := repo.Insert(context.Background(), &storage.ParsingRuleRecord{HostPattern: "x", TargetType: storage.TargetTypePage})
+	err := repo.Insert(context.Background(), &storage.ParserRuleRecord{HostPattern: "x", TargetType: storage.TargetTypePage})
 	require.NoError(t, err)
 	assert.Equal(t, 1, inner.insertCalls, "inner 호출은 정상")
 	// invalidator 가 nil 이라 panic 없이 통과 — 정상 동작 확인 만으로 충분.


### PR DESCRIPTION
## 연관 이슈
- Closes #374

<br>

## 구현 내용

[#372](https://github.com/EinSofINTEREST/IssueTracker/issues/372) Phase 1 (PR #373) 에서 DB schema 명칭을 \`parser_*\` 로 통일. 본 PR 은 그 후속 Phase 2 — Go 코드의 식별자 / 파일명까지 일관성 확장.

### 식별자 치환 (5종)
- \`ParsingRule\` → \`ParserRule\`
- \`ParsingRuleFilter\` → \`ParserRuleFilter\`
- \`ParsingRuleRecord\` → \`ParserRuleRecord\`
- \`ParsingRuleRepository\` → \`ParserRuleRepository\`
- \`parsingRuleRepo\` (cmd 변수) → \`parserRuleRepo\`

### 파일명 변경 (\`git mv\` 4개)
| 기존 | 변경 |
|---|---|
| \`internal/storage/parsing_rule.go\` | \`parser_rule.go\` |
| \`internal/storage/parsing_rule_invalidating.go\` | \`parser_rule_invalidating.go\` |
| \`internal/storage/postgres/parsing_rule.go\` | \`parser_rule.go\` |
| \`test/internal/storage/parsing_rule_invalidating_test.go\` | \`parser_rule_invalidating_test.go\` |

19개 .go 파일 / 199 라인 변경. 외부 module path / public API 변경 없음 (모두 \`internal/\` package).

<br>

## CI / 머지 게이트 점검

### 변경 영향 범위
- 영향 패키지/모듈: \`internal/storage\`, \`internal/storage/postgres\`, \`internal/processor/parser/*\`, \`cmd/issuetracker\`, \`test/internal/*\`
- 위험도: **Low** — Go 식별자 mechanical rename, DB 영향 없음 (Phase 1 에서 정합 완료)

### 검증
- \`go build ./...\` 통과
- \`go vet ./...\` 통과
- 전체 38 패키지 \`go test -race -count=1\` 통과

### Required Status Checks
- 통과 확인 대상 (PR Checks 탭에서 확인):
  - [ ] \`Commit Lint\`
  - [ ] \`PR Title Lint\`
  - [ ] \`Linked Issue Check\`
  - [ ] \`Format Check\`
  - [ ] \`Build\`
  - [ ] \`Test\`
  - [ ] \`Lint\`

### 롤백 계획
- PR revert 만으로 즉시 회귀
- DB schema 영향 없음 — 별도 마이그레이션 불필요

<br>

## TODO
- (없음) Phase 2 의 모든 완료 조건 충족 — #372 시리즈 완전 종결

<br>

## 논의 사항
- (없음) 단일 mechanical rename PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)