### PR TITLE
[FEAT#423] parser_rules.article 다운스트림 wiring — Content.Article 전파 + PublishedAt nullable + claudegen prompt

### DIFF
--- a/internal/processor/fetcher/core/models.go
+++ b/internal/processor/fetcher/core/models.go
@@ -154,7 +154,9 @@ type Content struct {
 	Summary string `json:"summary"`
 
 	// Metadata
-	Author      string     `json:"author"`
+	Author string `json:"author"`
+	// PublishedAt: 컨텐츠 발행 시각. zero-value (time.Time{}) 는 "미상" — DB 저장 시 NULL 로 매핑됩니다.
+	// parser_rules.article=TRUE 룰로 파싱된 page 만 news validator 가 PublishedAt 필수 강제 (이슈 #423).
 	PublishedAt time.Time  `json:"published_at"`
 	UpdatedAt   *time.Time `json:"updated_at,omitempty"`
 	Category    string     `json:"category"`
@@ -169,6 +171,16 @@ type Content struct {
 	ContentHash string  `json:"content_hash"`
 	WordCount   int     `json:"word_count"`  // content_bodies 테이블
 	Reliability float32 `json:"reliability"` // 신뢰도 0.0~1.0 (0.0: 미검증)
+
+	// Article: 적용된 parser_rule 의 article 플래그를 컨텐츠로 전파 (이슈 #423).
+	//
+	//   - true  : 순수 뉴스 기사 본문 페이지 — news validator 가 PublishedAt 필수 강제.
+	//             누락 시 VAL_001 → 기존 reparse 로직 (#364) 트리거.
+	//   - false : 뉴스 인덱스 / 이미지 / 멀티미디어 / 비-article 페이지 — PublishedAt 누락 허용.
+	//
+	// JSON 직렬화 / DB 저장 (content_meta 또는 별도 컬럼) 은 별도 후속 — 본 시점에서는 in-flight
+	// pipeline 컨텍스트 (parser → validate) 전파 용도. 영속화는 추후 필요 시 추가.
+	Article bool `json:"article,omitempty"`
 
 	// Extension (content_meta 테이블)
 	Extra map[string]interface{} `json:"extra,omitempty"` // 유형별 메타데이터 (JSONB)

--- a/internal/processor/fetcher/domain/general/convert.go
+++ b/internal/processor/fetcher/domain/general/convert.go
@@ -39,6 +39,7 @@ func ConvertPage(page *types.Page, raw *core.RawContent) *core.Content {
 		ImageURLs:    page.Images,
 		WordCount:    len(strings.Fields(page.MainContent)),
 		ContentHash:  ContentHash(page.MainContent),
+		Article:      page.Article,
 		CreatedAt:    time.Now(),
 	}
 }

--- a/internal/processor/parser/rule/claudegen/worker.go
+++ b/internal/processor/parser/rule/claudegen/worker.go
@@ -435,6 +435,8 @@ type enrichedOutput struct {
 	BlacklistReason    string              `json:"blacklist_reason"`
 	PageType           string              `json:"page_type"`
 	PageTypeConfidence float64             `json:"page_type_confidence"`
+	Article            bool                `json:"article"`
+	ArticleConfidence  float64             `json:"article_confidence"`
 	Selectors          storage.SelectorMap `json:"selectors"`
 	// SelfCheck 는 운영 진단용 — 본 worker 는 currently 무시 (호출자가 metrics / 로그에 활용 가능).
 	// 향후 self_check.warnings 가 있으면 LLM 재시도 trigger 로 사용 가능.
@@ -471,6 +473,8 @@ func parseEnrichedOutput(output string) (*llmgen.ExtractResult, error) {
 			Selectors:          eo.Selectors,
 			PageType:           normalizePageType(eo.PageType),
 			PageTypeConfidence: eo.PageTypeConfidence,
+			Article:            eo.Article,
+			ArticleConfidence:  eo.ArticleConfidence,
 		}, nil
 	case "":
 		// Schema 가 채워지지 않았거나 LLM 이 여전히 legacy SelectorMap-only 를 반환한 경우.

--- a/internal/processor/parser/rule/llmgen/extractor.go
+++ b/internal/processor/parser/rule/llmgen/extractor.go
@@ -50,6 +50,16 @@ type ExtractResult struct {
 	// 사후 검토 trigger 로 사용 가능.
 	PageTypeConfidence float64
 
+	// Article: 페이지가 단일 뉴스 기사 본문 (article body) 인지 — LLM 자체 분류 (이슈 #423).
+	// PageType 과 직교 (예: PageType=news + Article=true 가 "기사 본문", PageType=news + Article=false
+	// 가 "뉴스 인덱스"). 다운스트림 validator (news 도메인) 가 Article=true 에만 PublishedAt 필수 강제.
+	// Blacklist != nil 이면 의미 없음 (zero-value false).
+	Article bool
+
+	// ArticleConfidence: 0.0 ~ 1.0 — Article 분류에 대한 LLM 자기 보고 신뢰도.
+	// 운영자 사후 검토 trigger / weight 입력으로 사용 가능.
+	ArticleConfidence float64
+
 	// Blacklist: 페이지가 파싱 부적합 (광고 / interstitial / 빈 페이지 등) 일 때 비-nil.
 	// nil 이면 정상 추출 결과로 분기.
 	Blacklist *BlacklistDecision

--- a/internal/processor/parser/rule/llmgen/generator.go
+++ b/internal/processor/parser/rule/llmgen/generator.go
@@ -551,6 +551,7 @@ func (g *Generator) runOnce(ctx context.Context, host string, targetType storage
 		selectors storage.SelectorMap
 		modelName string
 		pageType  string // EnrichedExtractor 모드에서 채워짐. legacy 경로는 "" (미분류).
+		article   bool   // EnrichedExtractor 가 분류한 article body 여부 (이슈 #423). 기본 false.
 	)
 
 	if g.extractor != nil {
@@ -569,6 +570,11 @@ func (g *Generator) runOnce(ctx context.Context, host string, targetType storage
 			}
 			selectors = res.Selectors
 			pageType = string(res.PageType)
+			// list (target_type=list) 룰은 정의상 article body 가 아님 — 안전성을 위해 article=false 강제.
+			// page 룰만 LLM 의 article 분류를 반영 (#423).
+			if targetType == storage.TargetTypePage {
+				article = res.Article
+			}
 			if mn, ok := g.extractor.(modelNamer); ok {
 				modelName = mn.ModelName()
 			} else {
@@ -649,6 +655,7 @@ func (g *Generator) runOnce(ctx context.Context, host string, targetType storage
 		Confidence:  confidence,
 		Description: fmt.Sprintf("%s (sample url: %s, model: %s)", llmAutoDescription, sampleURL, modelName),
 		PageType:    pageType, // EnrichedExtractor 모드에서만 채워짐 — legacy 경로는 "" (미분류, #326).
+		Article:     article,  // EnrichedExtractor 의 article 분류 — page rule 만 반영, list 는 항상 false (#423).
 	}
 	var insertErr error
 	if stale {

--- a/internal/processor/parser/rule/parser.go
+++ b/internal/processor/parser/rule/parser.go
@@ -112,6 +112,7 @@ func (p *Parser) ParsePage(ctx context.Context, raw *core.RawContent) (*types.Pa
 		Tags:        extractFieldMulti(doc, rule.Selectors.Tags),
 		Images:      extractFieldMulti(doc, rule.Selectors.Images),
 		PublishedAt: p.extractDate(doc, rule.Selectors.PublishedAt),
+		Article:     rule.Article,
 	}
 
 	// Title 도 MainContent 와 동등한 필수 — selector 는 있지만 추출 결과 빈 경우도 stale 진단.

--- a/internal/processor/parser/types/types.go
+++ b/internal/processor/parser/types/types.go
@@ -46,6 +46,10 @@ type Page struct {
 	Tags        []string
 	Images      []string          // optional — page 내 핵심 이미지 URL
 	Metadata    map[string]string // 확장 — canonical_url / og:* / twitter:* 등 임의 메타
+
+	// Article 은 적용된 parser_rule 의 article 플래그 (이슈 #423). 다운스트림 validator 가
+	// PublishedAt 강제 여부를 결정. 기본 false — 룰이 명시적으로 article=true 인 경우만 true.
+	Article bool
 }
 
 // LinkItem 은 목록/링크-허브 페이지에서 추출한 단일 링크입니다.

--- a/internal/processor/validate/domain/news/validator.go
+++ b/internal/processor/validate/domain/news/validator.go
@@ -105,12 +105,22 @@ func (v *Validator) validateBody(c *core.Content) []types.ValidationError {
 	return nil
 }
 
+// validatePublishedAt 은 article=true 룰로 파싱된 뉴스 기사 본문 페이지에만 PublishedAt 을
+// 필수로 강제합니다 (이슈 #423).
+//
+//   - c.Article=true  : 순수 뉴스 기사 본문 — PublishedAt 누락 시 VAL_001 reject →
+//     기존 selector 재학습 reparse 로직 (이슈 #364) 트리거.
+//   - c.Article=false : 뉴스 인덱스 / 이미지 / 멀티미디어 / 비-article 페이지 —
+//     PublishedAt 누락 허용 (parser_rules.article=FALSE 운영자 opt-out 의미).
 func (v *Validator) validatePublishedAt(c *core.Content) []types.ValidationError {
+	if !c.Article {
+		return nil
+	}
 	if c.PublishedAt.IsZero() {
 		return []types.ValidationError{{
 			Field:   "PublishedAt",
 			Rule:    "required",
-			Message: "published_at is required for news content",
+			Message: "published_at is required for news article content (article=true rule)",
 		}}
 	}
 	return nil

--- a/internal/storage/postgres/content.go
+++ b/internal/storage/postgres/content.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
@@ -14,6 +15,18 @@ import (
 	"issuetracker/internal/storage"
 	"issuetracker/pkg/logger"
 )
+
+// nullablePublishedAt 은 zero time 을 SQL NULL 로 매핑합니다 (이슈 #423).
+//
+// contents.published_at 가 nullable 화 (migration 028) 된 이후, parser_rules.article=FALSE
+// 룰로 파싱된 컨텐츠는 PublishedAt 이 zero-value 일 수 있음. pgx 는 time.Time zero 를
+// '0001-01-01 00:00:00+00' 로 INSERT 하므로, 명시적 nil 변환이 필요합니다.
+func nullablePublishedAt(t time.Time) any {
+	if t.IsZero() {
+		return nil
+	}
+	return t
+}
 
 // pgContentRepository는 pgx/v5 기반 ContentRepository 구현체입니다.
 // 3개 테이블(contents, content_bodies, content_meta)을 투명하게 관리합니다.
@@ -293,7 +306,7 @@ func saveContentTx(ctx context.Context, tx pgx.Tx, c *core.Content) error {
 
 	_, err := tx.Exec(ctx, upsertContentCTE,
 		c.ID, c.SourceID, string(c.SourceType), c.Country, c.Language,
-		c.Title, c.Author, c.PublishedAt, c.UpdatedAt, c.Category, tags,
+		c.Title, c.Author, nullablePublishedAt(c.PublishedAt), c.UpdatedAt, c.Category, tags,
 		c.URL, c.CanonicalURL, c.ContentHash, c.Reliability, c.CreatedAt,
 		c.Body, c.Summary, c.WordCount,
 		imageURLs, mustMarshalJSON(buildContentMetaExtra(c)),
@@ -330,7 +343,7 @@ func queueContentBatch(batch *pgx.Batch, c *core.Content) {
 	}
 	batch.Queue(upsertContentCTE,
 		c.ID, c.SourceID, string(c.SourceType), c.Country, c.Language,
-		c.Title, c.Author, c.PublishedAt, c.UpdatedAt, c.Category, tags,
+		c.Title, c.Author, nullablePublishedAt(c.PublishedAt), c.UpdatedAt, c.Category, tags,
 		c.URL, c.CanonicalURL, c.ContentHash, c.Reliability, c.CreatedAt,
 		c.Body, c.Summary, c.WordCount,
 		imageURLs, mustMarshalJSON(buildContentMetaExtra(c)),
@@ -339,15 +352,17 @@ func queueContentBatch(batch *pgx.Batch, c *core.Content) {
 
 // scanContent는 pgx Row를 core.Content로 스캔합니다 (3테이블 JOIN 결과).
 // extra는 JSONB → []byte → map[string]interface{} 로 변환합니다.
+// published_at NULL (migration 028, 이슈 #423) 은 PublishedAt zero-value 로 복원됩니다.
 func scanContent(row pgx.Row) (*core.Content, error) {
 	var c core.Content
 	var sourceType string
+	var publishedAt *time.Time
 	var extraJSON []byte
 
 	err := row.Scan(
 		&c.ID, &c.SourceID, &sourceType, &c.Country, &c.Language,
 		&c.Title, &c.Body, &c.Summary,
-		&c.Author, &c.PublishedAt, &c.UpdatedAt, &c.Category, &c.Tags,
+		&c.Author, &publishedAt, &c.UpdatedAt, &c.Category, &c.Tags,
 		&c.URL, &c.CanonicalURL, &c.ImageURLs,
 		&c.ContentHash, &c.WordCount, &c.Reliability, &c.CreatedAt,
 		&extraJSON,
@@ -357,6 +372,9 @@ func scanContent(row pgx.Row) (*core.Content, error) {
 	}
 
 	c.SourceType = core.SourceType(sourceType)
+	if publishedAt != nil {
+		c.PublishedAt = *publishedAt
+	}
 	if extraJSON != nil {
 		if err := json.Unmarshal(extraJSON, &c.Extra); err != nil {
 			c.Extra = make(map[string]interface{})
@@ -381,14 +399,16 @@ const listSelectQuery = `
 
 // scanContentList는 List 쿼리 결과를 core.Content로 스캔합니다.
 // body, image_urls, extra는 빈 값으로 반환됩니다.
+// published_at NULL (migration 028, 이슈 #423) 은 PublishedAt zero-value 로 복원됩니다.
 func scanContentList(row pgx.Row) (*core.Content, error) {
 	var c core.Content
 	var sourceType string
+	var publishedAt *time.Time
 
 	err := row.Scan(
 		&c.ID, &c.SourceID, &sourceType, &c.Country, &c.Language,
 		&c.Title, &c.Summary,
-		&c.Author, &c.PublishedAt, &c.UpdatedAt, &c.Category, &c.Tags,
+		&c.Author, &publishedAt, &c.UpdatedAt, &c.Category, &c.Tags,
 		&c.URL, &c.CanonicalURL,
 		&c.ContentHash, &c.WordCount, &c.Reliability, &c.CreatedAt,
 	)
@@ -397,6 +417,9 @@ func scanContentList(row pgx.Row) (*core.Content, error) {
 	}
 
 	c.SourceType = core.SourceType(sourceType)
+	if publishedAt != nil {
+		c.PublishedAt = *publishedAt
+	}
 	// 목록 조회이므로 body, image_urls, extra는 기본값 유지
 	return &c, nil
 }
@@ -416,7 +439,7 @@ func buildContentListQuery(filter storage.ContentFilter) (string, []any) {
 	}
 
 	query := listSelectQuery + where +
-		fmt.Sprintf(" ORDER BY c.published_at DESC LIMIT %d OFFSET %d", limit, offset)
+		fmt.Sprintf(" ORDER BY c.published_at DESC NULLS LAST LIMIT %d OFFSET %d", limit, offset)
 
 	return query, args
 }

--- a/migrations/down/028_contents_published_at_nullable.sql
+++ b/migrations/down/028_contents_published_at_nullable.sql
@@ -1,0 +1,9 @@
+-- 028_contents_published_at_nullable DOWN — published_at NOT NULL 복원 (이슈 #423).
+--
+-- 운영 영향:
+--   현재 published_at IS NULL 인 row 가 존재하면 본 migration 은 실패.
+--   롤백 전에 NULL row 정리 필요 (예: DELETE FROM contents WHERE published_at IS NULL).
+--   복원은 ACCESS EXCLUSIVE lock + 즉시 해제 — rewrite 없음.
+
+ALTER TABLE contents
+  ALTER COLUMN published_at SET NOT NULL;

--- a/migrations/up/028_contents_published_at_nullable.sql
+++ b/migrations/up/028_contents_published_at_nullable.sql
@@ -1,0 +1,20 @@
+-- 028_contents_published_at_nullable: contents.published_at NOT NULL → NULL 허용 (이슈 #423)
+--
+-- 배경:
+--   기존 스키마는 published_at TIMESTAMPTZ NOT NULL — 모든 컨텐츠가 published_at 있어야 저장 가능.
+--   news 도메인의 비-article 페이지 (인덱스 / 이미지 / 멀티미디어) 는 published_at 부재가 정상인데도
+--   validator 가 reject + reparse trigger → 무한 재학습 → DLQ 도달 + 불필요 cost.
+--
+-- 정책 (이슈 #421, #423):
+--   - parser_rules.article=TRUE 룰로 파싱된 article body 페이지만 PublishedAt 강제 (news validator)
+--   - parser_rules.article=FALSE 룰로 파싱된 페이지는 published_at NULL 허용
+--
+-- 운영 영향:
+--   ALTER COLUMN DROP NOT NULL 은 PostgreSQL 에서 metadata only — rewrite 없음, ACCESS EXCLUSIVE lock
+--   순간만 잡고 즉시 해제. 운영 무중단.
+
+ALTER TABLE contents
+  ALTER COLUMN published_at DROP NOT NULL;
+
+COMMENT ON COLUMN contents.published_at IS
+  '컨텐츠 발행 시각. NULL = published_at 미상 (parser_rules.article=FALSE 룰로 파싱된 뉴스 인덱스 / 이미지 / 비-article 페이지). 이슈 #423.';

--- a/pkg/llm/prompt/assets/claudegen/page.user.txt
+++ b/pkg/llm/prompt/assets/claudegen/page.user.txt
@@ -11,6 +11,8 @@ Output schema:
   "blacklist_reason": "<korean reason if validity=blacklist, else null>",
   "page_type": "news" | "community" | "info" | "commercial" | "paper" | "other",
   "page_type_confidence": <float 0.0 to 1.0>,
+  "article": <boolean>,
+  "article_confidence": <float 0.0 to 1.0>,
   "selectors": {
     "title":        {"css": "<selector for page title>"},
     "main_content": {"css": "<selector for primary article body>", "multi": true},
@@ -46,6 +48,17 @@ Page type classification:
 - "paper"      — academic article / research paper / preprint
 - "other"      — anything not fitting above (catch-all)
 - `page_type_confidence` is your self-assessed certainty (0.0 ~ 1.0). Lower it for ambiguous cases.
+
+Article classification (orthogonal to page_type):
+- `article` = true ONLY when the page is a single news/blog/paper article body with a clear publish date — i.e., title + main_content + published_at all extractable from one editorial unit.
+- `article` = false for everything else, including:
+  * News index / section landing pages (lists of articles, no single body)
+  * Image gallery / video / multimedia hub pages
+  * Community thread lists / board indexes
+  * Tag / archive / search-result pages
+  * Wiki / info / commercial / other pages even if they have rich text
+- `article_confidence` is your self-assessed certainty for the article flag (0.0 ~ 1.0).
+- Downstream validators enforce `published_at` strictly only when `article=true`. Set conservatively — when in doubt, prefer `false`.
 
 Selector rules (when validity="ok"):
 1. Use only selectors that actually appear in the HTML — do not invent.

--- a/test/internal/processor/validate/domain/news/validator_test.go
+++ b/test/internal/processor/validate/domain/news/validator_test.go
@@ -93,6 +93,7 @@ func TestNewsValidator_Validate_BodyTooLong_ReturnsError(t *testing.T) {
 func TestNewsValidator_Validate_MissingPublishedAt_ReturnsError(t *testing.T) {
 	v := news.NewValidator(config.DefaultValidateConfig())
 	content := newNewsContent()
+	content.Article = true // article=true 룰에서만 PublishedAt 필수 강제 (이슈 #423)
 	content.PublishedAt = time.Time{}
 
 	result := v.Validate(context.Background(), content)
@@ -100,6 +101,22 @@ func TestNewsValidator_Validate_MissingPublishedAt_ReturnsError(t *testing.T) {
 	assert.False(t, result.IsValid)
 	assert.Equal(t, "PublishedAt", result.Errors[0].Field)
 	assert.Equal(t, "required", result.Errors[0].Rule)
+}
+
+// TestNewsValidator_Validate_MissingPublishedAt_NonArticle_Passes 는 article=false 룰로
+// 파싱된 비-article 페이지 (뉴스 인덱스 / 이미지) 에서 PublishedAt 누락이 통과되는지 검증합니다
+// (이슈 #423).
+func TestNewsValidator_Validate_MissingPublishedAt_NonArticle_Passes(t *testing.T) {
+	v := news.NewValidator(config.DefaultValidateConfig())
+	content := newNewsContent()
+	content.Article = false // 비-article 페이지
+	content.PublishedAt = time.Time{}
+
+	result := v.Validate(context.Background(), content)
+
+	for _, e := range result.Errors {
+		assert.NotEqual(t, "PublishedAt", e.Field, "비-article 컨텐츠는 PublishedAt 누락 통과 (이슈 #423)")
+	}
 }
 
 func TestNewsValidator_Validate_ExcessiveCaps_ReturnsSpamError(t *testing.T) {
@@ -146,6 +163,7 @@ func TestNewsValidator_Validate_QualityScoreRange(t *testing.T) {
 func TestNewsValidator_Validate_MultipleErrors_AllReported(t *testing.T) {
 	v := news.NewValidator(config.DefaultValidateConfig())
 	content := newNewsContent()
+	content.Article = true // article 룰에서만 PublishedAt 필수 강제 (이슈 #423)
 	content.Title = "Short"
 	content.Body = "Too short."
 	content.PublishedAt = time.Time{}

--- a/test/internal/processor/validate/domain/news/validator_test.go
+++ b/test/internal/processor/validate/domain/news/validator_test.go
@@ -106,6 +106,9 @@ func TestNewsValidator_Validate_MissingPublishedAt_ReturnsError(t *testing.T) {
 // TestNewsValidator_Validate_MissingPublishedAt_NonArticle_Passes 는 article=false 룰로
 // 파싱된 비-article 페이지 (뉴스 인덱스 / 이미지) 에서 PublishedAt 누락이 통과되는지 검증합니다
 // (이슈 #423).
+//
+// newNewsContent() 는 다른 모든 검증을 통과하는 유효 컨텐츠이므로 IsValid 가 true 여야 함 —
+// 단순 PublishedAt 필드 부재 체크보다 IsValid 직접 단언이 견고 (gemini PR #424 피드백).
 func TestNewsValidator_Validate_MissingPublishedAt_NonArticle_Passes(t *testing.T) {
 	v := news.NewValidator(config.DefaultValidateConfig())
 	content := newNewsContent()
@@ -114,9 +117,8 @@ func TestNewsValidator_Validate_MissingPublishedAt_NonArticle_Passes(t *testing.
 
 	result := v.Validate(context.Background(), content)
 
-	for _, e := range result.Errors {
-		assert.NotEqual(t, "PublishedAt", e.Field, "비-article 컨텐츠는 PublishedAt 누락 통과 (이슈 #423)")
-	}
+	assert.True(t, result.IsValid, "비-article 컨텐츠는 PublishedAt 누락 시에도 유효해야 합니다 (이슈 #423)")
+	assert.Empty(t, result.Errors, "비-article 컨텐츠는 PublishedAt 누락 시 에러가 없어야 합니다 (이슈 #423)")
 }
 
 func TestNewsValidator_Validate_ExcessiveCaps_ReturnsSpamError(t *testing.T) {

--- a/test/internal/processor/validate/worker/reparse_test.go
+++ b/test/internal/processor/validate/worker/reparse_test.go
@@ -88,6 +88,7 @@ func makeContentMsgWithReparseHeader(t *testing.T, content *core.Content, repars
 }
 
 // invalidNewsContent 는 PublishedAt 부재로 VAL_001 을 일으키는 news content 입니다.
+// Article=true 로 설정 — news validator 가 article 룰일 때만 PublishedAt 필수 강제 (이슈 #423).
 func invalidNewsContent() *core.Content {
 	return &core.Content{
 		ID:    "ref-001",
@@ -102,6 +103,7 @@ func invalidNewsContent() *core.Content {
 		Country:     "KR",
 		Language:    "ko",
 		PublishedAt: time.Time{}, // zero → VAL_001
+		Article:     true,        // article 룰 컨텍스트 — PublishedAt 필수 강제 트리거 (이슈 #423)
 	}
 }
 


### PR DESCRIPTION
## 연관 이슈

Closes #423

> **선행 PR**: #422 (parser_rules.article 컬럼 추가). 본 PR 은 #422 의 브랜치 위에서 작업됨 — #422 머지 후 자동으로 main diff 가 narrow 해짐.

## 배경

#422 에서 \`parser_rules.article BOOLEAN\` 컬럼을 추가했지만 다운스트림이 그 플래그를 사용하지 않음. 결과: 모든 news 페이지가 \`published_at\` 누락 시 reparse 5회 시도 후 DLQ — 뉴스 인덱스 / 이미지 / 멀티미디어 페이지는 published_at 부재가 정상인데도 불필요 cost + LLM 호출 폭증.

## 구현 내용

### 1. \`contents.published_at\` Nullable (migration 028)

\`\`\`sql
ALTER TABLE contents ALTER COLUMN published_at DROP NOT NULL;
\`\`\`

- PostgreSQL 에서 metadata only — ACCESS EXCLUSIVE lock 즉시 해제, rewrite 없음
- down: \`ALTER COLUMN ... SET NOT NULL\` (롤백 전 NULL row 정리 필요 — 주석 명시)

### 2. Content.Article 전파 경로

\`rule.Article\` → \`types.Page.Article\` (parser) → \`core.Content.Article\` (ConvertPage) → news validator 분기.

### 3. News Validator 조건부 PublishedAt 강제

\`validatePublishedAt\` 가 \`c.Article=true\` 일 때만 VAL_001 reject:
- \`article=true\` (operator opt-in 또는 LLM 분류) → PublishedAt 누락 → VAL_001 → 기존 reparse 로직 (#364) 트리거
- \`article=false\` → PublishedAt 누락 허용 → 정상 통과

### 4. PostgreSQL Content 레포 NULL 매핑

- \`nullablePublishedAt(t)\`: zero-value → SQL NULL, 그 외 → t
- scan 시 \`*time.Time\` 임시 변수로 NULL 흡수 → \`c.PublishedAt\` zero-value 복원
- ORDER BY \`published_at DESC NULLS LAST\` — 안정적 페이지네이션

### 5. claudegen 프롬프트 + extractor

- \`page.user.txt\`: \`article\` boolean + \`article_confidence\` 출력 + 분류 정책 (PageType 과 직교)
- \`list.user.txt\`: 정의상 article body 아니므로 prompt 미변경 — generator 가 list 룰일 때 article=false 강제
- claudegen \`enrichedOutput\` / \`parseEnrichedOutput\` 에 Article 매핑
- \`llmgen.ExtractResult.Article\` + Generator 가 page 룰에 한해 \`ParserRuleRecord.Article\` 로 저장

## CI / 머지 게이트 점검

- [x] gofmt 통과
- [x] \`go build ./...\` 성공
- [x] \`go test -race -count=1 -timeout=180s ./test/...\` 전체 PASS
- [x] \`go vet ./...\` clean

## 변경 영향 범위 + 위험도

- **DB 스키마**: ALTER COLUMN DROP NOT NULL — metadata only, lock 즉시 해제. 무중단.
- **기존 컨텐츠**: Content.Article 기본 false → news 도메인의 published_at 강제가 더 permissive 해짐. **의도된 동작** — article=true 룰만 strict 강제. 운영자 opt-in 정책 일관.
- **LLM cost**: article=false 페이지의 reparse 무한 루프 회피 → cost 감소 + DLQ traffic 감소.

## 롤백 계획

1. 본 PR revert 후 \`go run ./cmd/migrate-down -steps=1\` (028 down)
2. down 전 NULL row 정리 필요 (주석 명시):
   \`\`\`sql
   DELETE FROM contents WHERE published_at IS NULL;  -- 또는 placeholder 값 UPDATE
   \`\`\`

## 후속 작업 (별도 이슈 예정)

- claudegen prompt 의 \`article_confidence\` 를 \`ParserRuleRecord.Confidence\` 에 매핑 (현재는 받기만 함)
- 운영 대시보드에 article=true / false 룰 비율 분류 통계 추가