### PR TITLE
[REFAC#404] 공용 worker harness 패키지 internal/workerpool 추가

### DIFF
--- a/internal/workerpool/pool.go
+++ b/internal/workerpool/pool.go
@@ -76,6 +76,11 @@ type ConsumerPool struct {
 	wg         sync.WaitGroup
 	pollWg     sync.WaitGroup
 	pollCancel context.CancelFunc
+	// stopOnce 는 Stop 다중 호출 안전성 보장 (gemini PR #413 피드백 — close on closed
+	// channel panic 회피). 2회차 이후 Stop 은 nil 반환 — idempotent.
+	stopOnce sync.Once
+	// stopErr 는 첫 Stop 호출의 에러를 보존 — 2회차 호출은 동일 에러를 참조하지 않고 nil 반환.
+	stopErr error
 }
 
 // New 는 새 ConsumerPool 을 생성합니다.
@@ -121,11 +126,25 @@ func (p *ConsumerPool) Start(ctx context.Context) {
 	go p.poll(pollCtx)
 }
 
-// Stop 은 worker pool 을 정상 종료합니다.
+// Stop 은 worker pool 을 정상 종료합니다 — 다중 호출 안전 (gemini PR #413).
 //
 // ctx 는 worker drain timeout 으로 활용 — 만료 시 force close 로 진행 (commit 안 된 메시지는
 // 다음 기동에서 재소비). consumer.Close 는 항상 호출됩니다.
+//
+// 반환 정책:
+//   - drain graceful + consumer.Close OK → nil
+//   - drain timeout (ctx canceled 으로 worker 미완) → errors.Join(ctx.Err(), closeErr)
+//   - drain OK + consumer.Close 실패 → closeErr
+//
+// 2회차 이후 호출은 nil 반환 (idempotent).
 func (p *ConsumerPool) Stop(ctx context.Context) error {
+	p.stopOnce.Do(func() {
+		p.stopErr = p.stopImpl(ctx)
+	})
+	return p.stopErr
+}
+
+func (p *ConsumerPool) stopImpl(ctx context.Context) error {
 	log := p.logger(ctx)
 
 	// 1. poll 중단 — 새 메시지 fetch 안 함 + ctx.Err() 로 즉시 반환
@@ -144,15 +163,22 @@ func (p *ConsumerPool) Stop(ctx context.Context) error {
 		close(done)
 	}()
 
+	var drainErr error
 	select {
 	case <-done:
 		log.Info("worker pool drained gracefully")
 	case <-ctx.Done():
+		// ctx.Err() 를 단일 진실 공급원 (SoT) 으로 — 호출자가 errors.Is 로 분기 가능 (gemini PR #413).
+		drainErr = fmt.Errorf("worker drain timeout: %w", ctx.Err())
 		log.Warn("worker pool shutdown timeout, forcing close")
 	}
 
-	// 4. consumer close
-	return p.cfg.Consumer.Close()
+	// 4. consumer close (drainErr 있어도 항상 호출 — Kafka 리소스 정리 보장)
+	closeErr := p.cfg.Consumer.Close()
+	if drainErr != nil {
+		return errors.Join(drainErr, closeErr) // closeErr 가 nil 이면 errors.Join 이 drainErr 만 반환
+	}
+	return closeErr
 }
 
 // poll 은 Kafka 에서 메시지를 한 건씩 fetch 하여 jobs 채널에 dispatch 합니다.

--- a/internal/workerpool/pool.go
+++ b/internal/workerpool/pool.go
@@ -1,0 +1,251 @@
+// Package workerpool 은 Kafka consumer 기반 stage worker 의 공용 harness 를 제공합니다 (이슈 #404).
+//
+// 세 stage worker (fetcher / parser / validate) 가 동일하게 반복하던 lifecycle 코드
+// (poll → dispatch → commit → graceful shutdown) 를 단일 source-of-truth 로 통합 — 향후
+// 신규 stage 추가 시 boilerplate 비용 ↓ + 한 곳 수정이 세 stage 에 일관 반영.
+//
+// 설계 원칙 — minimal harness:
+//   - harness 가 owns:    poll / dispatch / worker_id 주입 / graceful shutdown / commit-with-drain
+//   - handler 가 owns:    메시지 unmarshal / 비즈니스 로직 / DLQ 라우팅 / requeue 결정 / StageGate
+//
+// stage-specific 결정 (DLQ vs requeue, validation 분기, CB / retry scheduler 통합) 은 handler
+// 에서 자유롭게 — harness 는 강제 정책 미보유. 공통 helper (CommitWithDrain) 만 노출.
+//
+// 마이그레이션 sub (Sub 2-4) 에서 stage 별 handler 가 본 harness 위에서 stage 핵심만 담는
+// 형태로 재구성됩니다.
+package workerpool
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"time"
+
+	"issuetracker/internal/bus"
+	"issuetracker/internal/processor/fetcher/core"
+	"issuetracker/pkg/logger"
+	"issuetracker/pkg/queue"
+)
+
+// DefaultDrainTimeout 은 graceful shutdown 으로 ctx 가 canceled 된 뒤 commit / publish 를
+// 한 번 더 시도할 때 사용하는 별도 context 의 fallback 타임아웃입니다.
+// at-least-once 시맨틱 보장 — 세 stage 의 기존 drainTimeout 과 동일 값.
+const DefaultDrainTimeout = 5 * time.Second
+
+// Handler 는 stage 별 메시지 처리 책임을 가지는 인터페이스입니다.
+//
+// 구현체는 stage-specific 로직 (unmarshal / validation / DLQ / requeue / commit) 의 모든
+// 권한을 갖습니다. harness 는 자체 commit 정책을 강제하지 않으며, handler 가 ConsumerPool.Commit
+// 을 통해 명시적으로 commit 합니다.
+//
+// goroutine-safe 해야 함 — workerCount > 1 시 동시 호출.
+type Handler interface {
+	Handle(ctx context.Context, msg *queue.Message)
+}
+
+// Config 는 ConsumerPool 생성 옵션입니다.
+type Config struct {
+	// Consumer 는 Kafka consumer (bus.Consumer = queue.Consumer alias).
+	Consumer bus.Consumer
+	// Handler 는 메시지 처리기.
+	Handler Handler
+	// WorkerCount 는 동시 처리 goroutine 수. 0 이하는 1 로 보정.
+	WorkerCount int
+	// DrainTimeout 은 shutdown 시 commit retry timeout. 0 이하면 DefaultDrainTimeout.
+	DrainTimeout time.Duration
+	// Log 는 lifecycle 로그용. nil 이면 noop logger.
+	Log *logger.Logger
+	// Name 은 로그 식별자 (예: "fetcher-high" / "parser" / "validator"). 빈 문자열 허용.
+	Name string
+}
+
+// ConsumerPool 은 generic Kafka consumer worker pool harness 입니다.
+//
+// 종료 순서 보장:
+//  1. pollCancel → poll goroutine 즉시 ctx.Err() 받고 종료
+//  2. pollWg.Wait — poll 이 jobs 채널 send 를 더 이상 시도 안 함을 보장
+//  3. close(jobs) — worker goroutine 의 range loop 종료 신호
+//  4. wg.Wait (ctx 또는 drainTimeout 으로 시간 cap)
+//  5. consumer.Close()
+//
+// 이 순서는 send-on-closed-channel panic 을 구조적으로 방지.
+type ConsumerPool struct {
+	cfg        Config
+	jobs       chan *queue.Message
+	wg         sync.WaitGroup
+	pollWg     sync.WaitGroup
+	pollCancel context.CancelFunc
+}
+
+// New 는 새 ConsumerPool 을 생성합니다.
+//
+// cfg.Consumer / cfg.Handler 는 nil 불허 — Start 전 panic 으로 fail-fast.
+// WorkerCount / DrainTimeout 은 0 이하면 default 적용.
+func New(cfg Config) *ConsumerPool {
+	if cfg.Consumer == nil {
+		panic("workerpool.New: Consumer must not be nil")
+	}
+	if cfg.Handler == nil {
+		panic("workerpool.New: Handler must not be nil")
+	}
+	if cfg.WorkerCount <= 0 {
+		cfg.WorkerCount = 1
+	}
+	if cfg.DrainTimeout <= 0 {
+		cfg.DrainTimeout = DefaultDrainTimeout
+	}
+	return &ConsumerPool{
+		cfg: cfg,
+		// 버퍼 worker_count*2 — polling 과 처리 사이 지연 흡수 (기존 세 stage 동일 값).
+		jobs: make(chan *queue.Message, cfg.WorkerCount*2),
+	}
+}
+
+// Start 는 poll + worker goroutine 들을 기동합니다 (non-blocking).
+//
+// 각 worker goroutine 은 0..WorkerCount-1 의 worker_id 가 ctx 에 첨부되어 handler 에 전달됩니다.
+// fetcher chromedp pool 의 per-worker Semaphore lookup 등 worker 자원 격리에 활용됩니다.
+func (p *ConsumerPool) Start(ctx context.Context) {
+	for i := 0; i < p.cfg.WorkerCount; i++ {
+		workerID := i
+		p.wg.Add(1)
+		go p.worker(ctx, workerID)
+	}
+
+	// poll goroutine 의 ctx 는 별도 cancel — Stop 시 poll 만 먼저 중단시켜 send-on-closed
+	// 회피. wg.Add 는 goroutine 시작 전 — "Add called concurrently with Wait" 패닉 방지.
+	pollCtx, cancel := context.WithCancel(ctx)
+	p.pollCancel = cancel
+	p.pollWg.Add(1)
+	go p.poll(pollCtx)
+}
+
+// Stop 은 worker pool 을 정상 종료합니다.
+//
+// ctx 는 worker drain timeout 으로 활용 — 만료 시 force close 로 진행 (commit 안 된 메시지는
+// 다음 기동에서 재소비). consumer.Close 는 항상 호출됩니다.
+func (p *ConsumerPool) Stop(ctx context.Context) error {
+	log := p.logger(ctx)
+
+	// 1. poll 중단 — 새 메시지 fetch 안 함 + ctx.Err() 로 즉시 반환
+	if p.pollCancel != nil {
+		p.pollCancel()
+	}
+	p.pollWg.Wait()
+
+	// 2. poll 종료 확정 후 jobs close — send-on-closed-channel panic 회피
+	close(p.jobs)
+
+	// 3. worker drain — ctx 만료 시 force progress (deferred consumer.Close 까지 진행)
+	done := make(chan struct{})
+	go func() {
+		p.wg.Wait()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		log.Info("worker pool drained gracefully")
+	case <-ctx.Done():
+		log.Warn("worker pool shutdown timeout, forcing close")
+	}
+
+	// 4. consumer close
+	return p.cfg.Consumer.Close()
+}
+
+// poll 은 Kafka 에서 메시지를 한 건씩 fetch 하여 jobs 채널에 dispatch 합니다.
+//
+// ctx cancel 시 즉시 반환 — Stop 의 pollCancel 호출이 본 goroutine 을 unblock 합니다.
+// FetchMessage 에러는 ctx canceled 가 아닌 경우만 ERROR — 운영 모니터링에서 정상 종료 흐름의
+// 오탐을 제거.
+func (p *ConsumerPool) poll(ctx context.Context) {
+	defer p.pollWg.Done()
+
+	log := p.logger(ctx)
+
+	for {
+		msg, err := p.cfg.Consumer.FetchMessage(ctx)
+		if err != nil {
+			if ctx.Err() != nil {
+				return
+			}
+			log.WithError(err).Error("failed to receive kafka message")
+			continue
+		}
+
+		select {
+		case p.jobs <- msg:
+		case <-ctx.Done():
+			return
+		}
+	}
+}
+
+// worker 는 jobs 채널에서 메시지를 받아 handler 에 위임합니다.
+//
+// worker_id 를 ctx 에 첨부하여 handler 가 per-worker 자원 lookup (chromedp 의 worker_id 별
+// Semaphore 등) 가능. range loop 는 jobs 채널 close 시 자연 종료.
+func (p *ConsumerPool) worker(ctx context.Context, workerID int) {
+	defer p.wg.Done()
+
+	ctx = core.WithWorkerID(ctx, workerID)
+
+	for msg := range p.jobs {
+		p.cfg.Handler.Handle(ctx, msg)
+	}
+}
+
+// Commit 은 메시지 offset 을 commit 합니다 — drain context 로 ctx canceled 시 재시도.
+//
+// handler 가 명시적으로 호출 — harness 는 자체 commit 정책 미보유 (stage 별 DLQ / requeue 결정
+// 후 handler 가 적절히 commit). 호출자는 commit 실패를 로깅 / metric 으로 반영.
+//
+// graceful shutdown 으로 ctx 가 canceled 된 경우 별도 context.WithoutCancel + DrainTimeout 으로
+// 한 번 더 시도 — at-least-once 정확도 향상.
+func (p *ConsumerPool) Commit(ctx context.Context, msg *queue.Message) error {
+	return CommitWithDrain(ctx, p.cfg.Consumer, msg, p.cfg.DrainTimeout)
+}
+
+// CommitWithDrain 은 메시지 commit + drain context retry 를 수행하는 stateless 헬퍼입니다.
+//
+// 첫 commit 시도 → ctx canceled 면 context.WithoutCancel + drainTimeout 으로 재시도 →
+// errors.Join 으로 최초 cancel 과 retry err 모두 보존. ConsumerPool 외부 (단위 테스트 / 다른
+// 콜러) 에서도 사용 가능.
+func CommitWithDrain(ctx context.Context, consumer bus.Consumer, msg *queue.Message, drainTimeout time.Duration) error {
+	err := consumer.CommitMessages(ctx, msg)
+	if err == nil {
+		return nil
+	}
+	if !errors.Is(err, context.Canceled) {
+		return fmt.Errorf("commit offset: %w", err)
+	}
+
+	// drain retry — cancellation 분리 + drainTimeout 으로 시간 cap.
+	if drainTimeout <= 0 {
+		drainTimeout = DefaultDrainTimeout
+	}
+	drainCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), drainTimeout)
+	defer cancel()
+
+	if retryErr := consumer.CommitMessages(drainCtx, msg); retryErr == nil {
+		return nil
+	} else {
+		// errors.Join — 호출자의 errors.Is(err, context.Canceled) 분기 안정성 보존.
+		return fmt.Errorf("commit offset (drain retry failed): %w", errors.Join(err, retryErr))
+	}
+}
+
+// logger 는 cfg.Log 가 있으면 그대로 반환, 없으면 ctx logger 로 fallback.
+// Name 이 설정되어 있으면 stage 식별자 필드 첨부.
+func (p *ConsumerPool) logger(ctx context.Context) *logger.Logger {
+	log := p.cfg.Log
+	if log == nil {
+		log = logger.FromContext(ctx)
+	}
+	if p.cfg.Name != "" {
+		log = log.WithField("worker_pool", p.cfg.Name)
+	}
+	return log
+}

