### PR TITLE
[REFAC#392] parser worker + fetcher chain_handler Kafka I/O → publisher facade

### DIFF
--- a/cmd/issuetracker/main.go
+++ b/cmd/issuetracker/main.go
@@ -223,7 +223,7 @@ func main() {
 	}
 
 	// fetcher 측 등록: fetcher_rules DB 에서 모든 source 를 읽어 일괄 등록.
-	if err := sources.RegisterAll(ctx, registry, fetcherRuleRepo, core.DefaultConfig(), rawSvc, crawlerProducer, fetcherResolver, chromedpRemoteURLs, log); err != nil {
+	if err := sources.RegisterAll(ctx, registry, fetcherRuleRepo, core.DefaultConfig(), rawSvc, jobPublisher, fetcherResolver, chromedpRemoteURLs, log); err != nil {
 		log.WithError(err).Fatal("failed to register crawlers from db")
 	}
 
@@ -565,10 +565,9 @@ func main() {
 
 	pw := parserWorker.NewParserWorker(
 		parserConsumer,
-		crawlerProducer, // normalized 토픽 발행 + chained article jobs 발행 시 publisher 가 동일 producer 사용
+		jobPublisher, // 이슈 #392 — 구 producer + JobPublisher 두 인자 통합 (publisher.Publisher 가 Forward + PublishChained 모두 제공)
 		rawSvc,
 		contentSvc,
-		jobPublisher,
 		ruleParser,
 		ruleResolver, // sample 누적 시 매칭 rule lookup
 		sampleRepo,

--- a/internal/processor/fetcher/domain/general/chain_handler.go
+++ b/internal/processor/fetcher/domain/general/chain_handler.go
@@ -9,6 +9,7 @@ import (
 
 	"issuetracker/internal/processor/fetcher/core"
 	"issuetracker/internal/processor/fetcher/rule"
+	"issuetracker/internal/publisher"
 	"issuetracker/internal/storage"
 	"issuetracker/internal/storage/service"
 	"issuetracker/pkg/logger"
@@ -48,24 +49,28 @@ type ChainHandler struct {
 	ChromedpChains []Handler     // worker_id 별 browser only chain
 	Resolver       rule.Resolver // optional. nil 이면 항상 DefaultChain 사용
 	RawSvc         service.RawContentService
-	Producer       queue.Producer
+	Pub            *publisher.Publisher
 	Log            *logger.Logger
 }
 
 // NewChainHandler 는 새 ChainHandler 를 생성합니다.
-// DefaultChain / RawSvc / Producer / Log 모두 비-nil 필수.
+// DefaultChain / RawSvc / Pub / Log 모두 비-nil 필수.
 // ChromedpChains 가 nil/empty 이면 룰 = 'chromedp' 매칭이어도 DefaultChain fallback (warn 로그).
 // Resolver 가 nil 이면 룰 조회 없이 항상 DefaultChain — 기존 동작 100% 보존.
 //
 // chromedpChains 길이는 chromedp pool 의 WorkerCount 와 일치해야 함 (호출자 책임).
 // 단일 Chrome 운영 호환 모드 (sub-issue #229 머지 직후 시점) 에서는 길이 1 의 slice 로 호출.
+//
+// 이슈 #392 — 구 queue.Producer 직접 주입 → publisher facade 주입으로 변경. Kafka I/O 단일
+// 책임 원칙 (메타 #385) 에 따라 chain_handler 가 republish/fetched_ref 발행 시 직접
+// producer.Publish 하지 않고 pub.Forward 위임.
 func NewChainHandler(
 	crawler SourceCrawler,
 	defaultChain Handler,
 	chromedpChains []Handler,
 	resolver rule.Resolver,
 	rawSvc service.RawContentService,
-	producer queue.Producer,
+	pub *publisher.Publisher,
 	log *logger.Logger,
 ) *ChainHandler {
 	return &ChainHandler{
@@ -74,7 +79,7 @@ func NewChainHandler(
 		ChromedpChains: chromedpChains,
 		Resolver:       resolver,
 		RawSvc:         rawSvc,
-		Producer:       producer,
+		Pub:            pub,
 		Log:            log,
 	}
 }
@@ -212,7 +217,7 @@ func extractHost(rawURL string) string {
 // selectChain 이 (chain, isChromedp) tuple 반환. ChromedpChains slice 모델로
 // 변경되어 chain 포인터 비교가 부적합 → isChromedp 플래그로 분기.
 func (h *ChainHandler) Handle(ctx context.Context, job *core.CrawlJob) ([]*core.Content, error) {
-	if h.DefaultChain == nil || h.Log == nil || h.RawSvc == nil || h.Producer == nil {
+	if h.DefaultChain == nil || h.Log == nil || h.RawSvc == nil || h.Pub == nil {
 		return nil, fmt.Errorf("chain handler is not properly initialized")
 	}
 
@@ -289,7 +294,7 @@ func (h *ChainHandler) processFetchedRaw(ctx context.Context, job *core.CrawlJob
 // ChromedpChains 미wiring 사이트 (예: yonhap) 에 대해서는 정의상 chromedp pool 이 큐 메시지를
 // 받지 않아야 하지만, 안전장치로 empty 일 때 graceful error.
 func (h *ChainHandler) HandleChromedpOnly(ctx context.Context, job *core.CrawlJob) ([]*core.Content, error) {
-	if h.Log == nil || h.RawSvc == nil || h.Producer == nil {
+	if h.Log == nil || h.RawSvc == nil || h.Pub == nil {
 		return nil, fmt.Errorf("chain handler is not properly initialized")
 	}
 	if !h.hasChromedpChain() {
@@ -335,7 +340,7 @@ func (h *ChainHandler) republishToChromedpQueue(ctx context.Context, job *core.C
 			"original": "goquery_pool",
 		},
 	}
-	if err := h.Producer.Publish(ctx, msg); err != nil {
+	if err := h.Pub.Forward(ctx, msg); err != nil {
 		return fmt.Errorf("publish chromedp queue: %w", err)
 	}
 	h.Log.WithFields(map[string]interface{}{
@@ -380,5 +385,5 @@ func (h *ChainHandler) publishFetchedRef(ctx context.Context, job *core.CrawlJob
 		Value:   payload,
 		Headers: headers,
 	}
-	return h.Producer.Publish(ctx, msg)
+	return h.Pub.Forward(ctx, msg)
 }

--- a/internal/processor/fetcher/domain/general/sources/registry.go
+++ b/internal/processor/fetcher/domain/general/sources/registry.go
@@ -19,10 +19,10 @@ import (
 	"issuetracker/internal/processor/fetcher/implementation/goquery"
 	"issuetracker/internal/processor/fetcher/rate_limiter"
 	"issuetracker/internal/processor/fetcher/rule"
+	"issuetracker/internal/publisher"
 	"issuetracker/internal/storage"
 	"issuetracker/internal/storage/service"
 	"issuetracker/pkg/logger"
-	"issuetracker/pkg/queue"
 )
 
 // dnsCacheTTL 는 fetcher rate limiter 가 사용하는 DNS resolver 의 entry TTL.
@@ -55,7 +55,7 @@ func RegisterAll(
 	fetcherRuleRepo storage.FetcherRuleRepository,
 	baseConfig core.Config,
 	rawSvc service.RawContentService,
-	producer queue.Producer,
+	pub *publisher.Publisher,
 	resolver rule.Resolver,
 	chromedpRemoteURLs []string,
 	log *logger.Logger,
@@ -89,7 +89,7 @@ func RegisterAll(
 	// CrawlerName 이 host 기반으로 통일 (#248) — source_name 키는 하위 호환 유지.
 	for sourceName, entry := range bySource {
 		h, err := buildHandler(sourceName, entry.Rec,
-			baseConfig, rawSvc, producer, resolver, chromedpRemoteURLs, dnsResolver, sourceConfigResolver, log)
+			baseConfig, rawSvc, pub, resolver, chromedpRemoteURLs, dnsResolver, sourceConfigResolver, log)
 		if err != nil {
 			return err
 		}
@@ -138,7 +138,7 @@ func buildHandler(
 	rec *storage.FetcherRuleRecord,
 	baseConfig core.Config,
 	rawSvc service.RawContentService,
-	producer queue.Producer,
+	pub *publisher.Publisher,
 	resolver rule.Resolver,
 	chromedpRemoteURLs []string,
 	dnsResolver core.IPResolver,
@@ -192,7 +192,7 @@ func buildHandler(
 		return nil, err
 	}
 
-	return general.NewChainHandler(crawler, defaultChain, chromedpChains, resolver, rawSvc, producer, log), nil
+	return general.NewChainHandler(crawler, defaultChain, chromedpChains, resolver, rawSvc, pub, log), nil
 }
 
 // SourceEntry 는 source_name 별 canonical row 와 그 row 가 canonical (base_url hostname ==

--- a/internal/processor/parser/worker/parser_worker.go
+++ b/internal/processor/parser/worker/parser_worker.go
@@ -34,6 +34,7 @@ import (
 	"issuetracker/internal/processor/parser"
 	"issuetracker/internal/processor/parser/rule"
 	"issuetracker/internal/processor/parser/rule/llmgen"
+	"issuetracker/internal/publisher"
 	"issuetracker/internal/storage"
 	"issuetracker/internal/storage/service"
 	"issuetracker/pkg/logger"
@@ -50,12 +51,14 @@ const (
 )
 
 // ParserWorker 는 TopicFetched consumer group 의 worker pool 입니다.
+//
+// 이슈 #392 — Kafka I/O (consume + 3 종 publish + chained job publish) 모두 publisher
+// facade 로 위임. queue 패키지에 직접 의존하지 않음 (consumer 는 publisher.Consumer 별칭).
 type ParserWorker struct {
-	consumer   *queue.KafkaConsumer
-	producer   queue.Producer
+	consumer   publisher.Consumer
+	pub        *publisher.Publisher
 	rawSvc     service.RawContentService
 	contentSvc service.ContentService
-	publisher  general.JobPublisher
 	parser     *rule.Parser
 	resolver   *rule.Resolver              // sample 누적 시 매칭된 rule lookup
 	sampleSvc  storage.SampleURLRepository // nil 허용 — nil 이면 sample 누적 skip (단계 4-1)
@@ -113,7 +116,9 @@ type PipelineGuard interface {
 
 // NewParserWorker 는 ParserWorker 를 생성합니다.
 //
-//   - publisher 는 nil 허용 — nil 이면 카테고리 chained jobs 발행 건너뜀 (이런 모드는 보통 운영 금지)
+//   - pub 는 nil 허용 — nil 이면 카테고리 chained jobs 발행 / Forward 모두 건너뜀
+//     (이런 모드는 보통 운영 금지, 테스트 fallback). 이슈 #392 — 구 publisher / producer 두
+//     필드 통합.
 //   - gate 는 nil 허용 — nil 이면 NoopStageGate 로 fallback (단일 인스턴스 환경에서 dedup + cap 비활성)
 //   - llmGen 은 nil 허용 — nil 이면 ErrNoRule 시 raw 잔존만 (LLM auto-rule 비활성)
 //   - resolver / sampleSvc 는 nil 허용 — nil 이면 sample 누적 skip
@@ -127,11 +132,10 @@ type PipelineGuard interface {
 // 가 동일 패턴으로 stage 별 동시성 cap + URL 중복 처리 차단을 단일 API 로 적용 — parser 단계는
 // raw.URL 단위로 acquire, Kafka rebalance 시 같은 raw 가 두 worker 에 도달해도 1회만 파싱.
 func NewParserWorker(
-	consumer *queue.KafkaConsumer,
-	producer queue.Producer,
+	consumer publisher.Consumer,
+	pub *publisher.Publisher,
 	rawSvc service.RawContentService,
 	contentSvc service.ContentService,
-	publisher general.JobPublisher,
 	parser *rule.Parser,
 	resolver *rule.Resolver,
 	sampleSvc storage.SampleURLRepository,
@@ -159,10 +163,9 @@ func NewParserWorker(
 	}
 	return &ParserWorker{
 		consumer:            consumer,
-		producer:            producer,
+		pub:                 pub,
 		rawSvc:              rawSvc,
 		contentSvc:          contentSvc,
-		publisher:           publisher,
 		parser:              parser,
 		resolver:            resolver,
 		sampleSvc:           sampleSvc,
@@ -382,7 +385,7 @@ func (w *ParserWorker) processCategoryPage(ctx context.Context, raw *core.RawCon
 	// (TTL fallback 으로 자동 회수).
 	defer w.releaseCategoryMarker(ctx, raw.URL, mlog)
 
-	if w.parser == nil || w.publisher == nil {
+	if w.parser == nil || w.pub == nil {
 		mlog.Debug("parser or publisher not configured, skipping category job")
 		w.deleteRaw(ctx, rawID, mlog)
 		return nil
@@ -425,12 +428,12 @@ func (w *ParserWorker) processCategoryPage(ctx context.Context, raw *core.RawCon
 	}
 
 	if len(articleURLs) > 0 {
-		if err := w.publisher.PublishChained(ctx, crawlerName, articleURLs, core.TargetTypeArticle, jobTimeout); err != nil {
+		if err := w.pub.PublishChained(ctx, crawlerName, articleURLs, core.TargetTypeArticle, jobTimeout); err != nil {
 			return fmt.Errorf("publish chained article jobs: %w", err)
 		}
 	}
 	if len(listURLs) > 0 {
-		if err := w.publisher.PublishChained(ctx, crawlerName, listURLs, core.TargetTypeCategory, jobTimeout); err != nil {
+		if err := w.pub.PublishChained(ctx, crawlerName, listURLs, core.TargetTypeCategory, jobTimeout); err != nil {
 			return fmt.Errorf("publish chained list jobs (extract_links_only): %w", err)
 		}
 	}
@@ -785,7 +788,7 @@ func (w *ParserWorker) publishContents(ctx context.Context, contents []*core.Con
 			Value:   pmBytes,
 			Headers: headers,
 		}
-		if err := w.producer.Publish(ctx, msg); err != nil {
+		if err := w.pub.Forward(ctx, msg); err != nil {
 			return fmt.Errorf("publish normalized: %w", err)
 		}
 	}
@@ -846,7 +849,7 @@ func (w *ParserWorker) RequeueForLLMRetry(ctx context.Context, ref core.RawConte
 			"crawler":     crawlerName,
 		},
 	}
-	if err := w.producer.Publish(pubCtx, msg); err != nil {
+	if err := w.pub.Forward(pubCtx, msg); err != nil {
 		w.log.WithFields(map[string]interface{}{
 			"raw_id":          ref.ID,
 			"url":             ref.URL,
@@ -897,7 +900,7 @@ func (w *ParserWorker) RequeueParsing(ctx context.Context, items []llmgen.Pendin
 				"timeout_ms": strconv.FormatInt(item.TimeoutMs, 10),
 			},
 		}
-		if err := w.producer.Publish(pubCtx, msg); err != nil {
+		if err := w.pub.Forward(pubCtx, msg); err != nil {
 			w.log.WithFields(map[string]interface{}{
 				"raw_id": item.RawRef.ID,
 				"url":    item.RawRef.URL,

--- a/internal/processor/parser/worker/parser_worker.go
+++ b/internal/processor/parser/worker/parser_worker.go
@@ -53,7 +53,9 @@ const (
 // ParserWorker 는 TopicFetched consumer group 의 worker pool 입니다.
 //
 // 이슈 #392 — Kafka I/O (consume + 3 종 publish + chained job publish) 모두 publisher
-// facade 로 위임. queue 패키지에 직접 의존하지 않음 (consumer 는 publisher.Consumer 별칭).
+// facade 로 위임. Kafka 구현체 (*queue.KafkaConsumer, queue.Producer) 에 직접 의존하지 않음.
+// queue 패키지 자체는 토픽 상수 (TopicFetched / TopicNormalized) 와 데이터 타입
+// (queue.Message) 사용을 위해 그대로 import — I/O 구현체 직접 호출만 publisher 위임.
 type ParserWorker struct {
 	consumer   publisher.Consumer
 	pub        *publisher.Publisher
@@ -116,9 +118,11 @@ type PipelineGuard interface {
 
 // NewParserWorker 는 ParserWorker 를 생성합니다.
 //
-//   - pub 는 nil 허용 — nil 이면 카테고리 chained jobs 발행 / Forward 모두 건너뜀
-//     (이런 모드는 보통 운영 금지, 테스트 fallback). 이슈 #392 — 구 publisher / producer 두
-//     필드 통합.
+//   - pub 는 운영 환경에서 **필수 wiring** — nil 이면 Forward / PublishChained 호출이
+//     `publisher: Forward called on nil *Publisher` 등 error 를 반환하고, 호출 사이트가
+//     ProcessMessage 실패로 분류 → commit skip → Kafka 가 동일 메시지를 무한 재배달 가능.
+//     nil 은 publish 경로에 도달하지 않는 단위 테스트 (예: stage gate 격리 검증) 에만 허용.
+//     이슈 #392 — 구 publisher / producer 두 필드 통합 + Copilot 피드백 반영.
 //   - gate 는 nil 허용 — nil 이면 NoopStageGate 로 fallback (단일 인스턴스 환경에서 dedup + cap 비활성)
 //   - llmGen 은 nil 허용 — nil 이면 ErrNoRule 시 raw 잔존만 (LLM auto-rule 비활성)
 //   - resolver / sampleSvc 는 nil 허용 — nil 이면 sample 누적 skip

--- a/test/internal/processor/fetcher/domain/general/chain_handler_chromedp_routing_test.go
+++ b/test/internal/processor/fetcher/domain/general/chain_handler_chromedp_routing_test.go
@@ -13,6 +13,7 @@ import (
 
 	"issuetracker/internal/processor/fetcher/core"
 	"issuetracker/internal/processor/fetcher/domain/general"
+	"issuetracker/internal/publisher"
 	"issuetracker/internal/storage"
 	"issuetracker/pkg/logger"
 	"issuetracker/pkg/queue"
@@ -71,13 +72,17 @@ func newRoutingHandler(t *testing.T, chains []general.Handler) *general.ChainHan
 	t.Helper()
 	log := logger.New(logger.DefaultConfig())
 	defaultChain := &fakeChain{id: "default"} // 본 테스트에서는 호출되지 않음
+	// 이슈 #392 — chain_handler 가 *publisher.Publisher 의존으로 변경됨.
+	// 본 테스트는 republish 경로 자체에 도달하지 않으므로 stubProducer 가 publisher 안에서
+	// 호출되지 않음 — publish 발생 시 stubProducer.Publish 의 panic 으로 invariant 위반 감지.
+	pub := publisher.New(stubProducer{}, nil, log)
 	return general.NewChainHandler(
 		nil, // SourceCrawler — HandleChromedpOnly 경로에서 사용 X
 		defaultChain,
 		chains,
 		nil,
 		stubRawSvc{},
-		stubProducer{},
+		pub,
 		log,
 	)
 }

--- a/test/internal/processor/fetcher/domain/general/chain_handler_reparse_propagation_test.go
+++ b/test/internal/processor/fetcher/domain/general/chain_handler_reparse_propagation_test.go
@@ -14,6 +14,7 @@ import (
 
 	"issuetracker/internal/processor/fetcher/core"
 	"issuetracker/internal/processor/fetcher/domain/general"
+	"issuetracker/internal/publisher"
 	"issuetracker/internal/storage"
 	"issuetracker/pkg/logger"
 	"issuetracker/pkg/queue"
@@ -77,13 +78,17 @@ func newCaptureHandler(t *testing.T, raw *core.RawContent, rawID string) (*gener
 	log := logger.New(logger.DefaultConfig())
 	rawSvc := &captureRawSvc{returnID: rawID}
 	prod := &captureProducer{}
+	// 이슈 #392 — chain_handler 가 *publisher.Publisher 의존으로 변경됨에 따라 mock producer 를
+	// 실제 publisher 로 wrap (Sub 5/7 동일 패턴). captureProducer.published 는 pub.Forward 위임
+	// 경로로 그대로 트리거됨.
+	pub := publisher.New(prod, nil, log)
 	h := general.NewChainHandler(
 		nil, // SourceCrawler — fast path 에서 사용 X
 		&successChain{raw: raw},
 		nil, // no chromedp chains
 		nil, // no resolver
 		rawSvc,
-		prod,
+		pub,
 		log,
 	)
 	return h, prod

--- a/test/internal/processor/parser/worker/helpers_test.go
+++ b/test/internal/processor/parser/worker/helpers_test.go
@@ -4,30 +4,34 @@ package worker_test
 
 import (
 	"issuetracker/internal/processor/parser/worker"
+	"issuetracker/internal/publisher"
 	"issuetracker/pkg/logger"
 	"issuetracker/pkg/queue"
 )
 
 // newMinimalWorker 는 RequeueForLLMRetry 테스트에만 필요한 최소 ParserWorker 를 생성합니다.
 // nil 허용 필드는 전부 nil 로 전달합니다.
+//
+// 이슈 #392 — parser_worker 가 publisher facade 의존으로 변경됨에 따라 mock producer 를
+// 실제 *publisher.Publisher 로 wrap (Sub 5/7 동일 패턴, newTestPublisher 와 등가).
 func newMinimalWorker(prod queue.Producer, log *logger.Logger) *worker.ParserWorker {
+	pub := publisher.New(prod, nil, log)
 	return worker.NewParserWorker(
-		nil,  // consumer
-		prod, // producer — RequeueForLLMRetry 가 사용
-		nil,  // rawSvc
-		nil,  // contentSvc
-		nil,  // publisher
-		nil,  // parser
-		nil,  // resolver
-		nil,  // sampleSvc
-		nil,  // gate
-		nil,  // llmGen
-		nil,  // failureCounter
-		nil,  // rawIDTracker
-		nil,  // upgrader
-		0,    // emptyBodyTitleMin
-		0,    // emptyBodyContentMin
-		1,    // workerCount
+		nil, // consumer
+		pub, // pub — RequeueForLLMRetry/Forward 가 사용
+		nil, // rawSvc
+		nil, // contentSvc
+		nil, // parser
+		nil, // resolver
+		nil, // sampleSvc
+		nil, // gate
+		nil, // llmGen
+		nil, // failureCounter
+		nil, // rawIDTracker
+		nil, // upgrader
+		0,   // emptyBodyTitleMin
+		0,   // emptyBodyContentMin
+		1,   // workerCount
 		log,
 	)
 }

--- a/test/internal/processor/parser/worker/stage_gate_test.go
+++ b/test/internal/processor/parser/worker/stage_gate_test.go
@@ -51,10 +51,9 @@ func (g *fakeStageGate) Acquire(_ context.Context, _ string) (func(), bool, erro
 func newGatedWorker(gate locks.StageGate, rawSvc *fakeRawSvc, log *logger.Logger) *parserWorker.ParserWorker {
 	return parserWorker.NewParserWorker(
 		nil,    // consumer
-		nil,    // producer
+		nil,    // pub
 		rawSvc, // rawSvc
 		nil,    // contentSvc
-		nil,    // publisher
 		nil,    // parser
 		nil,    // resolver
 		nil,    // sampleSvc


### PR DESCRIPTION
## 연관 이슈

Closes #392
부모 메타: #385 — Publisher 통합 Sub 7

추가 범위 (사용자 요청): fetcher 의 `chain_handler.go` 잔여 Kafka I/O 도 동일 PR 에 묶음. 메타 #385 의 어느 sub 에도 명시되지 않았지만 "Kafka I/O 단일 책임 원칙" 일관성 차원에서 통합.

## 구현 내용

### parser worker (Sub 7 본체)

| Before | After |
|---|---|
| `consumer *queue.KafkaConsumer` | `consumer publisher.Consumer` (Sub 5 의 별칭) |
| `producer queue.Producer` + `publisher general.JobPublisher` (필드 2개) | `pub *publisher.Publisher` (필드 1개 — concrete 가 양쪽 인터페이스 모두 제공) |
| `w.producer.Publish(...)` × 3 (TopicNormalized + 2× TopicFetched LLM/pending requeue) | `w.pub.Forward(...)` |
| `w.publisher.PublishChained(...)` × 2 (article / category chained jobs) | `w.pub.PublishChained(...)` |
| `NewParserWorker(consumer, producer, ..., publisher, ...)` | `NewParserWorker(consumer, pub, ...)` (인자 2개 통합) |

### fetcher chain_handler (추가 범위)

| Before | After |
|---|---|
| `Producer queue.Producer` 필드 | `Pub *publisher.Publisher` |
| `h.Producer.Publish` × 2 (`republishToChromedpQueue` + `publishFetchedRef`) | `h.Pub.Forward(...)` |
| `NewChainHandler(..., producer queue.Producer, ...)` | `NewChainHandler(..., pub *publisher.Publisher, ...)` |
| `sources/registry.go` pass-through `producer queue.Producer` | `pub *publisher.Publisher` (queue 직접 의존 제거) |

### cmd/issuetracker/main.go wiring

```diff
-	pw := parserWorker.NewParserWorker(parserConsumer, crawlerProducer, rawSvc, contentSvc, jobPublisher, ...)
+	pw := parserWorker.NewParserWorker(parserConsumer, jobPublisher, rawSvc, contentSvc, ...)  // producer + jobPublisher 통합

-	sources.RegisterAll(ctx, registry, ..., rawSvc, crawlerProducer, fetcherResolver, ...)
+	sources.RegisterAll(ctx, registry, ..., rawSvc, jobPublisher, fetcherResolver, ...)
```

### 테스트

- `test/.../parser/worker/helpers_test.go` `newMinimalWorker(prod, log)` 내부에서 `publisher.New(prod, nil, log)` 래핑 (Sub 5 의 `newTestPublisher` 패턴과 동일).
- `test/.../parser/worker/stage_gate_test.go` 생성자 인자 갯수 / 주석 정정.
- `test/.../fetcher/domain/general/chain_handler_*_test.go` 2 개 파일: captureProducer / stubProducer 를 `publisher.New(...)` 로 래핑.

## CI / 머지 게이트 점검

- [x] `gofmt -l` — clean
- [x] `go build ./internal/... ./cmd/issuetracker/ ./test/...` — pass
- [x] `go test -race -count=1 -timeout=180s` (parser worker / fetcher domain / publisher / worker) — 전 패키지 통과
- [x] PR 타이틀 `[REFAC#392]`
- [x] commit `[REFAC]:` prefix + 한국어

## 변경 영향 범위 + 위험도

- **영향**: parser worker + fetcher chain_handler + sources registry + main wiring + 4 test 파일
- **위험도 Medium → 동작 동등성 확보됨**:
  - publisher.Forward 는 thin pass-through (Sub 5 동일 검증)
  - PublishChained 는 기존 publisher.PublishChained 그대로 사용
  - 라이브 publish 시점/내용 무변경
- 다음 Sub 8 (#393) — validate worker + cmd/processor Kafka I/O 정리
- Sub 6 (#391) PriorityResolver chain 이동은 별도 진행

## 롤백 계획

PR revert 시 모든 시그니처가 동시에 원복 — wiring 회귀 없음.

🤖 Generated with [Claude Code](https://claude.com/claude-code)