### PR TITLE
[REFAC#431] storage Phase 2 — BlacklistService + ParserRuleService 신설 + Generator 의존성 역전

### DIFF
--- a/cmd/issuetracker/main.go
+++ b/cmd/issuetracker/main.go
@@ -31,7 +31,6 @@ import (
 	pgstore "issuetracker/internal/storage/postgres"
 	"issuetracker/internal/storage/primitive"
 	redisstore "issuetracker/internal/storage/redis"
-	"issuetracker/internal/storage/repository"
 	"issuetracker/internal/storage/service"
 	"issuetracker/pkg/config"
 	"issuetracker/pkg/links"
@@ -141,16 +140,21 @@ func main() {
 
 	// rule.Parser: parser_rules 테이블 기반 단일 파서 엔진.
 	// 사이트별 NaverParser/CNNParser/... 를 대체 — 모든 사이트가 본 단일 인스턴스를 공유.
-	// 모든 Repository 는 WrapXxxWithTimeout 으로 감싸 query-level timeout 적용 (이슈 #427).
-	// pgxpool.Acquire 가 MaxConns 고갈 상황에서 무한 대기하는 시나리오 차단.
-	parserRuleRepo := decorator.WrapParserRuleWithTimeout(pgstore.NewParserRuleRepository(pool, log), dbCfg.QueryTimeout)
-	ruleResolver, err := rule.NewResolver(parserRuleRepo)
+	//
+	// ParserRuleService (이슈 #431) 가 decorator chain (timeout + invalidating) 을 자동 합성 —
+	// resolver / invalidator wiring 은 service 내부에서 처리.
+	parserRuleRepoRaw := pgstore.NewParserRuleRepository(pool, log)
+	// resolver 는 timeout decorator 만 적용된 repo 로 lookup (cache invalidate 는 service 가 처리).
+	ruleResolver, err := rule.NewResolver(decorator.WrapParserRuleWithTimeout(parserRuleRepoRaw, dbCfg.QueryTimeout))
 	if err != nil {
 		log.WithError(err).Fatal("failed to construct rule resolver")
 	}
-	// parser_rules mutation → cache invalidate 자동 결합 (decorator 패턴).
-	// 호출처가 명시적 Invalidate 를 까먹어도 stale cache 발생 X — single source of truth.
-	parserRuleRepo = decorator.WrapWithInvalidator(parserRuleRepo, ruleResolver)
+	parserRuleSvc := service.NewParserRuleService(
+		parserRuleRepoRaw,
+		log,
+		service.WithParserRuleQueryTimeout(dbCfg.QueryTimeout),
+		service.WithParserRuleInvalidator(ruleResolver),
+	)
 	ruleParser, err := rule.NewParser(ruleResolver)
 	if err != nil {
 		log.WithError(err).Fatal("failed to construct rule parser")
@@ -158,23 +162,31 @@ func main() {
 
 	// page-parse 블랙리스트 — 카테고리 → article job 발행 단계에서 매칭 URL 차단.
 	// Enabled=false 시 Matcher 미주입 → parser_worker 가 모든 링크 그대로 발행 (기능 OFF).
+	//
+	// BlacklistService (이슈 #431) 가 decorator chain (timeout + invalidating cache) 을 내부 합성 +
+	// HandleLLMDecision 비즈니스 로직 캡슐화. Matcher 는 별도 구성 — read-only cache + match.
 	blacklistCfg, err := config.LoadBlacklist()
 	if err != nil {
 		log.WithError(err).Fatal("failed to load blacklist config")
 	}
 	var (
 		blacklistMatcher *rule.BlacklistMatcher
-		blacklistRepo    repository.BlacklistRepository // llmGen.SetBlacklistRepo 에 전달 (#326).
+		blacklistSvc     service.BlacklistService // llmGen.SetBlacklistService 에 전달 (#326, #431).
 	)
 	if blacklistCfg.Enabled {
-		repo := decorator.WrapBlacklistWithTimeout(pgstore.NewBlacklistRepository(pool, log), dbCfg.QueryTimeout)
-		bm, bmErr := rule.NewBlacklistMatcher(repo)
+		blacklistRepoRaw := pgstore.NewBlacklistRepository(pool, log)
+		// Matcher 는 timeout decorator 만 적용된 repo 로 lookup (cache invalidate 는 service 가 처리).
+		bm, bmErr := rule.NewBlacklistMatcher(decorator.WrapBlacklistWithTimeout(blacklistRepoRaw, dbCfg.QueryTimeout))
 		if bmErr != nil {
 			log.WithError(bmErr).Fatal("failed to construct blacklist matcher")
 		}
-		// invalidatingBlacklistRepo decorator: claudegen 자동 INSERT (#326) 시 Matcher cache flush.
-		blacklistRepo = decorator.WrapBlacklistWithInvalidator(repo, bm)
 		blacklistMatcher = bm
+		blacklistSvc = service.NewBlacklistService(
+			blacklistRepoRaw,
+			log,
+			service.WithBlacklistQueryTimeout(dbCfg.QueryTimeout),
+			service.WithBlacklistInvalidator(bm),
+		)
 		log.Info("page-parse blacklist enabled (parser_blacklist DB-backed)")
 	} else {
 		log.Info("page-parse blacklist disabled (BLACKLIST_ENABLED=false)")
@@ -462,7 +474,7 @@ func main() {
 		}).Info("LLM prompt loader enabled (file → embed chain)")
 	}
 
-	llmGen, err := llmgenwiring.Build(llmProvider, parserRuleRepo, ruleResolver, promptLoader, redisClientShared, log)
+	llmGen, err := llmgenwiring.Build(llmProvider, parserRuleSvc, ruleResolver, promptLoader, redisClientShared, log)
 	if err != nil {
 		log.WithError(err).Fatal("failed to build llmgen generator")
 	}
@@ -706,10 +718,10 @@ func main() {
 	}
 
 	// claudegen 의 EnrichedExtractor 분기에서 페이지를 blacklist 로 판정 시 자동 등록할
-	// repository 주입 (#326). blacklistRepo 가 nil (BLACKLIST_ENABLED=false) 이면
+	// service 주입 (이슈 #326, #431). blacklistSvc 가 nil (BLACKLIST_ENABLED=false) 이면
 	// Generator 내부 분기가 셀렉터 INSERT skip 만 보장.
-	if blacklistRepo != nil && llmGen != nil {
-		llmGen.SetBlacklistRepo(blacklistRepo)
+	if blacklistSvc != nil && llmGen != nil {
+		llmGen.SetBlacklistService(blacklistSvc)
 		log.Info("llmgen: 자동 blacklist 등록 활성화 (claudegen multi-step extraction)")
 	}
 
@@ -717,7 +729,7 @@ func main() {
 	// catch-all + llm-auto rule 의 누적 sample URL 로부터 path_pattern 정밀화.
 	// REFINEMENT_ENABLED=false 또는 config 실패 시 nil — 기존 catch-all rule 그대로 동작.
 	// metricsRegistry 는 nil 허용 — Record* 호출이 noop.
-	pathRefiner, err := refinerwiring.Build(llmProvider, promptLoader, parserRuleRepo, sampleRepo, ruleResolver, metricsRegistry, log)
+	pathRefiner, err := refinerwiring.Build(llmProvider, promptLoader, parserRuleSvc, sampleRepo, ruleResolver, metricsRegistry, log)
 	if err != nil {
 		log.WithError(err).Fatal("failed to build refiner")
 	}

--- a/internal/processor/parser/rule/llmgen/generator.go
+++ b/internal/processor/parser/rule/llmgen/generator.go
@@ -26,8 +26,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"net/url"
-	"regexp"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -136,14 +134,14 @@ type Generator struct {
 	// nil 이면 호출 안 함.
 	validateFailureHandler func(context.Context, core.RawContentRef, int, model.TargetType, string)
 
-	locker        primitive.InflightLocker       // 기본: memInflightLocker, Redis 활성 시: RedisInflightLocker
-	pendingQueue  primitive.PendingQueue         // nil 이면 pending URL 보존 비활성
-	requeueFn     RequeueFunc                    // nil 이면 재투입 비활성
-	semValidator  SelectorValidator              // nil 이면 의미 검증 건너뜀
-	blacklistRepo repository.BlacklistRepository // nil 이면 자동 blacklist 등록 skip (#326)
-	breaker       *HostBreaker                   // nil 이면 breaker 비활성 (이슈 #215)
-	wg            sync.WaitGroup
-	stopped       atomic.Bool
+	locker       primitive.InflightLocker // 기본: memInflightLocker, Redis 활성 시: RedisInflightLocker
+	pendingQueue primitive.PendingQueue   // nil 이면 pending URL 보존 비활성
+	requeueFn    RequeueFunc              // nil 이면 재투입 비활성
+	semValidator SelectorValidator        // nil 이면 의미 검증 건너뜀
+	blacklistSvc BlacklistAutoRegister    // nil 이면 자동 blacklist 등록 skip (#326). 이슈 #431 — repository 직접 의존 제거, service interface 로 추상화.
+	breaker      *HostBreaker             // nil 이면 breaker 비활성 (이슈 #215)
+	wg           sync.WaitGroup
+	stopped      atomic.Bool
 }
 
 // SetValidateFailureHandler 는 selector 검증 실패 시 호출할 콜백을 등록합니다.
@@ -185,13 +183,21 @@ func (g *Generator) SetExtractor(e SelectorExtractor) {
 	g.extractor = e
 }
 
-// SetBlacklistRepo 는 EnrichedExtractor 가 페이지를 blacklist 로 판정했을 때 등록할
-// repository 를 등록합니다 (#326). nil 이면 blacklist 자동 등록 skip — Generator 는 셀렉터
-// INSERT 만 skip 하고 다음 흐름 진행 (LLM retry 가능).
+// BlacklistAutoRegister 는 LLM blacklist 판정 결과를 자동 등록하는 최소 인터페이스입니다 (이슈 #431).
+//
+// storage/service.BlacklistService 가 본 인터페이스를 만족 — Generator 는 service 패키지를
+// 직접 import 하지 않고 인터페이스만 의존 (의존성 역전).
+type BlacklistAutoRegister interface {
+	HandleLLMDecision(ctx context.Context, host, sampleURL string, targetType model.TargetType, reason string) (inserted bool, err error)
+}
+
+// SetBlacklistService 는 EnrichedExtractor 가 페이지를 blacklist 로 판정했을 때 등록할
+// service 를 등록합니다 (이슈 #431, 기존 SetBlacklistRepo 대체). nil 이면 blacklist 자동 등록 skip —
+// Generator 는 셀렉터 INSERT 만 skip 하고 다음 흐름 진행 (LLM retry 가능).
 //
 // Stop 전에 설정해야 하며, goroutine-safe 하지 않으므로 초기화 시 1회만 호출합니다.
-func (g *Generator) SetBlacklistRepo(r repository.BlacklistRepository) {
-	g.blacklistRepo = r
+func (g *Generator) SetBlacklistService(svc BlacklistAutoRegister) {
+	g.blacklistSvc = svc
 }
 
 // SetBreaker 는 host 단위 LLM rate_limit circuit breaker 를 등록합니다 (이슈 #215).
@@ -764,71 +770,20 @@ func selectorMatches(doc *goquery.Document, fs *model.FieldSelector) bool {
 
 // handleBlacklistDecision 은 EnrichedExtractor 가 페이지를 blacklist 로 판정했을 때 호출됩니다.
 //
-// blacklistRepo 가 비-nil 이면 sampleURL 의 path 를 정확 일치 regex (escape + ^/$ anchor) 로
-// parser_blacklist 에 INSERT — 동일 URL 만 차단, 같은 host 의 다른 path 는 영향 없음.
-// 운영자가 후속으로 host-level catch-all 등 정책 widening 가능.
-//
-// 모든 실패 (blacklistRepo nil / Insert 에러 / ErrDuplicate) 는 non-fatal — 호출자는
-// 셀렉터 INSERT skip 만 보장하고 다음 흐름 진행. ErrDuplicate 는 같은 URL 이 이미 등록됨 — 정상.
+// blacklistSvc (BlacklistService) 가 비-nil 이면 service 에 위임 — path_pattern 변환 / INSERT /
+// ErrDuplicate 흡수 / 로그 모두 service 책임. 본 메서드는 nil 분기 + 위임만 (이슈 #431).
 func (g *Generator) handleBlacklistDecision(ctx context.Context, host, sampleURL string, targetType model.TargetType, decision *BlacklistDecision) {
-	logFields := map[string]interface{}{
-		"host":             host,
-		"sample_url":       sampleURL,
-		"target_type":      string(targetType),
-		"blacklist_reason": decision.Reason,
-	}
-
-	if g.blacklistRepo == nil {
-		g.log.WithFields(logFields).Info("page judged as blacklist by LLM but blacklistRepo not wired — selector insert skipped only")
+	if g.blacklistSvc == nil {
+		g.log.WithFields(map[string]interface{}{
+			"host":             host,
+			"sample_url":       sampleURL,
+			"target_type":      string(targetType),
+			"blacklist_reason": decision.Reason,
+		}).Info("page judged as blacklist by LLM but blacklistSvc not wired — selector insert skipped only")
 		return
 	}
-
-	pathPattern := pathPatternFromURL(sampleURL)
-	if pathPattern == "" {
-		// URL parse 실패 — host-wide catch-all 회피 (CodeRabbit Major 반영).
-		// 빈 path_pattern 은 host 전체 차단 효과인데, 단일 malformed URL 만 보고 host 전체를
-		// 차단하는 건 over-reach. 운영자 manual 등록 경로로 위임.
-		g.log.WithFields(logFields).Warn("blacklist insert skipped — sample URL parse failed (host-wide catch-all 회피)")
-		return
-	}
-	rec := &model.BlacklistRecord{
-		HostPattern: host,
-		PathPattern: pathPattern,
-		Reason:      decision.Reason,
-		Source:      model.BlacklistSourceAuto,
-		Mode:        model.BlacklistModeDrop,
-		Enabled:     true,
-	}
-	if err := g.blacklistRepo.Insert(ctx, rec); err != nil {
-		if errors.Is(err, storage.ErrDuplicate) {
-			g.log.WithFields(logFields).Info("page already in blacklist — selector insert skipped")
-			return
-		}
-		// Insert 실패는 non-fatal — 셀렉터 INSERT 는 어쨌든 skip.
-		g.log.WithFields(logFields).WithError(err).Warn("blacklist insert failed (non-fatal — selector insert still skipped)")
-		return
-	}
-	logFields["blacklist_id"] = rec.ID
-	g.log.WithFields(logFields).Info("page auto-blacklisted by LLM, selector insert skipped")
+	// service 가 INSERT / ErrDuplicate / 로그 모두 처리 — Generator 는 결과 무시 (모든 실패 non-fatal).
+	_, _ = g.blacklistSvc.HandleLLMDecision(ctx, host, sampleURL, targetType, decision.Reason)
 }
 
-// pathPatternFromURL 은 sampleURL 의 path 부분을 RE2 regex 로 escape 한 anchor pattern 을
-// 반환합니다. parser_blacklist 의 path_pattern 컬럼에 사용 — 정확히 동일한 URL 만 매칭.
-//
-// 정책 (CodeRabbit Major 반영):
-//   - URL parse 실패 → "" 반환 (호출자가 insert skip)
-//   - 정상 parse + 빈 path (예: https://example.com) → "/" 로 normalize → "^/$" pattern
-//     (이전: "" 반환으로 host-wide catch-all 이 되어 단일 root URL blacklist 가 host 전체
-//     차단 — 의도되지 않은 over-reach)
-//   - 정상 parse + non-empty path → "^<escaped>$"
-func pathPatternFromURL(sampleURL string) string {
-	u, err := url.Parse(sampleURL)
-	if err != nil {
-		return ""
-	}
-	path := u.Path
-	if path == "" {
-		path = "/"
-	}
-	return "^" + regexp.QuoteMeta(path) + "$"
-}
+// pathPatternFromURL 은 service/blacklist.go 로 이전 (이슈 #431).

--- a/internal/storage/service/blacklist.go
+++ b/internal/storage/service/blacklist.go
@@ -1,0 +1,167 @@
+// service 패키지의 blacklist.go 는 parser_blacklist 도메인의 비즈니스 로직을 캡슐화합니다 (이슈 #431).
+//
+// 책임:
+//   - LLM blacklist 결정 처리 (handleBlacklistDecision 흡수 — 이슈 #326)
+//     · sample URL → path_pattern regex 변환
+//     · ErrDuplicate graceful 흡수
+//     · over-reach (host-wide catch-all) 회피
+//   - Decorator chain 합성 (timeout + invalidating cache) — wiring 측 boilerplate 제거
+//   - 일반 CRUD 위임 (Insert / Update / Delete / GetByID / FindEnabledByHost / List)
+package service
+
+import (
+	"context"
+	"errors"
+	"net/url"
+	"regexp"
+	"time"
+
+	"issuetracker/internal/storage"
+	"issuetracker/internal/storage/decorator"
+	"issuetracker/internal/storage/model"
+	"issuetracker/internal/storage/repository"
+	"issuetracker/pkg/logger"
+)
+
+// BlacklistService 는 parser_blacklist 도메인의 비즈니스 boundary 입니다.
+type BlacklistService interface {
+	// HandleLLMDecision 은 LLM blacklist 판정 결과를 parser_blacklist 에 자동 등록합니다 (이슈 #326).
+	//
+	//   - sample URL 의 path 를 escape + ^/$ anchor 한 정확 일치 regex 로 path_pattern 생성
+	//   - URL parse 실패 → insert skip (host-wide catch-all over-reach 회피)
+	//   - INSERT 성공 → (true, nil)
+	//   - ErrDuplicate (이미 등록) → (false, nil) — 정상 (graceful 흡수)
+	//   - 그 외 INSERT 에러 → (false, err) — 호출자 정책 (현재 모두 warn 로그 후 흐름 계속)
+	HandleLLMDecision(ctx context.Context, host, sampleURL string, targetType model.TargetType, reason string) (inserted bool, err error)
+
+	// Insert 는 row 를 직접 INSERT (운영자 manual 또는 다른 source 경로용).
+	Insert(ctx context.Context, rec *model.BlacklistRecord) error
+	Update(ctx context.Context, rec *model.BlacklistRecord) error
+	Delete(ctx context.Context, id int64) error
+	GetByID(ctx context.Context, id int64) (*model.BlacklistRecord, error)
+	FindEnabledByHost(ctx context.Context, host string) ([]*model.BlacklistRecord, error)
+	List(ctx context.Context, filter model.BlacklistFilter) ([]*model.BlacklistRecord, error)
+}
+
+// blacklistService 는 BlacklistService 의 구현체입니다.
+type blacklistService struct {
+	repo repository.BlacklistRepository
+	log  *logger.Logger
+}
+
+// BlacklistServiceOption 은 NewBlacklistService 생성자 옵션입니다.
+type BlacklistServiceOption func(*blacklistServiceOptions)
+
+type blacklistServiceOptions struct {
+	timeout     time.Duration // 0 = 미적용
+	invalidator decorator.BlacklistInvalidator
+}
+
+// WithBlacklistQueryTimeout 은 repository 메서드에 query-level timeout 을 적용합니다.
+func WithBlacklistQueryTimeout(d time.Duration) BlacklistServiceOption {
+	return func(o *blacklistServiceOptions) { o.timeout = d }
+}
+
+// WithBlacklistInvalidator 는 mutation 후 자동으로 cache invalidate 를 트리거합니다.
+func WithBlacklistInvalidator(inv decorator.BlacklistInvalidator) BlacklistServiceOption {
+	return func(o *blacklistServiceOptions) { o.invalidator = inv }
+}
+
+// NewBlacklistService 는 BlacklistService 인스턴스를 생성합니다 (이슈 #431).
+//
+// Decorator chain 자동 합성 (안쪽 → 바깥쪽):
+//
+//	repo → invalidator (optional) → timeout (optional) → service
+//
+// timeout 은 mutation/read 모든 메서드 진입에 적용 (decorator.WrapBlacklistWithTimeout).
+// invalidator 는 mutation 메서드 (Insert/Update/Delete) 성공 후 host cache 무효화.
+func NewBlacklistService(repo repository.BlacklistRepository, log *logger.Logger, opts ...BlacklistServiceOption) BlacklistService {
+	o := &blacklistServiceOptions{}
+	for _, opt := range opts {
+		opt(o)
+	}
+	wrapped := repo
+	if o.invalidator != nil {
+		wrapped = decorator.WrapBlacklistWithInvalidator(wrapped, o.invalidator)
+	}
+	if o.timeout > 0 {
+		wrapped = decorator.WrapBlacklistWithTimeout(wrapped, o.timeout)
+	}
+	return &blacklistService{repo: wrapped, log: log}
+}
+
+// HandleLLMDecision 흡수 — 기존 llmgen.Generator.handleBlacklistDecision 의 로직.
+func (s *blacklistService) HandleLLMDecision(ctx context.Context, host, sampleURL string, targetType model.TargetType, reason string) (bool, error) {
+	logFields := map[string]interface{}{
+		"host":             host,
+		"sample_url":       sampleURL,
+		"target_type":      string(targetType),
+		"blacklist_reason": reason,
+	}
+
+	pathPattern := pathPatternFromURL(sampleURL)
+	if pathPattern == "" {
+		// URL parse 실패 — host-wide catch-all 회피.
+		s.log.WithFields(logFields).Warn("blacklist insert skipped — sample URL parse failed (host-wide catch-all 회피)")
+		return false, nil
+	}
+	rec := &model.BlacklistRecord{
+		HostPattern: host,
+		PathPattern: pathPattern,
+		Reason:      reason,
+		Source:      model.BlacklistSourceAuto,
+		Mode:        model.BlacklistModeDrop,
+		Enabled:     true,
+	}
+	if err := s.repo.Insert(ctx, rec); err != nil {
+		if errors.Is(err, storage.ErrDuplicate) {
+			s.log.WithFields(logFields).Info("page already in blacklist — selector insert skipped")
+			return false, nil
+		}
+		// Insert 실패는 non-fatal — 호출자가 warn 로그 후 흐름 계속.
+		s.log.WithFields(logFields).WithError(err).Warn("blacklist insert failed (non-fatal — selector insert still skipped)")
+		return false, err
+	}
+	logFields["blacklist_id"] = rec.ID
+	s.log.WithFields(logFields).Info("page auto-blacklisted by LLM, selector insert skipped")
+	return true, nil
+}
+
+// pathPatternFromURL 은 sampleURL 의 path 부분을 RE2 regex 로 escape 한 anchor pattern 을 반환합니다.
+//
+// 정책:
+//   - URL parse 실패 → "" 반환 (호출자가 insert skip)
+//   - 정상 parse + 빈 path → "/" 로 normalize → "^/$" pattern
+//   - 정상 parse + non-empty path → "^<escaped>$"
+func pathPatternFromURL(sampleURL string) string {
+	u, err := url.Parse(sampleURL)
+	if err != nil {
+		return ""
+	}
+	path := u.Path
+	if path == "" {
+		path = "/"
+	}
+	return "^" + regexp.QuoteMeta(path) + "$"
+}
+
+// 이하 CRUD 위임.
+
+func (s *blacklistService) Insert(ctx context.Context, rec *model.BlacklistRecord) error {
+	return s.repo.Insert(ctx, rec)
+}
+func (s *blacklistService) Update(ctx context.Context, rec *model.BlacklistRecord) error {
+	return s.repo.Update(ctx, rec)
+}
+func (s *blacklistService) Delete(ctx context.Context, id int64) error {
+	return s.repo.Delete(ctx, id)
+}
+func (s *blacklistService) GetByID(ctx context.Context, id int64) (*model.BlacklistRecord, error) {
+	return s.repo.GetByID(ctx, id)
+}
+func (s *blacklistService) FindEnabledByHost(ctx context.Context, host string) ([]*model.BlacklistRecord, error) {
+	return s.repo.FindEnabledByHost(ctx, host)
+}
+func (s *blacklistService) List(ctx context.Context, filter model.BlacklistFilter) ([]*model.BlacklistRecord, error) {
+	return s.repo.List(ctx, filter)
+}

--- a/internal/storage/service/parser_rule.go
+++ b/internal/storage/service/parser_rule.go
@@ -1,0 +1,114 @@
+// service 패키지의 parser_rule.go 는 parser_rules 도메인의 비즈니스 boundary 입니다 (이슈 #431).
+//
+// 책임:
+//   - Decorator chain 합성 (timeout + invalidating cache) — wiring 측 boilerplate 제거
+//   - Repository CRUD 위임 (Insert / InsertNextVersion / Update / UpdatePathPattern /
+//     FindActive / FindActiveCandidates / HasAnyRule / FindByNaturalKey / GetByID / List / Delete)
+//
+// 본 service 는 현 시점에선 단순 facade 역할 — cross-cutting 로직은 decorator 가 처리.
+// 향후 stale 재학습 / version fallback 등 비즈니스 로직이 등장하면 본 service 에서 추가.
+package service
+
+import (
+	"context"
+	"time"
+
+	"issuetracker/internal/storage/decorator"
+	"issuetracker/internal/storage/model"
+	"issuetracker/internal/storage/repository"
+	"issuetracker/pkg/logger"
+)
+
+// ParserRuleService 는 parser_rules 도메인의 비즈니스 boundary 입니다.
+type ParserRuleService interface {
+	Insert(ctx context.Context, r *model.ParserRuleRecord) error
+	Update(ctx context.Context, r *model.ParserRuleRecord) error
+	UpdatePathPattern(ctx context.Context, id int64, pattern, description string) error
+	GetByID(ctx context.Context, id int64) (*model.ParserRuleRecord, error)
+	FindActive(ctx context.Context, host string, targetType model.TargetType) (*model.ParserRuleRecord, error)
+	InsertNextVersion(ctx context.Context, r *model.ParserRuleRecord) error
+	HasAnyRule(ctx context.Context, hostPattern string, targetType model.TargetType) (exists, hasEnabled bool, err error)
+	FindByNaturalKey(ctx context.Context, sourceName, hostPattern, pathPattern string, targetType model.TargetType, version int) (*model.ParserRuleRecord, error)
+	FindActiveCandidates(ctx context.Context, host string, targetType model.TargetType) ([]*model.ParserRuleRecord, error)
+	List(ctx context.Context, filter model.ParserRuleFilter) ([]*model.ParserRuleRecord, error)
+	Delete(ctx context.Context, id int64) error
+}
+
+type parserRuleService struct {
+	repo repository.ParserRuleRepository
+	log  *logger.Logger
+}
+
+// ParserRuleServiceOption 은 NewParserRuleService 생성자 옵션입니다.
+type ParserRuleServiceOption func(*parserRuleServiceOptions)
+
+type parserRuleServiceOptions struct {
+	timeout     time.Duration
+	invalidator decorator.CacheInvalidator
+}
+
+// WithParserRuleQueryTimeout 은 repository 메서드에 query-level timeout 을 적용합니다.
+func WithParserRuleQueryTimeout(d time.Duration) ParserRuleServiceOption {
+	return func(o *parserRuleServiceOptions) { o.timeout = d }
+}
+
+// WithParserRuleInvalidator 는 mutation 후 자동으로 cache invalidate 를 트리거합니다.
+func WithParserRuleInvalidator(inv decorator.CacheInvalidator) ParserRuleServiceOption {
+	return func(o *parserRuleServiceOptions) { o.invalidator = inv }
+}
+
+// NewParserRuleService 는 ParserRuleService 인스턴스를 생성합니다 (이슈 #431).
+//
+// Decorator chain 자동 합성 (안쪽 → 바깥쪽):
+//
+//	repo → invalidator (optional) → timeout (optional) → service
+func NewParserRuleService(repo repository.ParserRuleRepository, log *logger.Logger, opts ...ParserRuleServiceOption) ParserRuleService {
+	o := &parserRuleServiceOptions{}
+	for _, opt := range opts {
+		opt(o)
+	}
+	wrapped := repo
+	if o.invalidator != nil {
+		wrapped = decorator.WrapWithInvalidator(wrapped, o.invalidator)
+	}
+	if o.timeout > 0 {
+		wrapped = decorator.WrapParserRuleWithTimeout(wrapped, o.timeout)
+	}
+	return &parserRuleService{repo: wrapped, log: log}
+}
+
+// 이하 CRUD 위임.
+
+func (s *parserRuleService) Insert(ctx context.Context, r *model.ParserRuleRecord) error {
+	return s.repo.Insert(ctx, r)
+}
+func (s *parserRuleService) Update(ctx context.Context, r *model.ParserRuleRecord) error {
+	return s.repo.Update(ctx, r)
+}
+func (s *parserRuleService) UpdatePathPattern(ctx context.Context, id int64, pattern, description string) error {
+	return s.repo.UpdatePathPattern(ctx, id, pattern, description)
+}
+func (s *parserRuleService) GetByID(ctx context.Context, id int64) (*model.ParserRuleRecord, error) {
+	return s.repo.GetByID(ctx, id)
+}
+func (s *parserRuleService) FindActive(ctx context.Context, host string, targetType model.TargetType) (*model.ParserRuleRecord, error) {
+	return s.repo.FindActive(ctx, host, targetType)
+}
+func (s *parserRuleService) InsertNextVersion(ctx context.Context, r *model.ParserRuleRecord) error {
+	return s.repo.InsertNextVersion(ctx, r)
+}
+func (s *parserRuleService) HasAnyRule(ctx context.Context, hostPattern string, targetType model.TargetType) (bool, bool, error) {
+	return s.repo.HasAnyRule(ctx, hostPattern, targetType)
+}
+func (s *parserRuleService) FindByNaturalKey(ctx context.Context, sourceName, hostPattern, pathPattern string, targetType model.TargetType, version int) (*model.ParserRuleRecord, error) {
+	return s.repo.FindByNaturalKey(ctx, sourceName, hostPattern, pathPattern, targetType, version)
+}
+func (s *parserRuleService) FindActiveCandidates(ctx context.Context, host string, targetType model.TargetType) ([]*model.ParserRuleRecord, error) {
+	return s.repo.FindActiveCandidates(ctx, host, targetType)
+}
+func (s *parserRuleService) List(ctx context.Context, filter model.ParserRuleFilter) ([]*model.ParserRuleRecord, error) {
+	return s.repo.List(ctx, filter)
+}
+func (s *parserRuleService) Delete(ctx context.Context, id int64) error {
+	return s.repo.Delete(ctx, id)
+}

--- a/test/internal/processor/parser/rule/llmgen/enriched_extractor_test.go
+++ b/test/internal/processor/parser/rule/llmgen/enriched_extractor_test.go
@@ -2,6 +2,8 @@ package llmgen_test
 
 import (
 	"context"
+	"net/url"
+	"regexp"
 	"sync"
 	"testing"
 	"time"
@@ -49,35 +51,43 @@ func (e *fakeEnrichedExtractor) callCount() int {
 	return e.calls
 }
 
-// recordingBlacklistRepo 는 Insert 호출을 기록하는 BlacklistRepository stub.
+// recordingBlacklistRepo 는 HandleLLMDecision 호출을 기록하는 BlacklistAutoRegister stub (이슈 #431).
+//
+// 이전 (#326) 에는 Generator 가 BlacklistRepository 를 직접 호출했으나, #431 에서 service
+// boundary 로 의존성 역전 — 본 stub 은 service interface 만 만족하면 됨.
 type recordingBlacklistRepo struct {
 	mu       sync.Mutex
 	inserts  []*model.BlacklistRecord
-	insertOK bool // false 면 ErrDuplicate 반환 (멱등성 검증)
+	insertOK bool // false 면 (false, ErrDuplicate) 반환 (멱등성 검증)
 }
 
-func (r *recordingBlacklistRepo) Insert(_ context.Context, rec *model.BlacklistRecord) error {
-	r.mu.Lock()
-	defer r.mu.Unlock()
-	r.inserts = append(r.inserts, rec)
-	if !r.insertOK {
-		return storage.ErrDuplicate
+// HandleLLMDecision 은 BlacklistAutoRegister 인터페이스를 만족합니다 (llmgen.Generator 가 의존).
+// 본 stub 은 실제 service 와 같은 path_pattern 변환 로직을 직접 수행 — 기존 테스트의 검증 부분
+// (rec.PathPattern Contains "/promo/123") 이 그대로 통과되도록.
+func (r *recordingBlacklistRepo) HandleLLMDecision(_ context.Context, host, sampleURL string, _ model.TargetType, reason string) (bool, error) {
+	u, err := url.Parse(sampleURL)
+	if err != nil {
+		return false, nil
 	}
-	return nil
-}
-
-func (r *recordingBlacklistRepo) Update(_ context.Context, _ *model.BlacklistRecord) error {
-	return nil
-}
-func (r *recordingBlacklistRepo) Delete(_ context.Context, _ int64) error { return nil }
-func (r *recordingBlacklistRepo) GetByID(_ context.Context, _ int64) (*model.BlacklistRecord, error) {
-	return nil, storage.ErrNotFound
-}
-func (r *recordingBlacklistRepo) FindEnabledByHost(_ context.Context, _ string) ([]*model.BlacklistRecord, error) {
-	return nil, nil
-}
-func (r *recordingBlacklistRepo) List(_ context.Context, _ model.BlacklistFilter) ([]*model.BlacklistRecord, error) {
-	return nil, nil
+	path := u.Path
+	if path == "" {
+		path = "/"
+	}
+	rec := &model.BlacklistRecord{
+		HostPattern: host,
+		PathPattern: "^" + regexp.QuoteMeta(path) + "$",
+		Reason:      reason,
+		Source:      model.BlacklistSourceAuto,
+		Mode:        model.BlacklistModeDrop,
+		Enabled:     true,
+	}
+	r.mu.Lock()
+	r.inserts = append(r.inserts, rec)
+	r.mu.Unlock()
+	if !r.insertOK {
+		return false, storage.ErrDuplicate
+	}
+	return true, nil
 }
 
 func (r *recordingBlacklistRepo) callCount() int {
@@ -103,7 +113,7 @@ func TestGenerator_EnrichedExtractor_BlacklistBranch(t *testing.T) {
 	g.SetExtractor(extractor)
 
 	blRepo := &recordingBlacklistRepo{insertOK: true}
-	g.SetBlacklistRepo(blRepo)
+	g.SetBlacklistService(blRepo)
 
 	g.Enqueue(context.Background(), "ads.example.com", model.TargetTypePage, &core.RawContent{
 		URL: "https://ads.example.com/promo/123", HTML: samplePageHTML,
@@ -172,7 +182,7 @@ func TestGenerator_EnrichedExtractor_BlacklistRepoNil_StillSkipsInsert(t *testin
 		},
 	}
 	g.SetExtractor(extractor)
-	// SetBlacklistRepo 미호출 — nil 상태.
+	// SetBlacklistService 미호출 — nil 상태.
 
 	g.Enqueue(context.Background(), "loginwall.example.com", model.TargetTypePage, &core.RawContent{
 		URL: "https://loginwall.example.com/secure", HTML: samplePageHTML,


### PR DESCRIPTION
## 연관 이슈

Closes #431 (메타: #429 Phase 2)

## 배경

메타 이슈 #429 의 Phase 2 — Phase 1 (#430) 의 구조 분리 위에서 **가치 명확한 service 두 개** 를 신설.

기존 (#326) 패턴:
\`\`\`go
// main.go wiring — decorator chain 수동 합성, 호출처가 정책 까먹기 쉬움
blacklistRepo := decorator.WrapBlacklistWithTimeout(pgstore.NewBlacklist..., timeout)
blacklistRepo = decorator.WrapBlacklistWithInvalidator(blacklistRepo, matcher)
llmGen.SetBlacklistRepo(blacklistRepo)

// llmgen.Generator — Repository 직접 의존, handleBlacklistDecision 에 path_pattern 로직 분산
\`\`\`

Phase 2 후:
\`\`\`go
// main.go wiring — service 생성자가 decorator chain 자동 합성
blacklistSvc := service.NewBlacklistService(blacklistRepoRaw, log,
    service.WithBlacklistQueryTimeout(timeout),
    service.WithBlacklistInvalidator(matcher),
)
llmGen.SetBlacklistService(blacklistSvc)

// llmgen.Generator — BlacklistAutoRegister 인터페이스만 의존 (의존성 역전)
\`\`\`

## 구현

### 신설 service

**1. \`internal/storage/service/blacklist.go\`**
- \`BlacklistService\` 인터페이스 + \`blacklistService\` 구현
- 핵심 메서드: \`HandleLLMDecision(ctx, host, sampleURL, targetType, reason) (inserted bool, err error)\`
  - llmgen.Generator.handleBlacklistDecision 의 path_pattern 변환 / INSERT / ErrDuplicate 흡수 / 로그 모두 흡수
  - pathPatternFromURL helper 도 service 로 이전
- Decorator chain 자동 합성: \`repo → invalidator → timeout → service\`
- Standard CRUD 위임

**2. \`internal/storage/service/parser_rule.go\`**
- \`ParserRuleService\` 인터페이스 + \`parserRuleService\` 구현
- Decorator chain 자동 합성 (timeout + invalidating cache)
- Standard CRUD 위임 (11개 메서드)
- 시그니처가 \`ParserRuleRepository\` 와 same-method-set — Go structural typing 으로 호출자가 자연 전달

### Option 패턴

\`\`\`go
service.NewBlacklistService(repo, log,
    service.WithBlacklistQueryTimeout(10*time.Second),
    service.WithBlacklistInvalidator(matcher),
)
service.NewParserRuleService(repo, log,
    service.WithParserRuleQueryTimeout(10*time.Second),
    service.WithParserRuleInvalidator(resolver),
)
\`\`\`

### Generator 의존성 역전

llmgen.Generator 가 BlacklistRepository 직접 의존 → **BlacklistAutoRegister** 인터페이스 의존 (이슈 #431):

\`\`\`go
// internal/processor/parser/rule/llmgen/generator.go
type BlacklistAutoRegister interface {
    HandleLLMDecision(ctx, host, sampleURL string, targetType, reason) (bool, error)
}
\`\`\`

service.BlacklistService 가 본 인터페이스를 만족 — llmgen 패키지는 storage/service 를 직접 import 하지 않음 (의존성 역전 / circular dep 회피).

handleBlacklistDecision 본문은 nil 분기 + 1줄 위임만 (~50줄 → ~10줄로 축소).

### main.go wiring

- repository import 제거
- parserRuleSvc 가 llmGen/refiner wiring 의 ParserRuleRepository 인자로 자연 전달 (structural typing)
- blacklistSvc 가 llmGen.SetBlacklistService 에 주입

## CI / 머지 게이트 점검

- [x] gofmt clean
- [x] \`go build ./...\` 성공
- [x] \`go vet ./...\` clean
- [x] \`go test -race -count=1 -timeout=180s ./test/...\` 전체 PASS
  - enriched_extractor_test 의 recordingBlacklistRepo stub 을 BlacklistAutoRegister 만족하도록 재작성

## 변경 영향 범위 + 위험도

- **동작 동일**: service 는 decorator + repository 의 facade — 로직 변경 없음
- **API 변경**: \`llmGen.SetBlacklistRepo\` → \`SetBlacklistService\` (사용처는 main.go + test 만)
- **의존성 역전**: llmgen → storage/service 직접 의존 없음 — 향후 service 패키지 리팩토링 시 llmgen 영향 0

## 후속 작업

- Phase 3 (#432): 단순 CRUD service 검토 (SchedulerEntry / SearchKeyword / SampleURL / FetcherRule) — thin pass-through 가치 검증 후 결정

## 롤백 계획

본 PR revert 시 main.go + generator.go + 테스트 stub 변경이 일괄 원복. service 파일 2개 삭제. 컴파일 즉시 통과.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Introduced service-layer abstractions for parser rules and blacklist handling to improve code organization and reliability.
  * Enhanced timeout and cache invalidation support for database operations.
  * Improved error handling for blacklist record operations with graceful duplicate absorption.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/EinSofINTEREST/IssueTracker/pull/434)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->