### PR TITLE
[FEAT#381] CategoryBased + Retry priority resolver — 3-tier 활용 시작 (#380 Sub A)

### DIFF
--- a/cmd/issuetracker/main.go
+++ b/cmd/issuetracker/main.go
@@ -105,7 +105,16 @@ func main() {
 	crawlerProducer := queue.NewProducer(crawlerKafkaCfg)
 	defer crawlerProducer.Close()
 
-	resolver := crawlerWorker.NewCompositeResolver(core.PriorityNormal)
+	// 이슈 #381 — CategoryBased + Retry resolver 신규 도입. cold-start fallback 은 Low.
+	// chain 순서 (앞쪽 우선):
+	//   1. RetryPriorityResolver       — RetryCount>0 → Normal (cycle 안정성)
+	//   2. CategoryBasedResolver       — Target.Metadata["category"] / TargetType → tier
+	//   3. SourcePriorityResolver      — backward compat (등록 룰 0개)
+	//   4. RuleBasedPriorityResolver   — backward compat (등록 룰 0개)
+	//   5. DefaultPriorityResolver     — fallback Low (cold-start = Low, 사용자 결정)
+	resolver := crawlerWorker.NewCompositeResolver(core.PriorityLow)
+	resolver.Add(crawlerWorker.NewRetryPriorityResolver())
+	resolver.Add(crawlerWorker.NewCategoryBasedResolver())
 	resolver.Add(crawlerWorker.NewSourcePriorityResolver(core.PriorityNormal))
 	resolver.Add(crawlerWorker.NewRuleBasedPriorityResolver(core.PriorityNormal))
 

--- a/internal/processor/fetcher/worker/resolver.go
+++ b/internal/processor/fetcher/worker/resolver.go
@@ -276,12 +276,27 @@ func (r *CategoryBasedResolver) isTraversalType(t core.TargetType) bool {
 	}
 }
 
+// tierToPriority 는 pkg/categories.Tier 문자열을 core.Priority 로 매핑합니다.
+//
+// pkg/categories 가 internal/ 를 import 하지 않도록 매핑은 caller (본 resolver) 에서 수행
+// (CodeRabbit PR #384 피드백 — 의존성 방향 pkg → internal 차단).
+func tierToPriority(t categories.Tier) core.Priority {
+	switch t {
+	case categories.TierHigh:
+		return core.PriorityHigh
+	case categories.TierNormal:
+		return core.PriorityNormal
+	default:
+		return core.PriorityLow
+	}
+}
+
 // Resolve 는 traversal 류면 Low, 그 외엔 카테고리 매핑된 tier 를 반환합니다.
 func (r *CategoryBasedResolver) Resolve(job *core.CrawlJob) core.Priority {
 	if r.isTraversalType(job.Target.Type) {
 		return core.PriorityLow
 	}
-	return r.extractCategory(job).Priority()
+	return tierToPriority(r.extractCategory(job).Tier())
 }
 
 // CanResolve 는 결정 가능 여부를 반환합니다:

--- a/internal/processor/fetcher/worker/resolver.go
+++ b/internal/processor/fetcher/worker/resolver.go
@@ -249,7 +249,13 @@ func NewCategoryBasedResolver() *CategoryBasedResolver {
 }
 
 // extractCategory 는 Target.Metadata 에서 카테고리 hint 를 추출합니다.
-// 값이 string 이 아니거나 부재면 CategoryUnknown 반환.
+//
+// 허용 타입 (Copilot PR #384 피드백 — Metadata 가 map[string]interface{} 라 호출자가
+// string / categories.Category 어느 쪽으로든 주입 가능):
+//   - string                — 일반 케이스 (scheduler 가 string(entry.Category) 로 주입)
+//   - categories.Category   — 호출자가 typed value 직접 주입한 경우 (방어)
+//
+// 그 외 타입 / 부재 / nil 은 CategoryUnknown 반환.
 func (r *CategoryBasedResolver) extractCategory(job *core.CrawlJob) categories.Category {
 	if job.Target.Metadata == nil {
 		return categories.CategoryUnknown
@@ -258,11 +264,14 @@ func (r *CategoryBasedResolver) extractCategory(job *core.CrawlJob) categories.C
 	if !ok {
 		return categories.CategoryUnknown
 	}
-	s, ok := v.(string)
-	if !ok {
+	switch x := v.(type) {
+	case string:
+		return categories.Category(x)
+	case categories.Category:
+		return x
+	default:
 		return categories.CategoryUnknown
 	}
-	return categories.Category(s)
 }
 
 // isTraversalType 은 TargetType 이 광범위 traverse 류 (sitemap / category / search_results) 인지 반환합니다.

--- a/internal/processor/fetcher/worker/resolver.go
+++ b/internal/processor/fetcher/worker/resolver.go
@@ -3,6 +3,7 @@ package worker
 
 import (
 	"issuetracker/internal/processor/fetcher/core"
+	"issuetracker/pkg/categories"
 )
 
 // ─────────────────────────────────────────────────────────────────────────
@@ -195,6 +196,103 @@ func (r *DefaultPriorityResolver) Resolve(_ *core.CrawlJob) core.Priority {
 // 종단 resolver이므로 모든 job에 대해 결정을 내립니다.
 func (r *DefaultPriorityResolver) CanResolve(_ *core.CrawlJob) bool {
 	return true
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// RetryPriorityResolver — retry 작업은 Normal 로 흡수
+// ─────────────────────────────────────────────────────────────────────────
+
+// RetryPriorityResolver 는 RetryCount > 0 인 job 을 Normal 로 강제 분류합니다 (이슈 #381).
+//
+// 의도:
+//   - reparse / requeue / backoff retry 가 High 로 흘러 폭주하는 것을 방지
+//   - retry 흐름이 일반 cycle (Normal) 에 흡수되어 High pool 의 시의성 자원 보존
+//
+// 체인 위치 — Explicit 다음 (가장 앞쪽) 권장. RetryCount 기준이라 카테고리 분기 전에 흡수.
+type RetryPriorityResolver struct{}
+
+// NewRetryPriorityResolver 는 RetryPriorityResolver 를 생성합니다.
+func NewRetryPriorityResolver() *RetryPriorityResolver {
+	return &RetryPriorityResolver{}
+}
+
+// Resolve 는 RetryCount > 0 이면 Normal 을 반환합니다. 0 이면 호출되지 않아야 합니다
+// (CompositeResolver 는 CanResolve=false 면 본 함수를 호출하지 않음).
+func (r *RetryPriorityResolver) Resolve(_ *core.CrawlJob) core.Priority {
+	return core.PriorityNormal
+}
+
+// CanResolve 는 job.RetryCount > 0 일 때만 true 를 반환합니다.
+// 0 이면 다음 resolver 에 위임.
+func (r *RetryPriorityResolver) CanResolve(job *core.CrawlJob) bool {
+	return job.RetryCount > 0
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// CategoryBasedResolver — Target.Metadata 의 카테고리 hint 기반 분류
+// ─────────────────────────────────────────────────────────────────────────
+
+// CategoryBasedResolver 는 job.Target.Metadata 의 "category" 키와 Target.Type 을
+// 기반으로 우선순위를 결정합니다 (이슈 #381).
+//
+// 결정 규칙:
+//  1. TargetType 이 sitemap / category / search_results 면 Low — 광범위 traverse
+//  2. Metadata["category"] 가 categories enum 에 매핑되면 해당 tier 반환
+//  3. 그 외 (TargetTypeArticle + category 미지정 등) 는 CanResolve=false → 다음 resolver 위임
+//
+// 카테고리 enum / 매핑은 pkg/categories 가 단일 source.
+type CategoryBasedResolver struct{}
+
+// NewCategoryBasedResolver 는 CategoryBasedResolver 를 생성합니다.
+func NewCategoryBasedResolver() *CategoryBasedResolver {
+	return &CategoryBasedResolver{}
+}
+
+// extractCategory 는 Target.Metadata 에서 카테고리 hint 를 추출합니다.
+// 값이 string 이 아니거나 부재면 CategoryUnknown 반환.
+func (r *CategoryBasedResolver) extractCategory(job *core.CrawlJob) categories.Category {
+	if job.Target.Metadata == nil {
+		return categories.CategoryUnknown
+	}
+	v, ok := job.Target.Metadata[categories.MetadataKey]
+	if !ok {
+		return categories.CategoryUnknown
+	}
+	s, ok := v.(string)
+	if !ok {
+		return categories.CategoryUnknown
+	}
+	return categories.Category(s)
+}
+
+// isTraversalType 은 TargetType 이 광범위 traverse 류 (sitemap / category / search_results) 인지 반환합니다.
+// Low 강제 분류 대상.
+func (r *CategoryBasedResolver) isTraversalType(t core.TargetType) bool {
+	switch t {
+	case core.TargetTypeSitemap, core.TargetTypeCategory, core.TargetTypeSearchResults:
+		return true
+	default:
+		return false
+	}
+}
+
+// Resolve 는 traversal 류면 Low, 그 외엔 카테고리 매핑된 tier 를 반환합니다.
+func (r *CategoryBasedResolver) Resolve(job *core.CrawlJob) core.Priority {
+	if r.isTraversalType(job.Target.Type) {
+		return core.PriorityLow
+	}
+	return r.extractCategory(job).Priority()
+}
+
+// CanResolve 는 결정 가능 여부를 반환합니다:
+//   - traversal 류 TargetType → 항상 결정 가능 (Low)
+//   - article + 알려진 카테고리 → 결정 가능
+//   - article + 미지정 / 미등록 카테고리 → false (다음 resolver 위임)
+func (r *CategoryBasedResolver) CanResolve(job *core.CrawlJob) bool {
+	if r.isTraversalType(job.Target.Type) {
+		return true
+	}
+	return r.extractCategory(job).IsKnown()
 }
 
 // ─────────────────────────────────────────────────────────────────────────

--- a/internal/scheduler/entries.go
+++ b/internal/scheduler/entries.go
@@ -88,9 +88,14 @@ func DefaultEntries(cfg config.SchedulerConfig) []ScheduleEntry {
 				URL:         cu.URL,
 				TargetType:  core.TargetTypeCategory,
 				Interval:    cfg.CategoryInterval,
-				Priority:    core.PriorityNormal,
-				Category:    cu.Category,
-				Timeout:     cfg.JobTimeout,
+				// 이슈 #381 — TargetTypeCategory 는 traversal 류 (CategoryBasedResolver 가
+				// 항상 Low 로 분류) 이므로 시드 priority 도 Low 로 일치 (gemini PR #384 피드백).
+				// scheduler.JobEmitter 는 resolver 를 거치지 않고 entry.Priority 로 직접 topic
+				// 결정 — 본 필드를 Low 로 두지 않으면 시드 job 이 Normal 큐로 가서 traversal
+				// 의도가 깨짐.
+				Priority: core.PriorityLow,
+				Category: cu.Category,
+				Timeout:  cfg.JobTimeout,
 			})
 		}
 	}

--- a/internal/scheduler/entries.go
+++ b/internal/scheduler/entries.go
@@ -4,55 +4,64 @@ import (
 	"net/url"
 
 	"issuetracker/internal/processor/fetcher/core"
+	"issuetracker/pkg/categories"
 	"issuetracker/pkg/config"
 )
+
+// categoryURL 은 (URL, category) 쌍으로 scheduler entry 의 입력입니다 (이슈 #381).
+//
+// 기존 string slice 에서 category 메타데이터를 함께 보존하도록 확장. category 는 pkg/categories
+// enum 으로 단일화되어 다운스트림 CategoryBasedResolver 가 priority 결정에 활용.
+type categoryURL struct {
+	URL      string
+	Category categories.Category
+}
 
 // sourceCategoryURLs 는 각 소스의 카테고리 URL 목록입니다.
 //
 // 기존 sources/{kr,us}/*/config.go 에 하드코딩된 CategoryURLs 를 이 맵으로 통합.
 // DefaultEntries 가 이 목록에서 ScheduleEntry 를 생성합니다.
-// 카테고리 이름 키는 사용하지 않으므로 map[string][]string 으로 URL 목록만 보관합니다.
 //
 // 본 맵은 이슈 #328 부터 fallback 전용 — DB 우선 (scheduler_entries 테이블) 정책.
 // scheduler_entries seed 는 migrations/up/019_scheduler_entries.sql 참조. interval 은
 // migration 020 부터 30m 단축 적용 — 본 fallback 은 cfg.CategoryInterval (env) 사용.
-var sourceCategoryURLs = map[string][]string{
+var sourceCategoryURLs = map[string][]categoryURL{
 	"naver": {
-		"https://news.naver.com/section/100", // politics
-		"https://news.naver.com/section/101", // economy
-		"https://news.naver.com/section/102", // society
-		"https://news.naver.com/section/103", // culture
-		"https://news.naver.com/section/104", // world
-		"https://news.naver.com/section/105", // it
+		{"https://news.naver.com/section/100", categories.CategoryPolitics},
+		{"https://news.naver.com/section/101", categories.CategoryEconomy},
+		{"https://news.naver.com/section/102", categories.CategorySociety},
+		{"https://news.naver.com/section/103", categories.CategoryCulture},
+		{"https://news.naver.com/section/104", categories.CategoryInternational},
+		{"https://news.naver.com/section/105", categories.CategoryTech},
 	},
 	"daum": {
-		"https://news.daum.net/politics",      // politics
-		"https://news.daum.net/economic",      // economy
-		"https://news.daum.net/society",       // society
-		"https://news.daum.net/culture",       // culture
-		"https://news.daum.net/foreign",       // world
-		"https://news.daum.net/tech",          // it
-		"https://news.daum.net/climate",       // climate
-		"https://news.daum.net/life",          // life
-		"https://news.daum.net/understanding", // column
+		{"https://news.daum.net/politics", categories.CategoryPolitics},
+		{"https://news.daum.net/economic", categories.CategoryEconomy},
+		{"https://news.daum.net/society", categories.CategorySociety},
+		{"https://news.daum.net/culture", categories.CategoryCulture},
+		{"https://news.daum.net/foreign", categories.CategoryInternational},
+		{"https://news.daum.net/tech", categories.CategoryTech},
+		{"https://news.daum.net/climate", categories.CategoryClimate},
+		{"https://news.daum.net/life", categories.CategoryLifestyle},
+		{"https://news.daum.net/understanding", categories.CategoryColumn},
 	},
 	"yonhap": {
-		"https://www.yna.co.kr/politics/all",      // politics
-		"https://www.yna.co.kr/economy/all",       // economy
-		"https://www.yna.co.kr/society/all",       // society
-		"https://www.yna.co.kr/culture/all",       // culture
-		"https://www.yna.co.kr/international/all", // world
+		{"https://www.yna.co.kr/politics/all", categories.CategoryPolitics},
+		{"https://www.yna.co.kr/economy/all", categories.CategoryEconomy},
+		{"https://www.yna.co.kr/society/all", categories.CategorySociety},
+		{"https://www.yna.co.kr/culture/all", categories.CategoryCulture},
+		{"https://www.yna.co.kr/international/all", categories.CategoryInternational},
 	},
 	"cnn": {
-		"https://edition.cnn.com",               // top
-		"https://edition.cnn.com/us",            // us
-		"https://edition.cnn.com/world",         // world
-		"https://edition.cnn.com/politics",      // politics
-		"https://edition.cnn.com/business",      // business
-		"https://edition.cnn.com/business/tech", // tech
-		"https://edition.cnn.com/health",        // health
-		"https://edition.cnn.com/entertainment", // entertainment
-		"https://edition.cnn.com/sport",         // sports
+		{"https://edition.cnn.com", categories.CategoryBreakingNews},
+		{"https://edition.cnn.com/us", categories.CategorySociety},
+		{"https://edition.cnn.com/world", categories.CategoryInternational},
+		{"https://edition.cnn.com/politics", categories.CategoryPolitics},
+		{"https://edition.cnn.com/business", categories.CategoryBusiness},
+		{"https://edition.cnn.com/business/tech", categories.CategoryTech},
+		{"https://edition.cnn.com/health", categories.CategoryHealth},
+		{"https://edition.cnn.com/entertainment", categories.CategoryEntertainment},
+		{"https://edition.cnn.com/sport", categories.CategorySports},
 	},
 }
 
@@ -72,14 +81,15 @@ func hostOf(rawURL string) string {
 func DefaultEntries(cfg config.SchedulerConfig) []ScheduleEntry {
 	var entries []ScheduleEntry
 	for _, urls := range sourceCategoryURLs {
-		for _, rawURL := range urls {
-			host := hostOf(rawURL)
+		for _, cu := range urls {
+			host := hostOf(cu.URL)
 			entries = append(entries, ScheduleEntry{
 				CrawlerName: host,
-				URL:         rawURL,
+				URL:         cu.URL,
 				TargetType:  core.TargetTypeCategory,
 				Interval:    cfg.CategoryInterval,
 				Priority:    core.PriorityNormal,
+				Category:    cu.Category,
 				Timeout:     cfg.JobTimeout,
 			})
 		}

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -301,11 +301,16 @@ func (s *Scheduler) Refresh(parent context.Context) error {
 }
 
 // sameEntry 는 두 entry 가 lifecycle 영향이 있는 필드 (Interval / Priority / TargetType /
-// Timeout) 가 모두 동일한지 확인합니다. CrawlerName / URL 은 entryKey 로 이미 동등.
+// Category / Timeout) 가 모두 동일한지 확인합니다. CrawlerName / URL 은 entryKey 로 이미 동등.
+//
+// Category 비교 (이슈 #381 — Copilot PR #384 피드백): 본 필드는 발행되는 CrawlJob 의
+// Target.Metadata 에 주입되어 다운스트림 CategoryBasedResolver 가 priority 결정에 사용.
+// 비교 누락 시 DB/설정에서 카테고리 변경되어도 goroutine 미 respawn → 변경 사항 미반영.
 func sameEntry(a, b ScheduleEntry) bool {
 	return a.Interval == b.Interval &&
 		a.Priority == b.Priority &&
 		a.TargetType == b.TargetType &&
+		a.Category == b.Category &&
 		a.Timeout == b.Timeout
 }
 

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"issuetracker/internal/processor/fetcher/core"
+	"issuetracker/pkg/categories"
 	"issuetracker/pkg/logger"
 	"issuetracker/pkg/urlguard"
 )
@@ -369,12 +370,20 @@ func (s *Scheduler) publish(ctx context.Context, entry ScheduleEntry) {
 		}
 	}
 
+	// 카테고리 hint 주입 (이슈 #381) — 다운스트림 CategoryBasedResolver 가 priority
+	// 결정에 사용. 빈 카테고리는 Metadata 키 자체를 생략하여 nil-safe 동작 보존.
+	var meta map[string]interface{}
+	if entry.Category != "" {
+		meta = map[string]interface{}{categories.MetadataKey: string(entry.Category)}
+	}
+
 	job := &core.CrawlJob{
 		ID:          id,
 		CrawlerName: entry.CrawlerName,
 		Target: core.Target{
-			URL:  entry.URL,
-			Type: entry.TargetType,
+			URL:      entry.URL,
+			Type:     entry.TargetType,
+			Metadata: meta,
 		},
 		Priority:    entry.Priority,
 		ScheduledAt: time.Now(),

--- a/internal/scheduler/source.go
+++ b/internal/scheduler/source.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"issuetracker/internal/processor/fetcher/core"
+	"issuetracker/pkg/categories"
 )
 
 // ScheduleEntry는 주기적으로 발행할 크롤 Job의 스케줄 항목입니다.
@@ -30,6 +31,14 @@ type ScheduleEntry struct {
 
 	// Priority는 crawl 토픽 우선순위입니다.
 	Priority core.Priority
+
+	// Category 는 본 entry 의 콘텐츠 도메인 분류입니다 (이슈 #381 — pkg/categories).
+	// scheduler 가 CrawlJob 생성 시 Target.Metadata["category"] 로 주입 → 다운스트림
+	// CategoryBasedResolver 가 priority 결정에 사용. 빈 값이면 미분류 (Low fallback).
+	//
+	// 본 필드는 entry 자체의 분류 — chained job (category page → article) 의 category
+	// 상속은 별도 follow-up (publisher 측 작업).
+	Category categories.Category
 
 	// Timeout은 개별 크롤 Job의 최대 실행 시간입니다.
 	Timeout time.Duration

--- a/pkg/categories/categories.go
+++ b/pkg/categories/categories.go
@@ -7,9 +7,11 @@
 //   - High   : 시의성 + 사회적 영향 高 — 정치 / 경제 / 사회 / 시사 / 속보
 //   - Normal : 일반 갱신 — 스포츠 / 문화 / IT / 연예 / 라이프 / 국제 / 커뮤니티
 //   - Low    : 광범위 탐색 — 사이트맵 / 카테고리 hub / 백필 / 미분류
+//
+// 의존성 방향: 본 패키지는 self-contained — internal/ 패키지를 import 하지 않습니다.
+// caller (internal/processor/fetcher/worker 등) 가 Tier 문자열을 core.Priority 로
+// 매핑합니다 (CodeRabbit PR #384 피드백 — pkg/ → internal/ 역의존 차단).
 package categories
-
-import "issuetracker/internal/processor/fetcher/core"
 
 // Category 는 콘텐츠의 도메인 분류입니다.
 type Category string
@@ -68,17 +70,29 @@ var normalCategories = map[Category]struct{}{
 	CategoryCommunity:     {},
 }
 
-// Priority 는 본 카테고리가 매핑되는 crawl 우선순위 tier 를 반환합니다.
+// Tier 는 carrousel 우선순위 분류 문자열입니다 (high / normal / low).
 //
-// 매핑되지 않은 카테고리 (CategoryUnknown 포함) 는 Low 반환 — cold-start / 미분류 처리.
-func (c Category) Priority() core.Priority {
+// pkg/categories 가 self-contained 유지를 위해 core.Priority 대신 string 반환 — caller
+// (internal/processor/fetcher/worker 의 resolver) 가 Tier → core.Priority 매핑.
+type Tier string
+
+const (
+	TierHigh   Tier = "high"
+	TierNormal Tier = "normal"
+	TierLow    Tier = "low"
+)
+
+// Tier 는 본 카테고리가 매핑되는 우선순위 tier 를 반환합니다.
+//
+// 매핑되지 않은 카테고리 (CategoryUnknown 포함) 는 TierLow 반환 — cold-start / 미분류 처리.
+func (c Category) Tier() Tier {
 	if _, ok := highCategories[c]; ok {
-		return core.PriorityHigh
+		return TierHigh
 	}
 	if _, ok := normalCategories[c]; ok {
-		return core.PriorityNormal
+		return TierNormal
 	}
-	return core.PriorityLow
+	return TierLow
 }
 
 // IsKnown 은 본 카테고리가 enum 에 등록되어 있는지 반환합니다.

--- a/pkg/categories/categories.go
+++ b/pkg/categories/categories.go
@@ -1,0 +1,97 @@
+// Package categories 는 크롤링 대상의 콘텐츠 카테고리 enum 과 priority tier 매핑을 제공합니다.
+//
+// 카테고리는 도메인 중립 — 사이트별 URL/section 매핑은 호출자 (scheduler entries 등) 가 담당.
+// 본 패키지는 enum + tier 매핑만 단일화하여 resolver / scheduler / publisher 가 공유.
+//
+// Tier 매핑 (이슈 #381):
+//   - High   : 시의성 + 사회적 영향 高 — 정치 / 경제 / 사회 / 시사 / 속보
+//   - Normal : 일반 갱신 — 스포츠 / 문화 / IT / 연예 / 라이프 / 국제 / 커뮤니티
+//   - Low    : 광범위 탐색 — 사이트맵 / 카테고리 hub / 백필 / 미분류
+package categories
+
+import "issuetracker/internal/processor/fetcher/core"
+
+// Category 는 콘텐츠의 도메인 분류입니다.
+type Category string
+
+// Category enum — scheduler entries 와 LLM extractor 의 page_type 양쪽에서 사용.
+const (
+	// High tier
+	CategoryPolitics       Category = "politics"
+	CategoryEconomy        Category = "economy"
+	CategorySociety        Category = "society"
+	CategoryCurrentAffairs Category = "current_affairs"
+	CategoryBreakingNews   Category = "breaking_news"
+
+	// Normal tier
+	CategorySports        Category = "sports"
+	CategoryCulture       Category = "culture"
+	CategoryTech          Category = "tech"
+	CategoryBusiness      Category = "business"
+	CategoryEntertainment Category = "entertainment"
+	CategoryLifestyle     Category = "lifestyle"
+	CategoryInternational Category = "international"
+	CategoryHealth        Category = "health"
+	CategoryClimate       Category = "climate"
+	CategoryColumn        Category = "column"
+	CategoryCommunity     Category = "community"
+
+	// Unknown — 미분류 (Low fallback)
+	CategoryUnknown Category = ""
+)
+
+// MetadataKey 는 Target.Metadata 에 카테고리를 저장할 때 사용하는 표준 키입니다.
+// publisher / resolver 가 동일 키로 read/write 하도록 단일화.
+const MetadataKey = "category"
+
+// highCategories 는 High tier 로 분류되는 카테고리 집합입니다.
+var highCategories = map[Category]struct{}{
+	CategoryPolitics:       {},
+	CategoryEconomy:        {},
+	CategorySociety:        {},
+	CategoryCurrentAffairs: {},
+	CategoryBreakingNews:   {},
+}
+
+// normalCategories 는 Normal tier 로 분류되는 카테고리 집합입니다.
+var normalCategories = map[Category]struct{}{
+	CategorySports:        {},
+	CategoryCulture:       {},
+	CategoryTech:          {},
+	CategoryBusiness:      {},
+	CategoryEntertainment: {},
+	CategoryLifestyle:     {},
+	CategoryInternational: {},
+	CategoryHealth:        {},
+	CategoryClimate:       {},
+	CategoryColumn:        {},
+	CategoryCommunity:     {},
+}
+
+// Priority 는 본 카테고리가 매핑되는 crawl 우선순위 tier 를 반환합니다.
+//
+// 매핑되지 않은 카테고리 (CategoryUnknown 포함) 는 Low 반환 — cold-start / 미분류 처리.
+func (c Category) Priority() core.Priority {
+	if _, ok := highCategories[c]; ok {
+		return core.PriorityHigh
+	}
+	if _, ok := normalCategories[c]; ok {
+		return core.PriorityNormal
+	}
+	return core.PriorityLow
+}
+
+// IsKnown 은 본 카테고리가 enum 에 등록되어 있는지 반환합니다.
+// 운영 / 디버깅 — 미등록 카테고리 hint 를 발견 시 로깅 / metric 용도.
+func (c Category) IsKnown() bool {
+	if c == CategoryUnknown {
+		return false
+	}
+	if _, ok := highCategories[c]; ok {
+		return true
+	}
+	if _, ok := normalCategories[c]; ok {
+		return true
+	}
+	return false
+}

--- a/test/internal/processor/fetcher/worker/category_resolver_test.go
+++ b/test/internal/processor/fetcher/worker/category_resolver_test.go
@@ -103,6 +103,35 @@ func TestCategoryBasedResolver_Article_ByCategory(t *testing.T) {
 	}
 }
 
+// TestCategoryBasedResolver_AcceptsTypedCategory 는 Target.Metadata 의 값이
+// categories.Category 타입 (= string alias) 으로 직접 주입돼도 정상 매핑되는지 검증
+// (Copilot PR #384 피드백 — string 단언만 하면 typed value 가 미분류로 새는 버그 방지).
+func TestCategoryBasedResolver_AcceptsTypedCategory(t *testing.T) {
+	r := worker.NewCategoryBasedResolver()
+
+	tests := []struct {
+		name string
+		val  interface{}
+		want core.Priority
+	}{
+		{"string politics → High", "politics", core.PriorityHigh},
+		{"typed Category politics → High", categories.CategoryPolitics, core.PriorityHigh},
+		{"typed Category sports → Normal", categories.CategorySports, core.PriorityNormal},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			job := &core.CrawlJob{
+				Target: core.Target{
+					Type:     core.TargetTypeArticle,
+					Metadata: map[string]interface{}{categories.MetadataKey: tt.val},
+				},
+			}
+			assert.True(t, r.CanResolve(job), "유효한 카테고리는 결정 가능")
+			assert.Equal(t, tt.want, r.Resolve(job))
+		})
+	}
+}
+
 func TestCategoryBasedResolver_Article_UnknownCategory_Delegates(t *testing.T) {
 	r := worker.NewCategoryBasedResolver()
 

--- a/test/internal/processor/fetcher/worker/category_resolver_test.go
+++ b/test/internal/processor/fetcher/worker/category_resolver_test.go
@@ -1,0 +1,202 @@
+package worker_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"issuetracker/internal/processor/fetcher/core"
+	"issuetracker/internal/processor/fetcher/worker"
+	"issuetracker/pkg/categories"
+)
+
+// ─────────────────────────────────────────────────────────────────────────────
+// RetryPriorityResolver (이슈 #381)
+// ─────────────────────────────────────────────────────────────────────────────
+
+func TestRetryPriorityResolver_CanResolve(t *testing.T) {
+	r := worker.NewRetryPriorityResolver()
+
+	tests := []struct {
+		name       string
+		retryCount int
+		want       bool
+	}{
+		{"RetryCount=0 → 위임 (다음 resolver)", 0, false},
+		{"RetryCount=1 → 흡수 (Normal)", 1, true},
+		{"RetryCount=5 → 흡수", 5, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			job := &core.CrawlJob{RetryCount: tt.retryCount}
+			assert.Equal(t, tt.want, r.CanResolve(job))
+		})
+	}
+}
+
+func TestRetryPriorityResolver_Resolve_AlwaysNormal(t *testing.T) {
+	r := worker.NewRetryPriorityResolver()
+
+	// CanResolve=true 인 케이스만 Resolve 호출됨 — 항상 Normal 반환.
+	job := &core.CrawlJob{RetryCount: 3}
+	assert.Equal(t, core.PriorityNormal, r.Resolve(job))
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// CategoryBasedResolver (이슈 #381)
+// ─────────────────────────────────────────────────────────────────────────────
+
+func newJobWithCategory(targetType core.TargetType, cat string) *core.CrawlJob {
+	job := &core.CrawlJob{
+		Target: core.Target{Type: targetType},
+	}
+	if cat != "" {
+		job.Target.Metadata = map[string]interface{}{
+			categories.MetadataKey: cat,
+		}
+	}
+	return job
+}
+
+func TestCategoryBasedResolver_Traversal_ForcesLow(t *testing.T) {
+	r := worker.NewCategoryBasedResolver()
+
+	tests := []struct {
+		name string
+		tt   core.TargetType
+	}{
+		{"sitemap → Low", core.TargetTypeSitemap},
+		{"category → Low", core.TargetTypeCategory},
+		{"search_results → Low", core.TargetTypeSearchResults},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// traversal type 은 metadata 무관하게 Low + 항상 결정 가능
+			job := newJobWithCategory(tt.tt, "politics") // category hint 있어도 무시
+			assert.True(t, r.CanResolve(job))
+			assert.Equal(t, core.PriorityLow, r.Resolve(job))
+		})
+	}
+}
+
+func TestCategoryBasedResolver_Article_ByCategory(t *testing.T) {
+	r := worker.NewCategoryBasedResolver()
+
+	tests := []struct {
+		name string
+		cat  string
+		want core.Priority
+	}{
+		{"politics → High", "politics", core.PriorityHigh},
+		{"economy → High", "economy", core.PriorityHigh},
+		{"society → High", "society", core.PriorityHigh},
+		{"sports → Normal", "sports", core.PriorityNormal},
+		{"tech → Normal", "tech", core.PriorityNormal},
+		{"community → Normal", "community", core.PriorityNormal},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			job := newJobWithCategory(core.TargetTypeArticle, tt.cat)
+			assert.True(t, r.CanResolve(job), "알려진 카테고리는 결정 가능해야 함")
+			assert.Equal(t, tt.want, r.Resolve(job))
+		})
+	}
+}
+
+func TestCategoryBasedResolver_Article_UnknownCategory_Delegates(t *testing.T) {
+	r := worker.NewCategoryBasedResolver()
+
+	tests := []struct {
+		name string
+		meta map[string]interface{}
+	}{
+		{"Metadata 자체 nil", nil},
+		{"category 키 없음", map[string]interface{}{"other": "x"}},
+		{"빈 문자열 category", map[string]interface{}{categories.MetadataKey: ""}},
+		{"미등록 category", map[string]interface{}{categories.MetadataKey: "unknown_topic"}},
+		{"비-문자열 category", map[string]interface{}{categories.MetadataKey: 42}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			job := &core.CrawlJob{
+				Target: core.Target{
+					Type:     core.TargetTypeArticle,
+					Metadata: tt.meta,
+				},
+			}
+			assert.False(t, r.CanResolve(job),
+				"미지정/미등록 카테고리는 다음 resolver 로 위임해야 함")
+		})
+	}
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// CompositeResolver 체인 통합 검증 (이슈 #381 의 chain 순서)
+// ─────────────────────────────────────────────────────────────────────────────
+
+func TestCompositeChain_RetryAndCategory_LowFallback(t *testing.T) {
+	// cmd/issuetracker/main.go 의 신규 chain 과 동일 구성:
+	// Retry → CategoryBased → Source → Rule → Default(Low)
+	composite := worker.NewCompositeResolver(core.PriorityLow)
+	composite.Add(worker.NewRetryPriorityResolver())
+	composite.Add(worker.NewCategoryBasedResolver())
+	composite.Add(worker.NewSourcePriorityResolver(core.PriorityNormal))
+	composite.Add(worker.NewRuleBasedPriorityResolver(core.PriorityNormal))
+
+	tests := []struct {
+		name string
+		job  *core.CrawlJob
+		want core.Priority
+	}{
+		{
+			name: "retry 우선 — politics article 이라도 RetryCount>0 → Normal",
+			job: &core.CrawlJob{
+				RetryCount: 2,
+				Target: core.Target{
+					Type:     core.TargetTypeArticle,
+					Metadata: map[string]interface{}{categories.MetadataKey: "politics"},
+				},
+			},
+			want: core.PriorityNormal,
+		},
+		{
+			name: "초기 fetch — politics article → High",
+			job: &core.CrawlJob{
+				Target: core.Target{
+					Type:     core.TargetTypeArticle,
+					Metadata: map[string]interface{}{categories.MetadataKey: "politics"},
+				},
+			},
+			want: core.PriorityHigh,
+		},
+		{
+			name: "category page → Low (traversal)",
+			job: &core.CrawlJob{
+				Target: core.Target{Type: core.TargetTypeCategory},
+			},
+			want: core.PriorityLow,
+		},
+		{
+			name: "미분류 article → Low (cold-start fallback)",
+			job: &core.CrawlJob{
+				Target: core.Target{Type: core.TargetTypeArticle},
+			},
+			want: core.PriorityLow,
+		},
+		{
+			name: "sports article → Normal",
+			job: &core.CrawlJob{
+				Target: core.Target{
+					Type:     core.TargetTypeArticle,
+					Metadata: map[string]interface{}{categories.MetadataKey: "sports"},
+				},
+			},
+			want: core.PriorityNormal,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, composite.Resolve(tt.job))
+		})
+	}
+}

