### PR TITLE
[REFAC#388] fetcher/rule/upgrader → publisher.PublishUpgrade 이동 (#385 Sub 3)

### DIFF
--- a/cmd/issuetracker/main.go
+++ b/cmd/issuetracker/main.go
@@ -526,8 +526,8 @@ func main() {
 			fetcherResolver,
 			rawIDTracker,
 			rawSvc,
-			crawlerProducer,
-			redisRaw, // nil 허용 — in-flight lock 비활성 (단일 인스턴스)
+			jobPublisher, // 이슈 #388 — publisher.UpgradePublisher (단일 facade)
+			redisRaw,     // nil 허용 — in-flight lock 비활성 (단일 인스턴스)
 			log,
 		)
 		if upErr != nil {

--- a/internal/processor/fetcher/rule/upgrader.go
+++ b/internal/processor/fetcher/rule/upgrader.go
@@ -58,13 +58,13 @@ const (
 //   - max 20 cap: 단일 사이클 republish 폭주 회피
 //   - 모든 단계 실패는 non-fatal — best-effort. 다음 카운팅 사이클이 자연스러운 retry.
 type Upgrader struct {
-	repo      storage.FetcherRuleRepository
-	resolver  Resolver
-	tracker   storage.RawIDTracker
-	rawSvc    service.RawContentService
-	publisher publisher.UpgradePublisher
-	redis     *goredis.Client // SETNX in-flight lock 용. nil 이면 lock 비활성 (단일 인스턴스 환경).
-	log       *logger.Logger
+	repo       storage.FetcherRuleRepository
+	resolver   Resolver
+	tracker    storage.RawIDTracker
+	rawSvc     service.RawContentService
+	upgradePub publisher.UpgradePublisher // gemini PR #398 — `publisher` package import 와 shadow 회피.
+	redis      *goredis.Client            // SETNX in-flight lock 용. nil 이면 lock 비활성 (단일 인스턴스 환경).
+	log        *logger.Logger
 }
 
 // NewUpgrader 는 Upgrader 를 생성합니다 (이슈 #388 — producer queue.Producer →
@@ -96,14 +96,17 @@ func NewUpgrader(
 	if pub == nil {
 		return nil, errors.New("rule: NewUpgrader requires non-nil UpgradePublisher")
 	}
+	if log == nil {
+		return nil, errors.New("rule: NewUpgrader requires non-nil Logger")
+	}
 	return &Upgrader{
-		repo:      repo,
-		resolver:  resolver,
-		tracker:   tracker,
-		rawSvc:    rawSvc,
-		publisher: pub,
-		redis:     redisClient,
-		log:       log,
+		repo:       repo,
+		resolver:   resolver,
+		tracker:    tracker,
+		rawSvc:     rawSvc,
+		upgradePub: pub,
+		redis:      redisClient,
+		log:        log,
 	}, nil
 }
 
@@ -250,7 +253,7 @@ func (u *Upgrader) republishRaws(ctx context.Context, host string, rawIDs []stri
 		return
 	}
 
-	if err := u.publisher.PublishUpgrade(ctx, host, msgs); err != nil {
+	if err := u.upgradePub.PublishUpgrade(ctx, host, msgs); err != nil {
 		// Kafka 실패 — 모든 ID 잔존 (다음 trigger 가 자연 retry).
 		u.logWarn("upgrader republish PublishUpgrade failed, all ids retained for retry", host, err)
 		return

--- a/internal/processor/fetcher/rule/upgrader.go
+++ b/internal/processor/fetcher/rule/upgrader.go
@@ -12,6 +12,7 @@ import (
 	goredis "github.com/redis/go-redis/v9"
 
 	"issuetracker/internal/processor/fetcher/core"
+	"issuetracker/internal/publisher"
 	"issuetracker/internal/storage"
 	"issuetracker/internal/storage/service"
 	"issuetracker/pkg/logger"
@@ -57,16 +58,17 @@ const (
 //   - max 20 cap: 단일 사이클 republish 폭주 회피
 //   - 모든 단계 실패는 non-fatal — best-effort. 다음 카운팅 사이클이 자연스러운 retry.
 type Upgrader struct {
-	repo     storage.FetcherRuleRepository
-	resolver Resolver
-	tracker  storage.RawIDTracker
-	rawSvc   service.RawContentService
-	producer queue.Producer
-	redis    *goredis.Client // SETNX in-flight lock 용. nil 이면 lock 비활성 (단일 인스턴스 환경).
-	log      *logger.Logger
+	repo      storage.FetcherRuleRepository
+	resolver  Resolver
+	tracker   storage.RawIDTracker
+	rawSvc    service.RawContentService
+	publisher publisher.UpgradePublisher
+	redis     *goredis.Client // SETNX in-flight lock 용. nil 이면 lock 비활성 (단일 인스턴스 환경).
+	log       *logger.Logger
 }
 
-// NewUpgrader 는 Upgrader 를 생성합니다.
+// NewUpgrader 는 Upgrader 를 생성합니다 (이슈 #388 — producer queue.Producer →
+// publisher.UpgradePublisher 의존 교체).
 //
 // 모든 인자는 nil 허용 안 함 (redis 만 nil 허용 — 단일 인스턴스 환경에서 lock 비활성).
 // nil 인자 발견 시 error.
@@ -75,7 +77,7 @@ func NewUpgrader(
 	resolver Resolver,
 	tracker storage.RawIDTracker,
 	rawSvc service.RawContentService,
-	producer queue.Producer,
+	pub publisher.UpgradePublisher,
 	redisClient *goredis.Client,
 	log *logger.Logger,
 ) (*Upgrader, error) {
@@ -91,17 +93,17 @@ func NewUpgrader(
 	if rawSvc == nil {
 		return nil, errors.New("rule: NewUpgrader requires non-nil RawContentService")
 	}
-	if producer == nil {
-		return nil, errors.New("rule: NewUpgrader requires non-nil Producer")
+	if pub == nil {
+		return nil, errors.New("rule: NewUpgrader requires non-nil UpgradePublisher")
 	}
 	return &Upgrader{
-		repo:     repo,
-		resolver: resolver,
-		tracker:  tracker,
-		rawSvc:   rawSvc,
-		producer: producer,
-		redis:    redisClient,
-		log:      log,
+		repo:      repo,
+		resolver:  resolver,
+		tracker:   tracker,
+		rawSvc:    rawSvc,
+		publisher: pub,
+		redis:     redisClient,
+		log:       log,
 	}, nil
 }
 
@@ -248,9 +250,9 @@ func (u *Upgrader) republishRaws(ctx context.Context, host string, rawIDs []stri
 		return
 	}
 
-	if err := u.producer.PublishBatch(ctx, msgs); err != nil {
+	if err := u.publisher.PublishUpgrade(ctx, host, msgs); err != nil {
 		// Kafka 실패 — 모든 ID 잔존 (다음 trigger 가 자연 retry).
-		u.logWarn("upgrader republish PublishBatch failed, all ids retained for retry", host, err)
+		u.logWarn("upgrader republish PublishUpgrade failed, all ids retained for retry", host, err)
 		return
 	}
 

--- a/internal/publisher/upgrade.go
+++ b/internal/publisher/upgrade.go
@@ -43,9 +43,12 @@ func (p *Publisher) PublishUpgrade(ctx context.Context, host string, msgs []queu
 	if err := p.producer.PublishBatch(ctx, msgs); err != nil {
 		return fmt.Errorf("upgrade publish batch (host=%s, count=%d): %w", host, len(msgs), err)
 	}
-	p.log.WithFields(map[string]interface{}{
-		"host":            host,
-		"republish_count": len(msgs),
-	}).Info("upgrade republish published")
+	// gemini PR #398 — defensive nil check (publisher.New 가 log 검증 안 하므로 caller 보호).
+	if p.log != nil {
+		p.log.WithFields(map[string]interface{}{
+			"host":            host,
+			"republish_count": len(msgs),
+		}).Info("upgrade republish published")
+	}
 	return nil
 }

--- a/internal/publisher/upgrade.go
+++ b/internal/publisher/upgrade.go
@@ -1,0 +1,51 @@
+package publisher
+
+import (
+	"context"
+	"fmt"
+
+	"issuetracker/pkg/queue"
+)
+
+// UpgradePublisher 는 fetcher auto-upgrade republish 메시지 배치 발행 책임을 정의하는
+// 인터페이스입니다 (이슈 #388 — 메타 #385 의 Kafka I/O 단일 책임 원칙에 따라 publisher
+// 패키지에서 계약을 정의 / 이슈 #396 의 원칙 적용).
+//
+// publisher.Publisher 가 본 인터페이스를 만족하며, 외부 모듈은 본 인터페이스를 통해 upgrade
+// 발행 기능을 주입받아 사용합니다.
+//
+// UpgradePublisher dispatches a batch of pre-built upgrade republish messages to Kafka.
+// Caller (fetcher Upgrader) is responsible for the decision logic (in-flight lock,
+// fetcher_rules upsert, raw ID collection, CrawlJob building with force_fetcher metadata);
+// this interface owns only the Kafka publish step.
+type UpgradePublisher interface {
+	PublishUpgrade(ctx context.Context, host string, msgs []queue.Message) error
+}
+
+// PublishUpgrade 는 fetcher auto-upgrade (goquery → chromedp) 결정 후 실패 raw 를 재발행하는
+// 메시지 배치를 Kafka 에 일괄 발행합니다 (이슈 #388).
+//
+// 책임 분리 (메타 #385 — fetcher 로직 강한 부분은 fetcher 잔존):
+//   - **publisher 책임**: PublishBatch 호출 + 일관 로그
+//   - **fetcher 책임 (Upgrader 잔존)**: 의사결정 (in-flight lock / GetByHost / Upsert /
+//     Invalidate / PeekByHost), force_fetcher metadata / token 부착, retry_reason /
+//     original_raw_id header 부착, stale tracking, CrawlJob 빌드
+//
+// host 인자는 로그 가시성 용 — 다운스트림 fetcher 가 메시지의 host 결정.
+// msgs 가 빈 슬라이스면 noop (nil error).
+//
+// PublishBatch 실패 시 모든 ID 가 잔존하도록 caller (Upgrader) 가 RemoveByHost 호출 안 함 —
+// 다음 trigger 가 자연 retry. 본 메소드는 단순 발행만 책임.
+func (p *Publisher) PublishUpgrade(ctx context.Context, host string, msgs []queue.Message) error {
+	if len(msgs) == 0 {
+		return nil
+	}
+	if err := p.producer.PublishBatch(ctx, msgs); err != nil {
+		return fmt.Errorf("upgrade publish batch (host=%s, count=%d): %w", host, len(msgs), err)
+	}
+	p.log.WithFields(map[string]interface{}{
+		"host":            host,
+		"republish_count": len(msgs),
+	}).Info("upgrade republish published")
+	return nil
+}

--- a/test/internal/publisher/upgrade_test.go
+++ b/test/internal/publisher/upgrade_test.go
@@ -1,0 +1,91 @@
+package publisher_test
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"issuetracker/internal/processor/fetcher/core"
+	"issuetracker/internal/publisher"
+	"issuetracker/pkg/logger"
+	"issuetracker/pkg/queue"
+)
+
+// upgradeFakeProducer — PublishUpgrade 전용 producer mock. PublishBatch 만 기록.
+type upgradeFakeProducer struct {
+	mu     sync.Mutex
+	calls  int
+	batch  []queue.Message
+	failOn error
+}
+
+func (m *upgradeFakeProducer) Publish(_ context.Context, _ queue.Message) error { return nil }
+func (m *upgradeFakeProducer) PublishBatch(_ context.Context, msgs []queue.Message) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.calls++
+	if m.failOn != nil {
+		err := m.failOn
+		m.failOn = nil
+		return err
+	}
+	m.batch = append([]queue.Message{}, msgs...)
+	return nil
+}
+func (m *upgradeFakeProducer) Close() error { return nil }
+
+func (m *upgradeFakeProducer) snapshot() (calls int, batch []queue.Message) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.calls, append([]queue.Message{}, m.batch...)
+}
+
+type upgradeFakeResolver struct{}
+
+func (upgradeFakeResolver) Resolve(_ *core.CrawlJob) core.Priority { return core.PriorityNormal }
+
+func newUpgradePublisher() (*publisher.Publisher, *upgradeFakeProducer) {
+	prod := &upgradeFakeProducer{}
+	pub := publisher.New(prod, upgradeFakeResolver{}, logger.New(logger.DefaultConfig()))
+	return pub, prod
+}
+
+// TestPublishUpgrade_EmptyMsgs_Noop 는 빈 슬라이스 시 PublishBatch 호출 없음 + nil 반환.
+func TestPublishUpgrade_EmptyMsgs_Noop(t *testing.T) {
+	pub, prod := newUpgradePublisher()
+	err := pub.PublishUpgrade(context.Background(), "host.com", nil)
+	require.NoError(t, err)
+	calls, _ := prod.snapshot()
+	assert.Equal(t, 0, calls, "빈 msgs 는 PublishBatch 호출 안 함")
+}
+
+// TestPublishUpgrade_NonEmpty_CallsPublishBatch 는 메시지 전달 시 PublishBatch 1회 호출 검증.
+func TestPublishUpgrade_NonEmpty_CallsPublishBatch(t *testing.T) {
+	pub, prod := newUpgradePublisher()
+
+	msgs := []queue.Message{
+		{Topic: queue.TopicCrawlNormal, Key: []byte("id-1"), Value: []byte(`{}`)},
+		{Topic: queue.TopicCrawlNormal, Key: []byte("id-2"), Value: []byte(`{}`)},
+	}
+	require.NoError(t, pub.PublishUpgrade(context.Background(), "host.com", msgs))
+
+	calls, batch := prod.snapshot()
+	assert.Equal(t, 1, calls, "PublishBatch 1회 호출")
+	assert.Len(t, batch, 2, "메시지 2건 전달")
+}
+
+// TestPublishUpgrade_BatchFailure_WrapsError 는 PublishBatch 실패 시 host / count 포함된 에러 반환.
+func TestPublishUpgrade_BatchFailure_WrapsError(t *testing.T) {
+	pub, prod := newUpgradePublisher()
+	prod.failOn = errors.New("kafka unavailable")
+
+	msgs := []queue.Message{{Topic: queue.TopicCrawlNormal, Key: []byte("id-1"), Value: []byte(`{}`)}}
+	err := pub.PublishUpgrade(context.Background(), "host.com", msgs)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "host.com")
+	assert.Contains(t, err.Error(), "count=1")
+}


### PR DESCRIPTION
## 연관 이슈
- Closes #388
- 부모 메타: #385
- 직전 prerequisite: #386 (Sub 1 facade) ✅ + #387 (Sub 2 seed) ✅ + #396 (interface 위치 원칙) ✅

<br>

## 구현 내용

#385 Sub 3 — auto-upgrade republish 의 Kafka publish 책임을 publisher facade 로 흡수. fetcher 의사결정 로직은 잔존 (책임 분리 원칙).

### 신규 (publisher)

| 파일 | 내용 |
|---|---|
| \`publisher/upgrade.go\` (신규) | \`UpgradePublisher\` interface (이슈 #396 원칙 — publisher 측 정의) + \`PublishUpgrade(ctx, host, msgs) error\` 메소드 |

### 책임 분리 (메타 #385)

| 역할 | 위치 |
|---|---|
| **PublishBatch + 일관 로그** | publisher.PublishUpgrade |
| **의사결정** (in-flight lock / GetByHost / Upsert / Invalidate / PeekByHost / RemoveByHost) | fetcher Upgrader |
| **force_fetcher metadata + token 부착** | fetcher Upgrader |
| **retry_reason / original_raw_id header 부착** | fetcher Upgrader |
| **stale tracking + CrawlJob 빌드** | fetcher Upgrader |

### fetcher 변경

- \`internal/processor/fetcher/rule/upgrader.go\`:
  - \`producer queue.Producer\` → \`publisher publisher.UpgradePublisher\`
  - \`u.producer.PublishBatch(ctx, msgs)\` → \`u.publisher.PublishUpgrade(ctx, host, msgs)\`
  - \`NewUpgrader\` 시그니처 변경 + 에러 메시지 정정 (\"Producer\" → \"UpgradePublisher\")

### cmd/issuetracker/main.go wiring

- \`crawlerProducer\` → \`jobPublisher\` (단일 facade)

### 테스트

\`test/internal/publisher/upgrade_test.go\` 신규 (3건):
- empty msgs → noop (PublishBatch 호출 X)
- non-empty → PublishBatch 1회 호출 검증
- 실패 시 host / count 포함 에러 wrap

<br>

## CI / 머지 게이트 점검

### 변경 영향 범위
- 영향: \`internal/publisher/upgrade.go\`, \`internal/processor/fetcher/rule/upgrader.go\`, \`cmd/issuetracker/main.go\`
- 위험도: **Low** — 책임 분리 + 인터페이스 도입. 동작 무변경.

### 검증
- \`go build ./...\` 통과
- \`go vet ./...\` 통과
- 전체 37 패키지 \`go test -race -count=1\` (clean cache) 통과

### Required Status Checks
- 통과 확인 대상: Commit Lint / PR Title Lint / Linked Issue Check / Format Check / Build / Test / Lint

### 롤백 계획
- PR revert — fetcher 측에 producer 의존 복원

<br>

## TODO
- (없음) Sub 3 scope 완료

<br>

## 논의 사항
- Sub 4 (#389 — retry_scheduler) / Sub 7 (#392 — parser worker) / Sub 8 (#393 — validate worker) 모두 본 PR 의 패턴 (Kafka I/O 만 publisher, 의사결정/빌드 책임은 caller 잔존) 적용 예정

🤖 Generated with [Claude Code](https://claude.com/claude-code)