### PR TITLE
[REFAC#393] validate worker + cmd/processor Kafka I/O → publisher facade

### DIFF
--- a/cmd/issuetracker/main.go
+++ b/cmd/issuetracker/main.go
@@ -789,6 +789,10 @@ func main() {
 	validateProducer := queue.NewProducer(validateKafkaCfg)
 	defer validateProducer.Close()
 
+	// 이슈 #393 — validate worker 가 publisher facade 의존. validate 전용 producer 를
+	// thin publisher 로 wrap (resolver/guard 불필요 — validate 는 Forward 만 사용).
+	validatePublisher := publisher.New(validateProducer, nil, log)
+
 	// Validate StageGate (이슈 #356) — ProcessingLock + per-stage Semaphore 합성.
 	validateCap := config.CapPerStage(workerCountsCfg.Validate, stageGateCfg.ValidateMaxConcurrentPerStage)
 	validateGate := locks.BuildStageGate(locks.StageValidator, validateCap, procLock, log)
@@ -802,7 +806,7 @@ func main() {
 		log.Warn("processing lock unavailable, validate stage gate falls back to noop")
 	}
 
-	validateWorker := validate.NewWorker(validateConsumer, validateProducer, contentSvc, validateGate, workerCountsCfg.Validate, validateCfg)
+	validateWorker := validate.NewWorker(validateConsumer, validatePublisher, contentSvc, validateGate, workerCountsCfg.Validate, validateCfg)
 
 	log.WithFields(map[string]interface{}{
 		"worker_count": workerCountsCfg.Validate,

--- a/cmd/processor/main.go
+++ b/cmd/processor/main.go
@@ -8,6 +8,7 @@ import (
 
 	"issuetracker/internal/locks"
 	"issuetracker/internal/processor/validate"
+	"issuetracker/internal/publisher"
 	pgstore "issuetracker/internal/storage/postgres"
 	"issuetracker/internal/storage/service"
 	"issuetracker/pkg/config"
@@ -94,11 +95,15 @@ func main() {
 	producer := queue.NewProducer(kafkaCfg)
 	defer producer.Close()
 
+	// 이슈 #393 — validate worker 가 publisher facade 의존으로 변경. processor 단독 실행은
+	// resolver / guard 가 필요 없으므로 nil resolver 로 thin publisher 만 생성.
+	pub := publisher.New(producer, nil, log)
+
 	// ── 5. Validate Worker 시작 ───────────────────────────────────────────────
 	// validator 결과 (passed/rejected) 는 contentSvc.UpdateValidationStatus 로 contents 에 기록.
 	// processor 단독 실행은 dev/test 시나리오 — Redis wiring 없이 NoopStageGate 사용 (dedup + cap 비활성).
 	// 다중 인스턴스 운영은 cmd/issuetracker 통합 바이너리에서 Redis 기반 ProcessingLock 합성된 StageGate 공유.
-	worker := validate.NewWorker(consumer, producer, contentSvc, locks.NewNoopStageGate(), validateWorkerCount, validateCfg)
+	worker := validate.NewWorker(consumer, pub, contentSvc, locks.NewNoopStageGate(), validateWorkerCount, validateCfg)
 	worker.Start(ctx)
 
 	log.WithFields(map[string]interface{}{

--- a/internal/processor/validate/worker.go
+++ b/internal/processor/validate/worker.go
@@ -11,6 +11,7 @@ import (
 
 	"issuetracker/internal/locks"
 	"issuetracker/internal/processor/fetcher/core"
+	"issuetracker/internal/publisher"
 	"issuetracker/internal/storage"
 	"issuetracker/internal/storage/service"
 	"issuetracker/pkg/config"
@@ -32,8 +33,8 @@ const drainTimeout = 5 * time.Second
 // validates it, and publishes ContentRef to issuetracker.validated.
 // On failure, deletes the contents record and routes to DLQ.
 type Worker struct {
-	consumer    queue.Consumer
-	producer    queue.Producer
+	consumer    publisher.Consumer
+	pub         *publisher.Publisher
 	contentSvc  service.ContentService
 	gate        locks.StageGate // nil 허용 → NoopStageGate 로 fallback (이슈 #356)
 	cfg         config.ValidateConfig
@@ -54,9 +55,12 @@ type Worker struct {
 // StageGate (ProcessingLock + Semaphore 합성, 이슈 #353/#354/#356) 로 fetcher / parser / validator
 // 가 동일 인터페이스로 단계별 dedup + per-stage 동시성 cap. validator 단계는 ContentRef.URL 단위로
 // acquire — Kafka rebalance 시 같은 ref 가 두 worker 에 도달해도 1회만 검증.
+//
+// 이슈 #393 — 구 queue.Consumer / queue.Producer 직접 주입 → publisher facade 주입으로 변경.
+// Kafka 구현체에 직접 의존하지 않음 (consumer 는 publisher.Consumer 별칭, publish 는 pub.Forward).
 func NewWorker(
-	consumer queue.Consumer,
-	producer queue.Producer,
+	consumer publisher.Consumer,
+	pub *publisher.Publisher,
 	contentSvc service.ContentService,
 	gate locks.StageGate,
 	workerCount int,
@@ -67,7 +71,7 @@ func NewWorker(
 	}
 	return &Worker{
 		consumer:    consumer,
-		producer:    producer,
+		pub:         pub,
 		contentSvc:  contentSvc,
 		gate:        gate,
 		cfg:         cfg,
@@ -381,7 +385,7 @@ func (w *Worker) publishValidatedRef(ctx context.Context, ref *core.ContentRef, 
 		},
 	}
 
-	return w.producer.Publish(ctx, outMsg)
+	return w.pub.Forward(ctx, outMsg)
 }
 
 // recordValidationRejected 는 validator 영구 실패 시 news_articles 에 reject 메타데이터를
@@ -461,11 +465,11 @@ func (w *Worker) sendToDLQ(ctx context.Context, msg *queue.Message, reason error
 		Headers: headers,
 	}
 
-	err := w.producer.Publish(ctx, dlqMsg)
+	err := w.pub.Forward(ctx, dlqMsg)
 	if err != nil && errors.Is(err, context.Canceled) {
 		drainCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), drainTimeout)
 		defer cancel()
-		err = w.producer.Publish(drainCtx, dlqMsg)
+		err = w.pub.Forward(drainCtx, dlqMsg)
 	}
 	if err != nil {
 		log.WithError(err).Error("failed to send message to dlq")
@@ -501,11 +505,11 @@ func (w *Worker) requeue(ctx context.Context, msg *queue.Message, pm *core.Proce
 		},
 	}
 
-	err = w.producer.Publish(ctx, requeueMsg)
+	err = w.pub.Forward(ctx, requeueMsg)
 	if err != nil && errors.Is(err, context.Canceled) {
 		drainCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), drainTimeout)
 		defer cancel()
-		err = w.producer.Publish(drainCtx, requeueMsg)
+		err = w.pub.Forward(drainCtx, requeueMsg)
 	}
 	if err != nil {
 		log.WithFields(map[string]interface{}{
@@ -589,11 +593,11 @@ func (w *Worker) republishForReparse(ctx context.Context, content *core.Content,
 		Headers: headers,
 	}
 
-	pubErr := w.producer.Publish(ctx, reparseMsg)
+	pubErr := w.pub.Forward(ctx, reparseMsg)
 	if pubErr != nil && errors.Is(pubErr, context.Canceled) {
 		drainCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), drainTimeout)
 		defer cancel()
-		pubErr = w.producer.Publish(drainCtx, reparseMsg)
+		pubErr = w.pub.Forward(drainCtx, reparseMsg)
 	}
 	if pubErr != nil {
 		log.WithFields(map[string]interface{}{

--- a/internal/processor/validate/worker.go
+++ b/internal/processor/validate/worker.go
@@ -66,6 +66,13 @@ func NewWorker(
 	workerCount int,
 	cfg config.ValidateConfig,
 ) *Worker {
+	// pub 은 4 publish 사이트 (validated / dlq / requeue / reparse) 가 dereference 하는 hard
+	// dependency. nil 주입 시 첫 publish 에서 publisher.Forward 가 error 를 반환하지만, validate
+	// worker 는 publish 실패 시 commit skip → Kafka 무한 재배달 — 운영 진단이 매우 어려워짐.
+	// Fail-fast 가 silent failure 보다 안전 (coderabbit PR #408 피드백).
+	if pub == nil {
+		panic("validate.NewWorker: pub must not be nil")
+	}
 	if gate == nil {
 		gate = locks.NewNoopStageGate()
 	}

--- a/test/internal/processor/validate/reparse_test.go
+++ b/test/internal/processor/validate/reparse_test.go
@@ -142,7 +142,7 @@ func TestWorker_Reparse_FirstAttempt_PublishesCrawlJob(t *testing.T) {
 		publishedCrawlJob = args.Get(1).(queue.Message)
 	}).Return(nil)
 
-	w := validate.NewWorker(consumer, producer, contentSvc, locks.NewNoopStageGate(), 1, cfg)
+	w := validate.NewWorker(consumer, newTestPublisher(producer), contentSvc, locks.NewNoopStageGate(), 1, cfg)
 	runProcessOnce(t, consumer, w, makeContentMsgWithReparseHeader(t, content, 0))
 
 	require.Equal(t, queue.TopicCrawlNormal, publishedCrawlJob.Topic)
@@ -198,7 +198,7 @@ func TestWorker_Reparse_PropagatesOriginalHeaders(t *testing.T) {
 	msg.Headers[core.HeaderTimeoutMs] = "60000" // 60s — 원본 timeout
 	msg.Headers["x-trace-id"] = "trace-abc-123"
 
-	w := validate.NewWorker(consumer, producer, contentSvc, locks.NewNoopStageGate(), 1, cfg)
+	w := validate.NewWorker(consumer, newTestPublisher(producer), contentSvc, locks.NewNoopStageGate(), 1, cfg)
 	runProcessOnce(t, consumer, w, msg)
 
 	// 원본 timeout_ms 가 그대로 reparse 메시지에 계승됨
@@ -233,7 +233,7 @@ func TestWorker_Reparse_MaxCount_NoCrawlJob(t *testing.T) {
 		return true
 	})).Return(nil)
 
-	w := validate.NewWorker(consumer, producer, contentSvc, locks.NewNoopStageGate(), 1, cfg)
+	w := validate.NewWorker(consumer, newTestPublisher(producer), contentSvc, locks.NewNoopStageGate(), 1, cfg)
 	runProcessOnce(t, consumer, w, makeContentMsgWithReparseHeader(t, content, core.MaxValidateReparseCount))
 
 	assert.False(t, crawlPublished, "max 도달 시 reparse CrawlJob 발행 X (기존 DLQ/requeue 흐름으로 폴스루)")
@@ -260,7 +260,7 @@ func TestWorker_Reparse_Disabled_NoCrawlJob(t *testing.T) {
 		return true
 	})).Return(nil)
 
-	w := validate.NewWorker(consumer, producer, contentSvc, locks.NewNoopStageGate(), 1, cfg)
+	w := validate.NewWorker(consumer, newTestPublisher(producer), contentSvc, locks.NewNoopStageGate(), 1, cfg)
 	runProcessOnce(t, consumer, w, makeContentMsgWithReparseHeader(t, content, 0))
 
 	assert.False(t, crawlPublished, "ReparseEnabled=false 시 reparse CrawlJob 발행 X")

--- a/test/internal/processor/validate/worker_test.go
+++ b/test/internal/processor/validate/worker_test.go
@@ -14,11 +14,21 @@ import (
 	"issuetracker/internal/locks"
 	"issuetracker/internal/processor/fetcher/core"
 	"issuetracker/internal/processor/validate"
+	"issuetracker/internal/publisher"
 	"issuetracker/internal/storage"
 	"issuetracker/internal/storage/service"
 	"issuetracker/pkg/config"
+	"issuetracker/pkg/logger"
 	"issuetracker/pkg/queue"
 )
+
+// newTestPublisher 는 validate worker 가 publisher facade 의존으로 변경된 후 (이슈 #393)
+// 기존 mockProducer 검증 흐름을 유지하기 위한 thin helper 입니다.
+// 실제 *publisher.Publisher 를 생성하되 내부 producer 로 mockProducer 를 주입 — worker 가
+// pub.Forward → producer.Publish 로 위임하므로 mock expectations 그대로 작동.
+func newTestPublisher(producer queue.Producer) *publisher.Publisher {
+	return publisher.New(producer, nil, logger.New(logger.DefaultConfig()))
+}
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Mock 구현체
@@ -155,7 +165,7 @@ func makeProcessingMessage(content *core.Content, retryCount int) *queue.Message
 }
 
 func newWorker(consumer queue.Consumer, producer queue.Producer, contentSvc service.ContentService) *validate.Worker {
-	return validate.NewWorker(consumer, producer, contentSvc, locks.NewNoopStageGate(), 1, config.DefaultValidateConfig())
+	return validate.NewWorker(consumer, newTestPublisher(producer), contentSvc, locks.NewNoopStageGate(), 1, config.DefaultValidateConfig())
 }
 
 func runWorker(t *testing.T, consumer *mockConsumer, w *validate.Worker, msg *queue.Message) {


### PR DESCRIPTION
## 연관 이슈

Closes #393
부모 메타: #385 — Publisher 통합 Sub 8 (마지막)

## 구현 내용

validate worker 의 Kafka I/O 책임을 publisher facade 로 위임. Sub 5 (#390) / Sub 7 (#392) 와 동일 패턴 — 같은 추상화 (publisher.Consumer / Forward) 를 마지막 stage 인 validate 에도 일관 적용.

### validate worker 변경

| Before | After |
|---|---|
| `consumer queue.Consumer` | `consumer publisher.Consumer` (alias) |
| `producer queue.Producer` | `pub *publisher.Publisher` |
| 4종 `w.producer.Publish(...)` | `w.pub.Forward(...)` |
| `NewWorker(consumer, producer, ...)` | `NewWorker(consumer, pub, ...)` |

4 publish 사이트:
- TopicValidated publish (검증 통과)
- TopicDLQ publish (검증 실패 라우팅)
- TopicNormalized publish (재큐잉)
- reparse publish (validator → parser 재학습 trigger, #366)

### cmd/issuetracker/main.go wiring

```diff
 validateProducer := queue.NewProducer(validateKafkaCfg)
 defer validateProducer.Close()
+validatePublisher := publisher.New(validateProducer, nil, log)

-validateWorker := validate.NewWorker(validateConsumer, validateProducer, ...)
+validateWorker := validate.NewWorker(validateConsumer, validatePublisher, ...)
```

validate 는 resolver / guard 불필요 (Forward 전용) — `publisher.New(producer, nil, log)` 로 thin wrap. crawlerProducer 와는 GroupID 가 다른 별개 producer 유지 (`GroupValidators`).

### cmd/processor/main.go (validator 단독 entry) wiring

```diff
 producer := queue.NewProducer(kafkaCfg)
 defer producer.Close()
+pub := publisher.New(producer, nil, log)

-worker := validate.NewWorker(consumer, producer, ...)
+worker := validate.NewWorker(consumer, pub, ...)
```

### 테스트

- `test/internal/processor/validate/worker_test.go` `newTestPublisher(producer)` 헬퍼 도입 (Sub 5/7 의 동일 패턴).
- `newWorker` 헬퍼 + 4 개 reparse_test 케이스 모두 `newTestPublisher(producer)` 래핑.
- 검증 로직 / DLQ 분기 / reparse trigger 검증 무변경 — pub.Forward 가 producer.Publish 위임이라 mockProducer expectations 그대로 작동.

## CI / 머지 게이트 점검

- [x] `gofmt -l internal/ cmd/ test/` — clean
- [x] `go build ./internal/... ./cmd/issuetracker/ ./cmd/processor/ ./test/...` — pass
- [x] `go test -race -count=1 -timeout=180s ./test/internal/processor/validate/... ./test/internal/publisher/... + 관련` — 전 패키지 통과
- [x] PR 타이틀 `[REFAC#393]`
- [x] commit `[REFAC]:` prefix + 한국어

## 변경 영향 범위 + 위험도

- **영향**: validate/worker + cmd/issuetracker + cmd/processor + 2 test 파일
- **위험도 Medium → 동작 동등성 확보됨**:
  - publisher.Forward 는 thin pass-through (Sub 5/7 동일 검증)
  - 라이브 publish 시점/내용 무변경
  - 양 entry point (통합 / 단독) 동일 wiring 패턴 — 정합성 유지

## 후속

Sub 8 머지 후 메타 #385 의 남은 sub:
- Sub 6 (#391) — PriorityResolver chain publisher 측 이동

Sub 6 까지 머지되면 메타 #385 close 가능.

## 롤백 계획

PR revert 시 모든 시그니처가 동시에 원복 — wiring 회귀 없음.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated internal publisher architecture to use a facade pattern, improving abstraction and decoupling from specific messaging infrastructure details. Processing behavior, performance, and user-facing functionality remain unchanged.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/EinSofINTEREST/IssueTracker/pull/408)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->