### PR TITLE
[REFAC#376] worker count 환경변수화 — hardcoded 5종 → env 노출

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -161,6 +161,16 @@ VALIDATE_COMMUNITY_QUALITY_THRESHOLD=0.4
 VALIDATE_COMMUNITY_MAX_REPEAT_RATIO=0.30
 VALIDATE_COMMUNITY_MIN_REPEAT_RUN=4
 
+# Worker count 튜닝 (이슈 #376) — 각 stage 의 goroutine 수. 양의 정수만 허용.
+# default 는 기존 hardcoded 값과 동일 — env 미설정 시 동작 100% 보존.
+# 운영 처리량 조정 시 본 값을 늘리면 동시 처리 수 비례 증가. StageGate cap
+# (worker_count/2) 도 함께 자동 조정됨.
+FETCHER_HIGH_WORKER_COUNT=3
+FETCHER_NORMAL_WORKER_COUNT=6
+FETCHER_LOW_WORKER_COUNT=2
+PARSER_WORKER_COUNT=6
+VALIDATE_WORKER_COUNT=8
+
 # Chromedp pool 설정 (이슈 #230) — JS heavy 사이트 크롤링용 headless Chrome pool
 FETCHER_CHROMEDP_POOL_ENABLED=true
 FETCHER_CHROMEDP_WORKER_COUNT=2

--- a/cmd/issuetracker/main.go
+++ b/cmd/issuetracker/main.go
@@ -42,13 +42,6 @@ import (
 	"issuetracker/pkg/redis"
 )
 
-const (
-	validateWorkerCount = 8
-	// parserWorkerCount: TopicFetched consumer group (issuetracker-parsers) 의 worker 수.
-	// fetcher worker 와 독립 — chromedp/LLM 등으로 parser 가 무거워질 때 별도 스케일.
-	parserWorkerCount = 6
-)
-
 func main() {
 	log := logger.New(logger.DefaultConfig())
 
@@ -71,6 +64,20 @@ func main() {
 		"shutdown_timeout":           shutdownCfg.Timeout.String(),
 		"claudegen_shutdown_timeout": shutdownCfg.ClaudegenTimeout.String(),
 	}).Info("shutdown timeouts loaded")
+
+	// 모든 stage 의 worker goroutine 수를 env 로 노출 (이슈 #376).
+	// default 는 기존 hardcoded 값과 동일 — env 미설정 시 동작 100% 보존.
+	workerCountsCfg, err := config.LoadWorkerCounts()
+	if err != nil {
+		log.WithError(err).Fatal("failed to load worker counts config")
+	}
+	log.WithFields(map[string]interface{}{
+		"fetcher_high":   workerCountsCfg.FetcherHigh,
+		"fetcher_normal": workerCountsCfg.FetcherNormal,
+		"fetcher_low":    workerCountsCfg.FetcherLow,
+		"parser":         workerCountsCfg.Parser,
+		"validate":       workerCountsCfg.Validate,
+	}).Info("worker counts loaded")
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -339,9 +346,9 @@ func main() {
 	}
 
 	managerCfg := crawlerWorker.ManagerConfig{
-		High:                  crawlerWorker.PoolConfig{Consumer: highConsumer, WorkerCount: 3},
-		Normal:                crawlerWorker.PoolConfig{Consumer: normalConsumer, WorkerCount: 6},
-		Low:                   crawlerWorker.PoolConfig{Consumer: lowConsumer, WorkerCount: 2},
+		High:                  crawlerWorker.PoolConfig{Consumer: highConsumer, WorkerCount: workerCountsCfg.FetcherHigh},
+		Normal:                crawlerWorker.PoolConfig{Consumer: normalConsumer, WorkerCount: workerCountsCfg.FetcherNormal},
+		Low:                   crawlerWorker.PoolConfig{Consumer: lowConsumer, WorkerCount: workerCountsCfg.FetcherLow},
 		ProcessingLock:        procLock,
 		RetryScheduler:        retryScheduler,
 		MaxConcurrentPerStage: stageGateCfg.FetcherMaxConcurrentPerStage,
@@ -544,11 +551,11 @@ func main() {
 	// Parser StageGate (이슈 #355) — ProcessingLock + per-stage Semaphore 합성.
 	// Semaphore capacity 는 PARSER_MAX_CONCURRENT_PER_STAGE 와 worker_count/2 의 min.
 	// stageGateCfg 는 fetcher managerCfg 직전 (위쪽) 에서 이미 로드.
-	parserCap := config.CapPerStage(parserWorkerCount, stageGateCfg.ParserMaxConcurrentPerStage)
+	parserCap := config.CapPerStage(workerCountsCfg.Parser, stageGateCfg.ParserMaxConcurrentPerStage)
 	parserGate := locks.BuildStageGate(locks.StageParser, parserCap, procLock, log)
 	if procLock != nil {
 		log.WithFields(map[string]interface{}{
-			"worker_count": parserWorkerCount,
+			"worker_count": workerCountsCfg.Parser,
 			"capacity":     parserCap,
 			"configured":   stageGateCfg.ParserMaxConcurrentPerStage,
 		}).Info("parser stage gate enabled (ProcessingLock + Semaphore)")
@@ -572,7 +579,7 @@ func main() {
 		fetcherUpgrader, // 임계값 도달 시 chromedp 자동 전환 + republish
 		fetcherUpgradeCfg.EmptyBodyTitleMin,
 		fetcherUpgradeCfg.EmptyBodyContentMin,
-		parserWorkerCount,
+		workerCountsCfg.Parser,
 		log,
 	)
 
@@ -788,11 +795,11 @@ func main() {
 	defer validateProducer.Close()
 
 	// Validate StageGate (이슈 #356) — ProcessingLock + per-stage Semaphore 합성.
-	validateCap := config.CapPerStage(validateWorkerCount, stageGateCfg.ValidateMaxConcurrentPerStage)
+	validateCap := config.CapPerStage(workerCountsCfg.Validate, stageGateCfg.ValidateMaxConcurrentPerStage)
 	validateGate := locks.BuildStageGate(locks.StageValidator, validateCap, procLock, log)
 	if procLock != nil {
 		log.WithFields(map[string]interface{}{
-			"worker_count": validateWorkerCount,
+			"worker_count": workerCountsCfg.Validate,
 			"capacity":     validateCap,
 			"configured":   stageGateCfg.ValidateMaxConcurrentPerStage,
 		}).Info("validate stage gate enabled (ProcessingLock + Semaphore)")
@@ -800,10 +807,10 @@ func main() {
 		log.Warn("processing lock unavailable, validate stage gate falls back to noop")
 	}
 
-	validateWorker := validate.NewWorker(validateConsumer, validateProducer, contentSvc, validateGate, validateWorkerCount, validateCfg)
+	validateWorker := validate.NewWorker(validateConsumer, validateProducer, contentSvc, validateGate, workerCountsCfg.Validate, validateCfg)
 
 	log.WithFields(map[string]interface{}{
-		"worker_count": validateWorkerCount,
+		"worker_count": workerCountsCfg.Validate,
 		"input_topic":  queue.TopicNormalized,
 		"output_topic": queue.TopicValidated,
 	}).Info("validate worker constructed")

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1505,3 +1505,90 @@ func LoadRetryScheduler(envFiles ...string) (RetrySchedulerConfig, error) {
 	}
 	return cfg, nil
 }
+
+// WorkerCountsConfig 는 처리 stage 별 worker goroutine 수를 일괄 관리합니다 (이슈 #376).
+//
+// 운영자가 처리량 튜닝 시 env 만 조정하면 즉시 반영 — 재빌드 불필요. 모든 필드 default 는
+// 기존 hardcoded 값과 동일하므로 env 미설정 시 동작 100% 보존.
+//
+// 명명 규약: 기존 `CLAUDE_CODE_WORKER_COUNT` / `FETCHER_CHROMEDP_WORKER_COUNT` 와 동일하게
+// `<STAGE>_WORKER_COUNT` 형식.
+type WorkerCountsConfig struct {
+	// FetcherHigh: priority=high crawler pool 의 worker 수.
+	// 환경변수 FETCHER_HIGH_WORKER_COUNT (default 3).
+	FetcherHigh int
+
+	// FetcherNormal: priority=normal crawler pool 의 worker 수.
+	// 환경변수 FETCHER_NORMAL_WORKER_COUNT (default 6).
+	FetcherNormal int
+
+	// FetcherLow: priority=low crawler pool 의 worker 수.
+	// 환경변수 FETCHER_LOW_WORKER_COUNT (default 2).
+	FetcherLow int
+
+	// Parser: parser worker (issuetracker.fetched consumer) 의 worker 수.
+	// 환경변수 PARSER_WORKER_COUNT (default 6).
+	Parser int
+
+	// Validate: validate worker (issuetracker.normalized consumer) 의 worker 수.
+	// 환경변수 VALIDATE_WORKER_COUNT (default 8).
+	Validate int
+}
+
+// DefaultWorkerCountsConfig 는 운영 기본값을 반환합니다.
+// 모든 값은 기존 cmd/issuetracker hardcoded 와 동일.
+func DefaultWorkerCountsConfig() WorkerCountsConfig {
+	return WorkerCountsConfig{
+		FetcherHigh:   3,
+		FetcherNormal: 6,
+		FetcherLow:    2,
+		Parser:        6,
+		Validate:      8,
+	}
+}
+
+// LoadWorkerCounts 는 .env 를 로드한 후 환경변수로 WorkerCountsConfig 를 구성합니다.
+//
+// 지원 환경변수 (모두 양의 정수 — 0 / 음수 / 비숫자는 invalid):
+//   - FETCHER_HIGH_WORKER_COUNT   (default 3)
+//   - FETCHER_NORMAL_WORKER_COUNT (default 6)
+//   - FETCHER_LOW_WORKER_COUNT    (default 2)
+//   - PARSER_WORKER_COUNT         (default 6)
+//   - VALIDATE_WORKER_COUNT       (default 8)
+func LoadWorkerCounts(envFiles ...string) (WorkerCountsConfig, error) {
+	if len(envFiles) == 0 {
+		envFiles = []string{".env"}
+	}
+	if err := godotenv.Load(envFiles...); err != nil && !errors.Is(err, os.ErrNotExist) {
+		return WorkerCountsConfig{}, fmt.Errorf("failed to load env files %v: %w", envFiles, err)
+	}
+
+	cfg := DefaultWorkerCountsConfig()
+
+	type binding struct {
+		envKey string
+		dest   *int
+	}
+	bindings := []binding{
+		{"FETCHER_HIGH_WORKER_COUNT", &cfg.FetcherHigh},
+		{"FETCHER_NORMAL_WORKER_COUNT", &cfg.FetcherNormal},
+		{"FETCHER_LOW_WORKER_COUNT", &cfg.FetcherLow},
+		{"PARSER_WORKER_COUNT", &cfg.Parser},
+		{"VALIDATE_WORKER_COUNT", &cfg.Validate},
+	}
+	for _, b := range bindings {
+		v := os.Getenv(b.envKey)
+		if v == "" {
+			continue
+		}
+		n, err := strconv.Atoi(v)
+		if err != nil {
+			return WorkerCountsConfig{}, fmt.Errorf("parse %s %q: %w", b.envKey, v, err)
+		}
+		if n < 1 {
+			return WorkerCountsConfig{}, fmt.Errorf("invalid %s %d: must be 1 or greater", b.envKey, n)
+		}
+		*b.dest = n
+	}
+	return cfg, nil
+}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1508,8 +1508,10 @@ func LoadRetryScheduler(envFiles ...string) (RetrySchedulerConfig, error) {
 
 // WorkerCountsConfig 는 처리 stage 별 worker goroutine 수를 일괄 관리합니다 (이슈 #376).
 //
-// 운영자가 처리량 튜닝 시 env 만 조정하면 즉시 반영 — 재빌드 불필요. 모든 필드 default 는
-// 기존 hardcoded 값과 동일하므로 env 미설정 시 동작 100% 보존.
+// 운영자가 처리량 튜닝 시 env 만 조정하면 재빌드 없이 다음 재시작에 반영 — 즉시
+// hot-reload 는 아님 (LoadWorkerCounts 가 startup 1회 호출). 변경 후 프로세스
+// 재시작 필요. 모든 필드 default 는 기존 hardcoded 값과 동일하므로 env 미설정 시
+// 동작 100% 보존.
 //
 // 명명 규약: 기존 `CLAUDE_CODE_WORKER_COUNT` / `FETCHER_CHROMEDP_WORKER_COUNT` 와 동일하게
 // `<STAGE>_WORKER_COUNT` 형식.

--- a/test/pkg/config/config_test.go
+++ b/test/pkg/config/config_test.go
@@ -892,3 +892,112 @@ func TestLoadRetryScheduler_InvalidValues(t *testing.T) {
 		})
 	}
 }
+
+// ─────────────────────────────────────────────────────────────────────────────
+// WorkerCountsConfig (이슈 #376)
+// ─────────────────────────────────────────────────────────────────────────────
+
+func TestLoadWorkerCounts_DefaultValues(t *testing.T) {
+	for _, k := range []string{
+		"FETCHER_HIGH_WORKER_COUNT",
+		"FETCHER_NORMAL_WORKER_COUNT",
+		"FETCHER_LOW_WORKER_COUNT",
+		"PARSER_WORKER_COUNT",
+		"VALIDATE_WORKER_COUNT",
+	} {
+		t.Setenv(k, "")
+	}
+
+	cfg, err := config.LoadWorkerCounts("/tmp/nonexistent-env-file.env")
+	require.NoError(t, err)
+
+	def := config.DefaultWorkerCountsConfig()
+	if cfg.FetcherHigh != def.FetcherHigh {
+		t.Errorf("FetcherHigh: got %d, want %d", cfg.FetcherHigh, def.FetcherHigh)
+	}
+	if cfg.FetcherNormal != def.FetcherNormal {
+		t.Errorf("FetcherNormal: got %d, want %d", cfg.FetcherNormal, def.FetcherNormal)
+	}
+	if cfg.FetcherLow != def.FetcherLow {
+		t.Errorf("FetcherLow: got %d, want %d", cfg.FetcherLow, def.FetcherLow)
+	}
+	if cfg.Parser != def.Parser {
+		t.Errorf("Parser: got %d, want %d", cfg.Parser, def.Parser)
+	}
+	if cfg.Validate != def.Validate {
+		t.Errorf("Validate: got %d, want %d", cfg.Validate, def.Validate)
+	}
+}
+
+func TestLoadWorkerCounts_EnvOverride(t *testing.T) {
+	t.Setenv("FETCHER_HIGH_WORKER_COUNT", "10")
+	t.Setenv("FETCHER_NORMAL_WORKER_COUNT", "20")
+	t.Setenv("FETCHER_LOW_WORKER_COUNT", "5")
+	t.Setenv("PARSER_WORKER_COUNT", "12")
+	t.Setenv("VALIDATE_WORKER_COUNT", "16")
+
+	cfg, err := config.LoadWorkerCounts("/tmp/nonexistent-env-file.env")
+	require.NoError(t, err)
+
+	if cfg.FetcherHigh != 10 || cfg.FetcherNormal != 20 || cfg.FetcherLow != 5 ||
+		cfg.Parser != 12 || cfg.Validate != 16 {
+		t.Errorf("env override 실패: %+v", cfg)
+	}
+}
+
+func TestLoadWorkerCounts_PartialOverride(t *testing.T) {
+	// 일부 env 만 설정 → 설정된 것만 변경, 나머지는 default 유지
+	for _, k := range []string{
+		"FETCHER_HIGH_WORKER_COUNT",
+		"FETCHER_NORMAL_WORKER_COUNT",
+		"FETCHER_LOW_WORKER_COUNT",
+		"PARSER_WORKER_COUNT",
+		"VALIDATE_WORKER_COUNT",
+	} {
+		t.Setenv(k, "")
+	}
+	t.Setenv("PARSER_WORKER_COUNT", "12")
+
+	cfg, err := config.LoadWorkerCounts("/tmp/nonexistent-env-file.env")
+	require.NoError(t, err)
+
+	def := config.DefaultWorkerCountsConfig()
+	if cfg.Parser != 12 {
+		t.Errorf("Parser env override 미반영: got %d, want 12", cfg.Parser)
+	}
+	if cfg.FetcherNormal != def.FetcherNormal {
+		t.Errorf("FetcherNormal: 미설정인데 default 와 다름: got %d, want %d",
+			cfg.FetcherNormal, def.FetcherNormal)
+	}
+}
+
+func TestLoadWorkerCounts_InvalidValues(t *testing.T) {
+	tests := []struct {
+		name string
+		key  string
+		val  string
+	}{
+		{"negative", "FETCHER_HIGH_WORKER_COUNT", "-1"},
+		{"zero", "PARSER_WORKER_COUNT", "0"},
+		{"non-numeric", "VALIDATE_WORKER_COUNT", "abc"},
+		{"float", "FETCHER_NORMAL_WORKER_COUNT", "1.5"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// reset all
+			for _, k := range []string{
+				"FETCHER_HIGH_WORKER_COUNT",
+				"FETCHER_NORMAL_WORKER_COUNT",
+				"FETCHER_LOW_WORKER_COUNT",
+				"PARSER_WORKER_COUNT",
+				"VALIDATE_WORKER_COUNT",
+			} {
+				t.Setenv(k, "")
+			}
+			t.Setenv(tt.key, tt.val)
+
+			_, err := config.LoadWorkerCounts("/tmp/nonexistent-env-file.env")
+			require.Error(t, err, "%s=%q 는 에러여야 함", tt.key, tt.val)
+		})
+	}
+}


### PR DESCRIPTION
## 연관 이슈
- Closes #376

<br>

## 구현 내용

운영자가 worker count 튜닝 시 재빌드 없이 env 만 조정해 즉시 반영할 수 있도록 메인 fetcher pool 과 parser/validate worker 의 hardcoded 5종을 env 로 노출.

### 신규 환경변수

| Env | Default | 대상 |
|---|---|---|
| \`FETCHER_HIGH_WORKER_COUNT\` | 3 | priority=high crawler pool |
| \`FETCHER_NORMAL_WORKER_COUNT\` | 6 | priority=normal crawler pool |
| \`FETCHER_LOW_WORKER_COUNT\` | 2 | priority=low crawler pool |
| \`PARSER_WORKER_COUNT\` | 6 | parser worker (issuetracker.fetched consumer) |
| \`VALIDATE_WORKER_COUNT\` | 8 | validate worker (issuetracker.normalized consumer) |

기존 \`CLAUDE_CODE_WORKER_COUNT\` / \`FETCHER_CHROMEDP_WORKER_COUNT\` 와 동일한 \`<STAGE>_WORKER_COUNT\` 명명 규약.

### 변경
- \`pkg/config\` 에 \`WorkerCountsConfig\` + \`DefaultWorkerCountsConfig\` + \`LoadWorkerCounts\` 추가
  - 양수 검증 (0 / 음수 / 비숫자 / float 명시 reject — \`LoadRedis\` 동일 패턴)
- \`cmd/issuetracker/main.go\` 의 5개 hardcoded 값 → config 교체
- \`.env.example\` 에 5개 env 항목 + 운영 의미 코멘트 추가
- \`test/pkg/config\` 에 단위 테스트 4건 (default / full override / partial override / invalid)

<br>

## CI / 머지 게이트 점검

### 변경 영향 범위
- 영향 패키지/모듈: \`pkg/config\`, \`cmd/issuetracker\`, \`.env.example\`, \`test/pkg/config\`
- 위험도: **Low** — default 유지로 env 미설정 시 동작 100% 보존, StageGate cap 자동 조정

### 검증
- \`go build ./...\` 통과
- \`go vet ./...\` 통과
- 전체 38 패키지 \`go test -race -count=1\` 통과

### Required Status Checks
- 통과 확인 대상 (PR Checks 탭에서 확인):
  - [ ] \`Commit Lint\`
  - [ ] \`PR Title Lint\`
  - [ ] \`Linked Issue Check\`
  - [ ] \`Format Check\`
  - [ ] \`Build\`
  - [ ] \`Test\`
  - [ ] \`Lint\`

### 롤백 계획
- PR revert 시 hardcoded 상수 복원 — env 정의는 잔존하나 무시됨 (clean)

<br>

## TODO
- (없음) 단발 변경

<br>

## 논의 사항
- claudegen pool 의 \`CLAUDE_CODE_WORKER_COUNT\` 도 본 struct 에 통합할지는 별도 이슈로 — 현재는 wiring 위치가 다르므로 scope 분리

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Worker concurrency counts for data fetching (high, normal, and low priority), parsing, and validation stages are now configurable through environment variables, enabling performance tuning without code recompilation.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/EinSofINTEREST/IssueTracker/pull/377)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->