### PR TITLE
[FEAT#421] parser_rules 에 article BOOLEAN 컬럼 추가

### DIFF
--- a/internal/storage/parser_rule.go
+++ b/internal/storage/parser_rule.go
@@ -164,7 +164,7 @@ type ParserRuleRecord struct {
 	//             해당 룰에 대해 검증 완화 또는 처리 분기.
 	//
 	// 기본값 false — operator 명시적 opt-in. PageType 과 직교 (예: PageType=news + article=true
-	// 가 \"기사 본문\", PageType=news + article=false 가 \"뉴스 인덱스\").
+	// 가 "기사 본문", PageType=news + article=false 가 "뉴스 인덱스").
 	Article bool
 
 	CreatedAt time.Time
@@ -188,8 +188,14 @@ type ParserRuleFilter struct {
 	HostPattern string     // 빈 문자열이면 전체
 	TargetType  TargetType // 빈 문자열이면 전체
 	OnlyEnabled bool       // true 면 enabled=true 만
-	Limit       int        // 0 이면 기본값 (50)
-	Offset      int
+
+	// Article: nil 이면 미적용 (article 무관 전체).
+	// 비-nil 이면 *Article 값과 동일한 행만 (true → article=TRUE, false → article=FALSE).
+	// tri-state 필요 — bool zero-value 가 "미적용" 인지 "false 매칭" 인지 구분되어야 함 (이슈 #421).
+	Article *bool
+
+	Limit  int // 0 이면 기본값 (50)
+	Offset int
 }
 
 // ParserRuleRepository 는 parser_rules 테이블에 대한 데이터 접근 인터페이스입니다.
@@ -202,7 +208,7 @@ type ParserRuleRepository interface {
 	Insert(ctx context.Context, r *ParserRuleRecord) error
 
 	// Update 는 ID 로 규칙을 갱신합니다. 존재하지 않으면 ErrNotFound 반환.
-	// 갱신 가능 필드: Selectors, Enabled, Description (자연키는 변경 불가).
+	// 갱신 가능 필드: Selectors, Confidence, Enabled, Description, Article (자연키 + PageType 은 변경 불가).
 	Update(ctx context.Context, r *ParserRuleRecord) error
 
 	// UpdatePathPattern 은 정밀화 워크플로 에서 호출 — path_pattern + description 갱신.

--- a/internal/storage/parser_rule.go
+++ b/internal/storage/parser_rule.go
@@ -156,6 +156,17 @@ type ParserRuleRecord struct {
 	// (별도 후속 이슈) 의 1차 입력.
 	PageType string
 
+	// Article 은 룰이 적용되는 페이지가 뉴스 기사 본문인지 표시합니다 (이슈 #421).
+	//
+	//   - true  : 순수 뉴스 기사 본문 페이지 — title + main_content + published_at 추출 대상.
+	//             validate / classifier 가 strict 검증 / 분류 적용.
+	//   - false : 뉴스 인덱스 / 이미지 / 멀티미디어 / 기타 비-article 페이지. 다운스트림이
+	//             해당 룰에 대해 검증 완화 또는 처리 분기.
+	//
+	// 기본값 false — operator 명시적 opt-in. PageType 과 직교 (예: PageType=news + article=true
+	// 가 \"기사 본문\", PageType=news + article=false 가 \"뉴스 인덱스\").
+	Article bool
+
 	CreatedAt time.Time
 	UpdatedAt time.Time
 }

--- a/internal/storage/postgres/parser_rule.go
+++ b/internal/storage/postgres/parser_rule.go
@@ -82,7 +82,7 @@ func (r *pgParserRuleRepository) Insert(ctx context.Context, rec *storage.Parser
 
 const sqlUpdateParserRule = `
 UPDATE parser_rules
-SET selectors = $2, confidence = $3, enabled = $4, description = $5
+SET selectors = $2, confidence = $3, enabled = $4, description = $5, article = $6
 WHERE id = $1
 RETURNING updated_at
 `
@@ -93,6 +93,8 @@ RETURNING updated_at
 // confidence 도 함께 갱신 — selectors 만 바뀌고 confidence 가 stale
 // 로 남으면 하류 validator 가 잘못된 신뢰도로 판단. 호출자는 selectors 변경 시 confidence 도
 // 같이 채워서 전달 (또는 nil/빈 map 으로 reset).
+//
+// 갱신 가능 필드: Selectors, Confidence, Enabled, Description, Article (자연키 + PageType 은 변경 불가).
 func (r *pgParserRuleRepository) Update(ctx context.Context, rec *storage.ParserRuleRecord) error {
 	selectors, err := json.Marshal(rec.Selectors)
 	if err != nil {
@@ -102,7 +104,7 @@ func (r *pgParserRuleRepository) Update(ctx context.Context, rec *storage.Parser
 	if err != nil {
 		return fmt.Errorf("marshal confidence: %w", err)
 	}
-	row := r.pool.QueryRow(ctx, sqlUpdateParserRule, rec.ID, selectors, confidence, rec.Enabled, rec.Description)
+	row := r.pool.QueryRow(ctx, sqlUpdateParserRule, rec.ID, selectors, confidence, rec.Enabled, rec.Description, rec.Article)
 	if err := row.Scan(&rec.UpdatedAt); err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			return storage.ErrNotFound
@@ -341,6 +343,11 @@ WHERE 1=1`
 	}
 	if f.OnlyEnabled {
 		query += " AND enabled = TRUE"
+	}
+	if f.Article != nil {
+		query += fmt.Sprintf(" AND article = $%d", idx)
+		args = append(args, *f.Article)
+		idx++
 	}
 
 	query += fmt.Sprintf(" ORDER BY source_name, host_pattern, target_type, version DESC LIMIT $%d OFFSET $%d", idx, idx+1)

--- a/internal/storage/postgres/parser_rule.go
+++ b/internal/storage/postgres/parser_rule.go
@@ -34,9 +34,9 @@ func NewParserRuleRepository(pool *pgxpool.Pool, log *logger.Logger) storage.Par
 
 const sqlInsertParserRule = `
 INSERT INTO parser_rules (
-  source_name, host_pattern, path_pattern, target_type, version, enabled, selectors, confidence, description, page_type
+  source_name, host_pattern, path_pattern, target_type, version, enabled, selectors, confidence, description, page_type, article
 ) VALUES (
-  $1, $2, $3, $4, $5, $6, $7, $8, $9, $10
+  $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11
 )
 RETURNING id, created_at, updated_at
 `
@@ -68,7 +68,7 @@ func (r *pgParserRuleRepository) Insert(ctx context.Context, rec *storage.Parser
 	}
 	row := r.pool.QueryRow(ctx, sqlInsertParserRule,
 		rec.SourceName, rec.HostPattern, rec.PathPattern, string(rec.TargetType), rec.Version,
-		rec.Enabled, selectors, confidence, rec.Description, rec.PageType,
+		rec.Enabled, selectors, confidence, rec.Description, rec.PageType, rec.Article,
 	)
 	if err := row.Scan(&rec.ID, &rec.CreatedAt, &rec.UpdatedAt); err != nil {
 		var pgErr *pgconn.PgError
@@ -151,7 +151,7 @@ func (r *pgParserRuleRepository) UpdatePathPattern(ctx context.Context, id int64
 }
 
 const sqlGetParserRuleByID = `
-SELECT id, source_name, host_pattern, path_pattern, target_type, version, enabled, selectors, confidence, description, page_type, created_at, updated_at
+SELECT id, source_name, host_pattern, path_pattern, target_type, version, enabled, selectors, confidence, description, page_type, article, created_at, updated_at
 FROM parser_rules
 WHERE id = $1
 `
@@ -170,7 +170,7 @@ func (r *pgParserRuleRepository) GetByID(ctx context.Context, id int64) (*storag
 }
 
 const sqlFindParserRuleByNaturalKey = `
-SELECT id, source_name, host_pattern, path_pattern, target_type, version, enabled, selectors, confidence, description, page_type, created_at, updated_at
+SELECT id, source_name, host_pattern, path_pattern, target_type, version, enabled, selectors, confidence, description, page_type, article, created_at, updated_at
 FROM parser_rules
 WHERE source_name  = $1
   AND host_pattern = $2
@@ -261,7 +261,7 @@ func (r *pgParserRuleRepository) HasAnyRule(ctx context.Context, hostPattern str
 //   - LENGTH(path_pattern) DESC : 더 구체적인 (긴) regex 패턴 우선 (path_pattern=” 은 길이 0 으로 마지막)
 //   - version DESC             : 같은 패턴 안에서 최신 버전 우선
 const sqlFindActiveCandidates = `
-SELECT id, source_name, host_pattern, path_pattern, target_type, version, enabled, selectors, confidence, description, page_type, created_at, updated_at
+SELECT id, source_name, host_pattern, path_pattern, target_type, version, enabled, selectors, confidence, description, page_type, article, created_at, updated_at
 FROM parser_rules
 WHERE host_pattern = $1
   AND target_type  = $2
@@ -318,7 +318,7 @@ func (r *pgParserRuleRepository) List(ctx context.Context, f storage.ParserRuleF
 	}
 
 	query := `
-SELECT id, source_name, host_pattern, path_pattern, target_type, version, enabled, selectors, confidence, description, page_type, created_at, updated_at
+SELECT id, source_name, host_pattern, path_pattern, target_type, version, enabled, selectors, confidence, description, page_type, article, created_at, updated_at
 FROM parser_rules
 WHERE 1=1`
 	args := make([]any, 0, 4)
@@ -384,7 +384,7 @@ func scanParserRule(s scanner) (*storage.ParserRuleRecord, error) {
 	var targetType string
 	if err := s.Scan(
 		&rec.ID, &rec.SourceName, &rec.HostPattern, &rec.PathPattern, &targetType, &rec.Version,
-		&rec.Enabled, &selectorsRaw, &confidenceRaw, &rec.Description, &rec.PageType,
+		&rec.Enabled, &selectorsRaw, &confidenceRaw, &rec.Description, &rec.PageType, &rec.Article,
 		&rec.CreatedAt, &rec.UpdatedAt,
 	); err != nil {
 		return nil, err

--- a/migrations/down/027_parser_rules_article_flag.sql
+++ b/migrations/down/027_parser_rules_article_flag.sql
@@ -1,0 +1,7 @@
+-- 027_parser_rules_article_flag DOWN — article 컬럼 삭제 (이슈 #421).
+--
+-- 운영 영향: 컬럼 drop 은 ACCESS EXCLUSIVE lock + 데이터 영구 손실.
+-- 롤백 시점에 article=TRUE 인 룰의 정보는 복원 불가.
+
+ALTER TABLE parser_rules
+  DROP COLUMN IF EXISTS article;

--- a/migrations/up/027_parser_rules_article_flag.sql
+++ b/migrations/up/027_parser_rules_article_flag.sql
@@ -1,0 +1,20 @@
+-- 027_parser_rules_article_flag: parser_rules 에 article BOOLEAN 컬럼 추가 (이슈 #421)
+--
+-- 배경:
+--   target_type=page + page_type=news 만으로는 룰이 적용되는 페이지가 실제 뉴스 기사
+--   본문 페이지인지 (article body 포함), 아니면 뉴스 인덱스 / 이미지 / 멀티미디어 페이지인지
+--   구분 불가. 다운스트림 (validate / classifier / 통계) 가 정확한 분기를 못 함.
+--
+-- 스키마:
+--   - article: BOOLEAN NOT NULL DEFAULT FALSE
+--   - FALSE = 뉴스 인덱스 / 이미지 / 멀티미디어 / 기타 비-article 페이지
+--   - TRUE  = 순수 뉴스 기사 본문 페이지 (title + main_content + published_at 등 추출 대상)
+--
+-- 보수적 default (FALSE) — 기존 룰 호환 + operator 명시적 opt-in. 다운스트림 활성화는
+-- 별도 후속 issue (validate strict 검증 article=false 룰에 완화 / classifier 통합 등).
+
+ALTER TABLE parser_rules
+  ADD COLUMN IF NOT EXISTS article BOOLEAN NOT NULL DEFAULT FALSE;
+
+COMMENT ON COLUMN parser_rules.article IS
+  '룰이 적용되는 페이지가 뉴스 기사 본문인지 (news 인덱스 / 이미지 / 멀티미디어 제외). true 면 article body 추출 대상 — validate 의 PublishedAt 등 strict 검증 적용. false 면 비-article 페이지 — 향후 downstream 처리 분기에 사용. 이슈 #421.';


### PR DESCRIPTION
## 연관 이슈

Closes #421

## 배경

`target_type=page + page_type=news` 만으로는 룰이 적용되는 페이지가 실제 뉴스 기사 본문 페이지인지 (article body 포함), 아니면 뉴스 인덱스 / 이미지 / 멀티미디어 페이지인지 구분 불가. 다운스트림 (validate / classifier / 통계) 가 정확한 분기를 못 함.

## 구현 내용

### 스키마 (migration 027)

`parser_rules` 에 `article BOOLEAN NOT NULL DEFAULT FALSE` 컬럼 추가:

- `false` : 뉴스 인덱스 / 이미지 / 멀티미디어 / 기타 비-article 페이지 (기본값)
- `true`  : 순수 뉴스 기사 본문 페이지 — title + main_content + published_at 등 추출 대상

보수적 default (FALSE) — 기존 룰 호환 + operator 명시적 opt-in.

### Go 레이어

- `internal/storage/parser_rule.go` — `ParserRuleRecord.Article bool` 필드 추가 (godoc 포함)
- `internal/storage/postgres/parser_rule.go` — INSERT (\$11 binding) + 4 SELECT + scanParserRule 갱신

### Down migration

`ALTER TABLE parser_rules DROP COLUMN IF EXISTS article` — ACCESS EXCLUSIVE lock + 데이터 영구 손실 주의 주석 포함.

## CI / 머지 게이트 점검

- [x] gofmt 통과
- [x] `go build ./internal/... ./cmd/... ./test/...`
- [x] `go test -race -count=1 -timeout=180s ./test/...` 모두 PASS
- [x] golangci-lint 통과 (로컬)

## 변경 영향 범위 + 위험도

- **DB 스키마**: ALTER TABLE ADD COLUMN — PostgreSQL 11+ 에서 `NOT NULL DEFAULT FALSE` 추가는 metadata only (rewrite 없음). 운영 영향 최소.
- **다운스트림**: 본 PR 은 컬럼 추가만. 실제 활용 (validate strict 검증 완화 / classifier 통합) 은 별도 후속 이슈로 분리.
- **기존 룰**: DEFAULT FALSE 로 모든 기존 행이 자동으로 `article=false` — 명시적 opt-in 필요.

## 롤백 계획

```bash
go run ./cmd/migrate-down -steps=1  # 027 down 실행
```

down migration 은 컬럼 drop — `article=true` 인 룰의 정보는 복원 불가 (운영 적용 전 확인 권장).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for designating parser rules for news article body pages, enabling distinct content extraction and validation behaviors compared to non-article page types (index, image, multimedia).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/EinSofINTEREST/IssueTracker/pull/422)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->