### PR TITLE
[REFAC#391] PriorityResolver chain → publisher 측 이동 + 모든 PublishX 통과

### DIFF
--- a/cmd/issuetracker/main.go
+++ b/cmd/issuetracker/main.go
@@ -105,9 +105,13 @@ func main() {
 	crawlerProducer := queue.NewProducer(crawlerKafkaCfg)
 	defer crawlerProducer.Close()
 
-	resolver := crawlerWorker.NewCompositeResolver(core.PriorityNormal)
-	resolver.Add(crawlerWorker.NewSourcePriorityResolver(core.PriorityNormal))
-	resolver.Add(crawlerWorker.NewRuleBasedPriorityResolver(core.PriorityNormal))
+	// 이슈 #391 — PriorityResolver chain 이 publisher 측으로 이동 + 모든 PublishX 가
+	// resolver 통과 (메타 #385 Sub 6). ExplicitPriorityResolver 를 chain 1순위 로 등록 —
+	// 발행자가 job.Priority 를 사전 명시한 경우 (seed entry / retry / upgrade) 그 값이 보존됨.
+	resolver := publisher.NewCompositeResolver(core.PriorityNormal)
+	resolver.Add(&publisher.ExplicitPriorityResolver{})
+	resolver.Add(publisher.NewSourcePriorityResolver(core.PriorityNormal))
+	resolver.Add(publisher.NewRuleBasedPriorityResolver(core.PriorityNormal))
 
 	highConsumer := queue.NewConsumer(crawlerKafkaCfg, queue.TopicCrawlHigh)
 	defer highConsumer.Close()

--- a/internal/processor/fetcher/worker/manager.go
+++ b/internal/processor/fetcher/worker/manager.go
@@ -82,7 +82,7 @@ type ManagerConfig struct {
 type PoolManager struct {
 	pools    map[core.Priority]*KafkaConsumerPool
 	pub      *publisher.Publisher
-	resolver PriorityResolver
+	resolver publisher.PriorityResolver
 	log      *logger.Logger
 
 	// chromedpPool 은 chromedp 전용 worker pool. nil 이면 비활성.
@@ -100,7 +100,7 @@ func NewPoolManager(
 	pub *publisher.Publisher,
 	handler JobHandler,
 	contentSvc service.ContentService,
-	resolver PriorityResolver,
+	resolver publisher.PriorityResolver,
 	log *logger.Logger,
 ) *PoolManager {
 	procLock := cfg.ProcessingLock
@@ -158,17 +158,17 @@ func NewPoolManager(
 	return mgr
 }
 
-// Publish는 CrawlJob을 PriorityResolver로 우선순위를 결정한 후 해당 Kafka crawl 토픽에 발행합니다.
+// Publish는 CrawlJob을 publisher facade 로 발행합니다. priority 결정은 publisher 내부의
+// resolver chain 이 buildMessage 에서 일괄 처리합니다 (이슈 #391 — 메타 #385 Sub 6).
 //
-// Publish resolves the job's priority via the configured PriorityResolver,
-// updates job.Priority in-place, and publishes to the correct crawl topic
-// (crawl.high / crawl.normal / crawl.low).
+// Publish delegates to publisher.PublishJob. Priority resolution is handled inside the
+// publisher's resolver chain via buildMessage — single source of truth across all
+// PublishX paths (seed / chained / job / retry).
 //
-// gemini PR #400 피드백 — marshal/topic/headers 구성은 publisher.PublishJob 에 위임.
-// manager 는 priority 결정 + 로깅만 책임 (priority resolver chain 통합은 Sub 6 에서).
+// 로깅을 위해 동일 resolver 를 한 번 더 평가 — ExplicitPriorityResolver 가 1순위라
+// 이후 buildMessage 의 평가와 같은 결과를 보장 (resolver 는 stateless · idempotent).
 func (m *PoolManager) Publish(ctx context.Context, job *core.CrawlJob) error {
 	priority := m.resolver.Resolve(job)
-	job.Priority = priority
 
 	m.log.WithFields(map[string]interface{}{
 		"job_id":   job.ID,

--- a/internal/processor/fetcher/worker/manager.go
+++ b/internal/processor/fetcher/worker/manager.go
@@ -167,8 +167,14 @@ func NewPoolManager(
 //
 // 로깅을 위해 동일 resolver 를 한 번 더 평가 — ExplicitPriorityResolver 가 1순위라
 // 이후 buildMessage 의 평가와 같은 결과를 보장 (resolver 는 stateless · idempotent).
+//
+// m.resolver 가 nil 인 경우 (테스트 wiring) 는 job.Priority 를 그대로 사용 — coderabbit
+// PR #409 피드백. publisher.buildMessage 가 nil resolver 를 fail-safe 로 허용하는 정책과 일관.
 func (m *PoolManager) Publish(ctx context.Context, job *core.CrawlJob) error {
-	priority := m.resolver.Resolve(job)
+	priority := job.Priority
+	if m.resolver != nil {
+		priority = m.resolver.Resolve(job)
+	}
 
 	m.log.WithFields(map[string]interface{}{
 		"job_id":   job.ID,

--- a/internal/publisher/chain.go
+++ b/internal/publisher/chain.go
@@ -116,8 +116,7 @@ func (p *Publisher) buildJobMessages(
 			MaxRetries:  DefaultMaxRetries,
 		}
 
-		job.Priority = p.resolver.Resolve(job)
-
+		// 이슈 #391 — resolver chain 통과는 buildMessage 가 흡수 (모든 PublishX 일관성).
 		msg, err := p.buildMessage(job)
 		if err != nil {
 			return nil, fmt.Errorf("build message for %s: %w", url, err)

--- a/internal/publisher/publisher.go
+++ b/internal/publisher/publisher.go
@@ -145,23 +145,28 @@ func (p *Publisher) PublishJob(ctx context.Context, job *core.CrawlJob) error {
 // 등록된 ExplicitPriorityResolver 가 그 값을 통과시켜 explicit 우선이 보존됩니다.
 //
 // resolver 가 nil 인 경우 (테스트 등) 는 기존 job.Priority 를 그대로 사용 — fail-safe.
+//
+// 부작용 회피 (gemini PR #409 피드백) — 외부에서 주입된 *job 의 Priority 를 직접 수정하지
+// 않도록 local 복사본의 Priority 만 갱신. 호출자 (예: PoolManager.Publish) 가 원본 job 의
+// Priority 변경을 기대하지 않더라도 안전. CrawlJob 은 작은 struct 이라 복사 비용 무시 가능.
 func (p *Publisher) buildMessage(job *core.CrawlJob) (queue.Message, error) {
+	j := *job
 	if p.resolver != nil {
-		job.Priority = p.resolver.Resolve(job)
+		j.Priority = p.resolver.Resolve(&j)
 	}
 
-	data, err := job.Marshal()
+	data, err := j.Marshal()
 	if err != nil {
-		return queue.Message{}, fmt.Errorf("marshal job %s: %w", job.ID, err)
+		return queue.Message{}, fmt.Errorf("marshal job %s: %w", j.ID, err)
 	}
 
 	return queue.Message{
-		Topic: CrawlTopic(job.Priority),
-		Key:   []byte(job.ID),
+		Topic: CrawlTopic(j.Priority),
+		Key:   []byte(j.ID),
 		Value: data,
 		Headers: map[string]string{
-			"crawler":  job.CrawlerName,
-			"priority": fmt.Sprintf("%d", int(job.Priority)),
+			"crawler":  j.CrawlerName,
+			"priority": fmt.Sprintf("%d", int(j.Priority)),
 		},
 	}, nil
 }

--- a/internal/publisher/publisher.go
+++ b/internal/publisher/publisher.go
@@ -52,10 +52,13 @@ type Message = queue.Message
 const DefaultMaxRetries = 3
 
 // PriorityResolver 는 CrawlJob 의 우선순위를 결정하는 인터페이스입니다.
-// worker.CompositeResolver 등이 이를 구현합니다.
+// 구현체 — ExplicitPriorityResolver / SourcePriorityResolver / RuleBasedPriorityResolver /
+// DefaultPriorityResolver / CompositeResolver (chain) — 모두 publisher 패키지의
+// [resolver.go](resolver.go) 에 위치 (이슈 #391 — 메타 #385 Sub 6).
 //
-// 메타 #385 Sub 6 에서 본 인터페이스 및 chain 구현이 publisher 측으로 이동될 예정 —
-// 그 시점에 본 인터페이스가 모든 PublishX 메소드의 priority 결정 단일 진입점이 됩니다.
+// 모든 PublishX 메소드의 priority 결정 단일 진입점 — 운영자가 한 곳에만 resolver 룰 추가하면
+// seed / chained / retry / upgrade 모든 경로에 일관 적용. ExplicitPriorityResolver 를 chain
+// 1순위 로 등록하면 발행자가 사전 명시한 priority 가 보존됨.
 type PriorityResolver interface {
 	Resolve(job *core.CrawlJob) core.Priority
 }
@@ -135,7 +138,18 @@ func (p *Publisher) PublishJob(ctx context.Context, job *core.CrawlJob) error {
 }
 
 // buildMessage 는 CrawlJob 을 Kafka Message 로 변환합니다.
+//
+// 이슈 #391 — 메타 #385 Sub 6: resolver chain 통과를 본 헬퍼에 흡수. 모든 PublishX
+// (Chained / Seed / Job / Retry / Redis retry republish) 가 buildMessage 를 거치므로
+// priority 결정이 단일 출처. 발행자가 job.Priority 를 사전 명시한 경우, chain 1순위로
+// 등록된 ExplicitPriorityResolver 가 그 값을 통과시켜 explicit 우선이 보존됩니다.
+//
+// resolver 가 nil 인 경우 (테스트 등) 는 기존 job.Priority 를 그대로 사용 — fail-safe.
 func (p *Publisher) buildMessage(job *core.CrawlJob) (queue.Message, error) {
+	if p.resolver != nil {
+		job.Priority = p.resolver.Resolve(job)
+	}
+
 	data, err := job.Marshal()
 	if err != nil {
 		return queue.Message{}, fmt.Errorf("marshal job %s: %w", job.ID, err)

--- a/internal/publisher/resolver.go
+++ b/internal/publisher/resolver.go
@@ -1,36 +1,28 @@
-// Package worker provides Kafka-based crawler worker pool and routing logic.
-package worker
+// Package publisher 의 priority resolver 모듈 (이슈 #391, 메타 #385 Sub 6).
+//
+// 구 internal/processor/fetcher/worker/resolver.go 위치에서 이동 — Kafka I/O 단일 책임
+// 원칙에 따라 PublishX 메소드의 priority routing 도 publisher 가 단일 출처.
+//
+// publisher.go 의 PriorityResolver 인터페이스를 본 파일의 chain/impl 들이 만족.
+package publisher
 
 import (
 	"issuetracker/internal/processor/fetcher/core"
 )
 
 // ─────────────────────────────────────────────────────────────────────────
-// PriorityResolver — 단독 사용 인터페이스
-// ─────────────────────────────────────────────────────────────────────────
-
-// PriorityResolver는 CrawlJob을 어떤 우선순위 Kafka 큐로 라우팅할지 결정하는 인터페이스입니다.
-//
-// PriorityResolver determines which priority queue (crawl.high / crawl.normal / crawl.low)
-// a CrawlJob should be routed to. Implementations must be safe for concurrent use.
-type PriorityResolver interface {
-	Resolve(job *core.CrawlJob) core.Priority
-}
-
-// ─────────────────────────────────────────────────────────────────────────
 // ChainablePriorityResolver — CompositeResolver 체인 등록용 인터페이스
 // ─────────────────────────────────────────────────────────────────────────
 
-// ChainablePriorityResolver는 CompositeResolver 체인에 등록 가능한 resolver 인터페이스입니다.
+// ChainablePriorityResolver 는 CompositeResolver 체인에 등록 가능한 resolver 인터페이스입니다.
 //
-// ChainablePriorityResolver extends PriorityResolver with CanResolve,
-// which signals whether this resolver has a definitive answer for the given job.
-// CanResolve가 false를 반환하면 CompositeResolver는 체인의 다음 resolver로 넘어갑니다.
+// PriorityResolver 를 만족하면서 CanResolve 로 chain 위임 신호 제공.
+// CanResolve 가 false 를 반환하면 CompositeResolver 는 체인의 다음 resolver 로 위임합니다.
 type ChainablePriorityResolver interface {
 	PriorityResolver
 
-	// CanResolve는 이 resolver가 job에 대해 확정적인 우선순위를 결정할 수 있는지 반환합니다.
-	// false 반환 시 CompositeResolver는 체인의 다음 resolver로 위임합니다.
+	// CanResolve 는 이 resolver 가 job 에 대해 확정적인 우선순위를 결정할 수 있는지 반환합니다.
+	// false 반환 시 CompositeResolver 는 체인의 다음 resolver 로 위임합니다.
 	CanResolve(job *core.CrawlJob) bool
 }
 
@@ -38,14 +30,16 @@ type ChainablePriorityResolver interface {
 // ExplicitPriorityResolver
 // ─────────────────────────────────────────────────────────────────────────
 
-// ExplicitPriorityResolver는 job.Priority에 명시된 값을 그대로 반환합니다.
+// ExplicitPriorityResolver 는 job.Priority 에 명시된 값을 그대로 반환합니다.
 //
-// ExplicitPriorityResolver passes through job.Priority unchanged.
-// Use when callers always set the priority field explicitly before publishing.
-// 유효하지 않은 Priority 값은 PriorityNormal로 보정합니다.
+// 발행자 (scheduler / retry / upgrade 등) 가 Priority 를 사전 명시한 경우 chain 의 다른
+// resolver 로 위임하지 않고 그대로 통과. 본 resolver 를 chain 의 **1순위** 로 등록하면
+// 모든 PublishX 가 resolver 를 통과하더라도 명시 priority 가 보존됩니다 (메타 #385 Sub 6).
+//
+// 유효하지 않은 Priority 값은 PriorityNormal 로 보정합니다.
 type ExplicitPriorityResolver struct{}
 
-// Resolve는 job.Priority를 검증하여 반환하고, 유효하지 않은 값은 PriorityNormal로 대체합니다.
+// Resolve 는 job.Priority 를 검증하여 반환하고, 유효하지 않은 값은 PriorityNormal 로 대체합니다.
 func (r *ExplicitPriorityResolver) Resolve(job *core.CrawlJob) core.Priority {
 	switch job.Priority {
 	case core.PriorityHigh, core.PriorityNormal, core.PriorityLow:
@@ -55,8 +49,8 @@ func (r *ExplicitPriorityResolver) Resolve(job *core.CrawlJob) core.Priority {
 	}
 }
 
-// CanResolve는 job.Priority가 유효한 값으로 명시된 경우에만 true를 반환합니다.
-// 제로값(0)이면 발행자가 Priority를 설정하지 않은 것으로 판단하여 false를 반환합니다.
+// CanResolve 는 job.Priority 가 유효한 값으로 명시된 경우에만 true 를 반환합니다.
+// 제로값 (0) 이면 발행자가 Priority 를 설정하지 않은 것으로 판단하여 false 를 반환.
 func (r *ExplicitPriorityResolver) CanResolve(job *core.CrawlJob) bool {
 	switch job.Priority {
 	case core.PriorityHigh, core.PriorityNormal, core.PriorityLow:
@@ -70,17 +64,17 @@ func (r *ExplicitPriorityResolver) CanResolve(job *core.CrawlJob) bool {
 // SourcePriorityResolver
 // ─────────────────────────────────────────────────────────────────────────
 
-// SourcePriorityResolver는 CrawlerName(소스 이름)을 기준으로 우선순위를 결정합니다.
+// SourcePriorityResolver 는 CrawlerName (소스 이름) 을 기준으로 우선순위를 결정합니다.
 //
-// SourcePriorityResolver routes jobs to priority queues based on the crawler's
-// source name. Useful when specific news sources (e.g. "breaking-news-crawler")
-// always require a fixed priority regardless of the job's Priority field.
+// 특정 소스 (예: breaking-news crawler) 가 항상 고정 우선순위를 가져야 할 때 사용 —
+// job.Priority 와 무관하게 매핑된 priority 를 적용. ExplicitPriorityResolver 보다
+// 뒤에 등록되면 explicit 가 우선.
 type SourcePriorityResolver struct {
 	rules    map[string]core.Priority
 	fallback core.Priority
 }
 
-// NewSourcePriorityResolver는 미등록 소스에 적용할 기본 우선순위를 지정하여 생성합니다.
+// NewSourcePriorityResolver 는 미등록 소스에 적용할 기본 우선순위를 지정하여 생성합니다.
 func NewSourcePriorityResolver(fallback core.Priority) *SourcePriorityResolver {
 	return &SourcePriorityResolver{
 		rules:    make(map[string]core.Priority),
@@ -88,14 +82,14 @@ func NewSourcePriorityResolver(fallback core.Priority) *SourcePriorityResolver {
 	}
 }
 
-// Register는 크롤러 이름과 우선순위를 매핑합니다.
+// Register 는 크롤러 이름과 우선순위를 매핑합니다.
 // 이미 등록된 이름을 재등록하면 덮어씁니다.
 func (r *SourcePriorityResolver) Register(crawlerName string, priority core.Priority) {
 	r.rules[crawlerName] = priority
 }
 
-// Resolve는 job.CrawlerName에 매핑된 우선순위를 반환합니다.
-// 매핑이 없으면 생성 시 지정한 fallback 우선순위를 반환합니다.
+// Resolve 는 job.CrawlerName 에 매핑된 우선순위를 반환합니다.
+// 매핑이 없으면 생성 시 지정한 fallback 우선순위를 반환.
 func (r *SourcePriorityResolver) Resolve(job *core.CrawlJob) core.Priority {
 	if p, ok := r.rules[job.CrawlerName]; ok {
 		return p
@@ -103,8 +97,8 @@ func (r *SourcePriorityResolver) Resolve(job *core.CrawlJob) core.Priority {
 	return r.fallback
 }
 
-// CanResolve는 job.CrawlerName이 등록된 소스인 경우에만 true를 반환합니다.
-// 미등록 소스는 체인의 다음 resolver로 위임합니다.
+// CanResolve 는 job.CrawlerName 이 등록된 소스인 경우에만 true 를 반환합니다.
+// 미등록 소스는 체인의 다음 resolver 로 위임합니다.
 func (r *SourcePriorityResolver) CanResolve(job *core.CrawlJob) bool {
 	_, ok := r.rules[job.CrawlerName]
 	return ok
@@ -114,31 +108,27 @@ func (r *SourcePriorityResolver) CanResolve(job *core.CrawlJob) bool {
 // RuleBasedPriorityResolver
 // ─────────────────────────────────────────────────────────────────────────
 
-// PriorityRule은 조건(Match)과 우선순위(Priority)를 갖는 단일 라우팅 규칙입니다.
+// PriorityRule 은 조건 (Match) 과 우선순위 (Priority) 를 갖는 단일 라우팅 규칙입니다.
 type PriorityRule struct {
-	// Match가 true를 반환하면 이 규칙의 Priority를 적용합니다.
+	// Match 가 true 를 반환하면 이 규칙의 Priority 를 적용합니다.
 	Match    func(job *core.CrawlJob) bool
 	Priority core.Priority
 }
 
-// RuleBasedPriorityResolver는 등록된 규칙을 순서대로 평가하여 첫 번째 매치의 우선순위를 반환합니다.
-//
-// RuleBasedPriorityResolver evaluates PriorityRule entries in insertion order
-// and returns the Priority of the first matching rule. If no rule matches,
-// the fallback priority is returned.
+// RuleBasedPriorityResolver 는 등록된 규칙을 순서대로 평가하여 첫 번째 매치의 우선순위를 반환합니다.
 type RuleBasedPriorityResolver struct {
 	rules    []PriorityRule
 	fallback core.Priority
 }
 
-// NewRuleBasedPriorityResolver는 기본 우선순위를 지정하여 빈 resolver를 생성합니다.
+// NewRuleBasedPriorityResolver 는 기본 우선순위를 지정하여 빈 resolver 를 생성합니다.
 func NewRuleBasedPriorityResolver(fallback core.Priority) *RuleBasedPriorityResolver {
 	return &RuleBasedPriorityResolver{
 		fallback: fallback,
 	}
 }
 
-// AddRule은 조건-우선순위 쌍을 규칙 체인 끝에 추가합니다.
+// AddRule 은 조건-우선순위 쌍을 규칙 체인 끝에 추가합니다.
 // 규칙은 추가된 순서대로 평가되며 먼저 추가된 규칙이 우선합니다.
 func (r *RuleBasedPriorityResolver) AddRule(
 	match func(job *core.CrawlJob) bool,
@@ -147,7 +137,7 @@ func (r *RuleBasedPriorityResolver) AddRule(
 	r.rules = append(r.rules, PriorityRule{Match: match, Priority: priority})
 }
 
-// Resolve는 등록된 규칙을 순서대로 평가합니다.
+// Resolve 는 등록된 규칙을 순서대로 평가합니다.
 // 매치되는 규칙이 없으면 fallback 우선순위를 반환합니다.
 func (r *RuleBasedPriorityResolver) Resolve(job *core.CrawlJob) core.Priority {
 	for _, rule := range r.rules {
@@ -158,8 +148,8 @@ func (r *RuleBasedPriorityResolver) Resolve(job *core.CrawlJob) core.Priority {
 	return r.fallback
 }
 
-// CanResolve는 등록된 규칙 중 하나라도 매치되는 경우 true를 반환합니다.
-// 규칙이 없거나 모두 매치되지 않으면 체인의 다음 resolver로 위임합니다.
+// CanResolve 는 등록된 규칙 중 하나라도 매치되는 경우 true 를 반환합니다.
+// 규칙이 없거나 모두 매치되지 않으면 체인의 다음 resolver 로 위임합니다.
 func (r *RuleBasedPriorityResolver) CanResolve(job *core.CrawlJob) bool {
 	for _, rule := range r.rules {
 		if rule.Match(job) {
@@ -173,26 +163,24 @@ func (r *RuleBasedPriorityResolver) CanResolve(job *core.CrawlJob) bool {
 // DefaultPriorityResolver — 종단 resolver
 // ─────────────────────────────────────────────────────────────────────────
 
-// DefaultPriorityResolver는 항상 고정된 우선순위를 반환하는 종단 resolver입니다.
+// DefaultPriorityResolver 는 항상 고정된 우선순위를 반환하는 종단 resolver 입니다.
 //
-// DefaultPriorityResolver always resolves to the configured priority.
-// CompositeResolver의 마지막 fallback으로 사용되어 모든 job이 반드시 우선순위를 갖도록 보장합니다.
+// CompositeResolver 의 마지막 fallback 으로 사용되어 모든 job 이 반드시 우선순위를 갖도록 보장.
 type DefaultPriorityResolver struct {
 	priority core.Priority
 }
 
-// NewDefaultPriorityResolver는 항상 지정된 우선순위를 반환하는 종단 resolver를 생성합니다.
+// NewDefaultPriorityResolver 는 항상 지정된 우선순위를 반환하는 종단 resolver 를 생성합니다.
 func NewDefaultPriorityResolver(priority core.Priority) *DefaultPriorityResolver {
 	return &DefaultPriorityResolver{priority: priority}
 }
 
-// Resolve는 항상 생성 시 지정한 우선순위를 반환합니다.
+// Resolve 는 항상 생성 시 지정한 우선순위를 반환합니다.
 func (r *DefaultPriorityResolver) Resolve(_ *core.CrawlJob) core.Priority {
 	return r.priority
 }
 
-// CanResolve는 항상 true를 반환합니다.
-// 종단 resolver이므로 모든 job에 대해 결정을 내립니다.
+// CanResolve 는 항상 true 를 반환합니다 — 종단 resolver.
 func (r *DefaultPriorityResolver) CanResolve(_ *core.CrawlJob) bool {
 	return true
 }
@@ -201,39 +189,39 @@ func (r *DefaultPriorityResolver) CanResolve(_ *core.CrawlJob) bool {
 // CompositeResolver — chain resolver
 // ─────────────────────────────────────────────────────────────────────────
 
-// CompositeResolver는 여러 ChainablePriorityResolver를 순서대로 평가하는 chain resolver입니다.
+// CompositeResolver 는 여러 ChainablePriorityResolver 를 순서대로 평가하는 chain resolver 입니다.
 //
-// CompositeResolver evaluates each registered resolver in order.
-// CanResolve가 true인 첫 번째 resolver의 Resolve 결과를 사용합니다.
-// 체인의 모든 resolver가 CanResolve=false를 반환하면 종단 DefaultPriorityResolver로 fallback합니다.
+// 각 등록된 resolver 의 CanResolve 가 true 인 첫 번째 resolver 의 Resolve 결과를 사용.
+// 체인의 모든 resolver 가 CanResolve=false 를 반환하면 종단 DefaultPriorityResolver 로 fallback.
 //
 // 사용 예:
 //
-//	composite := worker.NewCompositeResolver(core.PriorityNormal)
-//	composite.Add(sourceResolver)   // 1순위: 등록된 소스에 한해 결정
-//	composite.Add(ruleResolver)     // 2순위: 조건 규칙에 한해 결정
-//	// 3순위 (자동): DefaultPriorityResolver → Normal
+//	composite := publisher.NewCompositeResolver(core.PriorityNormal)
+//	composite.Add(&publisher.ExplicitPriorityResolver{})  // 1순위: 명시 priority 보존
+//	composite.Add(sourceResolver)                          // 2순위: 등록된 소스 매핑
+//	composite.Add(ruleResolver)                            // 3순위: 조건 규칙
+//	// 4순위 (자동): DefaultPriorityResolver → Normal
 type CompositeResolver struct {
 	chain    []ChainablePriorityResolver
 	terminal PriorityResolver // 체인 끝의 종단 resolver (항상 결정)
 }
 
-// NewCompositeResolver는 지정된 우선순위를 종단으로 갖는 CompositeResolver를 생성합니다.
-// 체인의 모든 resolver가 CanResolve=false를 반환하면 defaultPriority로 라우팅합니다.
+// NewCompositeResolver 는 지정된 우선순위를 종단으로 갖는 CompositeResolver 를 생성합니다.
+// 체인의 모든 resolver 가 CanResolve=false 를 반환하면 defaultPriority 로 라우팅합니다.
 func NewCompositeResolver(defaultPriority core.Priority) *CompositeResolver {
 	return &CompositeResolver{
 		terminal: NewDefaultPriorityResolver(defaultPriority),
 	}
 }
 
-// Add는 체인 끝에 resolver를 추가합니다.
-// 먼저 추가된 resolver가 높은 우선순위로 평가됩니다.
+// Add 는 체인 끝에 resolver 를 추가합니다.
+// 먼저 추가된 resolver 가 높은 우선순위로 평가됩니다.
 func (r *CompositeResolver) Add(resolver ChainablePriorityResolver) {
 	r.chain = append(r.chain, resolver)
 }
 
-// Resolve는 체인을 순서대로 평가하여 CanResolve=true인 첫 번째 resolver의 Priority를 반환합니다.
-// 체인이 비어있거나 모두 CanResolve=false이면 종단 DefaultPriorityResolver를 사용합니다.
+// Resolve 는 체인을 순서대로 평가하여 CanResolve=true 인 첫 번째 resolver 의 Priority 를 반환합니다.
+// 체인이 비어있거나 모두 CanResolve=false 이면 종단 DefaultPriorityResolver 를 사용.
 func (r *CompositeResolver) Resolve(job *core.CrawlJob) core.Priority {
 	for _, resolver := range r.chain {
 		if resolver.CanResolve(job) {
@@ -242,5 +230,3 @@ func (r *CompositeResolver) Resolve(job *core.CrawlJob) core.Priority {
 	}
 	return r.terminal.Resolve(job)
 }
-
-// ─────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## 연관 이슈

Closes #391
부모 메타: #385 — Publisher 통합 Sub 6 (**마지막**)

본 sub 머지로 메타 #385 (Publisher 통합) 완료.

## 구현 내용

### 1. resolver.go 위치 이동

```
internal/processor/fetcher/worker/resolver.go
  → internal/publisher/resolver.go
```

- 패키지 선언만 변경, 인터페이스 / 구현 로직 동일
- `ChainablePriorityResolver` / `ExplicitPriorityResolver` / `SourcePriorityResolver` / `RuleBasedPriorityResolver` / `DefaultPriorityResolver` / `CompositeResolver` 모두 이동
- `PriorityResolver` 인터페이스는 publisher.go 에 이미 정의 — 중복 제거

### 2. 모든 PublishX 가 resolver chain 통과

`publisher.buildMessage` 가 `p.resolver.Resolve(job)` 를 호출하도록 변경 — 단일 진입점.

| PublishX | 경로 |
|---|---|
| PublishChained (chain.go) | buildMessage 경유 → resolver 통과 |
| PublishSeed (seed.go) | buildMessage 경유 → resolver 통과 |
| PublishJob (publisher.go) | buildMessage 경유 → resolver 통과 |
| KafkaImmediateRetryScheduler.Enqueue (retry.go) | buildMessage 경유 → resolver 통과 |
| RedisDelayedRetryScheduler.republish (retry.go) | buildMessage 경유 → resolver 통과 |

chain.go 의 명시적 `job.Priority = p.resolver.Resolve(job)` 호출 제거 (이중 평가 회피).

### 3. ExplicitPriorityResolver 를 chain 1순위 로

```diff
-resolver := crawlerWorker.NewCompositeResolver(core.PriorityNormal)
-resolver.Add(crawlerWorker.NewSourcePriorityResolver(core.PriorityNormal))
-resolver.Add(crawlerWorker.NewRuleBasedPriorityResolver(core.PriorityNormal))
+resolver := publisher.NewCompositeResolver(core.PriorityNormal)
+resolver.Add(&publisher.ExplicitPriorityResolver{})       // 1순위: 명시 priority 보존
+resolver.Add(publisher.NewSourcePriorityResolver(core.PriorityNormal))
+resolver.Add(publisher.NewRuleBasedPriorityResolver(core.PriorityNormal))
```

발행자가 `job.Priority` 를 사전 명시한 경우 (scheduler seed entry / worker retry / fetcher upgrader 등) 그 값이 보존됨 — `ExplicitPriorityResolver.CanResolve` 가 true 반환.

### 4. fetcher/worker.PoolManager 정리

- `PriorityResolver` 필드 타입 → `publisher.PriorityResolver` (구 worker.PriorityResolver 정의 제거)
- `Publish()` 의 `job.Priority = priority` 갱신 제거 — publisher 가 buildMessage 안에서 처리. resolver 가 stateless · idempotent 라 manager 의 로깅용 평가는 안전.

## CI / 머지 게이트 점검

- [x] `gofmt -l internal/ cmd/ test/ examples/` — clean
- [x] `go build ./internal/... ./cmd/... ./test/... ./examples/...` — pass
- [x] `go test -race -count=1 -timeout=180s ./test/...` — 전 패키지 통과
- [x] PR 타이틀 `[REFAC#391]`
- [x] commit `[REFAC]:` prefix + 한국어

## 변경 영향 범위 + 위험도

- **영향**: publisher / fetcher worker manager / main.go wiring (5 파일, 5 changes)
- **위험도 Low**:
  - resolver 로직 자체 무변경 — 패키지 이동 + import path 변경
  - ExplicitPriorityResolver 추가로 발행자 명시 priority 가 보존됨 — 이전 동작 (Source/Rule 만 평가) 에서 explicit 가 누락되던 잠재 회귀 도리어 보강
  - 모든 기존 테스트 통과

## 메타 #385 완료

본 sub 머지 후 메타 #385 (Publisher 통합) 의 6 sub 모두 완료:

| Sub | 이슈 | PR | 상태 |
|---|---|---|---|
| 1 | #386 | #394/#395 | 머지 |
| 2 | #387 | #397 | 머지 |
| 3 | #388 | #398 | 머지 |
| 4 | #389 | #399 | 머지 |
| 5 | #390 | #400 | 머지 |
| 6 | #391 | **본 PR** | 머지 시 메타 close |
| 7 | #392 | #401 | 머지 |
| 8 | #393 | #408 | 머지 |

본 PR 머지 시 메타 #385 도 함께 close.

## 롤백 계획

PR revert 시 resolver 파일이 worker 측으로 다시 이동 + main.go wiring 원복 — 5 파일 동시 원복으로 회귀 없음.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  - Fixed priority handling during message publishing to correctly preserve explicitly set job priorities instead of overriding them with default values.

* **Chores**
  - Refactored internal priority resolution system for improved consistency and maintainability across publish operations.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/EinSofINTEREST/IssueTracker/pull/409)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->