### PR TITLE
[REFAC#406] parser/worker ParserWorker → workerpool harness 마이그레이션

### DIFF
--- a/internal/processor/fetcher/worker/pool.go
+++ b/internal/processor/fetcher/worker/pool.go
@@ -222,6 +222,9 @@ func (p *KafkaConsumerPool) SetPriority(name string) {
 //   - Handler / processJob / heartbeatLoop 가 FromContext(ctx) 로 로거를 얻을 때도 동일 필드를
 //     보도록 ctx 에 worker_pool 필드 logger 주입 (observability 보존).
 func (p *KafkaConsumerPool) Start(ctx context.Context) {
+	if p.pool != nil {
+		panic("fetcher worker pool: Start called more than once on the same instance")
+	}
 	name := "fetcher"
 	if p.priority != "" {
 		name = "fetcher-" + p.priority
@@ -249,9 +252,12 @@ func (p *KafkaConsumerPool) Start(ctx context.Context) {
 }
 
 // Stop 은 workerpool harness 를 정상 종료합니다 — graceful shutdown 순서 + drain timeout 위임.
+//
+// pool 이 미기동 (Start 미호출) 상태에서 Stop 호출 시 consumer.Close 만 수행 — Kafka 연결
+// 자원 누수 방지 (gemini PR #415 피드백 — 동일 패턴이 parser 와 일치).
 func (p *KafkaConsumerPool) Stop(ctx context.Context) error {
 	if p.pool == nil {
-		return nil
+		return p.consumer.Close()
 	}
 	return p.pool.Stop(ctx)
 }

--- a/internal/processor/parser/worker/parser_worker.go
+++ b/internal/processor/parser/worker/parser_worker.go
@@ -23,7 +23,6 @@ import (
 	"fmt"
 	"net/url"
 	"strconv"
-	"sync"
 	"time"
 	"unicode/utf8"
 
@@ -37,6 +36,7 @@ import (
 	"issuetracker/internal/processor/parser/rule/llmgen"
 	"issuetracker/internal/storage"
 	"issuetracker/internal/storage/service"
+	"issuetracker/internal/workerpool"
 	"issuetracker/pkg/logger"
 	"issuetracker/pkg/queue"
 )
@@ -105,7 +105,9 @@ type ParserWorker struct {
 	workerCount int
 	log         *logger.Logger
 
-	wg sync.WaitGroup
+	// pool 은 workerpool harness — Start 에서 lazy 생성. lifecycle (poll / dispatch / shutdown /
+	// commit-with-drain) 을 위임 (이슈 #406 — 메타 #403 Sub 3).
+	pool *workerpool.ConsumerPool
 }
 
 // PipelineGuard 는 Category cycle 종료 시 marker 를 release 하기 위한 최소 인터페이스입니다.
@@ -210,8 +212,11 @@ func (w *ParserWorker) SetStaleCounter(c storage.StaleCounter, threshold int) {
 	w.staleThreshold = threshold
 }
 
-// Start 는 worker goroutines 를 기동합니다 (non-blocking).
-// 호출자는 ctx cancel + Stop 으로 graceful shutdown 수행.
+// Start 는 workerpool harness 를 기동합니다 (이슈 #406 — 메타 #403 Sub 3).
+//
+// harness 가 N 개 worker goroutine + poll goroutine 을 관리하며, 각 메시지마다 본 worker 의
+// Handle 메소드를 호출합니다. ctx 에는 worker_pool 필드 logger 가 주입되어 Handle 내부에서
+// FromContext 로 접근 가능.
 func (w *ParserWorker) Start(ctx context.Context) {
 	w.log.WithFields(map[string]interface{}{
 		"worker_count": w.workerCount,
@@ -219,65 +224,62 @@ func (w *ParserWorker) Start(ctx context.Context) {
 		"output_topic": queue.TopicNormalized,
 	}).Info("parser worker started")
 
-	for i := 0; i < w.workerCount; i++ {
-		w.wg.Add(1)
-		go w.runWorker(ctx, i)
-	}
+	const name = "parser"
+	plainLog := logger.FromContext(ctx)
+	ctx = plainLog.WithField("worker_pool", name).ToContext(ctx)
+
+	w.pool = workerpool.New(workerpool.Config{
+		Consumer:     w.consumer,
+		Handler:      w,
+		WorkerCount:  w.workerCount,
+		DrainTimeout: workerpool.DefaultDrainTimeout,
+		Log:          plainLog,
+		Name:         name,
+	})
+	w.pool.Start(ctx)
 }
 
-// Stop 은 모든 worker goroutine 의 종료를 대기합니다.
-// 호출 전 ctx 가 cancel 되어야 함 (외부 책임).
+// Stop 은 workerpool harness 의 정상 종료를 수행합니다.
+// 호출 전 ctx 가 cancel 되어야 함 (외부 책임 — graceful shutdown).
 func (w *ParserWorker) Stop(ctx context.Context) error {
-	done := make(chan struct{})
-	go func() {
-		w.wg.Wait()
-		close(done)
-	}()
-
-	select {
-	case <-done:
-		w.log.Info("parser worker stopped")
-	case <-ctx.Done():
-		w.log.Warn("parser worker stop timeout")
+	if w.pool == nil {
+		return nil
 	}
-	return w.consumer.Close()
+	err := w.pool.Stop(ctx)
+	if err == nil {
+		w.log.Info("parser worker stopped")
+	} else {
+		w.log.WithError(err).Warn("parser worker stop returned error")
+	}
+	return err
 }
 
-func (w *ParserWorker) runWorker(ctx context.Context, idx int) {
-	defer w.wg.Done()
-	wlog := w.log.WithField("parser_worker_id", idx)
+// Handle 은 workerpool.Handler 구현 — 각 메시지마다 호출됩니다.
+//
+// 흐름:
+//   - ProcessMessage 성공 → commit
+//   - ErrStageGateNotAcquired → commit skip (Debug — 다른 worker 가 처리 중인 정상 dedup)
+//   - 기타 transient 에러 → commit skip (Warn — Kafka 가 redeliver)
+//
+// commit 실패는 ctx cancel 인 경우 강등하지 않으면 셧다운 시점에 noise. Warn 으로 가시성 유지.
+func (w *ParserWorker) Handle(ctx context.Context, msg *queue.Message) {
+	log := logger.FromContext(ctx)
 
-	for {
-		if ctx.Err() != nil {
+	if err := w.ProcessMessage(ctx, msg); err != nil {
+		// StageGate not-acquired sentinel — commit 없이 다음 메시지로. 정상 dedup 경로라
+		// Warn 대신 Debug (이슈 #355 PR #358 리뷰 반영).
+		if errors.Is(err, ErrStageGateNotAcquired) {
+			log.WithField("offset", msg.Offset).Debug("stage gate not acquired by this worker, uncommitted")
 			return
 		}
+		// ProcessMessage 가 commit 하지 않은 경우 — 재시도 위해 commit skip (Kafka 가 redeliver).
+		log.WithError(err).WithField("offset", msg.Offset).Warn("process message failed, will be redelivered")
+		return
+	}
 
-		msg, err := w.consumer.FetchMessage(ctx)
-		if err != nil {
-			if ctx.Err() != nil {
-				return
-			}
-			wlog.WithError(err).Warn("fetch message failed")
-			continue
-		}
-
-		if err := w.ProcessMessage(ctx, msg); err != nil {
-			// StageGate not-acquired sentinel — commit 없이 다음 메시지로. 다른 worker 가 처리 중이므로
-			// 시끄러운 Warn 대신 Debug. Kafka 가 같은 partition 의 다음 offset 으로 fetch 진행 — 같은
-			// msg 재배달은 lock 해제 + 재시도 stream 에서 발생 (이슈 #355 PR #358 리뷰 반영).
-			if errors.Is(err, ErrStageGateNotAcquired) {
-				wlog.WithField("offset", msg.Offset).Debug("stage gate not acquired by this worker, uncommitted")
-				continue
-			}
-			// processMessage 가 commit 안 한 경우 — 재시도 위해 commit skip (Kafka 가 redeliver).
-			wlog.WithError(err).WithField("offset", msg.Offset).Warn("process message failed, will be redelivered")
-			continue
-		}
-
-		if commitErr := w.consumer.CommitMessages(ctx, msg); commitErr != nil {
-			if ctx.Err() == nil {
-				wlog.WithError(commitErr).Warn("commit failed after success")
-			}
+	if commitErr := w.pool.Commit(ctx, msg); commitErr != nil {
+		if ctx.Err() == nil {
+			log.WithError(commitErr).Warn("commit failed after success")
 		}
 	}
 }

--- a/internal/processor/parser/worker/parser_worker.go
+++ b/internal/processor/parser/worker/parser_worker.go
@@ -285,7 +285,7 @@ func (w *ParserWorker) Handle(ctx context.Context, msg *queue.Message) {
 }
 
 // ErrStageGateNotAcquired 는 parser stage 의 ProcessingLock 이 다른 worker 에 점유 중이라
-// 본 worker 가 스킵해야 함을 나타내는 sentinel. runWorker 가 본 에러를 감지하면 Warn 대신
+// 본 worker 가 스킵해야 함을 나타내는 sentinel. Handle 메소드가 본 에러를 감지하면 Warn 대신
 // Debug 로 처리하여 정상 dedup 경로를 시끄럽게 만들지 않습니다 (PR #358 리뷰 반영).
 //
 // commit 정책: 본 sentinel 반환 시 호출자는 commit 하지 않음 — 같은 partition 의 다음 msg

--- a/internal/processor/parser/worker/parser_worker.go
+++ b/internal/processor/parser/worker/parser_worker.go
@@ -217,7 +217,13 @@ func (w *ParserWorker) SetStaleCounter(c storage.StaleCounter, threshold int) {
 // harness 가 N 개 worker goroutine + poll goroutine 을 관리하며, 각 메시지마다 본 worker 의
 // Handle 메소드를 호출합니다. ctx 에는 worker_pool 필드 logger 가 주입되어 Handle 내부에서
 // FromContext 로 접근 가능.
+//
+// 단일 호출 contract — 인스턴스당 1회만 호출 (gemini PR #415 피드백). 2회차 호출은 이전 pool
+// 의 reference 가 손실되어 자원 누수 위험이라 fail-fast panic.
 func (w *ParserWorker) Start(ctx context.Context) {
+	if w.pool != nil {
+		panic("parser worker: Start called more than once on the same instance")
+	}
 	w.log.WithFields(map[string]interface{}{
 		"worker_count": w.workerCount,
 		"input_topic":  queue.TopicFetched,
@@ -241,9 +247,12 @@ func (w *ParserWorker) Start(ctx context.Context) {
 
 // Stop 은 workerpool harness 의 정상 종료를 수행합니다.
 // 호출 전 ctx 가 cancel 되어야 함 (외부 책임 — graceful shutdown).
+//
+// pool 이 미기동 (Start 미호출) 상태에서 Stop 호출 시 consumer.Close 만 수행 — Kafka 연결
+// 자원 누수 방지 (gemini PR #415 피드백).
 func (w *ParserWorker) Stop(ctx context.Context) error {
 	if w.pool == nil {
-		return nil
+		return w.consumer.Close()
 	}
 	err := w.pool.Stop(ctx)
 	if err == nil {


### PR DESCRIPTION
## 연관 이슈

Closes #406
부모 메타: #403 — Kafka consumer pool 골격 공용화 Sub 3

## 구현 내용

`internal/processor/parser/worker/ParserWorker` 가 `internal/workerpool.ConsumerPool` harness 를 사용하도록 재구성. parser stage-specific 책임은 잔존, 공용 lifecycle 은 harness 위임. **라이브 동작 영향 0**.

### 책임 분리

| 담당 | 책임 |
|---|---|
| **harness** (workerpool) | poll / dispatch / worker_id ctx 주입 / graceful shutdown / commit-with-drain |
| **parser worker** | RawContentRef unmarshal / parsing rule / blacklist / LLM 재학습 hook / staleCounter / failureCounter / upgrader / publishNormalized |

ParserWorker 가 `workerpool.Handler` 인터페이스를 직접 구현 — 메시지마다 Handle 호출.

### 제거 (workerpool 로 이동된 것)

- `runWorker` (FetchMessage + dispatch 루프)
- `consumer.CommitMessages` 직접 호출 (workerpool `Commit` + `CommitWithDrain` 사용)
- `wg sync.WaitGroup` / `Stop` 의 wait + consumer.Close 종료 순서
- `sync` import (불필요)

### 신규

- `pool *workerpool.ConsumerPool` 필드 (Start 에서 lazy 생성)
- `Handle` 메소드 (workerpool.Handler 구현 — ProcessMessage + commit/skip 분기)

### 보존

- `ProcessMessage` (exported — 외부 테스트가 분기별 검증)
- `ErrStageGateNotAcquired` sentinel + Debug 로깅 (정상 dedup 경로)
- 모든 parser-specific 필드 (rule.Parser / blacklist / llmGen / staleCounter / upgrader 등)
- 외부 API (`NewParserWorker` / `Start` / `Stop` / `SetPipelineGuard` / `SetBlacklist` / `SetStaleCounter`)

### Handle 흐름

```
ProcessMessage(ctx, msg)
  ├── nil error → pool.Commit
  ├── ErrStageGateNotAcquired → commit skip + Debug (정상 dedup)
  └── other error → commit skip + Warn (Kafka redeliver)
```

## CI / 머지 게이트 점검

- [x] `gofmt -l` — clean
- [x] `go build ./internal/... ./cmd/...` — pass
- [x] `go test -race -count=1 -timeout=180s ./test/...` — 전 패키지 통과 (회귀 0)
- [x] PR 타이틀 `[REFAC#406]`
- [x] commit `[REFAC]:` prefix + 한국어

## 변경 영향 범위 + 위험도

- **영향**: 1 파일 (parser_worker.go)
  - +55 / -53 라인 — 비슷한 라인 수 (runWorker 제거 ≈ Handle 추가)
- **위험도 Low**:
  - 외부 API 무변경 — main.go / 테스트 / 다른 사용처 영향 없음
  - lifecycle 로직은 workerpool harness 가 동일 패턴으로 인수
  - 기존 parser worker 테스트 전부 통과

## 후속

- Sub 4 (#407): validate/worker 마이그레이션 — 마지막 sub PR 에서 메타 #403 close

## 롤백 계획

PR revert 시 parser_worker.go 가 자체 runWorker / Stop / wg 코드를 다시 보유 — workerpool 의존성 제거. workerpool 패키지 자체는 그대로 (fetcher 가 계속 사용).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal architecture of the message processing worker to enhance code maintainability and resource management.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/EinSofINTEREST/IssueTracker/pull/415)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->