--- a/test/pkg/categories/categories_test.go
+++ b/test/pkg/categories/categories_test.go
@@ -5,43 +5,42 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"issuetracker/internal/processor/fetcher/core"
 	"issuetracker/pkg/categories"
 )
 
-func TestCategory_Priority(t *testing.T) {
+func TestCategory_Tier(t *testing.T) {
 	tests := []struct {
 		name string
 		cat  categories.Category
-		want core.Priority
+		want categories.Tier
 	}{
 		// High tier
-		{"politics → High", categories.CategoryPolitics, core.PriorityHigh},
-		{"economy → High", categories.CategoryEconomy, core.PriorityHigh},
-		{"society → High", categories.CategorySociety, core.PriorityHigh},
-		{"current_affairs → High", categories.CategoryCurrentAffairs, core.PriorityHigh},
-		{"breaking_news → High", categories.CategoryBreakingNews, core.PriorityHigh},
+		{"politics → High", categories.CategoryPolitics, categories.TierHigh},
+		{"economy → High", categories.CategoryEconomy, categories.TierHigh},
+		{"society → High", categories.CategorySociety, categories.TierHigh},
+		{"current_affairs → High", categories.CategoryCurrentAffairs, categories.TierHigh},
+		{"breaking_news → High", categories.CategoryBreakingNews, categories.TierHigh},
 
 		// Normal tier
-		{"sports → Normal", categories.CategorySports, core.PriorityNormal},
-		{"culture → Normal", categories.CategoryCulture, core.PriorityNormal},
-		{"tech → Normal", categories.CategoryTech, core.PriorityNormal},
-		{"business → Normal", categories.CategoryBusiness, core.PriorityNormal},
-		{"entertainment → Normal", categories.CategoryEntertainment, core.PriorityNormal},
-		{"lifestyle → Normal", categories.CategoryLifestyle, core.PriorityNormal},
-		{"international → Normal", categories.CategoryInternational, core.PriorityNormal},
-		{"health → Normal", categories.CategoryHealth, core.PriorityNormal},
-		{"climate → Normal", categories.CategoryClimate, core.PriorityNormal},
-		{"column → Normal", categories.CategoryColumn, core.PriorityNormal},
-		{"community → Normal", categories.CategoryCommunity, core.PriorityNormal},
+		{"sports → Normal", categories.CategorySports, categories.TierNormal},
+		{"culture → Normal", categories.CategoryCulture, categories.TierNormal},
+		{"tech → Normal", categories.CategoryTech, categories.TierNormal},
+		{"business → Normal", categories.CategoryBusiness, categories.TierNormal},
+		{"entertainment → Normal", categories.CategoryEntertainment, categories.TierNormal},
+		{"lifestyle → Normal", categories.CategoryLifestyle, categories.TierNormal},
+		{"international → Normal", categories.CategoryInternational, categories.TierNormal},
+		{"health → Normal", categories.CategoryHealth, categories.TierNormal},
+		{"climate → Normal", categories.CategoryClimate, categories.TierNormal},
+		{"column → Normal", categories.CategoryColumn, categories.TierNormal},
+		{"community → Normal", categories.CategoryCommunity, categories.TierNormal},
 
 		// Unknown / 미등록 → Low
-		{"unknown empty → Low", categories.CategoryUnknown, core.PriorityLow},
-		{"미등록 hint → Low", categories.Category("foobar"), core.PriorityLow},
+		{"unknown empty → Low", categories.CategoryUnknown, categories.TierLow},
+		{"미등록 hint → Low", categories.Category("foobar"), categories.TierLow},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			assert.Equal(t, tt.want, tt.cat.Priority())
+			assert.Equal(t, tt.want, tt.cat.Tier())
 		})
 	}
 }

