### PR TITLE
[REFAC#419] parser/worker/parser_worker.go → worker.go + ParserWorker → Worker

### DIFF
--- a/cmd/issuetracker/main.go
+++ b/cmd/issuetracker/main.go
@@ -568,7 +568,7 @@ func main() {
 		log.Warn("processing lock unavailable, parser stage gate falls back to noop")
 	}
 
-	pw := parserWorker.NewWorker(
+	w := parserWorker.NewWorker(
 		parserConsumer,
 		jobPublisher, // 이슈 #392 — 구 producer + JobPublisher 두 인자 통합 (bus.Publisher 가 Forward + PublishChained 모두 제공)
 		rawSvc,
@@ -590,14 +590,14 @@ func main() {
 	// ── Pipeline Guard release ─────────────────────────────────────
 	// Category cycle 종료 시 marker release — scheduler 다음 주기에 즉시 진입 가능.
 	if pipelineGuard != nil {
-		pw.SetPipelineGuard(pipelineGuard)
+		w.SetPipelineGuard(pipelineGuard)
 	}
 
 	// ── Page-parse 블랙리스트 ───────────────────────────────────────
 	// 카테고리에서 추출된 article URL 중 blacklist 매칭은 bus.Publish 직전 drop.
 	// Matcher 가 nil (BLACKLIST_ENABLED=false) 이면 setter noop — 모든 링크 그대로 발행.
 	if blacklistMatcher != nil {
-		pw.SetBlacklist(blacklistMatcher)
+		w.SetBlacklist(blacklistMatcher)
 	}
 
 	// ── Stale rule 재학습 카운터 ───────────────────────────────────
@@ -619,7 +619,7 @@ func main() {
 		if scErr != nil {
 			log.WithError(scErr).Warn("failed to construct redis stale counter, stale relearn disabled at runtime")
 		} else {
-			pw.SetStaleCounter(sc, staleRelearnCfg.Threshold)
+			w.SetStaleCounter(sc, staleRelearnCfg.Threshold)
 			log.WithFields(map[string]interface{}{
 				"threshold": staleRelearnCfg.Threshold,
 				"window":    staleRelearnCfg.Window.String(),
@@ -637,7 +637,7 @@ func main() {
 	// selector 검증 실패 시 raw 를 issuetracker.fetched 에 재발행 — 룰 생성 성공 후 재파싱 기회 부여.
 	// llmGen 이 nil(LLM 비활성) 이면 wiring 불필요.
 	if llmGen != nil {
-		llmGen.SetValidateFailureHandler(pw.RequeueForLLMRetry)
+		llmGen.SetValidateFailureHandler(w.RequeueForLLMRetry)
 	}
 
 	// ── Pending URL 큐 ────────────────────────────────────────────
@@ -649,7 +649,7 @@ func main() {
 		if pqErr != nil {
 			log.WithError(pqErr).Fatal("failed to construct redis pending queue")
 		}
-		llmGen.SetPendingQueue(pq, pw.RequeueParsing)
+		llmGen.SetPendingQueue(pq, w.RequeueParsing)
 		log.Info("llmgen: Redis 기반 pending URL 큐 활성화")
 	}
 
@@ -827,7 +827,7 @@ func main() {
 	if err != nil {
 		log.WithError(err).Fatal("failed to construct fetcher stage")
 	}
-	parserStg, err := parser.NewStage(pw, cleaner, llmGen, pathRefiner, log)
+	parserStg, err := parser.NewStage(w, cleaner, llmGen, pathRefiner, log)
 	if err != nil {
 		log.WithError(err).Fatal("failed to construct parser stage")
 	}

--- a/cmd/issuetracker/main.go
+++ b/cmd/issuetracker/main.go
@@ -329,7 +329,7 @@ func main() {
 	}
 
 	// URL dedup — Ingestion Lock → Pipeline Guard 통합:
-	// Publisher / Scheduler / ParserWorker 가 동일 guard 를 공유하여 target type 별 정책 적용:
+	// Publisher / Scheduler / Worker 가 동일 guard 를 공유하여 target type 별 정책 적용:
 	//   - Article: 24h TTL (기존 IngestionLock 정책 유지)
 	//   - Category: 단명 TTL (default 60s) — cycle 종료 시 명시적 release + TTL fallback
 	jobPublisher.SetNormalizer(links.NewNormalizer())
@@ -568,7 +568,7 @@ func main() {
 		log.Warn("processing lock unavailable, parser stage gate falls back to noop")
 	}
 
-	pw := parserWorker.NewParserWorker(
+	pw := parserWorker.NewWorker(
 		parserConsumer,
 		jobPublisher, // 이슈 #392 — 구 producer + JobPublisher 두 인자 통합 (bus.Publisher 가 Forward + PublishChained 모두 제공)
 		rawSvc,

--- a/internal/processor/fetcher/worker/pool.go
+++ b/internal/processor/fetcher/worker/pool.go
@@ -150,7 +150,7 @@ func NewKafkaConsumerPoolWithOptions(
 	cbRegistry *resilience.CircuitBreakerRegistry,
 	gate locks.StageGate,
 ) *KafkaConsumerPool {
-	// nil guard — NewParserWorker / validate.NewWorker 와 일관성 보장.
+	// nil guard — NewWorker / validate.NewWorker 와 일관성 보장.
 	if gate == nil {
 		gate = locks.NewNoopStageGate()
 	}

--- a/internal/processor/parser/stage.go
+++ b/internal/processor/parser/stage.go
@@ -7,7 +7,7 @@
 // 사이클 없음.
 //
 // 본 stage 는 단일 worker 가 아닌 **여러 background goroutine 의 묶음** 입니다:
-//   - worker.ParserWorker (Kafka consume + 파싱 + content 저장)
+//   - worker.Worker (Kafka consume + 파싱 + content 저장)
 //   - worker.RawContentCleaner (잔존 raw_contents purge cron)
 //   - llmgen.Generator (ErrNoRule 시 async LLM 호출, optional)
 //   - refiner.Refiner (path_pattern 정밀화 polling, optional)
@@ -33,13 +33,13 @@ const stageName = "parser"
 // Stage 는 parser 단계의 모든 background goroutine 을 묶어 processor.Stage 로 노출합니다.
 //
 // component 의존 order (Stop 시 역순 처리):
-//  1. ParserWorker — Kafka consumer + 파싱 (필수)
+//  1. Worker — Kafka consumer + 파싱 (필수)
 //  2. RawContentCleaner — janitor (필수, Stop 은 ctx 무시)
-//  3. llmgen.Generator (선택) — ErrNoRule async LLM 호출. ParserWorker 가 유일 Enqueue source 이므로
-//     ParserWorker.Stop 후에 Stop 해야 in-flight LLM 호출 완료 보장.
+//  3. llmgen.Generator (선택) — ErrNoRule async LLM 호출. Worker 가 유일 Enqueue source 이므로
+//     Worker.Stop 후에 Stop 해야 in-flight LLM 호출 완료 보장.
 //  4. refiner.Refiner (선택) — interval polling. ctx cancel 시 cycle 즉시 종료.
 type Stage struct {
-	worker  *worker.ParserWorker
+	worker  *worker.Worker
 	cleaner *worker.RawContentCleaner
 	llmGen  *llmgen.Generator // nil 허용
 	refiner *refiner.Refiner  // nil 허용
@@ -49,14 +49,14 @@ type Stage struct {
 // NewStage 는 component 들을 받아 parser.Stage 를 반환합니다.
 // worker / cleaner / log 는 필수 (nil 이면 error), llmGen / refiner 는 nil 허용.
 func NewStage(
-	pw *worker.ParserWorker,
+	pw *worker.Worker,
 	cleaner *worker.RawContentCleaner,
 	llmGen *llmgen.Generator,
 	pathRefiner *refiner.Refiner,
 	log *logger.Logger,
 ) (*Stage, error) {
 	if pw == nil {
-		return nil, errors.New("parser: NewStage requires non-nil ParserWorker")
+		return nil, errors.New("parser: NewStage requires non-nil Worker")
 	}
 	if cleaner == nil {
 		return nil, errors.New("parser: NewStage requires non-nil RawContentCleaner")
@@ -78,7 +78,7 @@ func (s *Stage) Name() string { return stageName }
 
 // Start 는 parser 단계의 모든 background goroutine 을 기동합니다.
 //
-//   - ParserWorker: consumer pool start
+//   - Worker: consumer pool start
 //   - RawContentCleaner: cron start
 //   - refiner: polling goroutine start (있으면)
 //
@@ -94,7 +94,7 @@ func (s *Stage) Start(ctx context.Context) {
 // Stop 은 parser 단계의 graceful shutdown 을 수행합니다.
 //
 // 처리 순서가 중요:
-//  1. ParserWorker 먼저 — llmGen 의 유일 Enqueue source 차단
+//  1. Worker 먼저 — llmGen 의 유일 Enqueue source 차단
 //  2. llmGen — in-flight LLM 호출 완료 대기
 //  3. refiner — in-flight polling cycle 완료 대기
 //  4. RawContentCleaner — janitor 마지막
@@ -103,7 +103,7 @@ func (s *Stage) Start(ctx context.Context) {
 func (s *Stage) Stop(ctx context.Context) error {
 	var firstErr error
 
-	// 1. ParserWorker — Enqueue source 차단. 에러는 호출자 (main) 에서 stage 별로 일괄 로깅하므로
+	// 1. Worker — Enqueue source 차단. 에러는 호출자 (main) 에서 stage 별로 일괄 로깅하므로
 	// 본 위치에서는 중복 로그 회피 — 단순 first-error 보존만.
 	if err := s.worker.Stop(ctx); err != nil {
 		firstErr = err

--- a/internal/processor/parser/stage.go
+++ b/internal/processor/parser/stage.go
@@ -49,13 +49,13 @@ type Stage struct {
 // NewStage 는 component 들을 받아 parser.Stage 를 반환합니다.
 // worker / cleaner / log 는 필수 (nil 이면 error), llmGen / refiner 는 nil 허용.
 func NewStage(
-	pw *worker.Worker,
+	w *worker.Worker,
 	cleaner *worker.RawContentCleaner,
 	llmGen *llmgen.Generator,
 	pathRefiner *refiner.Refiner,
 	log *logger.Logger,
 ) (*Stage, error) {
-	if pw == nil {
+	if w == nil {
 		return nil, errors.New("parser: NewStage requires non-nil Worker")
 	}
 	if cleaner == nil {
@@ -65,7 +65,7 @@ func NewStage(
 		return nil, errors.New("parser: NewStage requires non-nil logger")
 	}
 	return &Stage{
-		worker:  pw,
+		worker:  w,
 		cleaner: cleaner,
 		llmGen:  llmGen,
 		refiner: pathRefiner,

--- a/internal/processor/parser/worker/worker.go
+++ b/internal/processor/parser/worker/worker.go
@@ -50,13 +50,13 @@ const (
 	defaultJobTimeout = 30 * time.Second
 )
 
-// ParserWorker 는 TopicFetched consumer group 의 worker pool 입니다.
+// Worker 는 TopicFetched consumer group 의 worker pool 입니다.
 //
 // 이슈 #392 — Kafka I/O (consume + 3 종 publish + chained job publish) 모두 publisher
 // facade 로 위임. Kafka 구현체 (*queue.KafkaConsumer, queue.Producer) 에 직접 의존하지 않음.
 // queue 패키지 자체는 토픽 상수 (TopicFetched / TopicNormalized) 와 데이터 타입
 // (queue.Message) 사용을 위해 그대로 import — I/O 구현체 직접 호출만 publisher 위임.
-type ParserWorker struct {
+type Worker struct {
 	consumer   bus.Consumer
 	pub        *bus.Publisher
 	rawSvc     service.RawContentService
@@ -118,7 +118,7 @@ type PipelineGuard interface {
 	Release(ctx context.Context, url string) error
 }
 
-// NewParserWorker 는 ParserWorker 를 생성합니다.
+// NewWorker 는 Worker 를 생성합니다.
 //
 //   - pub 는 운영 환경에서 **필수 wiring** — nil 이면 Forward / PublishChained 호출이
 //     `publisher: Forward called on nil *Publisher` 등 error 를 반환하고, 호출 사이트가
@@ -137,7 +137,7 @@ type PipelineGuard interface {
 // StageGate (ProcessingLock + Semaphore 합성, 이슈 #353/#354) 로 fetcher / parser / validator
 // 가 동일 패턴으로 stage 별 동시성 cap + URL 중복 처리 차단을 단일 API 로 적용 — parser 단계는
 // raw.URL 단위로 acquire, Kafka rebalance 시 같은 raw 가 두 worker 에 도달해도 1회만 파싱.
-func NewParserWorker(
+func NewWorker(
 	consumer bus.Consumer,
 	pub *bus.Publisher,
 	rawSvc service.RawContentService,
@@ -154,7 +154,7 @@ func NewParserWorker(
 	emptyBodyContentMin int,
 	workerCount int,
 	log *logger.Logger,
-) *ParserWorker {
+) *Worker {
 	if workerCount <= 0 {
 		workerCount = 1
 	}
@@ -167,7 +167,7 @@ func NewParserWorker(
 	if rawIDTracker == nil {
 		rawIDTracker = storage.NewNoopRawIDTracker()
 	}
-	return &ParserWorker{
+	return &Worker{
 		consumer:            consumer,
 		pub:                 pub,
 		rawSvc:              rawSvc,
@@ -189,7 +189,7 @@ func NewParserWorker(
 
 // SetPipelineGuard 는 Category cycle 완료 시 marker release 용 PipelineGuard 를 주입합니다.
 // nil 주입 시 release 비활성 (TTL fallback). Start 호출 전 wiring 단계에서 1회 설정.
-func (w *ParserWorker) SetPipelineGuard(g PipelineGuard) {
+func (w *Worker) SetPipelineGuard(g PipelineGuard) {
 	w.guard = g
 }
 
@@ -197,7 +197,7 @@ func (w *ParserWorker) SetPipelineGuard(g PipelineGuard) {
 //
 // nil 주입 시 차단 비활성 (모든 카테고리 링크가 그대로 article job 으로 발행).
 // Start 호출 전 wiring 단계에서 1회 설정.
-func (w *ParserWorker) SetBlacklist(b *rule.BlacklistMatcher) {
+func (w *Worker) SetBlacklist(b *rule.BlacklistMatcher) {
 	w.blacklist = b
 }
 
@@ -207,7 +207,7 @@ func (w *ParserWorker) SetBlacklist(b *rule.BlacklistMatcher) {
 // threshold <= 0 이면 threshold-crossing gate 비활성 — counter.Record 의 thresholdReached 만으로 트리거
 // (window 내 매 후속 호출마다 enqueue 가능, 호환 fallback).
 // Start 호출 전 wiring 단계에서 1회 설정.
-func (w *ParserWorker) SetStaleCounter(c storage.StaleCounter, threshold int) {
+func (w *Worker) SetStaleCounter(c storage.StaleCounter, threshold int) {
 	w.staleCounter = c
 	w.staleThreshold = threshold
 }
@@ -220,7 +220,7 @@ func (w *ParserWorker) SetStaleCounter(c storage.StaleCounter, threshold int) {
 //
 // 단일 호출 contract — 인스턴스당 1회만 호출 (gemini PR #415 피드백). 2회차 호출은 이전 pool
 // 의 reference 가 손실되어 자원 누수 위험이라 fail-fast panic.
-func (w *ParserWorker) Start(ctx context.Context) {
+func (w *Worker) Start(ctx context.Context) {
 	if w.pool != nil {
 		panic("parser worker: Start called more than once on the same instance")
 	}
@@ -250,7 +250,7 @@ func (w *ParserWorker) Start(ctx context.Context) {
 //
 // pool 이 미기동 (Start 미호출) 상태에서 Stop 호출 시 consumer.Close 만 수행 — Kafka 연결
 // 자원 누수 방지 (gemini PR #415 피드백).
-func (w *ParserWorker) Stop(ctx context.Context) error {
+func (w *Worker) Stop(ctx context.Context) error {
 	if w.pool == nil {
 		return w.consumer.Close()
 	}
@@ -271,7 +271,7 @@ func (w *ParserWorker) Stop(ctx context.Context) error {
 //   - 기타 transient 에러 → commit skip (Warn — Kafka 가 redeliver)
 //
 // commit 실패는 ctx cancel 인 경우 강등하지 않으면 셧다운 시점에 noise. Warn 으로 가시성 유지.
-func (w *ParserWorker) Handle(ctx context.Context, msg *queue.Message) {
+func (w *Worker) Handle(ctx context.Context, msg *queue.Message) {
 	log := logger.FromContext(ctx)
 
 	if err := w.ProcessMessage(ctx, msg); err != nil {
@@ -315,7 +315,7 @@ var ErrStageGateNotAcquired = errors.New("parser stage gate not acquired by this
 //
 // 일반적으로 runWorker 가 내부에서 호출하지만, 외부 테스트가 분기별 행동을 black-box 로
 // 검증할 수 있도록 exported. consumer 가 nil 인 worker 도 본 메소드는 호출 가능.
-func (w *ParserWorker) ProcessMessage(ctx context.Context, msg *queue.Message) error {
+func (w *Worker) ProcessMessage(ctx context.Context, msg *queue.Message) error {
 	var ref core.RawContentRef
 	if err := json.Unmarshal(msg.Value, &ref); err != nil {
 		w.log.WithError(err).Error("malformed RawContentRef payload, dropping")
@@ -394,7 +394,7 @@ func (w *ParserWorker) ProcessMessage(ctx context.Context, msg *queue.Message) e
 	return w.processArticlePage(ctx, raw, ref.ID, crawlerName, ref.LLMRetryCount, mlog)
 }
 
-func (w *ParserWorker) processCategoryPage(ctx context.Context, raw *core.RawContent, rawID, crawlerName string, jobTimeout time.Duration, llmRetryCount int, mlog *logger.Logger) error {
+func (w *Worker) processCategoryPage(ctx context.Context, raw *core.RawContent, rawID, crawlerName string, jobTimeout time.Duration, llmRetryCount int, mlog *logger.Logger) error {
 	// Category cycle 종료 시 PipelineGuard marker release — defer 로 어떤 경로
 	// (성공 / handleRuleError / 0 links / publish 실패) 든 release 보장. Release 실패는 non-fatal
 	// (TTL fallback 으로 자동 회수).
@@ -469,7 +469,7 @@ func (w *ParserWorker) processCategoryPage(ctx context.Context, raw *core.RawCon
 //
 // guard 미설정 시 noop. Release 실패는 non-fatal — TTL 만료 fallback 으로 자동 회수.
 // ctx.WithoutCancel 로 parent ctx 취소 신호 분리 — shutdown 중에도 release 시도 보장.
-func (w *ParserWorker) releaseCategoryMarker(ctx context.Context, url string, mlog *logger.Logger) {
+func (w *Worker) releaseCategoryMarker(ctx context.Context, url string, mlog *logger.Logger) {
 	if w.guard == nil {
 		return
 	}
@@ -482,7 +482,7 @@ func (w *ParserWorker) releaseCategoryMarker(ctx context.Context, url string, ml
 	}
 }
 
-func (w *ParserWorker) processArticlePage(ctx context.Context, raw *core.RawContent, rawID, crawlerName string, llmRetryCount int, mlog *logger.Logger) error {
+func (w *Worker) processArticlePage(ctx context.Context, raw *core.RawContent, rawID, crawlerName string, llmRetryCount int, mlog *logger.Logger) error {
 	if w.parser == nil {
 		mlog.Debug("parser not configured, skipping article")
 		w.deleteRaw(ctx, rawID, mlog)
@@ -521,7 +521,7 @@ func (w *ParserWorker) processArticlePage(ctx context.Context, raw *core.RawCont
 // rule.ErrParseFailure / rule.ErrEmptySelector 는 host 단위 카운터로
 // 누적 — 임계값 도달 시 단계 3 (#221) 의 chromedp 자동 전환 트리거 입력. ErrNoRule 은 LLM 자동
 // rule 생성 의 책임 영역이라 카운팅 제외 (다른 정책으로 처리됨).
-func (w *ParserWorker) handleRuleError(ctx context.Context, raw *core.RawContent, rawID, stage string, targetType storage.TargetType, err error, llmRetryCount int, crawlerName string, jobTimeout time.Duration, mlog *logger.Logger) error {
+func (w *Worker) handleRuleError(ctx context.Context, raw *core.RawContent, rawID, stage string, targetType storage.TargetType, err error, llmRetryCount int, crawlerName string, jobTimeout time.Duration, mlog *logger.Logger) error {
 	var rerr *rule.Error
 	if errors.As(err, &rerr) {
 		mlog.WithFields(map[string]interface{}{
@@ -593,7 +593,7 @@ func (w *ParserWorker) handleRuleError(ctx context.Context, raw *core.RawContent
 //
 // rawID 는 단계 3 의 chromedp 자동 전환 trigger 가 republish 대상으로 사용. 빈 문자열이면
 // Tracker 가 noop.
-func (w *ParserWorker) recordHostFailure(ctx context.Context, host, rawID string, reason storage.FailureReason, mlog *logger.Logger) {
+func (w *Worker) recordHostFailure(ctx context.Context, host, rawID string, reason storage.FailureReason, mlog *logger.Logger) {
 	if w.failureCounter == nil {
 		return
 	}
@@ -640,7 +640,7 @@ func (w *ParserWorker) recordHostFailure(ctx context.Context, host, rawID string
 //
 // 카운팅 / lookup 실패는 non-fatal — warn 로그만 남기고 정상 흐름 유지. 임계 도달 후 EnqueueStale
 // 은 비동기 (Generator 내부 goroutine) 라 본 함수 latency 영향 없음.
-func (w *ParserWorker) recordStaleAndMaybeRelearn(ctx context.Context, host string, targetType storage.TargetType, raw *core.RawContent, llmRetryCount int, crawlerName string, jobTimeout time.Duration, mlog *logger.Logger) {
+func (w *Worker) recordStaleAndMaybeRelearn(ctx context.Context, host string, targetType storage.TargetType, raw *core.RawContent, llmRetryCount int, crawlerName string, jobTimeout time.Duration, mlog *logger.Logger) {
 	if w.staleCounter == nil || w.llmGen == nil {
 		return
 	}
@@ -718,7 +718,7 @@ func hostOf(rawURL string) string {
 // 임계값이 0 이면 해당 필드 검증 비활성 (운영 옵션).
 //
 // rawID 도 host 별 추적 — 단계 3 의 republish 대상 수집.
-func (w *ParserWorker) recordEmptyBodyIfApplicable(ctx context.Context, raw *core.RawContent, rawID string, page *types.Page, mlog *logger.Logger) {
+func (w *Worker) recordEmptyBodyIfApplicable(ctx context.Context, raw *core.RawContent, rawID string, page *types.Page, mlog *logger.Logger) {
 	if w.emptyBodyTitleMin <= 0 && w.emptyBodyContentMin <= 0 {
 		return
 	}
@@ -745,7 +745,7 @@ func (w *ParserWorker) recordEmptyBodyIfApplicable(ctx context.Context, raw *cor
 }
 
 // publishContents 는 *core.Content 슬라이스를 contents 저장 + ContentRef 발행 (TopicNormalized).
-func (w *ParserWorker) publishContents(ctx context.Context, contents []*core.Content, crawlerName string) error {
+func (w *Worker) publishContents(ctx context.Context, contents []*core.Content, crawlerName string) error {
 	for _, c := range contents {
 		storedID, _, err := w.contentSvc.Store(ctx, c)
 		if err != nil {
@@ -823,7 +823,7 @@ const (
 // targetType, crawlerName 은 Kafka 메시지 헤더로 설정 — 재큐 후 processMessage 가 올바른
 // 파싱 경로 (category vs article) 로 분기할 수 있도록 보존합니다 (gemini/Copilot/CodeRabbit 피드백).
 // 재발행 실패는 non-fatal — raw 는 TTL cleanup 으로 최종 정리됩니다.
-func (w *ParserWorker) RequeueForLLMRetry(ctx context.Context, ref core.RawContentRef, llmRetryCount int, targetType storage.TargetType, crawlerName string) {
+func (w *Worker) RequeueForLLMRetry(ctx context.Context, ref core.RawContentRef, llmRetryCount int, targetType storage.TargetType, crawlerName string) {
 	nextCount := llmRetryCount + 1
 	if nextCount > maxLLMRetries {
 		w.log.WithFields(map[string]interface{}{
@@ -887,7 +887,7 @@ func (w *ParserWorker) RequeueForLLMRetry(ctx context.Context, ref core.RawConte
 //
 // 룰 생성 완료 후 호출 — 대기 중이던 URL 이 새 룰로 재파싱될 수 있도록 TopicFetched 에 투입.
 // Kafka 발행에 실패한 항목을 반환 — Generator 가 pending queue 에 재적재.
-func (w *ParserWorker) RequeueParsing(ctx context.Context, items []llmgen.PendingItem) (failed []llmgen.PendingItem) {
+func (w *Worker) RequeueParsing(ctx context.Context, items []llmgen.PendingItem) (failed []llmgen.PendingItem) {
 	// WithoutCancel 은 루프 외부에서 1회 — 루프마다 새 컨텍스트 파생 불필요 (Gemini 피드백).
 	baseCtx := context.WithoutCancel(ctx)
 	for _, item := range items {
@@ -929,7 +929,7 @@ func (w *ParserWorker) RequeueParsing(ctx context.Context, items []llmgen.Pendin
 
 // deleteRaw 는 처리 완료된 raw_contents row 를 즉시 정리합니다.
 // 실패는 non-fatal — cleanup cron 이 안전망으로 동작.
-func (w *ParserWorker) deleteRaw(ctx context.Context, rawID string, mlog *logger.Logger) {
+func (w *Worker) deleteRaw(ctx context.Context, rawID string, mlog *logger.Logger) {
 	if err := w.rawSvc.Delete(ctx, rawID); err != nil {
 		mlog.WithError(err).Warn("raw delete failed (non-fatal — cleanup cron will catch)")
 	}
@@ -946,7 +946,7 @@ func (w *ParserWorker) deleteRaw(ctx context.Context, rawID string, mlog *logger
 // 모든 실패 (lookup 실패 / Insert 에러 / cap 도달) 는 정상 흐름 차단 X — DEBUG/WARN 로그만.
 //
 // 변수명 matchedRule: import 된 rule 패키지와의 shadowing 회피.
-func (w *ParserWorker) accumulateSample(ctx context.Context, raw *core.RawContent, mlog *logger.Logger) {
+func (w *Worker) accumulateSample(ctx context.Context, raw *core.RawContent, mlog *logger.Logger) {
 	if w.resolver == nil || w.sampleSvc == nil {
 		return
 	}

--- a/test/internal/processor/parser/worker/helpers_test.go
+++ b/test/internal/processor/parser/worker/helpers_test.go
@@ -9,14 +9,14 @@ import (
 	"issuetracker/pkg/queue"
 )
 
-// newMinimalWorker 는 RequeueForLLMRetry 테스트에만 필요한 최소 ParserWorker 를 생성합니다.
+// newMinimalWorker 는 RequeueForLLMRetry 테스트에만 필요한 최소 Worker 를 생성합니다.
 // nil 허용 필드는 전부 nil 로 전달합니다.
 //
 // 이슈 #392 — parser_worker 가 publisher facade 의존으로 변경됨에 따라 mock producer 를
 // 실제 *bus.Publisher 로 wrap (Sub 5/7 동일 패턴, newTestPublisher 와 등가).
-func newMinimalWorker(prod queue.Producer, log *logger.Logger) *worker.ParserWorker {
+func newMinimalWorker(prod queue.Producer, log *logger.Logger) *worker.Worker {
 	pub := bus.New(prod, nil, log)
-	return worker.NewParserWorker(
+	return worker.NewWorker(
 		nil, // consumer
 		pub, // pub — RequeueForLLMRetry/Forward 가 사용
 		nil, // rawSvc

--- a/test/internal/processor/parser/worker/stage_gate_test.go
+++ b/test/internal/processor/parser/worker/stage_gate_test.go
@@ -47,9 +47,9 @@ func (g *fakeStageGate) Acquire(_ context.Context, _ string) (func(), bool, erro
 	return func() { atomic.AddInt64(&g.releaseCalls, 1) }, true, nil
 }
 
-// newGatedWorker 는 gate + rawSvc 를 주입한 ParserWorker 를 생성합니다.
-func newGatedWorker(gate locks.StageGate, rawSvc *fakeRawSvc, log *logger.Logger) *parserWorker.ParserWorker {
-	return parserWorker.NewParserWorker(
+// newGatedWorker 는 gate + rawSvc 를 주입한 Worker 를 생성합니다.
+func newGatedWorker(gate locks.StageGate, rawSvc *fakeRawSvc, log *logger.Logger) *parserWorker.Worker {
+	return parserWorker.NewWorker(
 		nil,    // consumer
 		nil,    // pub
 		rawSvc, // rawSvc


### PR DESCRIPTION
## 연관 이슈

Closes #419

## 구현 내용

PR #418 (이슈 #417 stage 패키지 정합화) 후속 — parser 의 주 worker 파일 / 타입명에 남아있던 redundant `Parser` prefix 정리.

### Before / After

| | Before | After |
|---|---|---|
| 파일 | `parser_worker.go` | `worker.go` |
| 타입 | `ParserWorker` | `Worker` |
| 생성자 | `NewParserWorker` | `NewWorker` |

`parser/worker` 패키지 경로 자체가 "parser worker" 를 표현 — `Parser` prefix 중복. validate 의 `worker.go` / `Worker` / `NewWorker` 패턴과 일치.

### 3 stage 비교

| stage | 주 worker 파일 | 주 worker 타입 |
|---|---|---|
| fetcher | `pool.go` | `KafkaConsumerPool` (concept-named, 다중 타입) |
| parser | `worker.go` (PR 적용 후) | `Worker` |
| validate | `worker.go` | `Worker` |

fetcher 는 pool / semaphore / manager 다중 타입 보유로 concept-named 유지 — 예외.

### 변경 영향 범위

- `internal/processor/parser/worker/parser_worker.go` → `worker.go` (rename)
- 호출처 5 파일:
  - `internal/processor/parser/worker/worker.go` (식별자 일괄 치환)
  - `internal/processor/parser/stage.go`
  - `internal/processor/fetcher/worker/pool.go` (주석만)
  - `cmd/issuetracker/main.go`
  - `test/internal/processor/parser/worker/{helpers_test.go, stage_gate_test.go}`

## CI / 머지 게이트 점검

- [x] `gofmt -l` — clean
- [x] `go build ./internal/... ./cmd/... ./test/...` — pass
- [x] `go test -race -count=1 -timeout=180s ./test/...` — 전 패키지 통과 (회귀 0)
- [x] PR 타이틀 `[REFAC#419]`
- [x] commit `[REFAC]:` prefix + 한국어

## 변경 영향 범위 + 위험도

- **영향**: 6 파일, +44/-44 라인 (식별자 / 파일명만 변경)
- **위험도 Low** — 순수 명명 정정, 동작 무변경

## 롤백 계획

PR revert 시 6 파일 동시 원복.

🤖 Generated with [Claude Code](https://claude.com/claude-code)