### PR TITLE
[REFAC#405] fetcher/worker KafkaConsumerPool → workerpool harness 마이그레이션

### DIFF
--- a/internal/processor/fetcher/worker/pool.go
+++ b/internal/processor/fetcher/worker/pool.go
@@ -213,18 +213,32 @@ func (p *KafkaConsumerPool) SetPriority(name string) {
 //
 // harness 가 N 개 worker goroutine + poll goroutine 을 관리하며, 각 메시지마다 본 pool 의
 // Handle 메소드를 호출합니다. heartbeat goroutine 은 priority 설정 시 별도 시작.
+//
+// 로깅 — worker_pool 필드 단일 책임 (gemini PR #414 피드백):
+//   - Name 은 priority 가 설정된 경우만 "fetcher-<priority>", 빈 경우 "fetcher" (trailing
+//     hyphen 회피).
+//   - worker_pool 필드는 workerpool.Config.Name 으로 한 번만 설정 → harness 가 자체 logger 에
+//     주입 (중복 회피).
+//   - Handler / processJob / heartbeatLoop 가 FromContext(ctx) 로 로거를 얻을 때도 동일 필드를
+//     보도록 ctx 에 worker_pool 필드 logger 주입 (observability 보존).
 func (p *KafkaConsumerPool) Start(ctx context.Context) {
-	log := logger.FromContext(ctx)
+	name := "fetcher"
 	if p.priority != "" {
-		log = log.WithField("worker_pool", "fetcher-"+p.priority)
+		name = "fetcher-" + p.priority
 	}
+	// plain logger 를 workerpool.Config.Log 로 전달 — harness 가 Name 으로 worker_pool 필드
+	// 단독 주입 (중복 회피). 동일 필드를 Handle/processJob/heartbeatLoop 의 ctx logger 에도
+	// 보존하기 위해 ctx 에 별도 ToContext 로 주입.
+	plainLog := logger.FromContext(ctx)
+	ctx = plainLog.WithField("worker_pool", name).ToContext(ctx)
+
 	p.pool = workerpool.New(workerpool.Config{
 		Consumer:     p.consumer,
 		Handler:      p,
 		WorkerCount:  p.workerCount,
 		DrainTimeout: drainTimeout,
-		Log:          log,
-		Name:         "fetcher-" + p.priority,
+		Log:          plainLog, // harness 가 자체 worker_pool 필드 주입 (Name 으로 1회)
+		Name:         name,
 	})
 	p.pool.Start(ctx)
 

--- a/internal/processor/fetcher/worker/pool.go
+++ b/internal/processor/fetcher/worker/pool.go
@@ -1,7 +1,9 @@
 // Package worker provides Kafka-based crawler worker pool implementation.
 //
 // worker 패키지는 Kafka consumer group 기반 크롤러 워커 풀을 제공합니다.
-// KafkaConsumerPool은 여러 goroutine이 병렬로 CrawlJob을 처리하도록 관리합니다.
+// KafkaConsumerPool 은 fetcher stage 특화 책임 (CircuitBreaker / RetryScheduler / StageGate /
+// publishNormalized 등) 을 담당하고, 공용 lifecycle (poll / dispatch / shutdown / commit) 은
+// internal/workerpool harness 에 위임합니다 (이슈 #405 — 메타 #403 Sub 2).
 package worker
 
 import (
@@ -9,7 +11,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"sync"
 	"sync/atomic"
 	"time"
 
@@ -17,6 +18,7 @@ import (
 	"issuetracker/internal/locks"
 	"issuetracker/internal/processor/fetcher/core"
 	"issuetracker/internal/storage/service"
+	"issuetracker/internal/workerpool"
 	"issuetracker/pkg/links"
 	"issuetracker/pkg/logger"
 	"issuetracker/pkg/queue"
@@ -24,13 +26,10 @@ import (
 	"issuetracker/pkg/urlguard"
 )
 
-// drainTimeout 은 graceful shutdown 으로 ctx 가 canceled 된 뒤 Kafka publish/commit 을
+// drainTimeout 은 graceful shutdown 으로 ctx 가 canceled 된 뒤 Kafka publish / commit 을
 // 한 번 더 시도할 때 사용하는 별도 context 의 타임아웃입니다.
-// at-least-once 시맨틱 보장을 위해 ctx canceled 직후 in-flight 메시지의 DLQ 발행·재큐잉·
-// offset 커밋을 마무리할 시간을 확보합니다.
-//
-// validate worker (internal/processor/validate/worker.go) 의 동일 상수와 정책을 일치시킵니다.
-const drainTimeout = 5 * time.Second
+// at-least-once 시맨틱 보장 — validate worker / workerpool harness 와 동일 값.
+const drainTimeout = workerpool.DefaultDrainTimeout
 
 // JobHandler는 CrawlJob을 처리하는 인터페이스입니다.
 // 구현체는 여러 goroutine에서 동시에 호출되므로 goroutine-safe해야 합니다.
@@ -51,35 +50,34 @@ var kafkaRequeuePolicy = core.RetryPolicy{
 	Jitter:       true,
 }
 
-// KafkaConsumerPool은 Kafka consumer group 기반 crawler worker pool입니다.
+// KafkaConsumerPool 은 Kafka consumer group 기반 crawler worker pool 입니다.
 //
-// Kafka 토픽에서 CrawlJob 메시지를 읽어 내부 채널을 통해 worker goroutine에 분배합니다.
-// 각 job의 처리 결과(Content)는 contents DB 테이블에 저장된 뒤 ContentRef만
-// issuetracker.normalized 토픽에 발행됩니다.
+// fetcher stage 특화 책임:
+//   - CircuitBreaker (소스별 자동 차단)
+//   - RetryScheduler (Kafka 즉시 재발행 / Redis 지연 발행)
+//   - StageGate (ProcessingLock + Semaphore)
+//   - URL 가드 (urlguard.Gate)
+//   - URL 정규화 (links.Normalizer)
+//   - publishNormalized (Content → contents DB + ContentRef Kafka 발행)
 //
-// 종료 순서 보장:
-//  1. ctx cancel → pollMessages 루프 탈출 → pollDone 닫힘
-//  2. Stop이 pollDone 대기 후 jobs 채널 close (send on closed channel panic 방지)
-//  3. worker goroutine들이 jobs 드레인 후 종료
-//  4. consumer.Close()
+// 공용 lifecycle (poll / dispatch / shutdown / commit) 은 internal/workerpool harness 에 위임.
+// KafkaConsumerPool 이 workerpool.Handler 인터페이스를 구현하여 메시지마다 Handle 호출됨.
 type KafkaConsumerPool struct {
 	consumer    bus.Consumer
 	pub         *bus.Publisher
 	handler     JobHandler
 	contentSvc  service.ContentService
 	workerCount int
-	jobs        chan jobItem
-	wg          sync.WaitGroup
 	cbRegistry  *resilience.CircuitBreakerRegistry
 	stageGate   locks.StageGate // nil 허용 → NoopStageGate (이슈 #356)
 	// normalizer는 URL 정규화기입니다.
 	// 미설정(nil) 이면 정규화가 적용되지 않으며, 기존 동작이 유지됩니다.
-	// atomic.Pointer 를 사용하여 polling/worker goroutine 의 동시 Load 와
-	// SetNormalizer 의 Store 사이에 race 가 발생하지 않도록 보장합니다.
+	// atomic.Pointer 를 사용하여 worker goroutine 의 동시 Load 와 SetNormalizer 의 Store
+	// 사이에 race 가 발생하지 않도록 보장합니다.
 	normalizer atomic.Pointer[links.Normalizer]
 	// gate 는 URL 가드 입니다.
 	// 미설정(nil) 이면 가드 비활성 — 모든 job 이 처리됩니다.
-	// processJob 진입 직후 검사하여 차단된 URL 의 처리를 skip 하고 message 만 commit.
+	// Handle 진입 직후 검사하여 차단된 URL 의 처리를 skip 하고 message 만 commit.
 	// atomic.Pointer 로 race-safe 한 lock-free 설정/조회.
 	gate atomic.Pointer[urlguard.Gate]
 	// retryScheduler 는 재시도 발행 시점을 관리하는 RetryScheduler 입니다.
@@ -87,21 +85,16 @@ type KafkaConsumerPool struct {
 	// 즉시 priority 토픽에 publish + worker 가 ScheduledAt 까지 sleep.
 	// atomic.Pointer 로 race-safe 설정 — Start 이후 SetRetryScheduler 호출에도 안전.
 	retryScheduler atomic.Pointer[bus.RetrySchedulerHolder]
-	// pollDone은 pollMessages goroutine이 완전히 종료됐음을 알리는 신호입니다.
-	// close(p.jobs) 전에 반드시 이 채널이 닫혔음을 확인해야 합니다.
-	pollDone chan struct{}
 
-	// heartbeat 가시성. processJob 진입 시 inc, defer 시 dec.
+	// heartbeat 가시성. Handle 진입 시 inc, defer 시 dec.
 	// 운영자가 "silent vs hang" 을 즉답하기 위한 단일 source of truth.
 	busyCount atomic.Int32
 	// priority 는 heartbeat 로그에 포함될 pool 식별자 ("high"/"normal"/"low").
 	// 빈 문자열이면 heartbeat goroutine 자체가 시작되지 않음 (테스트 호환).
 	priority string
-}
 
-type jobItem struct {
-	msg *queue.Message
-	job *core.CrawlJob
+	// pool 은 workerpool harness — Start 에서 lazy 생성.
+	pool *workerpool.ConsumerPool
 }
 
 // NewKafkaConsumerPool은 새로운 KafkaConsumerPool을 생성합니다.
@@ -158,7 +151,6 @@ func NewKafkaConsumerPoolWithOptions(
 	gate locks.StageGate,
 ) *KafkaConsumerPool {
 	// nil guard — NewParserWorker / validate.NewWorker 와 일관성 보장.
-	// 외부 호출자가 nil 을 전달해도 panic 없이 dedup + cap 비활성으로 동작.
 	if gate == nil {
 		gate = locks.NewNoopStageGate()
 	}
@@ -170,9 +162,6 @@ func NewKafkaConsumerPoolWithOptions(
 		workerCount: workerCount,
 		cbRegistry:  cbRegistry,
 		stageGate:   gate,
-		// 버퍼 크기: worker 수의 2배로 polling과 처리 사이의 지연을 흡수
-		jobs:     make(chan jobItem, workerCount*2),
-		pollDone: make(chan struct{}),
 	}
 }
 
@@ -187,34 +176,20 @@ func (p *KafkaConsumerPool) SetRetryScheduler(rs bus.RetryScheduler) {
 	p.retryScheduler.Store(&bus.RetrySchedulerHolder{Scheduler: rs})
 }
 
-// SetGate 는 processJob 진입 시 URL 검사에 사용할 urlguard.Gate 를 설정합니다.
+// SetGate 는 Handle 진입 시 URL 검사에 사용할 urlguard.Gate 를 설정합니다.
 // 미설정(nil) 시 가드 비활성 — 모든 job 이 정상 처리됩니다.
-//
-// 차단 시 동작: handler.Handle 호출 없이 메시지만 commit (큐에서 제거).
-// → 누적된 stale URL 메시지가 retry 사이클에 다시 발행되는 것을 차단.
-//
-// 동시성: atomic.Pointer 기반 lock-free — Start 이후 변경에도 race-safe.
 func (p *KafkaConsumerPool) SetGate(g *urlguard.Gate) {
 	p.gate.Store(g)
 }
 
 // SetNormalizer는 URL 정규화기를 설정합니다.
 // nil 이거나 미호출 시 정규화는 적용되지 않으며, 기존 동작이 유지됩니다.
-//
-// 적용 지점:
-//  1. Target.URL — pollMessages 에서 unmarshal 직후 (Ingestion Lock·ProcessingLock 키 일관성)
-//  2. Content.CanonicalURL — publishNormalized 에서 Store 직전 (DB 중복 탐지)
-//  3. Kafka 파티션 키 — publishNormalized 에서 CanonicalURL 사용 (파티션 ordering)
-//
-// 동시성: atomic.Pointer 기반 lock-free 설정/조회로 race-safe 합니다.
-// Start 이후 변경 시에도 worker goroutine 의 Load 와 race 가 발생하지 않습니다.
 func (p *KafkaConsumerPool) SetNormalizer(n *links.Normalizer) {
 	p.normalizer.Store(n)
 }
 
 // normalizeURL은 normalizer가 설정된 경우 URL을 정규화하여 반환합니다.
-// normalizer 미설정 / 빈 URL / 정규화 실패 시 원본을 그대로 반환하여
-// 정규화 도입이 기존 fetch/저장 경로를 깨지 않도록 보장합니다.
+// normalizer 미설정 / 빈 URL / 정규화 실패 시 원본을 그대로 반환.
 func (p *KafkaConsumerPool) normalizeURL(rawURL string) string {
 	n := p.normalizer.Load()
 	if n == nil || rawURL == "" {
@@ -228,46 +203,49 @@ func (p *KafkaConsumerPool) normalizeURL(rawURL string) string {
 }
 
 // SetPriority 는 heartbeat 로그에 사용할 pool 식별자를 설정합니다.
-// 빈 문자열이면 heartbeat goroutine 이 시작되지 않아 기존 동작이 유지됩니다.
+// 빈 문자열이면 heartbeat goroutine 이 시작되지 않습니다.
 // Start 호출 전에 설정해야 효과가 있습니다.
 func (p *KafkaConsumerPool) SetPriority(name string) {
 	p.priority = name
 }
 
-// Start는 worker goroutine들과 message polling goroutine을 시작합니다.
-// context가 cancel되면 polling이 중단되고 진행 중인 작업이 완료됩니다.
+// Start 는 workerpool harness 를 기동합니다.
 //
-// 각 worker goroutine 은 0..workerCount-1 의 worker_id 를 부여받아 ctx 에 실어 전달합니다
-// 다운스트림 JobHandler — 특히 ChromedpJobHandler — 는 worker_id 로 per-worker
-// 자원 (Semaphore, 추후 RemoteURL) 을 lookup 합니다. priority pool (high/normal/low) 의 worker_id
-// 는 의미가 없지만 (handler 가 무시) 모든 pool 이 동일 wiring 을 갖도록 일관성 보장.
+// harness 가 N 개 worker goroutine + poll goroutine 을 관리하며, 각 메시지마다 본 pool 의
+// Handle 메소드를 호출합니다. heartbeat goroutine 은 priority 설정 시 별도 시작.
 func (p *KafkaConsumerPool) Start(ctx context.Context) {
-	for i := 0; i < p.workerCount; i++ {
-		workerID := i
-		p.wg.Add(1)
-		go p.worker(ctx, workerID)
+	log := logger.FromContext(ctx)
+	if p.priority != "" {
+		log = log.WithField("worker_pool", "fetcher-"+p.priority)
 	}
+	p.pool = workerpool.New(workerpool.Config{
+		Consumer:     p.consumer,
+		Handler:      p,
+		WorkerCount:  p.workerCount,
+		DrainTimeout: drainTimeout,
+		Log:          log,
+		Name:         "fetcher-" + p.priority,
+	})
+	p.pool.Start(ctx)
 
-	// pollDone은 pollMessages가 완전히 종료된 후 닫힙니다.
-	// Stop에서 close(p.jobs) 전에 이 채널을 대기하여 send on closed channel panic을 방지합니다.
-	go func() {
-		defer close(p.pollDone)
-		p.pollMessages(ctx)
-	}()
-
-	// heartbeat goroutine. priority 가 설정된 경우만 시작 (테스트 호환).
-	// silent vs hang 즉답을 위해 30초마다 worker pool status 를 DEBUG 로 출력.
-	// ctx cancel 시 자체 종료 — wg 등록 안 함 (관찰용 goroutine).
+	// heartbeat goroutine — priority 가 설정된 경우만 (테스트 호환). ctx cancel 시 자체 종료.
 	if p.priority != "" {
 		go p.heartbeatLoop(ctx)
 	}
 }
 
+// Stop 은 workerpool harness 를 정상 종료합니다 — graceful shutdown 순서 + drain timeout 위임.
+func (p *KafkaConsumerPool) Stop(ctx context.Context) error {
+	if p.pool == nil {
+		return nil
+	}
+	return p.pool.Stop(ctx)
+}
+
 // heartbeatLoop 는 30초마다 worker pool 의 현재 상태 (busy/total/buffered) 를 DEBUG 로
-// 출력합니다. 운영자가 LOG_LEVEL=debug 로 토글 시 silent 구간이 정상 idle
-// 인지 (busy=0, buffer=0) 또는 long-running 처리 중인지 (busy>0) 즉답할 수 있습니다.
+// 출력합니다. 운영자가 LOG_LEVEL=debug 토글 시 silent vs hang 즉답.
 //
-// ctx cancel 시 자체 종료 — wg 미등록 (관찰용이라 셧다운을 차단할 책임 없음).
+// ctx cancel 시 자체 종료 — 관찰용이라 셧다운 차단 책임 없음.
 func (p *KafkaConsumerPool) heartbeatLoop(ctx context.Context) {
 	const interval = 30 * time.Second
 	ticker := time.NewTicker(interval)
@@ -281,135 +259,71 @@ func (p *KafkaConsumerPool) heartbeatLoop(ctx context.Context) {
 			return
 		case <-ticker.C:
 			busy := int(p.busyCount.Load())
+			buffered := 0
+			if p.pool != nil {
+				buffered = p.pool.JobsBuffered()
+			}
 			log.WithFields(map[string]interface{}{
 				"priority":      p.priority,
 				"busy_workers":  busy,
 				"total_workers": p.workerCount,
-				"jobs_buffered": len(p.jobs),
+				"jobs_buffered": buffered,
 			}).Debug("worker pool status")
 		}
 	}
 }
 
-// Stop은 pool을 정상 종료합니다.
+// Handle 은 workerpool.Handler 구현 — 각 메시지마다 호출됩니다.
 //
-// 종료 순서:
-//  1. pollMessages goroutine 종료 대기 (ctx cancel로 이미 탈출 중)
-//  2. jobs 채널 close — poll이 종료된 이후이므로 send/close 경합 없음
-//  3. worker goroutine 드레인 대기
-//  4. consumer close
-func (p *KafkaConsumerPool) Stop(ctx context.Context) error {
+// 흐름 (구 processJob):
+//  1. UnmarshalCrawlJob (실패 → DLQ + commit)
+//  2. URL 정규화 (적용 지점 ①)
+//  3. URL 가드 검사 (차단 → commit-only)
+//  4. ScheduledAt backoff 대기
+//  5. StageGate Acquire (skip → no commit; err → fail-open)
+//  6. CircuitBreaker Allow 검사 (open → DLQ + commit)
+//  7. handler.Handle (error → requeue/DLQ + commit; success → publishNormalized + commit)
+func (p *KafkaConsumerPool) Handle(ctx context.Context, msg *queue.Message) {
 	log := logger.FromContext(ctx)
 
-	// 1단계: poll goroutine이 완전히 종료될 때까지 대기
-	// ctx(shutdown timeout)가 만료되면 강제 진행하되, 이 경우 worker도 곧 timeout으로 종료됨
-	select {
-	case <-p.pollDone:
-	case <-ctx.Done():
-		log.Warn("poll goroutine shutdown timeout, proceeding with force close")
-	}
-
-	// 2단계: poll이 종료된 이후에만 jobs 채널 close
-	// poll goroutine이 더 이상 send하지 않으므로 send on closed channel panic 없음
-	close(p.jobs)
-
-	// 3단계: worker goroutine 드레인 대기
-	workersDone := make(chan struct{})
-	go func() {
-		p.wg.Wait()
-		close(workersDone)
-	}()
-
-	select {
-	case <-workersDone:
-		log.Info("all crawler workers finished gracefully")
-	case <-ctx.Done():
-		log.Warn("worker pool shutdown timeout, forcing close")
-	}
-
-	return p.consumer.Close()
-}
-
-func (p *KafkaConsumerPool) pollMessages(ctx context.Context) {
-	log := logger.FromContext(ctx)
-
-	for {
-		msg, err := p.consumer.FetchMessage(ctx)
-		if err != nil {
-			if ctx.Err() != nil {
-				return
-			}
-
-			log.WithError(err).Error("failed to receive kafka message")
-			continue
-		}
-
-		job, err := core.UnmarshalCrawlJob(msg.Value)
-		if err != nil {
-			log.WithError(err).Error("failed to unmarshal crawl job, sending to dlq")
-
-			// DLQ 발행 성공 시에만 원본 offset을 commit합니다.
-			// 발행 실패 시 commit을 건너뛰면 재소비 시 재시도되고,
-			// 발행 성공 시 commit을 수행해야 동일 메시지의 DLQ 중복 전송 루프를 방지할 수 있습니다.
-			if dlqErr := p.sendToDLQ(ctx, msg, err); dlqErr != nil {
-				logShutdownAware(ctx, log, dlqErr, "failed to send unmarshal-failed message to dlq, skipping commit to preserve message")
-				continue
-			}
-			if commitErr := p.commitMessage(ctx, msg); commitErr != nil {
-				logShutdownAware(ctx, log, commitErr, "failed to commit message after unmarshal-failure dlq")
-			}
-			continue
-		}
-
-		// 적용 지점 ①: Target.URL 정규화
-		// 다운스트림 모든 키(Ingestion Lock, ProcessingLock, Kafka 파티션)가 동일한 정규형을
-		// 사용하도록 가장 이른 시점에 한 번만 적용합니다.
-		// normalizer 미설정 시 원본이 반환되어 기존 동작이 유지됩니다.
-		job.Target.URL = p.normalizeURL(job.Target.URL)
-
-		select {
-		case p.jobs <- jobItem{msg: msg, job: job}:
-		case <-ctx.Done():
+	job, err := core.UnmarshalCrawlJob(msg.Value)
+	if err != nil {
+		log.WithError(err).Error("failed to unmarshal crawl job, sending to dlq")
+		if dlqErr := p.sendToDLQ(ctx, msg, err); dlqErr != nil {
+			logShutdownAware(ctx, log, dlqErr, "failed to send unmarshal-failed message to dlq, skipping commit to preserve message")
 			return
 		}
-	}
-}
-
-func (p *KafkaConsumerPool) worker(ctx context.Context, workerID int) {
-	defer p.wg.Done()
-
-	// worker_id 를 ctx 에 첨부. ChromedpJobHandler 가 per-worker Semaphore
-	// 슬롯을 선택하는 데 사용. priority pool 에서는 handler 가 ID 를 무시.
-	// general.ChainHandler 의 chromedpChains slice lookup 에도 동일 키 재사용.
-	ctx = core.WithWorkerID(ctx, workerID)
-
-	log := logger.FromContext(ctx)
-
-	for item := range p.jobs {
-		if err := p.processJob(ctx, item); err != nil {
-			// graceful shutdown 으로 발생한 context.Canceled 는 정상 종료 흐름이므로
-			// DEBUG 로 강등하여 알림·대시보드에서 오탐을 만들지 않도록 합니다.
-			jobLog := log.WithFields(map[string]interface{}{
-				"job_id":  item.job.ID,
-				"crawler": item.job.CrawlerName,
-			})
-			logShutdownAware(ctx, jobLog, err, "job processing failed")
+		if commitErr := p.pool.Commit(ctx, msg); commitErr != nil {
+			logShutdownAware(ctx, log, commitErr, "failed to commit message after unmarshal-failure dlq")
 		}
+		return
+	}
+
+	// 적용 지점 ①: Target.URL 정규화 — 다운스트림 모든 키 (Ingestion Lock / ProcessingLock /
+	// Kafka 파티션) 가 동일 정규형 사용. normalizer 미설정 시 원본 fallback.
+	job.Target.URL = p.normalizeURL(job.Target.URL)
+
+	if err := p.processJob(ctx, msg, job); err != nil {
+		// graceful shutdown 으로 발생한 context.Canceled 는 정상 종료 흐름이므로 DEBUG 로 강등.
+		jobLog := log.WithFields(map[string]interface{}{
+			"job_id":  job.ID,
+			"crawler": job.CrawlerName,
+		})
+		logShutdownAware(ctx, jobLog, err, "job processing failed")
 	}
 }
 
-func (p *KafkaConsumerPool) processJob(ctx context.Context, item jobItem) (err error) {
+func (p *KafkaConsumerPool) processJob(ctx context.Context, msg *queue.Message, job *core.CrawlJob) (err error) {
 	log := logger.FromContext(ctx)
 
-	// processJob 의 모든 return path 를 defer 로 wrap 하여 duration 측정 +
-	// busyCount 증감 (heartbeat 가시성). outcome 은 err 여부로 분기.
+	// busyCount 증감 + duration 측정 (heartbeat 가시성). outcome 은 err 여부로 분기.
 	p.busyCount.Add(1)
 	start := time.Now()
 	defer func() {
 		p.busyCount.Add(-1)
 		fields := map[string]interface{}{
-			"job_id":      item.job.ID,
-			"crawler":     item.job.CrawlerName,
+			"job_id":      job.ID,
+			"crawler":     job.CrawlerName,
 			"duration_ms": time.Since(start).Milliseconds(),
 		}
 		if err != nil {
@@ -420,31 +334,24 @@ func (p *KafkaConsumerPool) processJob(ctx context.Context, item jobItem) (err e
 		log.WithFields(fields).Debug("job processed")
 	}()
 
-	// URL 가드: processJob 진입 직후 차단 URL 을 즉시 거르고 commit
-	// → handler 호출·lock 획득·backoff 대기 등 모든 비용 회피
-	// → stale URL 메시지가 큐에서 즉시 제거되어 retry 사이클 차단
-	//
-	// item.job 은 pollMessages 에서 unmarshal 성공 후에만 jobs 채널로 전송되므로
-	// 본 시점에 nil 일 수 없음 (방어 검사 불필요).
+	// URL 가드: Handle 진입 직후 차단 URL 을 즉시 거르고 commit.
 	if g := p.gate.Load(); g != nil {
-		if !g.Allow(item.job.Target.URL, map[string]interface{}{
-			"crawler": item.job.CrawlerName,
-			"job_id":  item.job.ID,
+		if !g.Allow(job.Target.URL, map[string]interface{}{
+			"crawler": job.CrawlerName,
+			"job_id":  job.ID,
 			"stage":   "consumer",
 		}) {
-			return p.commitMessage(ctx, item.msg)
+			return p.pool.Commit(ctx, msg)
 		}
 	}
 
-	// 재큐잉 시 설정된 ScheduledAt이 미래면 해당 시점까지 대기합니다.
-	// ProcessingLock 획득 전에 대기하는 이유는 다음과 같습니다:
-	//  - 락을 먼저 잡으면 backoff 대기 시간(최대 5분)이 TTL(10분)을 소진시킴
-	//  - 다른 worker가 동일 URL 을 "처리 중"으로 오인해 불필요한 중복 스킵 발생
-	// time.After가 아닌 NewTimer + Stop을 사용하여 ctx 취소 시 타이머 자원을 즉시 해제합니다.
-	if delay := time.Until(item.job.ScheduledAt); delay > 0 {
+	// 재큐잉 시 설정된 ScheduledAt 이 미래면 해당 시점까지 대기.
+	// ProcessingLock 획득 전에 대기 — lock 먼저 잡으면 backoff 가 TTL 소진 + 동일 URL 의 다른
+	// worker 가 처리 중으로 오인 회피.
+	if delay := time.Until(job.ScheduledAt); delay > 0 {
 		log.WithFields(map[string]interface{}{
-			"job_id":   item.job.ID,
-			"crawler":  item.job.CrawlerName,
+			"job_id":   job.ID,
+			"crawler":  job.CrawlerName,
 			"delay_ms": delay.Milliseconds(),
 		}).Debug("waiting for backoff before processing retried job")
 
@@ -457,157 +364,128 @@ func (p *KafkaConsumerPool) processJob(ctx context.Context, item jobItem) (err e
 		}
 	}
 
-	// fetcher 단계 StageGate (ProcessingLock + Semaphore 합성, 이슈 #356) —
-	// 같은 URL 의 동시 fetch 차단 + per-stage 동시 슬롯 cap.
-	// Kafka rebalance/재시작으로 동일 메시지가 중복 소비될 때 + 같은 URL 의 다른 jobID 가 동시 처리될 때
-	// 모두 흡수. backoff 대기 이후에 Acquire 하여 슬롯 점유 시간을 실제 처리 구간으로 최소화합니다.
-	release, acquired, gateErr := p.stageGate.Acquire(ctx, item.job.Target.URL)
+	// fetcher 단계 StageGate (ProcessingLock + Semaphore 합성, 이슈 #356).
+	// backoff 대기 이후에 Acquire 하여 슬롯 점유 시간을 실제 처리 구간으로 최소화.
+	release, acquired, gateErr := p.stageGate.Acquire(ctx, job.Target.URL)
 	if gateErr != nil {
 		// ctx cancel / deadline → fail-open 시 취소된 ctx 로 불필요 작업 + per-stage cap 무력화 위험.
-		// commit 안 하고 종료 → Kafka redeliver 보장 (PR #358 패턴).
+		// commit 안 하고 종료 → Kafka redeliver 보장.
 		if ctx.Err() != nil {
 			return fmt.Errorf("fetcher stage gate acquire aborted by ctx: %w", gateErr)
 		}
-		// 그 외 인프라 에러 — 처리를 건너뛰지 않고 경고 후 진행 (graceful degrade).
-		// StageGate 장애가 크롤링 전체를 중단시키지 않도록 합니다.
+		// 그 외 인프라 에러 — graceful degrade.
 		log.WithFields(map[string]interface{}{
-			"job_id":  item.job.ID,
-			"crawler": item.job.CrawlerName,
-			"url":     item.job.Target.URL,
+			"job_id":  job.ID,
+			"crawler": job.CrawlerName,
+			"url":     job.Target.URL,
 		}).WithError(gateErr).Warn("failed to acquire fetcher stage gate, proceeding without gate")
 	} else if !acquired {
 		log.WithFields(map[string]interface{}{
-			"job_id":  item.job.ID,
-			"crawler": item.job.CrawlerName,
-			"url":     item.job.Target.URL,
+			"job_id":  job.ID,
+			"crawler": job.CrawlerName,
+			"url":     job.Target.URL,
 		}).Debug("fetcher processing lock already held by another worker, skipping")
-		// 다른 워커가 처리 중이므로 commit 없이 종료합니다.
-		// 처리 담당 워커의 commit 에 의존하여, 해당 워커 장애 시 재처리가 보장되도록 합니다.
+		// 다른 워커가 처리 중 — commit 없이 종료. 처리 담당 워커의 commit 에 의존.
 		return nil
 	} else {
-		// 운영자가 gate 획득 흐름을 추적할 수 있도록 DEBUG 로 success 기록.
 		log.WithFields(map[string]interface{}{
-			"job_id":  item.job.ID,
-			"crawler": item.job.CrawlerName,
-			"url":     item.job.Target.URL,
+			"job_id":  job.ID,
+			"crawler": job.CrawlerName,
+			"url":     job.Target.URL,
 		}).Debug("fetcher stage gate acquired")
 
 		defer func() {
-			release() // semaphore + lock 정리, internal 에서 shutdown ctx 보존.
+			release()
 			log.WithFields(map[string]interface{}{
-				"job_id":  item.job.ID,
-				"crawler": item.job.CrawlerName,
-				"url":     item.job.Target.URL,
+				"job_id":  job.ID,
+				"crawler": job.CrawlerName,
+				"url":     job.Target.URL,
 			}).Debug("fetcher stage gate released")
 		}()
 	}
 
-	// URL 단위 dedup 은 위 ProcessingLock + Publisher 단의 Ingestion Lock 두 층으로 보장.
-
 	log.WithFields(map[string]interface{}{
-		"job_id":  item.job.ID,
-		"crawler": item.job.CrawlerName,
-		"url":     item.job.Target.URL,
+		"job_id":  job.ID,
+		"crawler": job.CrawlerName,
+		"url":     job.Target.URL,
 	}).Info("crawl job started")
 
-	// circuit breaker가 open이면 DLQ로 보내고 원본을 commit합니다.
-	// 소스 복구 후 운영자가 DLQ에서 재처리합니다.
-	cb := p.cbRegistry.Get(item.job.CrawlerName)
+	// CircuitBreaker open → DLQ + commit. 소스 복구 후 운영자가 DLQ 재처리.
+	cb := p.cbRegistry.Get(job.CrawlerName)
 	if !cb.Allow() {
-		cbErr := &resilience.ErrCircuitOpen{Source: item.job.CrawlerName}
+		cbErr := &resilience.ErrCircuitOpen{Source: job.CrawlerName}
 		log.WithFields(map[string]interface{}{
-			"job_id":  item.job.ID,
-			"crawler": item.job.CrawlerName,
+			"job_id":  job.ID,
+			"crawler": job.CrawlerName,
 		}).Warn("circuit breaker open, sending job to dlq")
 
 		jobLog := log.WithFields(map[string]interface{}{
-			"job_id":  item.job.ID,
-			"crawler": item.job.CrawlerName,
+			"job_id":  job.ID,
+			"crawler": job.CrawlerName,
 		})
-		if publishErr := p.sendToDLQ(ctx, item.msg, cbErr); publishErr != nil {
+		if publishErr := p.sendToDLQ(ctx, msg, cbErr); publishErr != nil {
 			logShutdownAware(ctx, jobLog, publishErr, "failed to send circuit-broken job to dlq, skipping commit to preserve message")
-			return fmt.Errorf("circuit open dlq for job %s: %w", item.job.ID, publishErr)
+			return fmt.Errorf("circuit open dlq for job %s: %w", job.ID, publishErr)
 		}
-
-		if commitErr := p.commitMessage(ctx, item.msg); commitErr != nil {
+		if commitErr := p.pool.Commit(ctx, msg); commitErr != nil {
 			logShutdownAware(ctx, jobLog, commitErr, "failed to commit message after circuit breaker dlq")
 		}
-
 		return cbErr
 	}
 
 	// incoming msg.Headers 를 ctx 에 첨부 — chain_handler.publishFetchedRef 가 reparse_*
-	// 등 헤더를 TopicFetched 발행 메시지로 전파할 수 있도록 (이슈 #366).
-	handleCtx := core.WithInboxHeaders(ctx, item.msg.Headers)
-	contents, err := p.handler.Handle(handleCtx, item.job)
+	// 등 헤더를 TopicFetched 발행 메시지로 전파 (이슈 #366).
+	handleCtx := core.WithInboxHeaders(ctx, msg.Headers)
+	contents, err := p.handler.Handle(handleCtx, job)
 	if err != nil {
 		cb.RecordFailure()
 
-		// 재발행(requeue/DLQ)이 성공한 경우에만 원본 offset을 commit
-		// 발행 실패 시 commit하지 않아 offset이 남고, 재소비 시 재처리
+		// 재발행 (requeue / DLQ) 성공 시에만 원본 commit. 발행 실패 시 commit 안 함 → 재소비 시 재처리.
 		var publishErr error
-		if item.job.RetryCount >= item.job.MaxRetries {
-			publishErr = p.sendToDLQ(ctx, item.msg, err)
+		if job.RetryCount >= job.MaxRetries {
+			publishErr = p.sendToDLQ(ctx, msg, err)
 		} else {
-			publishErr = p.requeueWithRetry(ctx, item.job, err)
+			publishErr = p.requeueWithRetry(ctx, job, err)
 		}
 
 		jobLog := log.WithFields(map[string]interface{}{
-			"job_id":  item.job.ID,
-			"crawler": item.job.CrawlerName,
+			"job_id":  job.ID,
+			"crawler": job.CrawlerName,
 		})
 		if publishErr != nil {
 			logShutdownAware(ctx, jobLog, publishErr, "failed to republish job, skipping commit to preserve message")
-			return fmt.Errorf("handle job %s: republish: %w", item.job.ID, publishErr)
+			return fmt.Errorf("handle job %s: republish: %w", job.ID, publishErr)
 		}
-
-		if commitErr := p.commitMessage(ctx, item.msg); commitErr != nil {
+		if commitErr := p.pool.Commit(ctx, msg); commitErr != nil {
 			logShutdownAware(ctx, jobLog, commitErr, "failed to commit message after error handling")
 		}
-
-		return fmt.Errorf("handle job %s: %w", item.job.ID, err)
+		return fmt.Errorf("handle job %s: %w", job.ID, err)
 	}
 
 	if len(contents) == 0 {
-		// URL dedup 은 Publisher 의 Ingestion Lock (TTL 24h) 으로 보장 — fetch 성공 후
-		// 별도 캐시 등록 불필요. lock TTL 만료 시점에 자연스럽게 재크롤 가능.
+		// URL dedup 은 bus 의 Ingestion Lock (TTL 24h) 으로 보장 — fetch 성공 후 별도 캐시 등록 불필요.
 		cb.RecordSuccess()
-		return p.commitMessage(ctx, item.msg)
+		return p.pool.Commit(ctx, msg)
 	}
 
 	for _, c := range contents {
-		if err := p.publishNormalized(ctx, c, item.job); err != nil {
-			// publishNormalized 실패는 DB 저장/Kafka 발행 문제로 소스 자체의 건전성과 무관하지만
-			// 작업이 완결되지 않았으므로 성공으로 기록하지 않고 반환합니다.
-			return fmt.Errorf("publish normalized for job %s: %w", item.job.ID, err)
+		if err := p.publishNormalized(ctx, c, job); err != nil {
+			return fmt.Errorf("publish normalized for job %s: %w", job.ID, err)
 		}
 	}
 
-	// 모든 부수 효과(DB 저장 + Kafka 발행)가 성공한 시점에 circuit breaker에 성공 기록
 	cb.RecordSuccess()
-	return p.commitMessage(ctx, item.msg)
+	return p.pool.Commit(ctx, msg)
 }
 
-// publishNormalized는 Content를 contents DB에 저장한 뒤 ContentRef를
-// issuetracker.normalized 토픽에 ProcessingMessage로 발행합니다.
-// 다운스트림 validator는 ref.ID로 DB에서 전체 데이터를 조회합니다.
+// publishNormalized 는 Content 를 contents DB 에 저장한 뒤 ContentRef 를
+// issuetracker.normalized 토픽에 ProcessingMessage 로 발행합니다.
+// 다운스트림 validator 는 ref.ID 로 DB 에서 전체 데이터를 조회합니다.
 //
 // URL 정규화 (적용 지점 ②, ③):
-//   - CanonicalURL: 파서가 채운 값(예: <link rel="canonical">)을 우선 정규화하고,
-//     비어있으면 content.URL 을 정규화하여 채움 (파서 결정 우선순위 보존)
+//   - CanonicalURL: 파서가 채운 값을 우선 정규화, 비어있으면 content.URL 정규화
 //   - Kafka 파티션 키: CanonicalURL 사용 (동일 기사가 동일 파티션으로 라우팅)
-//
-// 주의: 현재 contents DB 의 unique 제약은 url 컬럼 (idx_contents_url) 이므로
-// CanonicalURL 정규화는 *DB 레벨* 중복 방지가 아닌 다운스트림 정규형 비교 및
-// 파티션 키 일관성에 기여합니다. DB 레벨 중복 방지는 별도 PR 에서 url 컬럼
-// 정규화 또는 unique 제약 변경으로 다뤄집니다.
-//
-// normalizer 미설정 시 normalizeURL 이 원본을 반환하여 기존 동작이 유지됩니다.
 func (p *KafkaConsumerPool) publishNormalized(ctx context.Context, content *core.Content, job *core.CrawlJob) error {
-	// 적용 지점 ②: CanonicalURL 정규화 (Store 직전)
-	// 우선순위: 파서가 채운 CanonicalURL > content.URL
-	// 파서가 <link rel="canonical"> 를 추출해 CanonicalURL 을 채운 경우 이를 보존하고,
-	// 비어있을 때만 content.URL 을 fallback 으로 사용합니다.
 	source := content.CanonicalURL
 	if source == "" {
 		source = content.URL
@@ -655,10 +533,6 @@ func (p *KafkaConsumerPool) publishNormalized(ctx context.Context, content *core
 		return fmt.Errorf("marshal processing message: %w", err)
 	}
 
-	// 적용 지점 ③: Kafka 파티션 키 — CanonicalURL 사용
-	// 동일 기사의 추적 파라미터/스킴 변형이 동일 파티션으로 라우팅되어
-	// ordering·CB·중복 처리 일관성이 보장됩니다.
-	// CanonicalURL 이 비어있으면 안전하게 content.URL 로 fallback 합니다.
 	partitionKey := content.CanonicalURL
 	if partitionKey == "" {
 		partitionKey = content.URL
@@ -678,50 +552,14 @@ func (p *KafkaConsumerPool) publishNormalized(ctx context.Context, content *core
 	return p.pub.Forward(ctx, msg)
 }
 
-// commitMessage 는 Kafka offset 을 commit 합니다.
-// graceful shutdown 으로 ctx 가 canceled 된 경우 drain context (timeout 포함, parent
-// cancel 분리) 로 한 번 더 시도하여 at-least-once 정확도를 높입니다.
-//
-// 재시도까지 실패하면 에러를 반환합니다 — 호출자(worker)는 이 에러를 보고 적절한 레벨
-// (context.Canceled → DEBUG, 그 외 → ERROR) 로 로깅합니다. commit 되지 않은 offset 은
-// 다음 worker 기동 시 재소비되어 동일 메시지가 다시 처리됩니다.
-func (p *KafkaConsumerPool) commitMessage(ctx context.Context, msg *queue.Message) error {
-	err := p.consumer.CommitMessages(ctx, msg)
-	if err == nil {
-		return nil
-	}
-
-	// graceful shutdown 으로 ctx 가 canceled 된 경우, drain context 로 한 번 더 시도
-	// context.WithoutCancel 로 cancellation 만 분리하고 trace ID·logger 필드 등 메타데이터는 보존
-	if errors.Is(err, context.Canceled) {
-		drainCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), drainTimeout)
-		defer cancel()
-		if retryErr := p.consumer.CommitMessages(drainCtx, msg); retryErr == nil {
-			return nil
-		} else {
-			// errors.Join 으로 최초 cancel 과 retryErr 를 모두 보존 — 호출자의
-			// errors.Is(err, context.Canceled) 분기가 안정적으로 매칭되도록 보장.
-			// retryErr 가 DeadlineExceeded 인 경우에도 chain 의 cancel 이 살아있음.
-			return fmt.Errorf("commit offset (drain retry failed): %w", errors.Join(err, retryErr))
-		}
-	}
-
-	return fmt.Errorf("commit offset: %w", err)
-}
-
 // sendToDLQ 는 메시지를 DLQ 토픽에 발행합니다.
-// graceful shutdown 으로 ctx 가 canceled 된 경우 drain context 로 한 번 더 시도하여
-// 데이터 무결성 작업(원본 메시지 보존)이 셧다운 직전에도 완료될 수 있도록 보장합니다.
-//
-// 로깅 정책: 본 함수는 로그를 직접 남기지 않고 에러만 반환합니다.
-// 호출자(pollMessages, processJob)가 logShutdownAware 로 통일된 강등 정책에 따라
-// 로깅하므로 이중 로깅을 방지합니다.
+// graceful shutdown 으로 ctx 가 canceled 된 경우 drain context 로 한 번 더 시도 — 원본 메시지
+// 보존 우선. 로그는 호출자가 logShutdownAware 로 통일 강등 정책에 따라 작성.
 func (p *KafkaConsumerPool) sendToDLQ(ctx context.Context, msg *queue.Message, reason error) error {
 	headers := make(map[string]string, len(msg.Headers)+2)
 	for k, v := range msg.Headers {
 		headers[k] = v
 	}
-
 	headers["original-topic"] = msg.Topic
 	headers["error"] = reason.Error()
 
@@ -736,8 +574,6 @@ func (p *KafkaConsumerPool) sendToDLQ(ctx context.Context, msg *queue.Message, r
 	if err != nil && errors.Is(err, context.Canceled) {
 		drainCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), drainTimeout)
 		defer cancel()
-		// errors.Join 으로 최초 cancel 과 retryErr 를 모두 보존 — 호출자의
-		// errors.Is(err, context.Canceled) 분기가 안정적으로 매칭되도록 보장.
 		if retryErr := p.pub.Forward(drainCtx, dlqMsg); retryErr != nil {
 			err = errors.Join(err, retryErr)
 		} else {
@@ -747,7 +583,6 @@ func (p *KafkaConsumerPool) sendToDLQ(ctx context.Context, msg *queue.Message, r
 	if err != nil {
 		return fmt.Errorf("send to dlq: %w", err)
 	}
-
 	return nil
 }
 
@@ -756,10 +591,9 @@ func (p *KafkaConsumerPool) requeueWithRetry(ctx context.Context, job *core.Craw
 
 	job.RetryCount++
 
-	// RetryCount 기반 exponential backoff 계산 후 ScheduledAt에 저장합니다.
-	// 실제 지연 적용은 RetryScheduler 구현체가 책임집니다:
-	//   - KafkaImmediateRetryScheduler (fallback): 즉시 publish — worker 가 sleep
-	//   - RedisDelayedRetryScheduler: Redis ZSET 보관 — worker 슬롯 점유 없음
+	// RetryCount 기반 exponential backoff 계산 후 ScheduledAt 에 저장.
+	// 실제 지연 적용은 RetryScheduler 구현체가 책임 — KafkaImmediate (worker sleep) 또는
+	// RedisDelayed (별 goroutine, 워커 슬롯 점유 없음).
 	backoffDelay := core.CalculateBackoff(kafkaRequeuePolicy, job.RetryCount)
 	job.ScheduledAt = time.Now().Add(backoffDelay)
 
@@ -774,14 +608,10 @@ func (p *KafkaConsumerPool) requeueWithRetry(ctx context.Context, job *core.Craw
 		"topic":    topic,
 	}).Warn("requeuing job with backoff delay")
 
-	// 로깅 정책: 본 함수는 publish 실패 로그를 직접 남기지 않고 에러만 반환합니다.
-	// 호출자(processJob)가 logShutdownAware 로 통일된 강등 정책에 따라 로깅합니다.
 	err := scheduler.Enqueue(ctx, job, reason)
 	if err != nil && errors.Is(err, context.Canceled) {
-		// graceful shutdown 으로 ctx 가 canceled 된 경우, drain context 로 한 번 더 시도
 		drainCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), drainTimeout)
 		defer cancel()
-		// errors.Join 으로 최초 cancel 과 retryErr 를 모두 보존
 		if retryErr := scheduler.Enqueue(drainCtx, job, reason); retryErr != nil {
 			err = errors.Join(err, retryErr)
 		} else {
@@ -791,13 +621,11 @@ func (p *KafkaConsumerPool) requeueWithRetry(ctx context.Context, job *core.Craw
 	if err != nil {
 		return fmt.Errorf("publish retry job: %w", err)
 	}
-
 	return nil
 }
 
 // resolveRetryScheduler 는 SetRetryScheduler 로 주입된 구현체를 반환하고, 미설정 시
-// 기존 동작 (즉시 Kafka publish + worker sleep) 을 보존하는 KafkaImmediateRetryScheduler
-// 를 lazy 생성합니다. 매 호출마다 새 인스턴스이지만 stateless 이므로 비용 무시 가능.
+// KafkaImmediateRetryScheduler 를 lazy 생성합니다 (기존 동작 — 즉시 publish + worker sleep).
 func (p *KafkaConsumerPool) resolveRetryScheduler() bus.RetryScheduler {
 	if h := p.retryScheduler.Load(); h != nil {
 		return h.Scheduler
@@ -808,17 +636,9 @@ func (p *KafkaConsumerPool) resolveRetryScheduler() bus.RetryScheduler {
 // logShutdownAware 는 graceful shutdown 으로 발생한 컨텍스트성 에러를 DEBUG 로,
 // 그 외 에러는 ERROR 로 기록하는 공통 헬퍼입니다.
 //
-// shutdown 직후 in-flight Kafka 작업(DLQ publish, commit, requeue)이 ctx cancel 로
-// 실패하는 것은 정상 종료 흐름의 일부이므로 ERROR 알림에서 제외합니다.
-//
-// 강등 조건은 ctx.Err() != nil 단독:
-//   - "셧다운으로 인한 cancel 인지" 의 진실의 단일 소스(SoT)는 호출자 ctx 의 상태.
-//   - 일부 라이브러리(예: chromedp)는 정상 timeout 후 내부 cleanup 으로 errors chain 에
-//     context.Canceled 를 포함시키는 경우가 있음. errors.Is(err, context.Canceled) 로
-//     판별하면 이 정상 케이스가 셧다운으로 오인되어 운영 모니터링에서 누락됨 (false positive).
-//   - drain context (context.WithoutCancel(ctx) + WithTimeout) 가 자체 timeout 으로
-//     context.DeadlineExceeded 를 반환하는 경우에도, 그 시점에 부모 ctx 가 cancel 됐다면
-//     ctx.Err() 검사로 셧다운으로 분류됨.
+// 강등 조건은 ctx.Err() != nil 단독 — 셧다운으로 인한 cancel 인지의 진실의 단일 소스 (SoT).
+// errors.Is(err, context.Canceled) 검사 시 chromedp 같은 라이브러리가 정상 timeout 후
+// context.Canceled 를 chain 에 포함하는 케이스를 셧다운으로 오인 (false positive).
 func logShutdownAware(ctx context.Context, log *logger.Logger, err error, msg string) {
 	if ctx != nil && ctx.Err() != nil {
 		log.WithError(err).Debug(msg)

--- a/internal/workerpool/pool.go
+++ b/internal/workerpool/pool.go
@@ -234,6 +234,13 @@ func (p *ConsumerPool) Commit(ctx context.Context, msg *queue.Message) error {
 	return CommitWithDrain(ctx, p.cfg.Consumer, msg, p.cfg.DrainTimeout)
 }
 
+// JobsBuffered 는 현재 jobs 채널에 대기 중인 메시지 수를 반환합니다 (운영 진단 / heartbeat 용).
+//
+// goroutine-safe — len(chan) 은 atomic snapshot. 호출 직후의 값일 수 있음.
+func (p *ConsumerPool) JobsBuffered() int {
+	return len(p.jobs)
+}
+
 // CommitWithDrain 은 메시지 commit + drain context retry 를 수행하는 stateless 헬퍼입니다.
 //
 // 첫 commit 시도 → ctx canceled 면 context.WithoutCancel + drainTimeout 으로 재시도 →


### PR DESCRIPTION
## 연관 이슈

Closes #405
부모 메타: #403 — Kafka consumer pool 골격 공용화 Sub 2

## 구현 내용

`internal/processor/fetcher/worker/KafkaConsumerPool` 이 `internal/workerpool.ConsumerPool` harness 를 사용하도록 재구성. fetcher stage-specific 책임은 잔존, 공용 lifecycle 은 harness 위임. **라이브 동작 영향 0**.

### 책임 분리

| 담당 | 책임 |
|---|---|
| **harness** (workerpool) | poll / dispatch / worker_id ctx 주입 / graceful shutdown / commit-with-drain |
| **fetcher pool** | UnmarshalCrawlJob / URL 정규화 / urlguard.Gate / ScheduledAt backoff / StageGate Acquire / CircuitBreaker / handler 호출 / publishNormalized / RetryScheduler / sendToDLQ / heartbeat |

KafkaConsumerPool 이 `workerpool.Handler` 인터페이스를 직접 구현 — 메시지마다 Handle 호출.

### 제거 (workerpool 로 이동된 것)

- `pollMessages` / `worker` / `Stop` 종료 순서 / `pollDone` 채널 / `jobs` 채널 / `wg`
- `jobItem` 타입 (Handle 가 msg/job 직접 다룸)
- `commitMessage` (workerpool 의 `Commit` + `CommitWithDrain` 사용)

### 신규

- `workerpool.JobsBuffered()` getter — heartbeat 의 `jobs_buffered` 가시성 보존

### 보존

- 모든 SetX setter (`SetRetryScheduler` / `SetGate` / `SetNormalizer` / `SetPriority`)
- CircuitBreaker / RetryScheduler 통합 그대로
- StageGate 적용 분기 (acquired / skip / err)
- heartbeat goroutine (priority 설정 시)
- DLQ + retry 의 drain context 패턴

### 외부 API

- `NewKafkaConsumerPool` / `NewKafkaConsumerPoolWithCB` / `NewKafkaConsumerPoolWithOptions` 시그니처 무변경
- `Start(ctx)` / `Stop(ctx) error` 무변경
- 모든 SetX setter 무변경

## CI / 머지 게이트 점검

- [x] `gofmt -l` — clean
- [x] `go build ./internal/... ./cmd/... ./pkg/... ./test/... ./examples/...` — pass
- [x] `go test -race -count=1 -timeout=180s ./test/...` — 전 패키지 통과 (회귀 0)
- [x] PR 타이틀 `[REFAC#405]`
- [x] commit `[REFAC]:` prefix + 한국어

## 변경 영향 범위 + 위험도

- **영향**: 2 파일
  - `internal/processor/fetcher/worker/pool.go`: 828 → 648 라인 (~180 라인 제거)
  - `internal/workerpool/pool.go`: `JobsBuffered()` getter 추가 (3 라인)
- **위험도 Medium → Low (동작 동등성 확보됨)**:
  - 외부 API 무변경 — manager / main.go / tests 영향 없음
  - lifecycle 로직은 workerpool harness 가 동일 패턴으로 인수
  - 기존 fetcher worker 테스트 전부 통과 (StageGate / DLQ / requeue / commit drain 시나리오)

## 후속

- Sub 3 (#406): parser/worker 마이그레이션
- Sub 4 (#407): validate/worker 마이그레이션 (마지막 sub PR 에서 메타 #403 close)

## 롤백 계획

PR revert 시 pool.go 가 자체 poll/worker/Stop 코드를 다시 보유 — workerpool 의존성 제거. workerpool 패키지 자체는 그대로 (다른 stage 마이그레이션에 미사용).

🤖 Generated with [Claude Code](https://claude.com/claude-code)