--- a/test/pkg/categories/categories_test.go
+++ b/test/pkg/categories/categories_test.go
@@ -1,0 +1,71 @@
+package categories_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"issuetracker/internal/processor/fetcher/core"
+	"issuetracker/pkg/categories"
+)
+
+func TestCategory_Priority(t *testing.T) {
+	tests := []struct {
+		name string
+		cat  categories.Category
+		want core.Priority
+	}{
+		// High tier
+		{"politics → High", categories.CategoryPolitics, core.PriorityHigh},
+		{"economy → High", categories.CategoryEconomy, core.PriorityHigh},
+		{"society → High", categories.CategorySociety, core.PriorityHigh},
+		{"current_affairs → High", categories.CategoryCurrentAffairs, core.PriorityHigh},
+		{"breaking_news → High", categories.CategoryBreakingNews, core.PriorityHigh},
+
+		// Normal tier
+		{"sports → Normal", categories.CategorySports, core.PriorityNormal},
+		{"culture → Normal", categories.CategoryCulture, core.PriorityNormal},
+		{"tech → Normal", categories.CategoryTech, core.PriorityNormal},
+		{"business → Normal", categories.CategoryBusiness, core.PriorityNormal},
+		{"entertainment → Normal", categories.CategoryEntertainment, core.PriorityNormal},
+		{"lifestyle → Normal", categories.CategoryLifestyle, core.PriorityNormal},
+		{"international → Normal", categories.CategoryInternational, core.PriorityNormal},
+		{"health → Normal", categories.CategoryHealth, core.PriorityNormal},
+		{"climate → Normal", categories.CategoryClimate, core.PriorityNormal},
+		{"column → Normal", categories.CategoryColumn, core.PriorityNormal},
+		{"community → Normal", categories.CategoryCommunity, core.PriorityNormal},
+
+		// Unknown / 미등록 → Low
+		{"unknown empty → Low", categories.CategoryUnknown, core.PriorityLow},
+		{"미등록 hint → Low", categories.Category("foobar"), core.PriorityLow},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, tt.cat.Priority())
+		})
+	}
+}
+
+func TestCategory_IsKnown(t *testing.T) {
+	tests := []struct {
+		name string
+		cat  categories.Category
+		want bool
+	}{
+		{"politics → true", categories.CategoryPolitics, true},
+		{"sports → true", categories.CategorySports, true},
+		{"community → true", categories.CategoryCommunity, true},
+		{"empty → false", categories.CategoryUnknown, false},
+		{"미등록 → false", categories.Category("foobar"), false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, tt.cat.IsKnown())
+		})
+	}
+}
+
+// TestMetadataKey 는 표준 키가 상수로 노출되어 다운스트림이 동일 키로 read/write 함을 검증.
+func TestMetadataKey(t *testing.T) {
+	assert.Equal(t, "category", categories.MetadataKey)
+}


