### PR TITLE
[REFAC#402] CircuitBreaker → pkg/resilience 추출 (재사용 가능 위치)

### DIFF
--- a/internal/processor/fetcher/worker/manager.go
+++ b/internal/processor/fetcher/worker/manager.go
@@ -12,6 +12,7 @@ import (
 	"issuetracker/pkg/config"
 	"issuetracker/pkg/logger"
 	"issuetracker/pkg/queue"
+	"issuetracker/pkg/resilience"
 )
 
 // buildStageCap 은 fetcher pool 의 Semaphore capacity 를 계산합니다.
@@ -107,7 +108,7 @@ func NewPoolManager(
 	// 세 개 Pool이 동일한 CircuitBreakerRegistry를 공유하여
 	// 소스별 실패 카운팅이 우선순위 경계 없이 누적됩니다.
 	// log 주입 — CB state 전이마다 INFO/WARN 로그.
-	cbRegistry := NewCircuitBreakerRegistry(DefaultCircuitBreakerConfig, log)
+	cbRegistry := resilience.NewCircuitBreakerRegistry(resilience.DefaultCircuitBreakerConfig, log)
 
 	// per-pool StageGate 합성 (이슈 #356) — pool 별 WorkerCount/2 cap.
 	// procLock nil 시 BuildStageGate 가 NoopStageGate 반환 → dedup+cap 자동 비활성.

--- a/internal/processor/fetcher/worker/pool.go
+++ b/internal/processor/fetcher/worker/pool.go
@@ -20,6 +20,7 @@ import (
 	"issuetracker/pkg/links"
 	"issuetracker/pkg/logger"
 	"issuetracker/pkg/queue"
+	"issuetracker/pkg/resilience"
 	"issuetracker/pkg/urlguard"
 )
 
@@ -69,7 +70,7 @@ type KafkaConsumerPool struct {
 	workerCount int
 	jobs        chan jobItem
 	wg          sync.WaitGroup
-	cbRegistry  *CircuitBreakerRegistry
+	cbRegistry  *resilience.CircuitBreakerRegistry
 	stageGate   locks.StageGate // nil 허용 → NoopStageGate (이슈 #356)
 	// normalizer는 URL 정규화기입니다.
 	// 미설정(nil) 이면 정규화가 적용되지 않으며, 기존 동작이 유지됩니다.
@@ -120,7 +121,7 @@ func NewKafkaConsumerPool(
 	// 본 헬퍼는 단순 호출용 (테스트/예제) 이라 logger 주입 안 함 — nil 이면 state 전이 로그 skip.
 	return NewKafkaConsumerPoolWithOptions(
 		consumer, pub, handler, contentSvc, workerCount,
-		NewCircuitBreakerRegistry(DefaultCircuitBreakerConfig, nil),
+		resilience.NewCircuitBreakerRegistry(resilience.DefaultCircuitBreakerConfig, nil),
 		locks.NewNoopStageGate(),
 	)
 }
@@ -133,7 +134,7 @@ func NewKafkaConsumerPoolWithCB(
 	handler JobHandler,
 	contentSvc service.ContentService,
 	workerCount int,
-	cbRegistry *CircuitBreakerRegistry,
+	cbRegistry *resilience.CircuitBreakerRegistry,
 ) *KafkaConsumerPool {
 	return NewKafkaConsumerPoolWithOptions(
 		consumer, pub, handler, contentSvc, workerCount,
@@ -153,7 +154,7 @@ func NewKafkaConsumerPoolWithOptions(
 	handler JobHandler,
 	contentSvc service.ContentService,
 	workerCount int,
-	cbRegistry *CircuitBreakerRegistry,
+	cbRegistry *resilience.CircuitBreakerRegistry,
 	gate locks.StageGate,
 ) *KafkaConsumerPool {
 	// nil guard — NewParserWorker / validate.NewWorker 와 일관성 보장.
@@ -513,7 +514,7 @@ func (p *KafkaConsumerPool) processJob(ctx context.Context, item jobItem) (err e
 	// 소스 복구 후 운영자가 DLQ에서 재처리합니다.
 	cb := p.cbRegistry.Get(item.job.CrawlerName)
 	if !cb.Allow() {
-		cbErr := &ErrCircuitOpen{Source: item.job.CrawlerName}
+		cbErr := &resilience.ErrCircuitOpen{Source: item.job.CrawlerName}
 		log.WithFields(map[string]interface{}{
 			"job_id":  item.job.ID,
 			"crawler": item.job.CrawlerName,

--- a/pkg/resilience/circuit_breaker.go
+++ b/pkg/resilience/circuit_breaker.go
@@ -1,4 +1,15 @@
-package worker
+// Package resilience provides reusable resilience patterns (circuit breaker,
+// retry helpers, etc.) that are agnostic of any business domain.
+//
+// 이슈 #402 — 구 internal/processor/fetcher/worker/circuit_breaker.go 위치에서 이동.
+// 도입 시점에는 fetcher 단일 사용처였으나, state machine 자체는 generic 한 resilience
+// 패턴이므로 pkg 으로 추출하여 classifier (LLM API) / parser LLM 호출 / 향후 외부
+// 의존성 보호 모두에 재사용 가능. fetcher worker 의 호출 site 는 import 경로만 변경.
+//
+// 네이밍 — `Source` 필드명 유지 (이슈 #402 옵션 a). 운영 dashboard / alert 가 참조하는
+// log 필드 `source` 와 일관성 보존 + LLM 호출 같은 미래 use case 도 "data source" 의미로
+// 자연스럽게 매핑됨.
+package resilience
 
 import (
 	"fmt"

--- a/pkg/resilience/circuit_breaker.go
+++ b/pkg/resilience/circuit_breaker.go
@@ -55,6 +55,26 @@ func (e *ErrCircuitOpen) Error() string {
 	return fmt.Sprintf("circuit breaker open for source %q", e.Source)
 }
 
+// Is 는 errors.Is 정밀 매칭을 지원합니다 (gemini PR #410 피드백).
+//
+// target 의 비어 있지 않은 필드에 대해 AND 비교 — Source 가 비어있으면 "임의 CB-open"
+// 으로 매칭, 명시되어 있으면 동일 Source 만 매칭. 부분 매칭으로 인한 오탐 회피.
+//
+// 사용 예:
+//
+//	errors.Is(err, &resilience.ErrCircuitOpen{})              // 임의 CB-open
+//	errors.Is(err, &resilience.ErrCircuitOpen{Source: "cnn"}) // cnn 소스만
+func (e *ErrCircuitOpen) Is(target error) bool {
+	t, ok := target.(*ErrCircuitOpen)
+	if !ok {
+		return false
+	}
+	if t.Source != "" && t.Source != e.Source {
+		return false
+	}
+	return true
+}
+
 // CircuitBreakerConfig는 circuit breaker 설정입니다.
 type CircuitBreakerConfig struct {
 	// MaxFailures: Open 전환 기준 연속 실패 횟수

--- a/test/internal/processor/fetcher/worker/pool_test.go
+++ b/test/internal/processor/fetcher/worker/pool_test.go
@@ -17,6 +17,7 @@ import (
 	"issuetracker/internal/storage/service"
 	"issuetracker/pkg/logger"
 	"issuetracker/pkg/queue"
+	"issuetracker/pkg/resilience"
 )
 
 // newTestPublisher 는 pool/manager 가 publisher facade 만 의존하도록 변경된 후 (이슈 #390)
@@ -413,7 +414,7 @@ func TestKafkaConsumerPool_ProcessJob_CircuitOpen_SendsToDLQ(t *testing.T) {
 	contentSvc := new(mockContentService)
 
 	// MaxFailures=1로 설정하여 즉시 circuit open 유도
-	cbRegistry := worker.NewCircuitBreakerRegistry(worker.CircuitBreakerConfig{
+	cbRegistry := resilience.NewCircuitBreakerRegistry(resilience.CircuitBreakerConfig{
 		MaxFailures: 1,
 		OpenTimeout: time.Minute,
 	}, nil)

--- a/test/internal/processor/fetcher/worker/processing_lock_pool_test.go
+++ b/test/internal/processor/fetcher/worker/processing_lock_pool_test.go
@@ -14,6 +14,7 @@ import (
 	"issuetracker/internal/processor/fetcher/core"
 	"issuetracker/internal/processor/fetcher/worker"
 	"issuetracker/pkg/queue"
+	"issuetracker/pkg/resilience"
 )
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -73,7 +74,7 @@ func TestKafkaConsumerPool_StageGate_AlreadyAcquired_SkipsWithoutCommit(t *testi
 
 	pool := worker.NewKafkaConsumerPoolWithOptions(
 		consumer, newTestPublisher(producer), handler, contentSvc, 1,
-		worker.NewCircuitBreakerRegistry(worker.DefaultCircuitBreakerConfig, nil),
+		resilience.NewCircuitBreakerRegistry(resilience.DefaultCircuitBreakerConfig, nil),
 		gate,
 	)
 
@@ -104,7 +105,7 @@ func TestKafkaConsumerPool_StageGate_Acquired_ReleasedAfterProcessing(t *testing
 
 	pool := worker.NewKafkaConsumerPoolWithOptions(
 		consumer, newTestPublisher(producer), handler, contentSvc, 1,
-		worker.NewCircuitBreakerRegistry(worker.DefaultCircuitBreakerConfig, nil),
+		resilience.NewCircuitBreakerRegistry(resilience.DefaultCircuitBreakerConfig, nil),
 		gate,
 	)
 
@@ -142,7 +143,7 @@ func TestKafkaConsumerPool_StageGate_AcquireError_ProceedsWithoutGate(t *testing
 
 	pool := worker.NewKafkaConsumerPoolWithOptions(
 		consumer, newTestPublisher(producer), handler, contentSvc, 1,
-		worker.NewCircuitBreakerRegistry(worker.DefaultCircuitBreakerConfig, nil),
+		resilience.NewCircuitBreakerRegistry(resilience.DefaultCircuitBreakerConfig, nil),
 		gate,
 	)
 

--- a/test/pkg/resilience/circuit_breaker_test.go
+++ b/test/pkg/resilience/circuit_breaker_test.go
@@ -1,4 +1,4 @@
-package worker_test
+package resilience_test
 
 import (
 	"testing"
@@ -7,7 +7,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"issuetracker/internal/processor/fetcher/worker"
+	"issuetracker/pkg/resilience"
 )
 
 // cbPollTimeout은 OpenTimeout 경과를 기다리는 require.Eventually 상한입니다.
@@ -17,8 +17,8 @@ const (
 	cbPollTick    = 2 * time.Millisecond
 )
 
-func newTestCBConfig(maxFailures int, openTimeout time.Duration) worker.CircuitBreakerConfig {
-	return worker.CircuitBreakerConfig{
+func newTestCBConfig(maxFailures int, openTimeout time.Duration) resilience.CircuitBreakerConfig {
+	return resilience.CircuitBreakerConfig{
 		MaxFailures: maxFailures,
 		OpenTimeout: openTimeout,
 	}
@@ -27,7 +27,7 @@ func newTestCBConfig(maxFailures int, openTimeout time.Duration) worker.CircuitB
 // TestCircuitBreaker_InitialState_AllowsRequests는
 // 초기 Closed 상태에서 요청을 허용하는지 검증합니다.
 func TestCircuitBreaker_InitialState_AllowsRequests(t *testing.T) {
-	registry := worker.NewCircuitBreakerRegistry(newTestCBConfig(3, time.Minute), nil)
+	registry := resilience.NewCircuitBreakerRegistry(newTestCBConfig(3, time.Minute), nil)
 	cb := registry.Get("cnn")
 
 	assert.True(t, cb.Allow())
@@ -37,7 +37,7 @@ func TestCircuitBreaker_InitialState_AllowsRequests(t *testing.T) {
 // TestCircuitBreaker_ExceedsMaxFailures_OpensCircuit는
 // MaxFailures 연속 실패 후 Open 상태로 전환되는지 검증합니다.
 func TestCircuitBreaker_ExceedsMaxFailures_OpensCircuit(t *testing.T) {
-	registry := worker.NewCircuitBreakerRegistry(newTestCBConfig(3, time.Minute), nil)
+	registry := resilience.NewCircuitBreakerRegistry(newTestCBConfig(3, time.Minute), nil)
 	cb := registry.Get("cnn")
 
 	cb.RecordFailure()
@@ -53,7 +53,7 @@ func TestCircuitBreaker_ExceedsMaxFailures_OpensCircuit(t *testing.T) {
 // TestCircuitBreaker_SuccessResetFailures_StaysClosed는
 // 성공 기록 시 실패 카운터가 초기화되는지 검증합니다.
 func TestCircuitBreaker_SuccessResetFailures_StaysClosed(t *testing.T) {
-	registry := worker.NewCircuitBreakerRegistry(newTestCBConfig(3, time.Minute), nil)
+	registry := resilience.NewCircuitBreakerRegistry(newTestCBConfig(3, time.Minute), nil)
 	cb := registry.Get("cnn")
 
 	cb.RecordFailure()
@@ -68,7 +68,7 @@ func TestCircuitBreaker_SuccessResetFailures_StaysClosed(t *testing.T) {
 // TestCircuitBreaker_OpenTimeout_TransitionsToHalfOpen는
 // OpenTimeout 경과 후 HalfOpen으로 전환되어 probe를 허용하는지 검증합니다.
 func TestCircuitBreaker_OpenTimeout_TransitionsToHalfOpen(t *testing.T) {
-	registry := worker.NewCircuitBreakerRegistry(newTestCBConfig(1, 10*time.Millisecond), nil)
+	registry := resilience.NewCircuitBreakerRegistry(newTestCBConfig(1, 10*time.Millisecond), nil)
 	cb := registry.Get("naver")
 
 	cb.RecordFailure() // 1회 실패 → Open
@@ -89,7 +89,7 @@ func TestCircuitBreaker_OpenTimeout_TransitionsToHalfOpen(t *testing.T) {
 // TestCircuitBreaker_HalfOpenProbeSuccess_ClosesCircuit는
 // HalfOpen probe 성공 시 Closed로 전환되는지 검증합니다.
 func TestCircuitBreaker_HalfOpenProbeSuccess_ClosesCircuit(t *testing.T) {
-	registry := worker.NewCircuitBreakerRegistry(newTestCBConfig(1, 10*time.Millisecond), nil)
+	registry := resilience.NewCircuitBreakerRegistry(newTestCBConfig(1, 10*time.Millisecond), nil)
 	cb := registry.Get("naver")
 
 	cb.RecordFailure()
@@ -103,7 +103,7 @@ func TestCircuitBreaker_HalfOpenProbeSuccess_ClosesCircuit(t *testing.T) {
 // TestCircuitBreaker_HalfOpenProbeFailure_ReopensCircuit는
 // HalfOpen probe 실패 시 다시 Open으로 전환되는지 검증합니다.
 func TestCircuitBreaker_HalfOpenProbeFailure_ReopensCircuit(t *testing.T) {
-	registry := worker.NewCircuitBreakerRegistry(newTestCBConfig(1, 10*time.Millisecond), nil)
+	registry := resilience.NewCircuitBreakerRegistry(newTestCBConfig(1, 10*time.Millisecond), nil)
 	cb := registry.Get("naver")
 
 	cb.RecordFailure()
@@ -117,7 +117,7 @@ func TestCircuitBreaker_HalfOpenProbeFailure_ReopensCircuit(t *testing.T) {
 // TestCircuitBreakerRegistry_IsolatesPerSource는
 // 소스별로 독립적인 circuit breaker가 관리되는지 검증합니다.
 func TestCircuitBreakerRegistry_IsolatesPerSource(t *testing.T) {
-	registry := worker.NewCircuitBreakerRegistry(newTestCBConfig(2, time.Minute), nil)
+	registry := resilience.NewCircuitBreakerRegistry(newTestCBConfig(2, time.Minute), nil)
 
 	cnn := registry.Get("cnn")
 	naver := registry.Get("naver")
@@ -137,7 +137,7 @@ func TestCircuitBreakerRegistry_IsolatesPerSource(t *testing.T) {
 // TestCircuitBreakerRegistry_GetReturnsSameInstance는
 // 동일 소스에 대해 동일 인스턴스를 반환하는지 검증합니다.
 func TestCircuitBreakerRegistry_GetReturnsSameInstance(t *testing.T) {
-	registry := worker.NewCircuitBreakerRegistry(worker.DefaultCircuitBreakerConfig, nil)
+	registry := resilience.NewCircuitBreakerRegistry(resilience.DefaultCircuitBreakerConfig, nil)
 
 	cb1 := registry.Get("cnn")
 	cb2 := registry.Get("cnn")


### PR DESCRIPTION
## 연관 이슈

Closes #402

## 구현 내용

`internal/processor/fetcher/worker/circuit_breaker.go` 를 도메인 의존성 0 인 generic 위치 `pkg/resilience/` 로 추출. 도입 시점에는 fetcher 단일 사용처였으나 state machine 자체는 fully generic resilience pattern 이므로 LLM 호출처 등 향후 다른 stage 에서도 재사용 가능.

### 이동

```
internal/processor/fetcher/worker/circuit_breaker.go
  → pkg/resilience/circuit_breaker.go
```

- 패키지 선언: `worker` → `resilience`
- state machine (Closed / HalfOpen / Open) / API surface / 동작 전부 동일

### 네이밍 결정 (옵션 a — Source 유지)

| 식별자 | 결정 |
|---|---|
| `ErrCircuitOpen.Source` | 유지 |
| `CircuitBreaker.source` | 유지 |
| `Registry.Get(source string)` | 유지 |
| 로그 필드 `"source"` | 유지 |

이유:
- 운영 dashboard / alert 가 참조하는 log 필드 `source` 와의 일관성 보존 (조회 호환)
- 미래 LLM use case 도 "data source" 의미로 자연스럽게 매핑 — LLM provider 도 일종의 upstream source
- 추출 + 네이밍 변경 동시 진행 시 리스크 ↑ — 분리하여 본 PR 은 위치 이동만

### 호출처 갱신

- `internal/processor/fetcher/worker/pool.go`: cbRegistry 필드 + 생성자 시그니처 → `*resilience.CircuitBreakerRegistry`. `&resilience.ErrCircuitOpen{...}` 생성.
- `internal/processor/fetcher/worker/manager.go`: `NewCircuitBreakerRegistry` 호출 → `resilience.NewCircuitBreakerRegistry`.

### 테스트 이동

- `test/internal/processor/fetcher/worker/circuit_breaker_test.go` → `test/pkg/resilience/circuit_breaker_test.go`
- 패키지: `worker_test` → `resilience_test`
- import 갱신 + 타입 reference 일괄 변경 (worker.X → resilience.X)
- worker 종속 다른 테스트 (`pool_test.go`, `processing_lock_pool_test.go`) 의 CB 참조도 `resilience.X` 로 갱신

## CI / 머지 게이트 점검

- [x] `gofmt -l internal/ cmd/ test/ pkg/` — clean
- [x] `go build ./internal/... ./cmd/... ./pkg/... ./test/...` — pass
- [x] `go test -race -count=1 -timeout=180s ./test/...` — 전 패키지 통과 (test/pkg/resilience 신규 + test/internal/processor/fetcher/worker 포함)
- [x] PR 타이틀 `[REFAC#402]`
- [x] commit `[REFAC]:` prefix + 한국어

## 변경 영향 범위 + 위험도

- **영향**: pkg/resilience (신규) / fetcher worker pool + manager / 3 test 파일
- **위험도 Low**:
  - 순수 위치 이동 + import 경로 변경 — state machine / API / 동작 무변경
  - 모든 기존 테스트 새 위치 / 새 import 로 통과
  - 운영 로그 필드 (`source`) 호환 유지

## 후속 (별도 sub-issue)

LLM 호출처 CB 적용은 본 issue 외 분리 진행 예정:
- `internal/classifier/` LLM API 호출
- `internal/processor/parser/rule/claudegen/`
- `internal/processor/parser/rule/llmgen/`

## 롤백 계획

PR revert 시 6 파일이 동시에 원복 — 호출처 import 갱신도 같이 되돌아감.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized resilience and circuit breaker handling for improved code organization and maintainability.
  
* **Improvements**
  * Enhanced circuit breaker error detection with more precise error matching capabilities.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/EinSofINTEREST/IssueTracker/pull/410)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->