--- a/test/internal/workerpool/pool_test.go
+++ b/test/internal/workerpool/pool_test.go
@@ -234,6 +234,40 @@ func TestPool_ShutdownOrder_NoSendOnClosed(t *testing.T) {
 	// panic 없이 도달하면 성공.
 }
 
+// TestPool_Stop_Idempotent 는 Stop 2회 호출 시 panic 없이 idempotent 동작.
+// (close on closed channel 회피 — gemini PR #413 피드백.)
+func TestPool_Stop_Idempotent(t *testing.T) {
+	consumer := new(mockConsumer)
+	handler := &captureHandler{}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	consumer.On("FetchMessage", mock.Anything).
+		Run(func(_ mock.Arguments) { cancel() }).
+		Return(nil, context.Canceled)
+	consumer.On("Close").Return(nil).Once()
+
+	pool := workerpool.New(workerpool.Config{
+		Consumer:    consumer,
+		Handler:     handler,
+		WorkerCount: 1,
+		Log:         testLog(),
+		Name:        "test",
+	})
+
+	pool.Start(ctx)
+	<-ctx.Done()
+
+	stopCtx, stopCancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer stopCancel()
+	err1 := pool.Stop(stopCtx)
+	require.NoError(t, err1)
+	// 2회차 호출 — panic 없이 nil 반환
+	err2 := pool.Stop(stopCtx)
+	require.NoError(t, err2)
+	// consumer.Close 는 1회만 호출됨 (Once 매처 확인)
+	consumer.AssertExpectations(t)
+}
+
 // TestPool_Stop_DrainTimeout 은 worker 가 처리 중 (handler block) 일 때 ctx 만료로 force
 // progress 하는지 검증.
 func TestPool_Stop_DrainTimeout(t *testing.T) {
@@ -271,7 +305,9 @@ func TestPool_Stop_DrainTimeout(t *testing.T) {
 	stopCtx, stopCancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
 	defer stopCancel()
 	stopErr := pool.Stop(stopCtx)
-	require.NoError(t, stopErr) // consumer.Close 는 무사 호출됨
+	// drain timeout → errors.Join 으로 ctx.Err() 포함 — 호출자가 errors.Is 로 timeout 분기 가능.
+	require.Error(t, stopErr)
+	assert.ErrorIs(t, stopErr, context.DeadlineExceeded)
 }
 
 // ─────────────────────────────────────────────────────────────────────────────

--- a/test/internal/workerpool/pool_test.go
+++ b/test/internal/workerpool/pool_test.go
@@ -1,0 +1,343 @@
+package workerpool_test
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	"issuetracker/internal/processor/fetcher/core"
+	"issuetracker/internal/workerpool"
+	"issuetracker/pkg/logger"
+	"issuetracker/pkg/queue"
+)
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Mocks
+// ─────────────────────────────────────────────────────────────────────────────
+
+type mockConsumer struct {
+	mock.Mock
+}
+
+func (m *mockConsumer) FetchMessage(ctx context.Context) (*queue.Message, error) {
+	args := m.Called(ctx)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*queue.Message), args.Error(1)
+}
+
+func (m *mockConsumer) CommitMessages(ctx context.Context, msgs ...*queue.Message) error {
+	args := m.Called(ctx, msgs)
+	return args.Error(0)
+}
+
+func (m *mockConsumer) Close() error {
+	args := m.Called()
+	return args.Error(0)
+}
+
+// captureHandler 는 Handle 호출의 메시지 + worker_id 를 캡쳐합니다.
+type captureHandler struct {
+	mu        sync.Mutex
+	calls     []captureCall
+	onHandle  func(ctx context.Context, msg *queue.Message)
+	callCount atomic.Int32
+}
+
+type captureCall struct {
+	msg      *queue.Message
+	workerID int
+}
+
+func (h *captureHandler) Handle(ctx context.Context, msg *queue.Message) {
+	h.callCount.Add(1)
+	h.mu.Lock()
+	h.calls = append(h.calls, captureCall{
+		msg:      msg,
+		workerID: core.WorkerIDFromContext(ctx),
+	})
+	h.mu.Unlock()
+	if h.onHandle != nil {
+		h.onHandle(ctx, msg)
+	}
+}
+
+func (h *captureHandler) snapshot() []captureCall {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	out := make([]captureCall, len(h.calls))
+	copy(out, h.calls)
+	return out
+}
+
+func testLog() *logger.Logger { return logger.New(logger.DefaultConfig()) }
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Constructor invariants
+// ─────────────────────────────────────────────────────────────────────────────
+
+// TestNew_NilConsumer_Panics 는 Consumer nil 주입 시 fail-fast 보장.
+func TestNew_NilConsumer_Panics(t *testing.T) {
+	assert.PanicsWithValue(t, "workerpool.New: Consumer must not be nil", func() {
+		workerpool.New(workerpool.Config{Handler: &captureHandler{}})
+	})
+}
+
+// TestNew_NilHandler_Panics 는 Handler nil 주입 시 fail-fast 보장.
+func TestNew_NilHandler_Panics(t *testing.T) {
+	assert.PanicsWithValue(t, "workerpool.New: Handler must not be nil", func() {
+		workerpool.New(workerpool.Config{Consumer: new(mockConsumer)})
+	})
+}
+
+// TestNew_WorkerCountDefault 는 WorkerCount 0 이하 시 1 로 보정.
+func TestNew_WorkerCountDefault(t *testing.T) {
+	// panic 없이 생성되면 정상 — 내부 jobs 버퍼 크기는 외부 노출 안 되므로 동작 검증으로 확인.
+	pool := workerpool.New(workerpool.Config{
+		Consumer:    new(mockConsumer),
+		Handler:     &captureHandler{},
+		WorkerCount: 0,
+	})
+	assert.NotNil(t, pool)
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Lifecycle / shutdown
+// ─────────────────────────────────────────────────────────────────────────────
+
+// TestPool_StartProcess_SingleMessage 는 단일 메시지를 worker 가 처리하는 기본 흐름.
+func TestPool_StartProcess_SingleMessage(t *testing.T) {
+	consumer := new(mockConsumer)
+	handler := &captureHandler{}
+
+	msg := &queue.Message{
+		Topic: "test",
+		Key:   []byte("k1"),
+		Value: []byte("v1"),
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	consumer.On("FetchMessage", mock.Anything).Return(msg, nil).Once()
+	consumer.On("FetchMessage", mock.Anything).
+		Run(func(_ mock.Arguments) { cancel() }).
+		Return(nil, context.Canceled)
+	consumer.On("Close").Return(nil)
+
+	pool := workerpool.New(workerpool.Config{
+		Consumer:    consumer,
+		Handler:     handler,
+		WorkerCount: 1,
+		Log:         testLog(),
+		Name:        "test",
+	})
+
+	pool.Start(ctx)
+	<-ctx.Done()
+
+	stopCtx, stopCancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer stopCancel()
+	require.NoError(t, pool.Stop(stopCtx))
+
+	snap := handler.snapshot()
+	require.Len(t, snap, 1)
+	assert.Equal(t, msg, snap[0].msg)
+}
+
+// TestPool_WorkerID_Injected 는 workerCount > 1 시 worker_id 가 ctx 에 첨부됨을 검증.
+func TestPool_WorkerID_Injected(t *testing.T) {
+	consumer := new(mockConsumer)
+	handler := &captureHandler{}
+
+	// 충분히 많은 메시지로 multi-worker 활성화 확인.
+	msgs := make([]*queue.Message, 6)
+	for i := range msgs {
+		msgs[i] = &queue.Message{Topic: "t", Key: []byte("k"), Value: []byte("v")}
+	}
+
+	consumer.On("FetchMessage", mock.Anything).Return(msgs[0], nil).Once()
+	consumer.On("FetchMessage", mock.Anything).Return(msgs[1], nil).Once()
+	consumer.On("FetchMessage", mock.Anything).Return(msgs[2], nil).Once()
+	consumer.On("FetchMessage", mock.Anything).Return(msgs[3], nil).Once()
+	consumer.On("FetchMessage", mock.Anything).Return(msgs[4], nil).Once()
+	consumer.On("FetchMessage", mock.Anything).Return(msgs[5], nil).Once()
+	ctx, cancel := context.WithCancel(context.Background())
+	consumer.On("FetchMessage", mock.Anything).
+		Run(func(_ mock.Arguments) { cancel() }).
+		Return(nil, context.Canceled)
+	consumer.On("Close").Return(nil)
+
+	// 의도적으로 worker 처리 지연 — 여러 worker_id 가 호출되도록.
+	handler.onHandle = func(_ context.Context, _ *queue.Message) {
+		time.Sleep(5 * time.Millisecond)
+	}
+
+	pool := workerpool.New(workerpool.Config{
+		Consumer:    consumer,
+		Handler:     handler,
+		WorkerCount: 3,
+		Log:         testLog(),
+		Name:        "test",
+	})
+
+	pool.Start(ctx)
+	<-ctx.Done()
+
+	stopCtx, stopCancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer stopCancel()
+	require.NoError(t, pool.Stop(stopCtx))
+
+	snap := handler.snapshot()
+	require.Len(t, snap, 6)
+	// 모든 worker_id 가 [0, 3) 범위에 있어야 함.
+	ids := make(map[int]bool)
+	for _, c := range snap {
+		assert.GreaterOrEqual(t, c.workerID, 0)
+		assert.Less(t, c.workerID, 3)
+		ids[c.workerID] = true
+	}
+	// 최소 2개 이상의 worker 가 활성화 (3개 모두 보장은 timing-dependent 라 looser check).
+	assert.GreaterOrEqual(t, len(ids), 2, "multi-worker dispatch should engage multiple worker ids")
+}
+
+// TestPool_ShutdownOrder_NoSendOnClosed 는 Stop 순서 안전성 검증 —
+// poll 이 jobs 채널 close 이후 send 시도 시 panic 발생하지 않아야 함.
+func TestPool_ShutdownOrder_NoSendOnClosed(t *testing.T) {
+	consumer := new(mockConsumer)
+	handler := &captureHandler{}
+
+	// FetchMessage 가 무한히 반환되도록 — Stop 의 pollCancel 만으로 종료.
+	consumer.On("FetchMessage", mock.Anything).Return(&queue.Message{Topic: "t", Key: []byte("k"), Value: []byte("v")}, nil)
+	consumer.On("Close").Return(nil)
+
+	pool := workerpool.New(workerpool.Config{
+		Consumer:    consumer,
+		Handler:     handler,
+		WorkerCount: 2,
+		Log:         testLog(),
+		Name:        "test",
+	})
+
+	pool.Start(context.Background())
+	time.Sleep(20 * time.Millisecond) // 폴 + 처리 활성화 시간 확보
+
+	stopCtx, stopCancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer stopCancel()
+	require.NoError(t, pool.Stop(stopCtx))
+	// panic 없이 도달하면 성공.
+}
+
+// TestPool_Stop_DrainTimeout 은 worker 가 처리 중 (handler block) 일 때 ctx 만료로 force
+// progress 하는지 검증.
+func TestPool_Stop_DrainTimeout(t *testing.T) {
+	consumer := new(mockConsumer)
+	handler := &captureHandler{}
+
+	// handler 가 영원히 block.
+	blockCh := make(chan struct{})
+	defer close(blockCh)
+	handler.onHandle = func(_ context.Context, _ *queue.Message) {
+		<-blockCh
+	}
+
+	consumer.On("FetchMessage", mock.Anything).Return(&queue.Message{Topic: "t"}, nil).Once()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	consumer.On("FetchMessage", mock.Anything).
+		Run(func(_ mock.Arguments) { cancel() }).
+		Return(nil, context.Canceled)
+	consumer.On("Close").Return(nil)
+
+	pool := workerpool.New(workerpool.Config{
+		Consumer:    consumer,
+		Handler:     handler,
+		WorkerCount: 1,
+		Log:         testLog(),
+		Name:        "test",
+	})
+
+	pool.Start(ctx)
+	<-ctx.Done()
+	time.Sleep(20 * time.Millisecond) // worker 가 handler 진입 시간 확보
+
+	// ctx timeout 으로 force progress — handler 가 block 중이라도 Stop 반환.
+	stopCtx, stopCancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer stopCancel()
+	stopErr := pool.Stop(stopCtx)
+	require.NoError(t, stopErr) // consumer.Close 는 무사 호출됨
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Commit / drain
+// ─────────────────────────────────────────────────────────────────────────────
+
+// TestCommitWithDrain_Success 는 정상 ctx 에서 1회 commit 성공.
+func TestCommitWithDrain_Success(t *testing.T) {
+	consumer := new(mockConsumer)
+	msg := &queue.Message{Topic: "t"}
+
+	consumer.On("CommitMessages", mock.Anything, mock.Anything).Return(nil).Once()
+
+	err := workerpool.CommitWithDrain(context.Background(), consumer, msg, time.Second)
+	require.NoError(t, err)
+	consumer.AssertExpectations(t)
+}
+
+// TestCommitWithDrain_CtxCanceled_DrainRetrySucceeds 는 첫 commit 가 ctx canceled 로 실패
+// 했을 때 drain context 로 한 번 더 시도 → 성공 시 nil 반환.
+func TestCommitWithDrain_CtxCanceled_DrainRetrySucceeds(t *testing.T) {
+	consumer := new(mockConsumer)
+	msg := &queue.Message{Topic: "t"}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // 사전 cancel
+
+	// 첫 호출 — canceled ctx → context.Canceled
+	consumer.On("CommitMessages", ctx, mock.Anything).Return(context.Canceled).Once()
+	// drain 재시도 — 다른 ctx → 성공
+	consumer.On("CommitMessages", mock.MatchedBy(func(c context.Context) bool {
+		return c != ctx && c.Err() == nil
+	}), mock.Anything).Return(nil).Once()
+
+	err := workerpool.CommitWithDrain(ctx, consumer, msg, time.Second)
+	require.NoError(t, err)
+	consumer.AssertExpectations(t)
+}
+
+// TestCommitWithDrain_CtxCanceled_DrainRetryAlsoFails 는 drain 재시도도 실패 시
+// errors.Is(err, context.Canceled) 로 분기 가능해야 함.
+func TestCommitWithDrain_CtxCanceled_DrainRetryAlsoFails(t *testing.T) {
+	consumer := new(mockConsumer)
+	msg := &queue.Message{Topic: "t"}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	consumer.On("CommitMessages", ctx, mock.Anything).Return(context.Canceled).Once()
+	// drain 재시도도 deadline exceed (timeout = 1ms 강제)
+	consumer.On("CommitMessages", mock.Anything, mock.Anything).Return(errors.New("broker down")).Once()
+
+	err := workerpool.CommitWithDrain(ctx, consumer, msg, time.Millisecond)
+	require.Error(t, err)
+	// errors.Join 으로 최초 cancel 보존 — 호출자의 cancel 분기 안정성.
+	assert.ErrorIs(t, err, context.Canceled)
+}
+
+// TestCommitWithDrain_NonCancelError_NoRetry 는 ctx canceled 아닌 일반 에러는 재시도 X.
+func TestCommitWithDrain_NonCancelError_NoRetry(t *testing.T) {
+	consumer := new(mockConsumer)
+	msg := &queue.Message{Topic: "t"}
+
+	consumer.On("CommitMessages", mock.Anything, mock.Anything).Return(errors.New("broker down")).Once()
+
+	err := workerpool.CommitWithDrain(context.Background(), consumer, msg, time.Second)
+	require.Error(t, err)
+	consumer.AssertExpectations(t) // 1회만 호출 (재시도 X)
+}


### PR DESCRIPTION
## 연관 이슈

Closes #404
부모 메타: #403 — Kafka consumer pool 골격 공용화 Sub 1 (마이그레이션 base)

## 구현 내용

세 stage worker (fetcher/parser/validate) 가 공유할 generic Kafka consumer worker pool harness 패키지 신규 생성. **마이그레이션은 본 sub 범위 외** — 본 PR 는 패키지 + 단위 테스트만.

### 설계 원칙 — minimal harness

| 책임 | 담당 |
|---|---|
| poll / dispatch / worker_id 주입 / graceful shutdown / commit-with-drain | **harness** |
| 메시지 unmarshal / 비즈니스 로직 / DLQ 라우팅 / requeue 결정 / StageGate | **handler** |

stage-specific 결정 (DLQ vs requeue, validation 분기, CircuitBreaker / RetryScheduler 통합) 은 handler 에서 자유롭게. harness 는 강제 정책 미보유 — 공통 helper (`CommitWithDrain`) 만 노출.

### 핵심 API

```go
type Handler interface {
    Handle(ctx context.Context, msg *queue.Message)
}

type Config struct {
    Consumer     bus.Consumer
    Handler      Handler
    WorkerCount  int
    DrainTimeout time.Duration  // 0 → DefaultDrainTimeout (5s)
    Log          *logger.Logger
    Name         string         // log identifier (e.g. "fetcher-high", "parser")
}

func New(cfg Config) *ConsumerPool          // nil Consumer/Handler → panic (fail-fast)
func (p *ConsumerPool) Start(ctx)
func (p *ConsumerPool) Stop(ctx) error
func (p *ConsumerPool) Commit(ctx, msg) error

// stateless 헬퍼 — 외부 사용 가능
func CommitWithDrain(ctx, consumer bus.Consumer, msg *queue.Message, drainTimeout time.Duration) error
```

### 종료 순서 (send-on-closed-channel panic 구조적 방지)

1. `pollCancel` → poll goroutine 즉시 ctx.Err() 받고 종료
2. `pollWg.Wait` — poll 이 jobs 채널 send 를 더 이상 시도 안 함을 보장
3. `close(jobs)` — worker goroutine 의 range loop 종료 신호
4. `wg.Wait` (ctx 또는 DrainTimeout 으로 시간 cap)
5. `consumer.Close()`

### worker_id ctx 첨부

각 worker goroutine 은 0..WorkerCount-1 의 `worker_id` 가 ctx 에 first-class 첨부 (`core.WithWorkerID`) → fetcher chromedp pool 의 per-worker Semaphore lookup 등 자원 격리에 활용 가능.

### 테스트 커버리지 (race)

- New nil guard (Consumer / Handler) — fail-fast panic
- 단일 메시지 처리 + worker_id 주입 검증
- multi-worker dispatch 시 다중 worker_id 활성화 (timing-stable)
- Stop 순서 안전성 (send-on-closed panic 회피)
- Stop drain timeout (handler block 시 force progress)
- CommitWithDrain: 성공 / ctx canceled+drain 재시도 성공 / 둘 다 실패 시 errors.Join 으로 `context.Canceled` 보존
- non-cancel 에러는 재시도 X

## CI / 머지 게이트 점검

- [x] `gofmt -l internal/workerpool/ test/internal/workerpool/` — clean
- [x] `go build ./...` — pass
- [x] `go test -race -count=1 -timeout=60s ./test/internal/workerpool/...` — pass
- [x] `go test -race -count=1 -timeout=180s ./test/...` — 전 패키지 회귀 0
- [x] PR 타이틀 `[REFAC#404]`
- [x] commit `[REFAC]:` prefix + 한국어

## 변경 영향 범위 + 위험도

- **영향**: 신규 파일 2개 (구현 + 테스트). 기존 코드 변경 0.
- **위험도 Low**:
  - 신규 패키지라 기존 동작 영향 0
  - 설계가 minimal 이라 Sub 2~4 마이그레이션 시 stage-specific 분기 흡수 자유로움
  - handler-owned 정책으로 stage 별 미세 차이 (LLM 재학습 / chromedp 분기 / reparse count) 보존

## 후속

- Sub 2 (#405): fetcher/worker pool → 본 harness 위로 마이그레이션
- Sub 3 (#406): parser/worker 마이그레이션
- Sub 4 (#407): validate/worker 마이그레이션 (마지막 sub PR 에서 메타 #403 close)

## 롤백 계획

PR revert 시 신규 파일 2개 제거만으로 원상복귀 — 기존 코드 미수정.

🤖 Generated with [Claude Code](https://claude.com/claude-code)