### PR TITLE
[FEAT#439] pkg/config env 값 검증 강화 — parse helper 도입

### DIFF
--- a/pkg/config/internal/parse/parse.go
+++ b/pkg/config/internal/parse/parse.go
@@ -1,0 +1,223 @@
+// Package parse 는 pkg/config 의 모든 sub-package 가 env 값을 일관된 정책으로 파싱/검증하는
+// helper 모음입니다 (이슈 #439).
+//
+// 각 helper 는:
+//   - env 변수가 비어있으면 noop (default 값 보존)
+//   - 비어있지 않으면 파싱 시도, 실패 시 명확한 wrap 에러 반환
+//   - 의미적 경계 검증 (port 범위 / 양수 / 비음수 / ratio 등) 실패 시 명확한 에러
+//
+// 잘못된 env 값에 의한 silent degraded 동작 (무한 대기 / 0 port 등) 방지가 목적.
+//
+// 호출 패턴 (Load 함수 내):
+//
+//	if err := parse.Port("POSTGRES_PORT", &cfg.Port); err != nil {
+//	    return DBConfig{}, err
+//	}
+package parse
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// Port 는 env 를 TCP/IP port (1-65535) 로 파싱합니다.
+func Port(key string, dest *int) error {
+	v := os.Getenv(key)
+	if v == "" {
+		return nil
+	}
+	n, err := strconv.Atoi(v)
+	if err != nil {
+		return fmt.Errorf("parse %s %q: %w", key, v, err)
+	}
+	if n < 1 || n > 65535 {
+		return fmt.Errorf("%s %d out of range (1-65535)", key, n)
+	}
+	*dest = n
+	return nil
+}
+
+// PositiveDuration 은 env 를 time.Duration 으로 파싱 + 양수 (> 0) 검증.
+//
+// 사용: timeout 류 — 0 / 음수 timeout 은 무한 대기 / 즉시 실패 위험.
+func PositiveDuration(key string, dest *time.Duration) error {
+	v := os.Getenv(key)
+	if v == "" {
+		return nil
+	}
+	d, err := time.ParseDuration(v)
+	if err != nil {
+		return fmt.Errorf("parse %s %q: %w", key, v, err)
+	}
+	if d <= 0 {
+		return fmt.Errorf("%s %s must be positive", key, d)
+	}
+	*dest = d
+	return nil
+}
+
+// NonNegativeDuration 은 env 를 time.Duration 으로 파싱 + 비음수 (>= 0) 검증.
+//
+// 사용: 0 이 "비활성" 의미인 경우 (예: QueryTimeout=0 → timeout 미적용).
+func NonNegativeDuration(key string, dest *time.Duration) error {
+	v := os.Getenv(key)
+	if v == "" {
+		return nil
+	}
+	d, err := time.ParseDuration(v)
+	if err != nil {
+		return fmt.Errorf("parse %s %q: %w", key, v, err)
+	}
+	if d < 0 {
+		return fmt.Errorf("%s %s must be non-negative", key, d)
+	}
+	*dest = d
+	return nil
+}
+
+// PositiveInt 는 env 를 int 로 파싱 + 양수 검증 (> 0).
+func PositiveInt(key string, dest *int) error {
+	v := os.Getenv(key)
+	if v == "" {
+		return nil
+	}
+	n, err := strconv.Atoi(v)
+	if err != nil {
+		return fmt.Errorf("parse %s %q: %w", key, v, err)
+	}
+	if n <= 0 {
+		return fmt.Errorf("%s %d must be positive", key, n)
+	}
+	*dest = n
+	return nil
+}
+
+// NonNegativeInt 는 env 를 int 로 파싱 + 비음수 검증 (>= 0).
+//
+// 사용: 0 이 "비활성" 또는 "무제한" 의미인 경우 (예: MaxBacklog=0 → throttle 비활성).
+func NonNegativeInt(key string, dest *int) error {
+	v := os.Getenv(key)
+	if v == "" {
+		return nil
+	}
+	n, err := strconv.Atoi(v)
+	if err != nil {
+		return fmt.Errorf("parse %s %q: %w", key, v, err)
+	}
+	if n < 0 {
+		return fmt.Errorf("%s %d must be non-negative", key, n)
+	}
+	*dest = n
+	return nil
+}
+
+// PositiveInt32 는 PositiveInt 의 int32 변형.
+func PositiveInt32(key string, dest *int32) error {
+	v := os.Getenv(key)
+	if v == "" {
+		return nil
+	}
+	n, err := strconv.ParseInt(v, 10, 32)
+	if err != nil {
+		return fmt.Errorf("parse %s %q: %w", key, v, err)
+	}
+	if n <= 0 {
+		return fmt.Errorf("%s %d must be positive", key, n)
+	}
+	*dest = int32(n)
+	return nil
+}
+
+// NonNegativeInt32 는 NonNegativeInt 의 int32 변형.
+func NonNegativeInt32(key string, dest *int32) error {
+	v := os.Getenv(key)
+	if v == "" {
+		return nil
+	}
+	n, err := strconv.ParseInt(v, 10, 32)
+	if err != nil {
+		return fmt.Errorf("parse %s %q: %w", key, v, err)
+	}
+	if n < 0 {
+		return fmt.Errorf("%s %d must be non-negative", key, n)
+	}
+	*dest = int32(n)
+	return nil
+}
+
+// NonNegativeInt64 는 NonNegativeInt 의 int64 변형.
+func NonNegativeInt64(key string, dest *int64) error {
+	v := os.Getenv(key)
+	if v == "" {
+		return nil
+	}
+	n, err := strconv.ParseInt(v, 10, 64)
+	if err != nil {
+		return fmt.Errorf("parse %s %q: %w", key, v, err)
+	}
+	if n < 0 {
+		return fmt.Errorf("%s %d must be non-negative", key, n)
+	}
+	*dest = n
+	return nil
+}
+
+// Ratio 는 env 를 float64 로 파싱 + [0.0, 1.0] 범위 검증.
+//
+// 사용: 비율 / 확률 류 (cap_ratio / sample_rate 등).
+func Ratio(key string, dest *float64) error {
+	v := os.Getenv(key)
+	if v == "" {
+		return nil
+	}
+	f, err := strconv.ParseFloat(v, 64)
+	if err != nil {
+		return fmt.Errorf("parse %s %q: %w", key, v, err)
+	}
+	if f < 0 || f > 1 {
+		return fmt.Errorf("%s %g out of range [0.0, 1.0]", key, f)
+	}
+	*dest = f
+	return nil
+}
+
+// Bool 은 env 를 bool 로 파싱합니다.
+func Bool(key string, dest *bool) error {
+	v := os.Getenv(key)
+	if v == "" {
+		return nil
+	}
+	b, err := strconv.ParseBool(v)
+	if err != nil {
+		return fmt.Errorf("parse %s %q: %w", key, v, err)
+	}
+	*dest = b
+	return nil
+}
+
+// String 은 env 를 string 으로 그대로 적용 (비어있지 않을 때만).
+func String(key string, dest *string) {
+	if v := os.Getenv(key); v != "" {
+		*dest = v
+	}
+}
+
+// Enum 은 env 를 string 으로 파싱하되 allowed 집합에 포함되어야 함.
+//
+// 사용: provider / mode 류 (typo 로 인한 silent fallback 회피).
+func Enum(key string, allowed []string, dest *string) error {
+	v := os.Getenv(key)
+	if v == "" {
+		return nil
+	}
+	for _, a := range allowed {
+		if v == a {
+			*dest = v
+			return nil
+		}
+	}
+	return fmt.Errorf("%s %q not in allowed set [%s]", key, v, strings.Join(allowed, ", "))
+}

--- a/pkg/config/internal/parse/parse.go
+++ b/pkg/config/internal/parse/parse.go
@@ -199,10 +199,14 @@ func Bool(key string, dest *bool) error {
 }
 
 // String 은 env 를 string 으로 그대로 적용 (비어있지 않을 때만).
-func String(key string, dest *string) {
+//
+// 다른 helper 와 시그니처 일관성을 위해 error 를 반환 — 실제 실패 케이스는 없어 항상 nil.
+// 호출부에서 `for _, op := range []error{...}` 패턴에 합류시킬 수 있도록 하기 위함.
+func String(key string, dest *string) error {
 	if v := os.Getenv(key); v != "" {
 		*dest = v
 	}
+	return nil
 }
 
 // Enum 은 env 를 string 으로 파싱하되 allowed 집합에 포함되어야 함.

--- a/pkg/config/internal/parse/parse_test.go
+++ b/pkg/config/internal/parse/parse_test.go
@@ -260,13 +260,15 @@ func TestString(t *testing.T) {
 	t.Run("non-empty applies", func(t *testing.T) {
 		setEnv(t, "PARSE_TEST_STR_OK", "hello")
 		dest := "default"
-		parse.String("PARSE_TEST_STR_OK", &dest)
+		err := parse.String("PARSE_TEST_STR_OK", &dest)
+		assert.NoError(t, err)
 		assert.Equal(t, "hello", dest)
 	})
 
 	t.Run("empty preserves default", func(t *testing.T) {
 		dest := "default"
-		parse.String("PARSE_TEST_STR_EMPTY", &dest)
+		err := parse.String("PARSE_TEST_STR_EMPTY", &dest)
+		assert.NoError(t, err)
 		assert.Equal(t, "default", dest)
 	})
 }

--- a/pkg/config/internal/parse/parse_test.go
+++ b/pkg/config/internal/parse/parse_test.go
@@ -1,0 +1,299 @@
+package parse_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"issuetracker/pkg/config/internal/parse"
+)
+
+// helper: env 키 설정 후 t.Cleanup 으로 자동 unset.
+func setEnv(t *testing.T, key, value string) {
+	t.Helper()
+	t.Setenv(key, value)
+}
+
+func TestPort(t *testing.T) {
+	t.Run("empty preserves default", func(t *testing.T) {
+		dest := 5432
+		err := parse.Port("PARSE_TEST_PORT_EMPTY", &dest)
+		assert.NoError(t, err)
+		assert.Equal(t, 5432, dest)
+	})
+
+	t.Run("valid port", func(t *testing.T) {
+		setEnv(t, "PARSE_TEST_PORT_OK", "8080")
+		dest := 5432
+		err := parse.Port("PARSE_TEST_PORT_OK", &dest)
+		assert.NoError(t, err)
+		assert.Equal(t, 8080, dest)
+	})
+
+	t.Run("zero rejected", func(t *testing.T) {
+		setEnv(t, "PARSE_TEST_PORT_ZERO", "0")
+		dest := 5432
+		err := parse.Port("PARSE_TEST_PORT_ZERO", &dest)
+		assert.Error(t, err)
+		assert.Equal(t, 5432, dest) // 변경되지 않음
+	})
+
+	t.Run("above 65535 rejected", func(t *testing.T) {
+		setEnv(t, "PARSE_TEST_PORT_BIG", "70000")
+		dest := 5432
+		err := parse.Port("PARSE_TEST_PORT_BIG", &dest)
+		assert.Error(t, err)
+	})
+
+	t.Run("non-numeric rejected", func(t *testing.T) {
+		setEnv(t, "PARSE_TEST_PORT_BAD", "abc")
+		dest := 5432
+		err := parse.Port("PARSE_TEST_PORT_BAD", &dest)
+		assert.Error(t, err)
+	})
+}
+
+func TestPositiveDuration(t *testing.T) {
+	t.Run("positive accepted", func(t *testing.T) {
+		setEnv(t, "PARSE_TEST_DUR_OK", "5s")
+		dest := time.Second
+		err := parse.PositiveDuration("PARSE_TEST_DUR_OK", &dest)
+		assert.NoError(t, err)
+		assert.Equal(t, 5*time.Second, dest)
+	})
+
+	t.Run("zero rejected", func(t *testing.T) {
+		setEnv(t, "PARSE_TEST_DUR_ZERO", "0s")
+		dest := time.Second
+		err := parse.PositiveDuration("PARSE_TEST_DUR_ZERO", &dest)
+		assert.Error(t, err)
+	})
+
+	t.Run("negative rejected", func(t *testing.T) {
+		setEnv(t, "PARSE_TEST_DUR_NEG", "-1s")
+		dest := time.Second
+		err := parse.PositiveDuration("PARSE_TEST_DUR_NEG", &dest)
+		assert.Error(t, err)
+	})
+
+	t.Run("invalid format rejected", func(t *testing.T) {
+		setEnv(t, "PARSE_TEST_DUR_BAD", "abc")
+		dest := time.Second
+		err := parse.PositiveDuration("PARSE_TEST_DUR_BAD", &dest)
+		assert.Error(t, err)
+	})
+}
+
+func TestNonNegativeDuration(t *testing.T) {
+	t.Run("zero accepted", func(t *testing.T) {
+		setEnv(t, "PARSE_TEST_NND_ZERO", "0s")
+		dest := time.Second
+		err := parse.NonNegativeDuration("PARSE_TEST_NND_ZERO", &dest)
+		assert.NoError(t, err)
+		assert.Equal(t, time.Duration(0), dest)
+	})
+
+	t.Run("negative rejected", func(t *testing.T) {
+		setEnv(t, "PARSE_TEST_NND_NEG", "-1s")
+		dest := time.Second
+		err := parse.NonNegativeDuration("PARSE_TEST_NND_NEG", &dest)
+		assert.Error(t, err)
+	})
+}
+
+func TestPositiveInt(t *testing.T) {
+	t.Run("positive accepted", func(t *testing.T) {
+		setEnv(t, "PARSE_TEST_PI_OK", "10")
+		dest := 1
+		err := parse.PositiveInt("PARSE_TEST_PI_OK", &dest)
+		assert.NoError(t, err)
+		assert.Equal(t, 10, dest)
+	})
+
+	t.Run("zero rejected", func(t *testing.T) {
+		setEnv(t, "PARSE_TEST_PI_ZERO", "0")
+		dest := 1
+		err := parse.PositiveInt("PARSE_TEST_PI_ZERO", &dest)
+		assert.Error(t, err)
+	})
+
+	t.Run("negative rejected", func(t *testing.T) {
+		setEnv(t, "PARSE_TEST_PI_NEG", "-1")
+		dest := 1
+		err := parse.PositiveInt("PARSE_TEST_PI_NEG", &dest)
+		assert.Error(t, err)
+	})
+}
+
+func TestNonNegativeInt(t *testing.T) {
+	t.Run("zero accepted", func(t *testing.T) {
+		setEnv(t, "PARSE_TEST_NNI_ZERO", "0")
+		dest := 1
+		err := parse.NonNegativeInt("PARSE_TEST_NNI_ZERO", &dest)
+		assert.NoError(t, err)
+		assert.Equal(t, 0, dest)
+	})
+
+	t.Run("negative rejected", func(t *testing.T) {
+		setEnv(t, "PARSE_TEST_NNI_NEG", "-1")
+		dest := 1
+		err := parse.NonNegativeInt("PARSE_TEST_NNI_NEG", &dest)
+		assert.Error(t, err)
+	})
+}
+
+func TestPositiveInt32(t *testing.T) {
+	t.Run("positive accepted", func(t *testing.T) {
+		setEnv(t, "PARSE_TEST_PI32_OK", "25")
+		var dest int32 = 1
+		err := parse.PositiveInt32("PARSE_TEST_PI32_OK", &dest)
+		assert.NoError(t, err)
+		assert.Equal(t, int32(25), dest)
+	})
+
+	t.Run("zero rejected", func(t *testing.T) {
+		setEnv(t, "PARSE_TEST_PI32_ZERO", "0")
+		var dest int32 = 1
+		err := parse.PositiveInt32("PARSE_TEST_PI32_ZERO", &dest)
+		assert.Error(t, err)
+	})
+}
+
+func TestNonNegativeInt32(t *testing.T) {
+	t.Run("zero accepted", func(t *testing.T) {
+		setEnv(t, "PARSE_TEST_NNI32_ZERO", "0")
+		var dest int32 = 5
+		err := parse.NonNegativeInt32("PARSE_TEST_NNI32_ZERO", &dest)
+		assert.NoError(t, err)
+		assert.Equal(t, int32(0), dest)
+	})
+
+	t.Run("negative rejected", func(t *testing.T) {
+		setEnv(t, "PARSE_TEST_NNI32_NEG", "-1")
+		var dest int32 = 5
+		err := parse.NonNegativeInt32("PARSE_TEST_NNI32_NEG", &dest)
+		assert.Error(t, err)
+	})
+}
+
+func TestNonNegativeInt64(t *testing.T) {
+	t.Run("zero accepted (throttle disabled)", func(t *testing.T) {
+		setEnv(t, "PARSE_TEST_NNI64_ZERO", "0")
+		var dest int64 = 100
+		err := parse.NonNegativeInt64("PARSE_TEST_NNI64_ZERO", &dest)
+		assert.NoError(t, err)
+		assert.Equal(t, int64(0), dest)
+	})
+
+	t.Run("negative rejected", func(t *testing.T) {
+		setEnv(t, "PARSE_TEST_NNI64_NEG", "-1")
+		var dest int64 = 100
+		err := parse.NonNegativeInt64("PARSE_TEST_NNI64_NEG", &dest)
+		assert.Error(t, err)
+	})
+}
+
+func TestRatio(t *testing.T) {
+	t.Run("in range accepted", func(t *testing.T) {
+		setEnv(t, "PARSE_TEST_RATIO_OK", "0.5")
+		dest := 0.1
+		err := parse.Ratio("PARSE_TEST_RATIO_OK", &dest)
+		assert.NoError(t, err)
+		assert.InDelta(t, 0.5, dest, 1e-9)
+	})
+
+	t.Run("zero accepted", func(t *testing.T) {
+		setEnv(t, "PARSE_TEST_RATIO_ZERO", "0")
+		dest := 0.5
+		err := parse.Ratio("PARSE_TEST_RATIO_ZERO", &dest)
+		assert.NoError(t, err)
+	})
+
+	t.Run("one accepted", func(t *testing.T) {
+		setEnv(t, "PARSE_TEST_RATIO_ONE", "1.0")
+		dest := 0.5
+		err := parse.Ratio("PARSE_TEST_RATIO_ONE", &dest)
+		assert.NoError(t, err)
+	})
+
+	t.Run("below zero rejected", func(t *testing.T) {
+		setEnv(t, "PARSE_TEST_RATIO_NEG", "-0.1")
+		dest := 0.5
+		err := parse.Ratio("PARSE_TEST_RATIO_NEG", &dest)
+		assert.Error(t, err)
+	})
+
+	t.Run("above one rejected", func(t *testing.T) {
+		setEnv(t, "PARSE_TEST_RATIO_BIG", "1.1")
+		dest := 0.5
+		err := parse.Ratio("PARSE_TEST_RATIO_BIG", &dest)
+		assert.Error(t, err)
+	})
+}
+
+func TestBool(t *testing.T) {
+	t.Run("true", func(t *testing.T) {
+		setEnv(t, "PARSE_TEST_BOOL_T", "true")
+		dest := false
+		err := parse.Bool("PARSE_TEST_BOOL_T", &dest)
+		assert.NoError(t, err)
+		assert.True(t, dest)
+	})
+
+	t.Run("invalid rejected", func(t *testing.T) {
+		setEnv(t, "PARSE_TEST_BOOL_BAD", "yeppers")
+		dest := false
+		err := parse.Bool("PARSE_TEST_BOOL_BAD", &dest)
+		assert.Error(t, err)
+	})
+
+	t.Run("empty preserves default", func(t *testing.T) {
+		dest := true
+		err := parse.Bool("PARSE_TEST_BOOL_EMPTY", &dest)
+		assert.NoError(t, err)
+		assert.True(t, dest)
+	})
+}
+
+func TestString(t *testing.T) {
+	t.Run("non-empty applies", func(t *testing.T) {
+		setEnv(t, "PARSE_TEST_STR_OK", "hello")
+		dest := "default"
+		parse.String("PARSE_TEST_STR_OK", &dest)
+		assert.Equal(t, "hello", dest)
+	})
+
+	t.Run("empty preserves default", func(t *testing.T) {
+		dest := "default"
+		parse.String("PARSE_TEST_STR_EMPTY", &dest)
+		assert.Equal(t, "default", dest)
+	})
+}
+
+func TestEnum(t *testing.T) {
+	allowed := []string{"gemini", "openai", "anthropic"}
+
+	t.Run("matched", func(t *testing.T) {
+		setEnv(t, "PARSE_TEST_ENUM_OK", "openai")
+		dest := "gemini"
+		err := parse.Enum("PARSE_TEST_ENUM_OK", allowed, &dest)
+		assert.NoError(t, err)
+		assert.Equal(t, "openai", dest)
+	})
+
+	t.Run("unmatched rejected", func(t *testing.T) {
+		setEnv(t, "PARSE_TEST_ENUM_BAD", "qwen")
+		dest := "gemini"
+		err := parse.Enum("PARSE_TEST_ENUM_BAD", allowed, &dest)
+		assert.Error(t, err)
+		assert.Equal(t, "gemini", dest)
+	})
+
+	t.Run("empty preserves default", func(t *testing.T) {
+		dest := "gemini"
+		err := parse.Enum("PARSE_TEST_ENUM_EMPTY", allowed, &dest)
+		assert.NoError(t, err)
+		assert.Equal(t, "gemini", dest)
+	})
+}

--- a/pkg/config/llm/llm.go
+++ b/pkg/config/llm/llm.go
@@ -4,10 +4,11 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"strconv"
 	"time"
 
 	"github.com/joho/godotenv"
+
+	"issuetracker/pkg/config/internal/parse"
 )
 
 // LLMConfig 는 LLM rule generator wiring 설정입니다.