### PR DESCRIPTION
## 연관 이슈
- Closes #381
- 부모 메타: #380

<br>

## 구현 내용

라이브 분석에서 fetcher pool 활용도 측정 결과 **high (3 worker) + low (2 worker) = 5 worker 0% utilization** 이었음 (모든 job 이 Normal 로 흘러감). 본 PR 은 정적 카테고리 + Target.Type 기반 resolver 두 개를 추가하여 즉시 3-tier 활용을 시작한다.

### 신규 컴포넌트

1. **`pkg/categories`** — 카테고리 enum + tier 매핑 단일 source
   | Tier | Categories |
   |---|---|
   | High | politics, economy, society, current_affairs, breaking_news |
   | Normal | sports, culture, tech, business, entertainment, lifestyle, international, health, climate, column, community |
   | Low (fallback) | Unknown / 미등록 |

2. **`worker.RetryPriorityResolver`** — \`RetryCount > 0\` → Normal 강제 (cycle 안정성)

3. **`worker.CategoryBasedResolver`** — `Target.Metadata[\"category\"]` + `TargetType` 기반
   - traversal (sitemap / category / search_results) → Low
   - 알려진 카테고리 → tier 매핑
   - 미지정 / 미등록 → 다음 resolver 위임

### 변경

- `scheduler.ScheduleEntry` 에 `Category` 필드 추가
- `scheduler.sourceCategoryURLs` 를 `(URL, Category)` 쌍으로 재구조화 — 기존 코멘트로만 표시되던 카테고리 매핑이 데이터로 명시화
- `scheduler` 가 `CrawlJob` 생성 시 `Target.Metadata[\"category\"]` 주입
- `cmd/issuetracker/main.go` resolver chain 갱신:
  ```
  1. RetryPriorityResolver       — retry 흡수 (Normal)
  2. CategoryBasedResolver       — 카테고리 기반
  3. SourcePriorityResolver      — backward compat
  4. RuleBasedPriorityResolver   — backward compat
  5. DefaultPriorityResolver(Low) — cold-start = Low (사용자 결정)
  ```

### 테스트
- pkg/categories: Priority/IsKnown 매핑 + 미등록 fallback
- worker.CategoryResolver: traversal force / 카테고리 매칭 / 미지정 위임
- worker.RetryResolver: count 0/1/5 분기
- Composite chain 통합: retry > category > fallback Low

<br>

## CI / 머지 게이트 점검

### 변경 영향 범위
- 영향: `pkg/categories`, `internal/processor/fetcher/worker/resolver.go`, `internal/scheduler/*`, `cmd/issuetracker/main.go`
- 위험도: **Low** — 시드 entry 에 카테고리 명시된 host 는 즉시 분배, 미명시 host 는 Low (기존 Normal 에서 변경되지만 cold-start 의도된 동작)

### 검증
- `go build ./...` 통과
- `go vet ./...` 통과
- 전체 39 패키지 `go test -race -count=1` 통과 (이전 38 + 신규 categories)

### Required Status Checks
- 통과 확인 대상 (PR Checks 탭에서 확인):
  - [ ] `Commit Lint`
  - [ ] `PR Title Lint`
  - [ ] `Linked Issue Check`
  - [ ] `Format Check`
  - [ ] `Build`
  - [ ] `Test`
  - [ ] `Lint`

### 롤백 계획
- Resolver chain 5줄 revert → 기존 단순 Normal fallback 으로 즉시 회귀
- DB 영향 없음 (Target.Metadata 는 Kafka 페이로드만 영향)

<br>

## TODO
- (없음) Sub A scope 완료

<br>

## 논의 사항 / 후속 (Phase 2, 별도 이슈 권장)
- **Chained job category 상속** — publisher 가 category page → article 발행 시 부모 Target.Metadata 의 category 를 자식에 전파. 현재는 미구현 → article 들은 traversal 모드의 Low 가 아니라 미지정 article 로 cold-start Low fallback.
- **Host metadata 단위 카테고리** — fetcher_rules JSONB 확장으로 host 가 항상 같은 카테고리 군이면 entry 별 명시 부담 감소.
- Sub B (#382 — Host signal scoring) 의 동적 High↔Normal 결정은 본 PR 위에 얹힘.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added content categorization system with 17 distinct topic categories (Politics, Economy, Sports, Tech, etc.).
  * Implemented intelligent job prioritization based on content categories and retry attempts.
  * Enhanced scheduling logic to assign appropriate priority levels to crawl jobs based on content type and category classification.

* **Tests**
  * Added comprehensive test coverage for priority resolution and category-based routing logic.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/EinSofINTEREST/IssueTracker/pull/384)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->