### PR TITLE
[FEAT#425] precheck 패키지 신설 — fetcher/parser 진입점 URL 처리 가부 일괄 게이트

### DIFF
--- a/cmd/issuetracker/main.go
+++ b/cmd/issuetracker/main.go
@@ -24,6 +24,7 @@ import (
 	refinerwiring "issuetracker/internal/processor/parser/rule/refiner/wiring"
 	"issuetracker/internal/processor/parser/rule/validator"
 	parserWorker "issuetracker/internal/processor/parser/worker"
+	"issuetracker/internal/processor/precheck"
 	"issuetracker/internal/processor/validate"
 	validateWorkerPkg "issuetracker/internal/processor/validate/worker"
 	"issuetracker/internal/scheduler"
@@ -612,12 +613,17 @@ func main() {
 		w.SetPipelineGuard(pipelineGuard)
 	}
 
-	// ── Page-parse 블랙리스트 ───────────────────────────────────────
-	// 카테고리에서 추출된 article URL 중 blacklist 매칭은 bus.Publish 직전 drop.
-	// Matcher 가 nil (BLACKLIST_ENABLED=false) 이면 setter noop — 모든 링크 그대로 발행.
-	if blacklistMatcher != nil {
-		w.SetBlacklist(blacklistMatcher)
-	}
+	// ── Precheck 게이트 (이슈 #425) ───────────────────────────────────
+	// fetcher / parser 진입점에서 URL 처리 가부를 일괄 판정. 현재 단일 Source (blacklist) 등록 —
+	// 향후 rate_limit / robots / domain_throttle 등 추가 시 본 wiring 만 확장.
+	//
+	// blacklistMatcher 가 nil (BLACKLIST_ENABLED=false) 이면 NewBlacklistSource 가 nil 반환,
+	// precheck.New 가 nil source 를 자동 필터링 → 모든 URL Allow (게이트 비활성).
+	precheckDecider := precheck.New(precheck.NewBlacklistSource(blacklistMatcher))
+	// parser worker — 진입점 + outgoing chained URL filter.
+	w.SetPrecheck(precheckDecider)
+	// fetcher worker pool manager — 모든 priority pool + chromedp pool 에 일괄 주입.
+	manager.SetPrecheck(precheckDecider)
 
 	// ── Stale rule 재학습 카운터 ───────────────────────────────────
 	// host 단위 stale parse failure 누적 — 임계 도달 시 Generator.EnqueueStale 트리거.

--- a/internal/processor/fetcher/worker/manager.go
+++ b/internal/processor/fetcher/worker/manager.go
@@ -8,6 +8,7 @@ import (
 	"issuetracker/internal/bus"
 	"issuetracker/internal/locks"
 	"issuetracker/internal/processor/fetcher/core"
+	"issuetracker/internal/processor/precheck"
 	"issuetracker/internal/storage/service"
 	"issuetracker/pkg/config"
 	"issuetracker/pkg/logger"
@@ -171,6 +172,18 @@ func NewPoolManager(
 //
 // m.resolver 가 nil 인 경우 (테스트 wiring) 는 job.Priority 를 그대로 사용 — coderabbit
 // PR #409 피드백. bus.buildMessage 가 nil resolver 를 fail-safe 로 허용하는 정책과 일관.
+// SetPrecheck 는 모든 worker pool (high/normal/low + chromedp) 에 precheck.Decider 를 일괄 주입합니다 (이슈 #425).
+//
+// nil 주입 시 게이트 비활성. Start 호출 전 wiring 단계에서 1회 호출.
+func (m *PoolManager) SetPrecheck(d precheck.Decider) {
+	for _, p := range m.pools {
+		p.SetPrecheck(d)
+	}
+	if m.chromedpPool != nil {
+		m.chromedpPool.SetPrecheck(d)
+	}
+}
+
 func (m *PoolManager) Publish(ctx context.Context, job *core.CrawlJob) error {
 	priority := job.Priority
 	if m.resolver != nil {

--- a/internal/processor/fetcher/worker/pool.go
+++ b/internal/processor/fetcher/worker/pool.go
@@ -17,6 +17,7 @@ import (
 	"issuetracker/internal/bus"
 	"issuetracker/internal/locks"
 	"issuetracker/internal/processor/fetcher/core"
+	"issuetracker/internal/processor/precheck"
 	"issuetracker/internal/storage/service"
 	"issuetracker/internal/workerpool"
 	"issuetracker/pkg/links"
@@ -80,6 +81,14 @@ type KafkaConsumerPool struct {
 	// Handle 진입 직후 검사하여 차단된 URL 의 처리를 skip 하고 message 만 commit.
 	// atomic.Pointer 로 race-safe 한 lock-free 설정/조회.
 	gate atomic.Pointer[urlguard.Gate]
+
+	// precheck 는 URL 처리 가부 일괄 게이트 (이슈 #425). nil 이면 게이트 비활성.
+	// URL 가드 이후 backoff 대기 전에 검사하여 blacklist / 향후 rate_limit 등이 결정한
+	// Drop 을 즉시 commit-only 로 처리, 불필요한 fetch / rate_limit budget 소모 회피.
+	//
+	// atomic.Pointer 로 race-safe 설정 — Start 이후 SetPrecheck 호출에도 안전.
+	// precheckHolder 는 인터페이스를 wrap 한 struct (atomic.Pointer 가 concrete type 만 지원).
+	precheckGate atomic.Pointer[precheckHolder]
 	// retryScheduler 는 재시도 발행 시점을 관리하는 RetryScheduler 입니다.
 	// 미설정(nil) 이면 lazy 로 KafkaImmediateRetryScheduler 가 사용되어 기존 동작 유지 —
 	// 즉시 priority 토픽에 publish + worker 가 ScheduledAt 까지 sleep.
@@ -180,6 +189,20 @@ func (p *KafkaConsumerPool) SetRetryScheduler(rs bus.RetryScheduler) {
 // 미설정(nil) 시 가드 비활성 — 모든 job 이 정상 처리됩니다.
 func (p *KafkaConsumerPool) SetGate(g *urlguard.Gate) {
 	p.gate.Store(g)
+}
+
+// precheckHolder 는 precheck.Decider 인터페이스를 atomic.Pointer 에 담기 위한 wrap struct 입니다.
+// (atomic.Pointer[T] 가 concrete type 만 지원하기 때문).
+type precheckHolder struct{ Decider precheck.Decider }
+
+// SetPrecheck 는 Handle 진입 시 URL 처리 가부를 결정할 precheck.Decider 를 설정합니다 (이슈 #425).
+// 미설정(nil) 시 게이트 비활성 — 모든 job 이 정상 처리됩니다.
+func (p *KafkaConsumerPool) SetPrecheck(d precheck.Decider) {
+	if d == nil {
+		p.precheckGate.Store(nil)
+		return
+	}
+	p.precheckGate.Store(&precheckHolder{Decider: d})
 }
 
 // SetNormalizer는 URL 정규화기를 설정합니다.
@@ -361,6 +384,24 @@ func (p *KafkaConsumerPool) processJob(ctx context.Context, msg *queue.Message, 
 			"job_id":  job.ID,
 			"stage":   "consumer",
 		}) {
+			return p.pool.Commit(ctx, msg)
+		}
+	}
+
+	// Precheck 게이트 (이슈 #425): URL 가드 이후 backoff 대기 / StageGate 진입 전에 검사.
+	// VerdictDrop → fetch / rate_limit budget 소모 회피 + commit-only.
+	// VerdictExtractLinksOnly → fetcher 단계는 정상 fetch 진행 (target_type=Category 강제 변환은
+	//   parser worker outgoing filter 가 처리; 본 stage 는 fetch 만 보장하면 됨).
+	if ph := p.precheckGate.Load(); ph != nil && ph.Decider != nil {
+		dec := ph.Decider.CheckURL(ctx, job.Target.URL)
+		if dec.Verdict == precheck.VerdictDrop {
+			log.WithFields(map[string]interface{}{
+				"job_id":  job.ID,
+				"crawler": job.CrawlerName,
+				"url":     job.Target.URL,
+				"source":  dec.Source,
+				"reason":  dec.Reason,
+			}).Info("precheck dropped url, skipping fetch")
 			return p.pool.Commit(ctx, msg)
 		}
 	}

--- a/internal/processor/parser/rule/blacklist_matcher.go
+++ b/internal/processor/parser/rule/blacklist_matcher.go
@@ -230,6 +230,12 @@ func (m *BlacklistMatcher) Classify(ctx context.Context, urls []string) Blacklis
 //
 // 매칭 없음: ("", nil). lookup 에러: ("", err). 매칭됨: (mode, nil).
 // LENGTH(path_pattern) DESC 정렬 후보에서 첫 매칭 row 의 mode 사용 — 더 구체적 path 우선.
+//
+// MatchedMode 는 본 함수의 exported 별칭입니다 (precheck.blacklistSource 등 단일 URL hot-path 호출용).
+func (m *BlacklistMatcher) MatchedMode(ctx context.Context, rawURL string) (model.BlacklistMode, error) {
+	return m.matchedMode(ctx, rawURL)
+}
+
 func (m *BlacklistMatcher) matchedMode(ctx context.Context, rawURL string) (model.BlacklistMode, error) {
 	host, path, err := extractHostPath(rawURL)
 	if err != nil {

--- a/internal/processor/parser/worker/worker.go
+++ b/internal/processor/parser/worker/worker.go
@@ -463,6 +463,9 @@ func (w *Worker) processCategoryPage(ctx context.Context, raw *core.RawContent, 
 	//   - VerdictExtractLinksOnly  : list 로 강제 발행 → fetch + ParseLinks 만 진행 (ParsePage skip)
 	//   - VerdictDrop              : 어느 슬라이스에도 미포함 (완전 drop, fetch / parse 안 함)
 	// Decider 미설정 (nil) 이면 모든 URL 을 article 로 통과 (기능 OFF).
+	//
+	// Legacy compat: precheck 미설정 + blacklist Matcher 설정 (SetBlacklist 호환 호출자) 시
+	// 기존 blacklist.Classify 경로로 fallback — 호출자 영향 없음 (gemini high 피드백, PR #436).
 	articleURLs := urls
 	var listURLs []string
 	droppedCount := 0
@@ -479,6 +482,12 @@ func (w *Worker) processCategoryPage(ctx context.Context, raw *core.RawContent, 
 				droppedCount++
 			}
 		}
+	} else if w.blacklist != nil && len(urls) > 0 {
+		// SetBlacklist 만 호출한 호환 경로 — 본 PR (#436) 이전 동작 보존.
+		decision := w.blacklist.Classify(ctx, urls)
+		articleURLs = decision.Allowed
+		listURLs = decision.ExtractLinksOnly
+		droppedCount = len(urls) - len(decision.Allowed) - len(decision.ExtractLinksOnly)
 	}
 
 	if len(articleURLs) == 0 && len(listURLs) == 0 {
@@ -538,14 +547,17 @@ func (w *Worker) processArticlePage(ctx context.Context, raw *core.RawContent, r
 	}
 
 	// Precheck 진입 게이트 (이슈 #425): blacklist 등 이미 차단된 URL 이 파서에 도달했을 때
-	// LLM 재호출 / Resolver lookup 모두 회피. drop 결정이면 raw 삭제 + commit.
+	// LLM 재호출 / Resolver lookup 모두 회피. drop / extract_links_only 모두 drop 처리 —
+	// article path 에서 list verdict 는 부적합 (raw 가 article 으로 fetch 된 후 policy 변경 race
+	// window). 가장 보수적 동작: deleteRaw + commit (gemini medium 피드백, PR #436).
 	if w.precheck != nil {
-		if dec := w.precheck.CheckURL(ctx, raw.URL); dec.Verdict == precheck.VerdictDrop {
+		if dec := w.precheck.CheckURL(ctx, raw.URL); dec.Verdict != precheck.VerdictAllow {
 			mlog.WithFields(map[string]interface{}{
-				"url":    raw.URL,
-				"source": dec.Source,
-				"reason": dec.Reason,
-			}).Info("precheck dropped raw url at parser entry, skipping parse")
+				"url":     raw.URL,
+				"source":  dec.Source,
+				"reason":  dec.Reason,
+				"verdict": dec.Verdict.String(),
+			}).Info("precheck blocked raw url at parser entry, skipping parse")
 			w.deleteRaw(ctx, rawID, mlog)
 			return nil
 		}

--- a/internal/processor/parser/worker/worker.go
+++ b/internal/processor/parser/worker/worker.go
@@ -34,6 +34,7 @@ import (
 	"issuetracker/internal/processor/parser/rule"
 	"issuetracker/internal/processor/parser/rule/llmgen"
 	"issuetracker/internal/processor/parser/types"
+	"issuetracker/internal/processor/precheck"
 	"issuetracker/internal/storage"
 	"issuetracker/internal/storage/model"
 	"issuetracker/internal/storage/primitive"
@@ -93,7 +94,15 @@ type Worker struct {
 	// blacklist: page-parse 블랙리스트 Matcher.
 	// nil 허용 — nil 이면 차단 비활성 (모든 카테고리 링크가 그대로 발행).
 	// processCategoryPage 의 bus.PublishChained 직전에 Filter 호출.
+	//
+	// Deprecated: 신규 코드는 precheck.Decider 사용 (이슈 #425). 본 필드는 호환을 위해 잔존 —
+	// 향후 BlacklistMatcher 가 precheck.Source 로 통합되면 제거.
 	blacklist *rule.BlacklistMatcher
+
+	// precheck: URL 처리 가부 일괄 게이트 (이슈 #425).
+	// nil 허용 — nil 이면 게이트 비활성. processArticlePage / processCategoryPage 진입 직후 검사 +
+	// outgoing chained URL filter 에서 batch 검사.
+	precheck precheck.Decider
 
 	// staleCounter: stale rule 재학습 트리거 카운터.
 	// nil 허용 — nil 이면 stale 재학습 비활성 (chromedp 자동 전환만 동작).
@@ -200,8 +209,22 @@ func (w *Worker) SetPipelineGuard(g PipelineGuard) {
 //
 // nil 주입 시 차단 비활성 (모든 카테고리 링크가 그대로 article job 으로 발행).
 // Start 호출 전 wiring 단계에서 1회 설정.
+//
+// Deprecated: 신규 wiring 은 SetPrecheck 사용 (이슈 #425).
 func (w *Worker) SetBlacklist(b *rule.BlacklistMatcher) {
 	w.blacklist = b
+}
+
+// SetPrecheck 는 URL 처리 가부 일괄 게이트를 주입합니다 (이슈 #425).
+//
+// nil 주입 시 게이트 비활성. Start 호출 전 wiring 단계에서 1회 설정.
+//
+// 적용 위치:
+//   - processArticlePage / processCategoryPage 진입 시 raw.URL 검사 (이미 blacklist 인 URL 의
+//     LLM 재호출 회피)
+//   - processCategoryPage 의 outgoing chained URL filter (기존 blacklist.Classify 대체)
+func (w *Worker) SetPrecheck(d precheck.Decider) {
+	w.precheck = d
 }
 
 // SetStaleCounter 는 stale rule 재학습 트리거 카운터 + 임계값을 주입합니다.
@@ -409,6 +432,20 @@ func (w *Worker) processCategoryPage(ctx context.Context, raw *core.RawContent, 
 		return nil
 	}
 
+	// Precheck 진입 게이트 (이슈 #425): blacklist 등 이미 차단된 URL 이 파서에 도달했을 때
+	// LLM 재호출 / Resolver lookup 모두 회피. drop 결정이면 raw 삭제 + commit.
+	if w.precheck != nil {
+		if dec := w.precheck.CheckURL(ctx, raw.URL); dec.Verdict == precheck.VerdictDrop {
+			mlog.WithFields(map[string]interface{}{
+				"url":    raw.URL,
+				"source": dec.Source,
+				"reason": dec.Reason,
+			}).Info("precheck dropped raw url at parser entry, skipping parse")
+			w.deleteRaw(ctx, rawID, mlog)
+			return nil
+		}
+	}
+
 	items, err := w.parser.ParseLinks(ctx, raw)
 	if err != nil {
 		return w.handleRuleError(ctx, raw, rawID, "parse_links", model.TargetTypeList, err, llmRetryCount, crawlerName, jobTimeout, mlog)
@@ -421,19 +458,27 @@ func (w *Worker) processCategoryPage(ctx context.Context, raw *core.RawContent, 
 
 	urls := uniqueURLs(items, maxChainedURLs)
 
-	// page-parse 블랙리스트 적용 — mode 별 분기:
-	//   - 'drop' 매칭     : 어느 슬라이스에도 미포함 (완전 drop, fetch / parse 안 함)
-	//   - 'extract_links_only' 매칭 : list 로 강제 발행 → fetch + ParseLinks 만 진행 (ParsePage skip)
-	//   - 매칭 X         : 정상 article 로 발행
-	// Matcher 미설정 (nil) 이면 모든 URL 을 article 로 통과 (기능 OFF).
+	// Outgoing chained URL filter (이슈 #425): precheck decider 가 verdict 별로 분기:
+	//   - VerdictAllow             : 정상 article 로 발행
+	//   - VerdictExtractLinksOnly  : list 로 강제 발행 → fetch + ParseLinks 만 진행 (ParsePage skip)
+	//   - VerdictDrop              : 어느 슬라이스에도 미포함 (완전 drop, fetch / parse 안 함)
+	// Decider 미설정 (nil) 이면 모든 URL 을 article 로 통과 (기능 OFF).
 	articleURLs := urls
 	var listURLs []string
 	droppedCount := 0
-	if w.blacklist != nil && len(urls) > 0 {
-		decision := w.blacklist.Classify(ctx, urls)
-		articleURLs = decision.Allowed
-		listURLs = decision.ExtractLinksOnly
-		droppedCount = len(urls) - len(decision.Allowed) - len(decision.ExtractLinksOnly)
+	if w.precheck != nil && len(urls) > 0 {
+		decisions := w.precheck.CheckURLs(ctx, urls)
+		articleURLs = articleURLs[:0]
+		for i, dec := range decisions {
+			switch dec.Verdict {
+			case precheck.VerdictAllow:
+				articleURLs = append(articleURLs, urls[i])
+			case precheck.VerdictExtractLinksOnly:
+				listURLs = append(listURLs, urls[i])
+			case precheck.VerdictDrop:
+				droppedCount++
+			}
+		}
 	}
 
 	if len(articleURLs) == 0 && len(listURLs) == 0 {
@@ -490,6 +535,20 @@ func (w *Worker) processArticlePage(ctx context.Context, raw *core.RawContent, r
 		mlog.Debug("parser not configured, skipping article")
 		w.deleteRaw(ctx, rawID, mlog)
 		return nil
+	}
+
+	// Precheck 진입 게이트 (이슈 #425): blacklist 등 이미 차단된 URL 이 파서에 도달했을 때
+	// LLM 재호출 / Resolver lookup 모두 회피. drop 결정이면 raw 삭제 + commit.
+	if w.precheck != nil {
+		if dec := w.precheck.CheckURL(ctx, raw.URL); dec.Verdict == precheck.VerdictDrop {
+			mlog.WithFields(map[string]interface{}{
+				"url":    raw.URL,
+				"source": dec.Source,
+				"reason": dec.Reason,
+			}).Info("precheck dropped raw url at parser entry, skipping parse")
+			w.deleteRaw(ctx, rawID, mlog)
+			return nil
+		}
 	}
 
 	page, err := w.parser.ParsePage(ctx, raw)

--- a/internal/processor/precheck/blacklist.go
+++ b/internal/processor/precheck/blacklist.go
@@ -4,17 +4,19 @@ import (
 	"context"
 
 	"issuetracker/internal/processor/parser/rule"
+	"issuetracker/internal/storage/model"
 )
 
 // blacklistSource 는 parser_blacklist 매칭을 precheck Source 로 노출합니다 (이슈 #425).
 //
-// rule.BlacklistMatcher 의 Classify 결과를 단일 URL 기준 Decision 으로 변환:
+// rule.BlacklistMatcher.MatchedMode (single-URL hot path) 로 mode 를 받아 Decision 으로 변환:
 //
-//   - Classify.Allowed         (매칭 X)  → VerdictAllow
-//   - Classify.ExtractLinksOnly (mode=extract_links_only) → VerdictExtractLinksOnly
-//   - 둘 다 미포함 (mode=drop)            → VerdictDrop
+//   - 매칭 없음 (또는 lookup 에러)     → VerdictAllow (fail-open, Matcher 기존 정책 일관)
+//   - mode='extract_links_only'        → VerdictExtractLinksOnly
+//   - mode='drop'                      → VerdictDrop
 //
-// best-effort: lookup 에러 등으로 인한 internal 실패 시 Allow (fail-open) — Matcher 의 기존 정책 일관.
+// 이전 구현은 Classify(슬라이스) 를 1-URL 로 호출하여 매 호출마다 두 슬라이스 alloc — fetcher/
+// parser 의 hot path 라 부담. MatchedMode 직접 호출로 alloc 0 (gemini medium 피드백, PR #436).
 type blacklistSource struct {
 	matcher *rule.BlacklistMatcher
 }
@@ -33,21 +35,41 @@ func NewBlacklistSource(matcher *rule.BlacklistMatcher) Source {
 func (s *blacklistSource) Name() string { return "blacklist" }
 
 func (s *blacklistSource) Check(ctx context.Context, rawURL string) Decision {
-	decision := s.matcher.Classify(ctx, []string{rawURL})
-	if len(decision.Allowed) == 1 {
+	mode, err := s.matcher.MatchedMode(ctx, rawURL)
+	if err != nil {
+		// lookup 에러 → Allow (fail-open). Matcher.Classify / Filter 와 동일 정책.
 		return Decision{Verdict: VerdictAllow, Source: "blacklist"}
 	}
-	if len(decision.ExtractLinksOnly) == 1 {
-		return Decision{
-			Verdict: VerdictExtractLinksOnly,
-			Source:  "blacklist",
-			Reason:  "blacklist:extract_links_only",
-		}
+	return modeToDecision(mode)
+}
+
+// CheckBatch 는 BatchSource 의 구현 — Classify (slice-returning batch) 결과를 Decision 슬라이스로 변환.
+//
+// urls 의 모든 entry 가 동일 인덱스로 정확히 매핑 — Classify 의 Allowed/ExtractLinksOnly 슬라이스
+// 에서 두 번 lookup 보다 set membership 검사로 단순화.
+func (s *blacklistSource) CheckBatch(ctx context.Context, urls []string) []Decision {
+	if len(urls) == 0 {
+		return nil
 	}
-	// 둘 다 미포함 → drop 매칭
-	return Decision{
-		Verdict: VerdictDrop,
-		Source:  "blacklist",
-		Reason:  "blacklist:drop",
+	out := make([]Decision, len(urls))
+	for i, u := range urls {
+		mode, err := s.matcher.MatchedMode(ctx, u)
+		if err != nil {
+			out[i] = Decision{Verdict: VerdictAllow, Source: "blacklist"}
+			continue
+		}
+		out[i] = modeToDecision(mode)
+	}
+	return out
+}
+
+func modeToDecision(mode model.BlacklistMode) Decision {
+	switch mode {
+	case model.BlacklistModeExtractLinksOnly:
+		return Decision{Verdict: VerdictExtractLinksOnly, Source: "blacklist", Reason: "blacklist:extract_links_only"}
+	case model.BlacklistModeDrop:
+		return Decision{Verdict: VerdictDrop, Source: "blacklist", Reason: "blacklist:drop"}
+	default:
+		return Decision{Verdict: VerdictAllow, Source: "blacklist"}
 	}
 }

--- a/internal/processor/precheck/blacklist.go
+++ b/internal/processor/precheck/blacklist.go
@@ -1,0 +1,53 @@
+package precheck
+
+import (
+	"context"
+
+	"issuetracker/internal/processor/parser/rule"
+)
+
+// blacklistSource 는 parser_blacklist 매칭을 precheck Source 로 노출합니다 (이슈 #425).
+//
+// rule.BlacklistMatcher 의 Classify 결과를 단일 URL 기준 Decision 으로 변환:
+//
+//   - Classify.Allowed         (매칭 X)  → VerdictAllow
+//   - Classify.ExtractLinksOnly (mode=extract_links_only) → VerdictExtractLinksOnly
+//   - 둘 다 미포함 (mode=drop)            → VerdictDrop
+//
+// best-effort: lookup 에러 등으로 인한 internal 실패 시 Allow (fail-open) — Matcher 의 기존 정책 일관.
+type blacklistSource struct {
+	matcher *rule.BlacklistMatcher
+}
+
+// NewBlacklistSource 는 BlacklistMatcher 를 wrap 한 precheck Source 를 반환합니다.
+//
+// matcher 가 nil 이면 nil 반환 — precheck.New 가 nil source 를 자동 필터링하므로 wiring 측 분기 불필요
+// (BLACKLIST_ENABLED=false 시 nil 전달 패턴).
+func NewBlacklistSource(matcher *rule.BlacklistMatcher) Source {
+	if matcher == nil {
+		return nil
+	}
+	return &blacklistSource{matcher: matcher}
+}
+
+func (s *blacklistSource) Name() string { return "blacklist" }
+
+func (s *blacklistSource) Check(ctx context.Context, rawURL string) Decision {
+	decision := s.matcher.Classify(ctx, []string{rawURL})
+	if len(decision.Allowed) == 1 {
+		return Decision{Verdict: VerdictAllow, Source: "blacklist"}
+	}
+	if len(decision.ExtractLinksOnly) == 1 {
+		return Decision{
+			Verdict: VerdictExtractLinksOnly,
+			Source:  "blacklist",
+			Reason:  "blacklist:extract_links_only",
+		}
+	}
+	// 둘 다 미포함 → drop 매칭
+	return Decision{
+		Verdict: VerdictDrop,
+		Source:  "blacklist",
+		Reason:  "blacklist:drop",
+	}
+}

--- a/internal/processor/precheck/precheck.go
+++ b/internal/processor/precheck/precheck.go
@@ -1,0 +1,138 @@
+// Package precheck 는 fetcher / parser / 기타 processor stage 가 URL 을 실제로 처리하기 전에
+// 처리 가부를 일괄 판정하는 공용 진입 게이트입니다 (이슈 #425).
+//
+// 설계 목표:
+//   - 다중 stage 의 진입점 (fetch / parse / outgoing chained URL filter 등) 에서 동일 게이트 호출
+//   - cross-cutting 정책 (blacklist / 향후 rate_limit / robots / domain throttle 등) 의 plug-in
+//   - 각 Source 는 의존성 역전 — 본 패키지는 BlacklistMatcher / rate_limit 등의 구현체를 모름
+//
+// 호출 패턴:
+//
+//	d := precheck.New(blacklistSource, ...)
+//	v := d.CheckURL(ctx, jobURL)
+//	switch v.Verdict {
+//	case precheck.VerdictAllow:           // 정상 진행
+//	case precheck.VerdictDrop:            // commit-only, 처리 skip
+//	case precheck.VerdictExtractLinksOnly: // 파서 단계에서 list 강제 분기
+//	}
+package precheck
+
+import (
+	"context"
+)
+
+// Verdict 는 단일 URL 의 처리 결정입니다.
+type Verdict int
+
+const (
+	// VerdictAllow: 정상 진행 (모든 Source 가 통과).
+	VerdictAllow Verdict = iota
+	// VerdictDrop: 처리 중단 — fetch / parse 스킵, commit-only.
+	VerdictDrop
+	// VerdictExtractLinksOnly: list 강제 분기 — fetch + ParseLinks 만 진행 (ParsePage skip).
+	// blacklist 도메인의 'extract_links_only' mode 와 의미 동일.
+	VerdictExtractLinksOnly
+)
+
+func (v Verdict) String() string {
+	switch v {
+	case VerdictAllow:
+		return "allow"
+	case VerdictDrop:
+		return "drop"
+	case VerdictExtractLinksOnly:
+		return "extract_links_only"
+	default:
+		return "unknown"
+	}
+}
+
+// Decision 은 Source 또는 Decider 의 판정 결과입니다.
+//
+//   - Verdict: 결정 자체
+//   - Reason : 로깅 / 메트릭용 짧은 사유 (예: "blacklist:ad_redirect")
+//   - Source : 결정을 내린 Source 이름 (예: "blacklist"). 다중 Source chain 의 가시성 확보.
+type Decision struct {
+	Verdict Verdict
+	Reason  string
+	Source  string
+}
+
+// Allowed 는 Verdict 가 Allow 인지 확인하는 helper 입니다.
+func (d Decision) Allowed() bool { return d.Verdict == VerdictAllow }
+
+// Source 는 단일 URL 의 처리 가부를 판정하는 plug-in 인터페이스입니다.
+//
+// 각 Source 는 자신의 도메인 정책 (blacklist 매칭 / rate_limit 제한 / robots 정책 등) 을 기반으로
+// 판정합니다. Decider 가 등록된 Source 들을 순차 호출 — 첫 non-Allow 결정에서 short-circuit.
+//
+// 구현체는 goroutine-safe 해야 합니다.
+type Source interface {
+	// Name 은 Source 식별자입니다 (예: "blacklist"). Decision.Source 에 그대로 들어갑니다.
+	Name() string
+
+	// Check 는 단일 URL 에 대한 판정을 반환합니다.
+	//
+	// 본 Source 의 정책이 적용되지 않으면 VerdictAllow 반환 — 다음 Source 로 흐름이 계속됨.
+	// 본 Source 가 Drop / ExtractLinksOnly 결정하면 그 자리에서 short-circuit.
+	Check(ctx context.Context, rawURL string) Decision
+}
+
+// Decider 는 등록된 Source chain 으로 URL 처리 가부를 일괄 판정하는 boundary 입니다.
+//
+// 호출자는 본 인터페이스만 의존 — Source 구현체 / 추가는 wiring 단계에서 처리.
+type Decider interface {
+	// CheckURL 은 단일 URL 의 판정을 반환합니다.
+	//
+	// 등록된 Source 들을 등록 순서대로 순회 — 첫 non-Allow 결정에서 short-circuit.
+	// 모든 Source 가 Allow 면 VerdictAllow 반환.
+	CheckURL(ctx context.Context, rawURL string) Decision
+
+	// CheckURLs 는 batch 편의 메서드 — 각 URL 에 대해 CheckURL 호출 후 슬라이스 반환.
+	// 호출 순서대로 결과 슬라이스도 동일 순서. 빈 입력은 빈 슬라이스 반환.
+	CheckURLs(ctx context.Context, urls []string) []Decision
+}
+
+// chainDecider 는 Source 슬라이스를 순차 호출하는 Decider 구현입니다.
+type chainDecider struct {
+	sources []Source
+}
+
+// New 는 Source 슬라이스를 chain 으로 묶은 Decider 를 반환합니다.
+//
+// sources 가 빈 슬라이스 / nil 이면 모든 URL 을 Allow 처리 (no-op gate).
+func New(sources ...Source) Decider {
+	// nil source 는 무시 — wiring 단계의 conditional 활성화 (예: BLACKLIST_ENABLED=false 시 nil 전달) 편의.
+	filtered := make([]Source, 0, len(sources))
+	for _, s := range sources {
+		if s != nil {
+			filtered = append(filtered, s)
+		}
+	}
+	return &chainDecider{sources: filtered}
+}
+
+func (d *chainDecider) CheckURL(ctx context.Context, rawURL string) Decision {
+	for _, s := range d.sources {
+		dec := s.Check(ctx, rawURL)
+		if dec.Verdict != VerdictAllow {
+			// short-circuit + Source 이름 보장 (구현체가 깜빡 비워둬도 추적 가능).
+			if dec.Source == "" {
+				dec.Source = s.Name()
+			}
+			return dec
+		}
+	}
+	return Decision{Verdict: VerdictAllow}
+}
+
+func (d *chainDecider) CheckURLs(ctx context.Context, urls []string) []Decision {
+	if len(urls) == 0 {
+		return nil
+	}
+	out := make([]Decision, len(urls))
+	for i, u := range urls {
+		out[i] = d.CheckURL(ctx, u)
+	}
+	return out
+}

--- a/internal/processor/precheck/precheck.go
+++ b/internal/processor/precheck/precheck.go
@@ -78,6 +78,17 @@ type Source interface {
 	Check(ctx context.Context, rawURL string) Decision
 }
 
+// BatchSource 는 batch 호출을 native 로 처리할 수 있는 Source 의 optional 확장 인터페이스입니다 (이슈 #425, PR #436 gemini medium).
+//
+// Source 가 본 인터페이스도 구현하면 Decider.CheckURLs 가 개별 Check 루프 대신 batch 호출을 사용 —
+// mutex 잠금 / map lookup / SQL round-trip 등 per-call 오버헤드를 amortize.
+//
+// 구현 의무는 없음 (Source 만 구현해도 됨). Decider 가 type assertion 으로 자동 분기.
+type BatchSource interface {
+	Source
+	CheckBatch(ctx context.Context, urls []string) []Decision
+}
+
 // Decider 는 등록된 Source chain 으로 URL 처리 가부를 일괄 판정하는 boundary 입니다.
 //
 // 호출자는 본 인터페이스만 의존 — Source 구현체 / 추가는 wiring 단계에서 처리.
@@ -129,6 +140,19 @@ func (d *chainDecider) CheckURL(ctx context.Context, rawURL string) Decision {
 func (d *chainDecider) CheckURLs(ctx context.Context, urls []string) []Decision {
 	if len(urls) == 0 {
 		return nil
+	}
+	// 단일 Source 가 BatchSource 도 구현하면 native batch 사용 — per-call mutex/lookup 오버헤드 amortize.
+	// 다중 Source 의 chain short-circuit 은 per-URL loop 가 자연스러우므로 fallback.
+	if len(d.sources) == 1 {
+		if bs, ok := d.sources[0].(BatchSource); ok {
+			out := bs.CheckBatch(ctx, urls)
+			for i := range out {
+				if out[i].Verdict != VerdictAllow && out[i].Source == "" {
+					out[i].Source = bs.Name()
+				}
+			}
+			return out
+		}
 	}
 	out := make([]Decision, len(urls))
 	for i, u := range urls {

--- a/test/internal/processor/precheck/precheck_test.go
+++ b/test/internal/processor/precheck/precheck_test.go
@@ -136,3 +136,45 @@ func (emptySourceSource) Name() string { return "empty" }
 func (emptySourceSource) Check(_ context.Context, _ string) precheck.Decision {
 	return precheck.Decision{Verdict: precheck.VerdictDrop}
 }
+
+// batchableSource 는 Source + BatchSource 모두 구현 — CheckBatch 우선 호출 검증용.
+type batchableSource struct {
+	checkCalls int
+	batchCalls int
+}
+
+func (b *batchableSource) Name() string { return "batchable" }
+func (b *batchableSource) Check(_ context.Context, _ string) precheck.Decision {
+	b.checkCalls++
+	return precheck.Decision{Verdict: precheck.VerdictAllow}
+}
+func (b *batchableSource) CheckBatch(_ context.Context, urls []string) []precheck.Decision {
+	b.batchCalls++
+	out := make([]precheck.Decision, len(urls))
+	for i := range urls {
+		out[i] = precheck.Decision{Verdict: precheck.VerdictAllow}
+	}
+	return out
+}
+
+func TestDecider_CheckURLs_UsesBatchSource_WhenSingleSource(t *testing.T) {
+	src := &batchableSource{}
+	d := precheck.New(src)
+
+	decisions := d.CheckURLs(context.Background(), []string{"a", "b", "c"})
+	assert.Len(t, decisions, 3)
+	assert.Equal(t, 1, src.batchCalls, "단일 Source + BatchSource → CheckBatch 1회 호출")
+	assert.Equal(t, 0, src.checkCalls, "Check 개별 호출 회피")
+}
+
+func TestDecider_CheckURLs_FallsBackToPerURL_WhenMultiSource(t *testing.T) {
+	src := &batchableSource{}
+	allow := &fakeSource{name: "allow", verdict: precheck.VerdictAllow}
+	d := precheck.New(src, allow)
+
+	decisions := d.CheckURLs(context.Background(), []string{"a", "b"})
+	assert.Len(t, decisions, 2)
+	// 다중 Source chain → per-URL Check (BatchSource 활용 안 함).
+	assert.Equal(t, 0, src.batchCalls, "다중 Source 일 때는 BatchSource fast-path 비활성")
+	assert.Equal(t, 2, src.checkCalls, "각 URL 에 대해 Check 1회씩")
+}

--- a/test/internal/processor/precheck/precheck_test.go
+++ b/test/internal/processor/precheck/precheck_test.go
@@ -73,11 +73,6 @@ func TestDecider_EmptySources_AllowsAll(t *testing.T) {
 }
 
 func TestDecider_CheckURLs_BatchOrder(t *testing.T) {
-	// 첫 번째 URL 만 차단하는 Source — index 별 다른 verdict 반환을 위한 inline 구현.
-	type batchSource struct {
-		blockHost string
-	}
-	// 위 inline 구조체는 메서드 정의를 못 하므로 별도 함수형 source.
 	src := dynamicSource{blockedURL: "https://block.example.com"}
 	d := precheck.New(src)
 
@@ -91,7 +86,6 @@ func TestDecider_CheckURLs_BatchOrder(t *testing.T) {
 	assert.Equal(t, precheck.VerdictAllow, decisions[0].Verdict)
 	assert.Equal(t, precheck.VerdictDrop, decisions[1].Verdict)
 	assert.Equal(t, precheck.VerdictAllow, decisions[2].Verdict)
-	_ = batchSource{} // 사용하지 않음 — type assertion 위해 정의했으나 dynamicSource 로 대체
 }
 
 func TestDecider_CheckURLs_EmptyInput(t *testing.T) {

--- a/test/internal/processor/precheck/precheck_test.go
+++ b/test/internal/processor/precheck/precheck_test.go
@@ -1,0 +1,144 @@
+package precheck_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"issuetracker/internal/processor/precheck"
+)
+
+// fakeSource 는 미리 지정된 verdict 를 반환하는 stub 입니다.
+type fakeSource struct {
+	name    string
+	verdict precheck.Verdict
+	calls   int
+}
+
+func (s *fakeSource) Name() string { return s.name }
+func (s *fakeSource) Check(_ context.Context, _ string) precheck.Decision {
+	s.calls++
+	return precheck.Decision{Verdict: s.verdict, Reason: s.name + ":test", Source: s.name}
+}
+
+func TestDecider_AllAllow_ReturnsAllow(t *testing.T) {
+	a := &fakeSource{name: "a", verdict: precheck.VerdictAllow}
+	b := &fakeSource{name: "b", verdict: precheck.VerdictAllow}
+	d := precheck.New(a, b)
+
+	dec := d.CheckURL(context.Background(), "https://example.com")
+	assert.Equal(t, precheck.VerdictAllow, dec.Verdict)
+	assert.Equal(t, 1, a.calls)
+	assert.Equal(t, 1, b.calls)
+}
+
+func TestDecider_FirstNonAllow_ShortCircuits(t *testing.T) {
+	a := &fakeSource{name: "a", verdict: precheck.VerdictAllow}
+	b := &fakeSource{name: "b", verdict: precheck.VerdictDrop}
+	c := &fakeSource{name: "c", verdict: precheck.VerdictAllow}
+	d := precheck.New(a, b, c)
+
+	dec := d.CheckURL(context.Background(), "https://example.com")
+	assert.Equal(t, precheck.VerdictDrop, dec.Verdict)
+	assert.Equal(t, "b", dec.Source)
+	assert.Equal(t, 1, a.calls)
+	assert.Equal(t, 1, b.calls)
+	assert.Equal(t, 0, c.calls, "Drop 결정 후 후속 Source 는 호출되지 않음")
+}
+
+func TestDecider_ExtractLinksOnly_PropagatesVerdict(t *testing.T) {
+	a := &fakeSource{name: "a", verdict: precheck.VerdictExtractLinksOnly}
+	d := precheck.New(a)
+
+	dec := d.CheckURL(context.Background(), "https://example.com")
+	assert.Equal(t, precheck.VerdictExtractLinksOnly, dec.Verdict)
+	assert.Equal(t, "a", dec.Source)
+}
+
+func TestDecider_NilSourceFiltered(t *testing.T) {
+	a := &fakeSource{name: "a", verdict: precheck.VerdictAllow}
+	// nil source 는 New 가 자동 필터링 — wiring 단계 conditional 활성화 (예: BLACKLIST_ENABLED=false).
+	d := precheck.New(nil, a, nil)
+
+	dec := d.CheckURL(context.Background(), "https://example.com")
+	assert.Equal(t, precheck.VerdictAllow, dec.Verdict)
+	assert.Equal(t, 1, a.calls)
+}
+
+func TestDecider_EmptySources_AllowsAll(t *testing.T) {
+	d := precheck.New()
+	dec := d.CheckURL(context.Background(), "https://example.com")
+	assert.Equal(t, precheck.VerdictAllow, dec.Verdict)
+}
+
+func TestDecider_CheckURLs_BatchOrder(t *testing.T) {
+	// 첫 번째 URL 만 차단하는 Source — index 별 다른 verdict 반환을 위한 inline 구현.
+	type batchSource struct {
+		blockHost string
+	}
+	// 위 inline 구조체는 메서드 정의를 못 하므로 별도 함수형 source.
+	src := dynamicSource{blockedURL: "https://block.example.com"}
+	d := precheck.New(src)
+
+	urls := []string{
+		"https://allow.example.com",
+		"https://block.example.com",
+		"https://other.example.com",
+	}
+	decisions := d.CheckURLs(context.Background(), urls)
+	assert.Len(t, decisions, 3)
+	assert.Equal(t, precheck.VerdictAllow, decisions[0].Verdict)
+	assert.Equal(t, precheck.VerdictDrop, decisions[1].Verdict)
+	assert.Equal(t, precheck.VerdictAllow, decisions[2].Verdict)
+	_ = batchSource{} // 사용하지 않음 — type assertion 위해 정의했으나 dynamicSource 로 대체
+}
+
+func TestDecider_CheckURLs_EmptyInput(t *testing.T) {
+	d := precheck.New()
+	decisions := d.CheckURLs(context.Background(), nil)
+	assert.Nil(t, decisions)
+}
+
+// dynamicSource 는 URL 별로 다른 verdict 를 반환하는 stub 입니다.
+type dynamicSource struct {
+	blockedURL string
+}
+
+func (s dynamicSource) Name() string { return "dynamic" }
+func (s dynamicSource) Check(_ context.Context, url string) precheck.Decision {
+	if url == s.blockedURL {
+		return precheck.Decision{Verdict: precheck.VerdictDrop, Reason: "blocked", Source: "dynamic"}
+	}
+	return precheck.Decision{Verdict: precheck.VerdictAllow}
+}
+
+func TestVerdict_String(t *testing.T) {
+	assert.Equal(t, "allow", precheck.VerdictAllow.String())
+	assert.Equal(t, "drop", precheck.VerdictDrop.String())
+	assert.Equal(t, "extract_links_only", precheck.VerdictExtractLinksOnly.String())
+}
+
+func TestDecision_Allowed(t *testing.T) {
+	assert.True(t, precheck.Decision{Verdict: precheck.VerdictAllow}.Allowed())
+	assert.False(t, precheck.Decision{Verdict: precheck.VerdictDrop}.Allowed())
+	assert.False(t, precheck.Decision{Verdict: precheck.VerdictExtractLinksOnly}.Allowed())
+}
+
+func TestDecider_AutoFillsSourceName(t *testing.T) {
+	// Source 가 Decision.Source 를 비워둬도 Decider 가 short-circuit 시 자동 채움.
+	src := emptySourceSource{}
+	d := precheck.New(src)
+
+	dec := d.CheckURL(context.Background(), "https://example.com")
+	assert.Equal(t, precheck.VerdictDrop, dec.Verdict)
+	assert.Equal(t, "empty", dec.Source, "Decision.Source 비어있으면 Decider 가 Name() 으로 자동 채움")
+}
+
+// emptySourceSource 는 Decision.Source 를 비워두는 stub.
+type emptySourceSource struct{}
+
+func (emptySourceSource) Name() string { return "empty" }
+func (emptySourceSource) Check(_ context.Context, _ string) precheck.Decision {
+	return precheck.Decision{Verdict: precheck.VerdictDrop}
+}


### PR DESCRIPTION
## 연관 이슈

Closes #425

## 배경

기존 \`BlacklistMatcher.Classify\` 는 parser worker 가 카테고리 파싱 후 outgoing chained URL filter 로만 호출. 직접 발행 (scheduler / seed) 된 차단 URL 은 fetcher → parser → claudegen 까지 흘러가 \`ErrDuplicate\` 흡수되었지만 **HTTP fetch + LLM 세션 비용** 발생 (관측 사례: inven.co.kr 4회 재호출).

## 구현 — \`internal/processor/precheck/\` 신설

설계 핵심:
- **plug-in Source 패턴** — blacklist 가 첫 source, 향후 rate_limit / robots / domain_throttle 추가 시 wiring 만 확장
- **3-way verdict** (Allow / Drop / ExtractLinksOnly) — blacklist 의 mode 와 의미 일치 + 향후 정책 확장 친화
- **chain short-circuit** — 첫 non-Allow 결정에서 후속 Source skip (효율 + 명확한 책임 분기)

### 패키지 구조

\`\`\`
internal/processor/precheck/
├── precheck.go    # Decider / Source / Decision / Verdict + chainDecider
└── blacklist.go   # BlacklistMatcher wrap → precheck Source
\`\`\`

### 인터페이스 요약

\`\`\`go
type Decider interface {
    CheckURL(ctx, rawURL string) Decision         // 단일 URL
    CheckURLs(ctx, urls []string) []Decision      // batch
}

type Source interface {
    Name() string
    Check(ctx, rawURL string) Decision
}

type Decision struct { Verdict Verdict; Reason string; Source string }
\`\`\`

## 적용 진입점

| 위치 | 호출 패턴 | 효과 |
|---|---|---|
| **Fetcher** \`KafkaConsumerPool.processJob\` | URL Guard 이후 / Backoff·StageGate 전에 \`CheckURL\` | Drop URL 의 HTTP fetch + rate_limit budget 회피 |
| **Parser** \`processArticlePage\` / \`processCategoryPage\` 진입 | raw.URL \`CheckURL\` — Drop 이면 deleteRaw + commit | LLM 재호출 / Resolver lookup 회피 |
| **Parser** outgoing chained URL filter | 기존 \`blacklist.Classify\` 자리에 \`CheckURLs\` | 3-way 분기 (Allow / ExtractLinksOnly / Drop) 유지 |

\`PoolManager.SetPrecheck\` 는 모든 priority pool (high/normal/low) + chromedp pool 에 일괄 주입.

## main.go wiring

\`\`\`go
precheckDecider := precheck.New(precheck.NewBlacklistSource(blacklistMatcher))
w.SetPrecheck(precheckDecider)           // parser worker
manager.SetPrecheck(precheckDecider)     // fetcher pool manager (전체 pool 일괄)
\`\`\`

\`BLACKLIST_ENABLED=false\` 시 \`NewBlacklistSource(nil)\` 이 nil 반환 → \`precheck.New\` 가 자동 필터링 → 게이트 자연 비활성.

## CI / 머지 게이트 점검

- [x] gofmt clean
- [x] \`go build ./...\` 성공
- [x] \`go vet ./...\` clean
- [x] \`go test -race -count=1 -timeout=180s ./test/...\` 전체 PASS
- [x] precheck 단위 테스트 10건 추가 (chain / short-circuit / nil filter / empty / batch / 자동 Source 채움 등)

## 변경 영향 범위 + 위험도

- **외부 호환**: \`Worker.SetBlacklist\` 는 Deprecated 로 유지 — 기존 호출자 영향 없음
- **운영 효과**: 이미 차단된 URL 의 불필요 fetch / LLM 세션 회피 (이슈 #425 의 관측 사례)
- **확장성**: 새 Source (rate_limit / robots) 추가 시 \`Source\` 인터페이스 구현 + wiring 의 \`precheck.New(...)\` 에 추가만

## 후속 작업 (별도 이슈)

- 신규 Source 추가: rate_limit / robots.txt / domain throttle 등
- 정책 메트릭 (Prometheus): Decider 단의 verdict 카운터

## 롤백 계획

본 PR revert 시 모든 호출자 영향 0 (Worker.SetBlacklist 호환 잔존). precheck 패키지 자체 삭제 + main.go wiring 원복.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a unified URL filtering gate system that standardizes URL decision-making across parser and fetcher components with flexible verdict outcomes (allow, drop, extract links only).

* **Tests**
  * Added comprehensive test coverage for the new URL filtering system, including batch processing and source priority evaluation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/EinSofINTEREST/IssueTracker/pull/436)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->