@@ -65,25 +66,17 @@ func LoadLLM(envFiles ...string) (LLMConfig, error) {
 
 	cfg := DefaultLLMConfig()
 
-	if v := os.Getenv("LLM_ENABLED"); v != "" {
-		b, err := strconv.ParseBool(v)
-		if err != nil {
-			return LLMConfig{}, fmt.Errorf("parse LLM_ENABLED %q: %w", v, err)
+	// 검증 강화 (이슈 #439): provider enum, 양수 timeout.
+	// LLM_PROVIDER 미설정 시 default "gemini" 유지 — 빈 문자열만 skip.
+	parse.String("LLM_MODEL", &cfg.Model)
+	for _, op := range []error{
+		parse.Bool("LLM_ENABLED", &cfg.Enabled),
+		parse.Enum("LLM_PROVIDER", []string{"gemini", "openai", "anthropic", "claude"}, &cfg.Provider),
+		parse.PositiveDuration("LLM_TIMEOUT", &cfg.Timeout),
+	} {
+		if op != nil {
+			return LLMConfig{}, op
 		}
-		cfg.Enabled = b
-	}
-	if v := os.Getenv("LLM_PROVIDER"); v != "" {
-		cfg.Provider = v
-	}
-	if v := os.Getenv("LLM_MODEL"); v != "" {
-		cfg.Model = v
-	}
-	if v := os.Getenv("LLM_TIMEOUT"); v != "" {
-		d, err := time.ParseDuration(v)
-		if err != nil {
-			return LLMConfig{}, fmt.Errorf("parse LLM_TIMEOUT %q: %w", v, err)
-		}
-		cfg.Timeout = d
 	}
 
 	cfg.APIKey = lookupLLMAPIKey(cfg.Provider)

--- a/pkg/config/llm/llm.go
+++ b/pkg/config/llm/llm.go
@@ -68,8 +68,8 @@ func LoadLLM(envFiles ...string) (LLMConfig, error) {
 
 	// 검증 강화 (이슈 #439): provider enum, 양수 timeout.
 	// LLM_PROVIDER 미설정 시 default "gemini" 유지 — 빈 문자열만 skip.
-	parse.String("LLM_MODEL", &cfg.Model)
 	for _, op := range []error{
+		parse.String("LLM_MODEL", &cfg.Model),
 		parse.Bool("LLM_ENABLED", &cfg.Enabled),
 		parse.Enum("LLM_PROVIDER", []string{"gemini", "openai", "anthropic", "claude"}, &cfg.Provider),
 		parse.PositiveDuration("LLM_TIMEOUT", &cfg.Timeout),

--- a/pkg/config/processor/scheduler.go
+++ b/pkg/config/processor/scheduler.go
@@ -4,10 +4,11 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"strconv"
 	"time"
 
 	"github.com/joho/godotenv"
+
+	"issuetracker/pkg/config/internal/parse"
 )
 
 // SchedulerConfig는 Job Scheduler의 크롤 주기 설정을 나타냅니다.
@@ -49,45 +50,13 @@ func LoadScheduler(envFiles ...string) (SchedulerConfig, error) {
 
 	cfg := DefaultSchedulerConfig()
 
-	parseDuration := func(key string, dest *time.Duration) error {
-		if v := os.Getenv(key); v != "" {
-			d, err := time.ParseDuration(v)
-			if err != nil {
-				return fmt.Errorf("parse %s %q: %w", key, v, err)
-			}
-			*dest = d
-		}
-		return nil
-	}
-
-	parseInt := func(key string, dest *int) error {
-		if v := os.Getenv(key); v != "" {
-			n, err := strconv.Atoi(v)
-			if err != nil {
-				return fmt.Errorf("parse %s %q: %w", key, v, err)
-			}
-			*dest = n
-		}
-		return nil
-	}
-
-	parseInt64 := func(key string, dest *int64) error {
-		if v := os.Getenv(key); v != "" {
-			n, err := strconv.ParseInt(v, 10, 64)
-			if err != nil {
-				return fmt.Errorf("parse %s %q: %w", key, v, err)
-			}
-			*dest = n
-		}
-		return nil
-	}
-
+	// 검증 강화 (이슈 #439): duration 양수 / retries 비음수 / backlog 비음수.
 	for _, op := range []error{
-		parseDuration("SCHEDULER_CATEGORY_INTERVAL", &cfg.CategoryInterval),
-		parseDuration("SCHEDULER_JOB_TIMEOUT", &cfg.JobTimeout),
-		parseInt("SCHEDULER_MAX_RETRIES", &cfg.MaxRetries),
-		parseInt64("SCHEDULER_MAX_BACKLOG", &cfg.MaxBacklog),
-		parseDuration("SCHEDULER_BACKLOG_CHECK_TIMEOUT", &cfg.BacklogCheckTimeout),
+		parse.PositiveDuration("SCHEDULER_CATEGORY_INTERVAL", &cfg.CategoryInterval),
+		parse.PositiveDuration("SCHEDULER_JOB_TIMEOUT", &cfg.JobTimeout),
+		parse.NonNegativeInt("SCHEDULER_MAX_RETRIES", &cfg.MaxRetries),
+		parse.NonNegativeInt64("SCHEDULER_MAX_BACKLOG", &cfg.MaxBacklog), // 0 = throttle disabled
+		parse.PositiveDuration("SCHEDULER_BACKLOG_CHECK_TIMEOUT", &cfg.BacklogCheckTimeout),
 	} {
 		if op != nil {
 			return SchedulerConfig{}, op

--- a/pkg/config/processor/validate.go
+++ b/pkg/config/processor/validate.go
@@ -4,9 +4,10 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"strconv"
 
 	"github.com/joho/godotenv"
+
+	"issuetracker/pkg/config/internal/parse"
 )
 
 // ValidateConfig는 Content 검증 단계의 임계값 설정을 나타냅니다.
@@ -71,56 +72,36 @@ func LoadValidate(envFiles ...string) (ValidateConfig, error) {
 
 	cfg := DefaultValidateConfig()
 
-	parseInt := func(key string, dest *int) error {
-		if v := os.Getenv(key); v != "" {
-			n, err := strconv.Atoi(v)
-			if err != nil {
-				return fmt.Errorf("parse %s %q: %w", key, v, err)
-			}
-			*dest = n
-		}
-		return nil
-	}
-
-	parseFloat := func(key string, dest *float64) error {
-		if v := os.Getenv(key); v != "" {
-			f, err := strconv.ParseFloat(v, 64)
-			if err != nil {
-				return fmt.Errorf("parse %s %q: %w", key, v, err)
-			}
-			*dest = f
-		}
-		return nil
-	}
-
-	if v := os.Getenv("VALIDATE_REPARSE_ENABLED"); v != "" {
-		b, err := strconv.ParseBool(v)
-		if err != nil {
-			return ValidateConfig{}, fmt.Errorf("parse VALIDATE_REPARSE_ENABLED %q: %w", v, err)
-		}
-		cfg.ReparseEnabled = b
-	}
-
+	// 검증 강화 (이슈 #439): 모든 길이/카운트는 양수, 모든 ratio/threshold/weight 는 [0.0, 1.0].
 	for _, op := range []error{
-		parseInt("VALIDATE_NEWS_TITLE_MIN_LEN", &cfg.NewsTitleMinLen),
-		parseInt("VALIDATE_NEWS_TITLE_MAX_LEN", &cfg.NewsTitleMaxLen),
-		parseInt("VALIDATE_NEWS_BODY_MIN_LEN", &cfg.NewsBodyMinLen),
-		parseInt("VALIDATE_NEWS_BODY_MAX_LEN", &cfg.NewsBodyMaxLen),
-		parseInt("VALIDATE_NEWS_MIN_WORD_COUNT", &cfg.NewsMinWordCount),
-		parseFloat("VALIDATE_NEWS_QUALITY_THRESHOLD", &cfg.NewsQualityThreshold),
-		parseFloat("VALIDATE_NEWS_MAX_CAP_RATIO", &cfg.NewsMaxCapRatio),
-		parseFloat("VALIDATE_NEWS_MAX_PUNCT_RATIO", &cfg.NewsMaxPunctRatio),
-		parseFloat("VALIDATE_NEWS_WEIGHT_WORD_COUNT", &cfg.NewsWeightWordCount),
-		parseFloat("VALIDATE_NEWS_WEIGHT_META", &cfg.NewsWeightMeta),
-		parseFloat("VALIDATE_NEWS_WEIGHT_STRUCTURE", &cfg.NewsWeightStructure),
-		parseInt("VALIDATE_COMMUNITY_BODY_MIN_LEN", &cfg.CommunityBodyMinLen),
-		parseFloat("VALIDATE_COMMUNITY_QUALITY_THRESHOLD", &cfg.CommunityQualityThreshold),
-		parseFloat("VALIDATE_COMMUNITY_MAX_REPEAT_RATIO", &cfg.CommunityMaxRepeatRatio),
-		parseInt("VALIDATE_COMMUNITY_MIN_REPEAT_RUN", &cfg.CommunityMinRepeatRun),
+		parse.Bool("VALIDATE_REPARSE_ENABLED", &cfg.ReparseEnabled),
+		parse.PositiveInt("VALIDATE_NEWS_TITLE_MIN_LEN", &cfg.NewsTitleMinLen),
+		parse.PositiveInt("VALIDATE_NEWS_TITLE_MAX_LEN", &cfg.NewsTitleMaxLen),
+		parse.PositiveInt("VALIDATE_NEWS_BODY_MIN_LEN", &cfg.NewsBodyMinLen),
+		parse.PositiveInt("VALIDATE_NEWS_BODY_MAX_LEN", &cfg.NewsBodyMaxLen),
+		parse.PositiveInt("VALIDATE_NEWS_MIN_WORD_COUNT", &cfg.NewsMinWordCount),
+		parse.Ratio("VALIDATE_NEWS_QUALITY_THRESHOLD", &cfg.NewsQualityThreshold),
+		parse.Ratio("VALIDATE_NEWS_MAX_CAP_RATIO", &cfg.NewsMaxCapRatio),
+		parse.Ratio("VALIDATE_NEWS_MAX_PUNCT_RATIO", &cfg.NewsMaxPunctRatio),
+		parse.Ratio("VALIDATE_NEWS_WEIGHT_WORD_COUNT", &cfg.NewsWeightWordCount),
+		parse.Ratio("VALIDATE_NEWS_WEIGHT_META", &cfg.NewsWeightMeta),
+		parse.Ratio("VALIDATE_NEWS_WEIGHT_STRUCTURE", &cfg.NewsWeightStructure),
+		parse.PositiveInt("VALIDATE_COMMUNITY_BODY_MIN_LEN", &cfg.CommunityBodyMinLen),
+		parse.Ratio("VALIDATE_COMMUNITY_QUALITY_THRESHOLD", &cfg.CommunityQualityThreshold),
+		parse.Ratio("VALIDATE_COMMUNITY_MAX_REPEAT_RATIO", &cfg.CommunityMaxRepeatRatio),
+		parse.PositiveInt("VALIDATE_COMMUNITY_MIN_REPEAT_RUN", &cfg.CommunityMinRepeatRun),
 	} {
 		if op != nil {
 			return ValidateConfig{}, op
 		}
+	}
+
+	// 의미적 일관성 검사: Min < Max.
+	if cfg.NewsTitleMinLen > cfg.NewsTitleMaxLen {
+		return ValidateConfig{}, fmt.Errorf("VALIDATE_NEWS_TITLE_MIN_LEN (%d) cannot exceed _MAX_LEN (%d)", cfg.NewsTitleMinLen, cfg.NewsTitleMaxLen)
+	}
+	if cfg.NewsBodyMinLen > cfg.NewsBodyMaxLen {
+		return ValidateConfig{}, fmt.Errorf("VALIDATE_NEWS_BODY_MIN_LEN (%d) cannot exceed _MAX_LEN (%d)", cfg.NewsBodyMinLen, cfg.NewsBodyMaxLen)
 	}
 
 	return cfg, nil

--- a/pkg/config/storage/db.go
+++ b/pkg/config/storage/db.go
@@ -72,13 +72,12 @@ func Load(envFiles ...string) (DBConfig, error) {
 	cfg := DefaultDBConfig()
 
 	// 검증 강화 (이슈 #439): port 범위, 양수 timeout, 비음수 conn 수.
-	parse.String("POSTGRES_HOST", &cfg.Host)
-	parse.String("POSTGRES_USER", &cfg.User)
-	parse.String("POSTGRES_PASSWORD", &cfg.Password)
-	parse.String("POSTGRES_DB", &cfg.Database)
-	parse.String("POSTGRES_SSLMODE", &cfg.SSLMode)
-
 	for _, op := range []error{
+		parse.String("POSTGRES_HOST", &cfg.Host),
+		parse.String("POSTGRES_USER", &cfg.User),
+		parse.String("POSTGRES_PASSWORD", &cfg.Password),
+		parse.String("POSTGRES_DB", &cfg.Database),
+		parse.String("POSTGRES_SSLMODE", &cfg.SSLMode),
 		parse.Port("POSTGRES_PORT", &cfg.Port),
 		parse.PositiveInt32("POSTGRES_MAX_CONNS", &cfg.MaxConns),    // > 0 — 0 면 connection 획득 불가
 		parse.NonNegativeInt32("POSTGRES_MIN_CONNS", &cfg.MinConns), // >= 0 — 0 면 idle pool 없음

--- a/pkg/config/storage/db.go
+++ b/pkg/config/storage/db.go
@@ -6,10 +6,11 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"strconv"
 	"time"
 
 	"github.com/joho/godotenv"
+
+	"issuetracker/pkg/config/internal/parse"
 )
 
 // DBConfig는 PostgreSQL 연결 설정을 나타냅니다.
@@ -70,55 +71,28 @@ func Load(envFiles ...string) (DBConfig, error) {
 
 	cfg := DefaultDBConfig()
 
-	if v := os.Getenv("POSTGRES_HOST"); v != "" {
-		cfg.Host = v
-	}
-	if v := os.Getenv("POSTGRES_PORT"); v != "" {
-		p, err := strconv.Atoi(v)
-		if err != nil {
-			return DBConfig{}, fmt.Errorf("parse POSTGRES_PORT %q: %w", v, err)
+	// 검증 강화 (이슈 #439): port 범위, 양수 timeout, 비음수 conn 수.
+	parse.String("POSTGRES_HOST", &cfg.Host)
+	parse.String("POSTGRES_USER", &cfg.User)
+	parse.String("POSTGRES_PASSWORD", &cfg.Password)
+	parse.String("POSTGRES_DB", &cfg.Database)
+	parse.String("POSTGRES_SSLMODE", &cfg.SSLMode)
+
+	for _, op := range []error{
+		parse.Port("POSTGRES_PORT", &cfg.Port),
+		parse.PositiveInt32("POSTGRES_MAX_CONNS", &cfg.MaxConns),    // > 0 — 0 면 connection 획득 불가
+		parse.NonNegativeInt32("POSTGRES_MIN_CONNS", &cfg.MinConns), // >= 0 — 0 면 idle pool 없음
+		parse.PositiveDuration("POSTGRES_CONN_TIMEOUT", &cfg.ConnTimeout),
+		parse.NonNegativeDuration("POSTGRES_QUERY_TIMEOUT", &cfg.QueryTimeout), // 0 = legacy 호환 미적용
+	} {
+		if op != nil {
+			return DBConfig{}, op
 		}
-		cfg.Port = p
 	}
-	if v := os.Getenv("POSTGRES_USER"); v != "" {
-		cfg.User = v
-	}
-	if v := os.Getenv("POSTGRES_PASSWORD"); v != "" {
-		cfg.Password = v
-	}
-	if v := os.Getenv("POSTGRES_DB"); v != "" {
-		cfg.Database = v
-	}
-	if v := os.Getenv("POSTGRES_SSLMODE"); v != "" {
-		cfg.SSLMode = v
-	}
-	if v := os.Getenv("POSTGRES_MAX_CONNS"); v != "" {
-		n, err := strconv.ParseInt(v, 10, 32)
-		if err != nil {
-			return DBConfig{}, fmt.Errorf("parse POSTGRES_MAX_CONNS %q: %w", v, err)
-		}
-		cfg.MaxConns = int32(n)
-	}
-	if v := os.Getenv("POSTGRES_MIN_CONNS"); v != "" {
-		n, err := strconv.ParseInt(v, 10, 32)
-		if err != nil {
-			return DBConfig{}, fmt.Errorf("parse POSTGRES_MIN_CONNS %q: %w", v, err)
-		}
-		cfg.MinConns = int32(n)
-	}
-	if v := os.Getenv("POSTGRES_CONN_TIMEOUT"); v != "" {
-		d, err := time.ParseDuration(v)
-		if err != nil {
-			return DBConfig{}, fmt.Errorf("parse POSTGRES_CONN_TIMEOUT %q: %w", v, err)
-		}
-		cfg.ConnTimeout = d
-	}
-	if v := os.Getenv("POSTGRES_QUERY_TIMEOUT"); v != "" {
-		d, err := time.ParseDuration(v)
-		if err != nil {
-			return DBConfig{}, fmt.Errorf("parse POSTGRES_QUERY_TIMEOUT %q: %w", v, err)
-		}
-		cfg.QueryTimeout = d
+
+	// MinConns > MaxConns 면 pgxpool 이 거부하므로 사전 검증으로 친절한 메시지 제공.
+	if cfg.MinConns > cfg.MaxConns {
+		return DBConfig{}, fmt.Errorf("POSTGRES_MIN_CONNS (%d) cannot exceed POSTGRES_MAX_CONNS (%d)", cfg.MinConns, cfg.MaxConns)
 	}
 
 	return cfg, nil


### PR DESCRIPTION
## 연관 이슈
- Closes #439

<br>

## 구현 내용

PR #438 / #441 리뷰에서 지적된 env 값 검증 누락(6+건)을 일괄 해결. 공통 helper sub-package 도입으로 DRY + 일관 정책 강제.

### 1. `pkg/config/internal/parse/` (신규)
- env 파싱·검증 helper sub-package — `internal/` 로 외부 노출 차단
- 정책: 미설정 → noop (default 보존) / 비어있지 않으면 파싱 + 의미적 검증
- 제공 helper: `Port` (1-65535), `PositiveDuration` / `NonNegativeDuration`, `PositiveInt` / `NonNegativeInt` / `PositiveInt32` / `NonNegativeInt32` / `NonNegativeInt64`, `Ratio` ([0.0, 1.0]), `Bool`, `String`, `Enum`
- 단위 테스트: 경계값 / 잘못된 값 / 빈 값 케이스 모두 커버

### 2. `pkg/config/storage/db.go`
- `POSTGRES_PORT`: 1-65535 (이전: strconv.Atoi 만)
- `POSTGRES_MAX_CONNS`: 양수, `MIN_CONNS`: 비음수
- `POSTGRES_CONN_TIMEOUT`: 양수, `QUERY_TIMEOUT`: 비음수 (0 = legacy 호환 미적용)
- `MinConns > MaxConns` 사전 검증 (pgxpool 거부 전 친절 메시지)

### 3. `pkg/config/llm/llm.go`
- `LLM_PROVIDER`: enum 검증 `["gemini", "openai", "anthropic", "claude"]` — typo silent fallback 회피
- `LLM_TIMEOUT`: 양수 검증

### 4. `pkg/config/processor/scheduler.go`
- 로컬 helper (parseDuration/parseInt/parseInt64) 제거 → parse pkg 위임
- duration 양수 / retries 비음수 / backlog 비음수 (0 = throttle 비활성)

### 5. `pkg/config/processor/validate.go`
- News/Community 임계값 16개 일괄 검증 — 길이/카운트 양수, ratio/weight [0,1]
- Min/Max 의미적 일관성 검사 (TitleMinLen ≤ TitleMaxLen 등)

<br>

## CI / 머지 게이트 점검

### 변경 영향 범위
- 영향 패키지/모듈: `pkg/config/internal/parse` (신규), `pkg/config/storage`, `pkg/config/llm`, `pkg/config/processor`
- 위험도: `Low` — 검증만 추가, 정상 입력에 대한 동작 변화 없음. 잘못된 env 값에 대해서는 fail-fast 로 전환 (기존 silent degraded 보다 안전)

### Required Status Checks
- [ ] `Commit Lint`
- [ ] `PR Title Lint`
- [ ] `Linked Issue Check`
- [ ] `Format Check`
- [ ] `Build`
- [ ] `Test`
- [ ] `Lint`

### 롤백 계획
- revert PR 단일 작업 — 신규 sub-package + 4 Load 함수만 영향. 의존 코드 변경 없음.

<br>

## TODO
- [x] parse helper sub-package + 단위 테스트
- [x] db / llm / scheduler / validate 적용
- [x] gofmt / vet / build / `go test -race ./...` 그린

<br>

## 논의 사항
- 추가 audit 결과: app/log.go (switch enum), llm/path_infer.go / classifier.go / prompt.go / refinement.go, processor/blacklist.go / stale_relearn.go, fetcher/auto_upgrade.go / chromedp_pool.go 모두 기존에 자체 bound 검증이 존재 — 본 PR 에서는 미수정 (향후 일관성을 위해 별도 이슈로 점진 마이그레이션 검토 가능)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Implemented centralized validation for environment variable configuration with semantic bounds checking (port ranges, positive/non-negative values, duration constraints, enumeration validation).

* **Tests**
  * Added comprehensive test suite for configuration parsing and validation.

* **Refactor**
  * Updated configuration modules to use consistent parsing and validation approach across the system.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/EinSofINTEREST/IssueTracker/pull/442)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->