### PR TITLE
[FEAT#443] cmd/issuetracker stage-toggle env flags

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -184,6 +184,16 @@ FETCHER_LOW_WORKER_COUNT=2
 PARSER_WORKER_COUNT=6
 VALIDATE_WORKER_COUNT=8
 
+# Stage toggle (이슈 #443) — 단일 issuetracker 바이너리에서 stage 별 활성/비활성 제어.
+# 모두 true 가 default — env 미설정 시 동작 100% 보존.
+# 운영자가 같은 바이너리를 fetcher-only / parser-only / validate-only / scheduler-only
+# 노드로 배포할 수 있도록. Kafka consumer group 이 partition 분배를 처리하므로 stage 간
+# 결합은 토픽 경유로 유지됨. 모두 false 면 fatal — 의미 없으므로 명시적 거부.
+STAGES_FETCHER_ENABLED=true
+STAGES_PARSER_ENABLED=true
+STAGES_VALIDATE_ENABLED=true
+STAGES_SCHEDULER_ENABLED=true
+
 # Chromedp pool 설정 (이슈 #230) — JS heavy 사이트 크롤링용 headless Chrome pool
 FETCHER_CHROMEDP_POOL_ENABLED=true
 FETCHER_CHROMEDP_WORKER_COUNT=2

--- a/cmd/issuetracker/main.go
+++ b/cmd/issuetracker/main.go
@@ -88,6 +88,20 @@ func main() {
 		"validate":       workerCountsCfg.Validate,
 	}).Info("worker counts loaded")
 
+	// Stage toggle (이슈 #443) — env 로 stage 별 활성/비활성 제어. 모두 true 가 default
+	// 이므로 env 미설정 시 동작 100% 보존. fetcher-only / parser-only / validate-only
+	// 노드를 같은 바이너리로 띄울 수 있도록 stage Start 호출만 gating.
+	stagesCfg, err := runtimecfg.LoadStages()
+	if err != nil {
+		log.WithError(err).Fatal("failed to load stages config")
+	}
+	log.WithFields(map[string]interface{}{
+		"fetcher":   stagesCfg.FetcherEnabled,
+		"parser":    stagesCfg.ParserEnabled,
+		"validate":  stagesCfg.ValidateEnabled,
+		"scheduler": stagesCfg.SchedulerEnabled,
+	}).Info("stage toggles loaded")
+
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
@@ -800,12 +814,18 @@ func main() {
 		}).Info("scheduler backlog throttle enabled")
 	}
 
-	sched.Start(ctx)
-	// Resolver 가 wiring 되어 있으면 30s 주기 refresh — DB 변경 자동 반영.
-	// resolver 자체 5min TTL cache 가 DB 부하 흡수, 짧은 refresh 가 stall 빈도 줄임.
-	sched.StartRefreshLoop(ctx, 30*time.Second)
+	// 이슈 #443 — scheduler stage 비활성 시 Start 호출만 skip.
+	// 구성요소 (entries / resolver / publisher) 는 그대로 둠 — DB 부하·메모리 미미.
+	if stagesCfg.SchedulerEnabled {
+		sched.Start(ctx)
+		// Resolver 가 wiring 되어 있으면 30s 주기 refresh — DB 변경 자동 반영.
+		// resolver 자체 5min TTL cache 가 DB 부하 흡수, 짧은 refresh 가 stall 빈도 줄임.
+		sched.StartRefreshLoop(ctx, 30*time.Second)
 
-	log.WithField("entry_count", len(entries)).Info("scheduler started")
+		log.WithField("entry_count", len(entries)).Info("scheduler started")
+	} else {
+		log.Info("scheduler disabled by STAGES_SCHEDULER_ENABLED=false")
+	}
 
 	// ══════════════════════════════════════════════════════════════════════════
 	// Processor (Validate)
@@ -867,20 +887,42 @@ func main() {
 		log.WithError(err).Fatal("failed to construct validate stage")
 	}
 
+	// 이슈 #443 — stage 별 활성 플래그에 따라 selective Start.
+	// 구성은 위에서 항상 진행 (Kafka Reader 는 FetchMessage 호출 전까지 group 미참여 —
+	// 비활성 stage 의 phantom consumer 우려 없음). 비활성 시 Start 만 skip.
+	stages := []processor.Stage{}
+	if stagesCfg.FetcherEnabled {
+		stages = append(stages, fetcherStage)
+	} else {
+		log.Info("fetcher stage disabled by STAGES_FETCHER_ENABLED=false")
+	}
+	if stagesCfg.ParserEnabled {
+		stages = append(stages, parserStg)
+	} else {
+		log.Info("parser stage disabled by STAGES_PARSER_ENABLED=false")
+	}
+	if stagesCfg.ValidateEnabled {
+		stages = append(stages, validateStage)
+	} else {
+		log.Info("validate stage disabled by STAGES_VALIDATE_ENABLED=false")
+	}
+
 	// chromedp 자동 upgrade 의 자가 회복 안전장치 — interval 마다 reason='auto_upgrade_validation'
 	// row 를 goquery 로 reset. ENABLED=false 시 stage 미등록 (단계 3 의 upgrade-only 동작 유지).
-	stages := []processor.Stage{fetcherStage, parserStg, validateStage}
+	// fetcher stage 비활성 시 downgrader 도 의미 없으므로 함께 skip.
 	downgradeCfg, err := fetchercfg.LoadFetcherAutoDowngrade()
 	if err != nil {
 		log.WithError(err).Fatal("failed to load fetcher auto-downgrade config")
 	}
-	if downgradeCfg.Enabled {
+	if stagesCfg.FetcherEnabled && downgradeCfg.Enabled {
 		downgrader, err := fetcherRule.NewDowngrader(fetcherRuleRepo, fetcherResolver, downgradeCfg.Interval, log)
 		if err != nil {
 			log.WithError(err).Fatal("failed to construct fetcher auto-downgrade stage")
 		}
 		stages = append(stages, downgrader)
 		log.WithField("interval", downgradeCfg.Interval.String()).Info("fetcher auto-downgrade enabled")
+	} else if !stagesCfg.FetcherEnabled {
+		log.Info("fetcher auto-downgrade skipped (fetcher stage disabled)")
 	} else {
 		log.Info("fetcher auto-downgrade disabled (FETCHER_AUTO_DOWNGRADE_ENABLED=false)")
 	}

--- a/pkg/config/runtime/stages.go
+++ b/pkg/config/runtime/stages.go
@@ -1,0 +1,79 @@
+package runtimecfg
+
+import (
+	"errors"
+	"fmt"
+	"os"
+
+	"github.com/joho/godotenv"
+
+	"issuetracker/pkg/config/internal/parse"
+)
+
+// StagesConfig 는 cmd/issuetracker 가 한 프로세스 안에서 어느 단계 워커를 기동할지
+// 제어합니다 (이슈 #443).
+//
+// 모든 stage 가 default true — env 미설정 시 기존 동작 (모든 stage 동시 기동) 그대로 보존.
+// 운영자는 stage 별로 false 를 줘서 같은 바이너리를 fetcher-only / parser-only /
+// validate-only / scheduler-only 노드로 배포할 수 있음. Kafka consumer group 이
+// partition 분배를 처리하므로 stage 간 결합은 토픽 경유로 유지됨.
+//
+// 모든 stage 가 false 면 의미가 없으므로 LoadStages 가 명시적 에러를 반환.
+type StagesConfig struct {
+	// FetcherEnabled: fetcher worker pool (high/normal/low + chromedp) 기동 여부.
+	// 환경변수 STAGES_FETCHER_ENABLED (default true).
+	FetcherEnabled bool
+
+	// ParserEnabled: parser worker (issuetracker.fetched consumer) 기동 여부.
+	// 환경변수 STAGES_PARSER_ENABLED (default true).
+	ParserEnabled bool
+
+	// ValidateEnabled: validate worker (issuetracker.normalized consumer) 기동 여부.
+	// 환경변수 STAGES_VALIDATE_ENABLED (default true).
+	ValidateEnabled bool
+
+	// SchedulerEnabled: scheduler (crawl job emitter) 기동 여부.
+	// 환경변수 STAGES_SCHEDULER_ENABLED (default true).
+	SchedulerEnabled bool
+}
+
+// DefaultStagesConfig 는 모든 stage 활성화된 상태를 반환합니다 (backward compat).
+func DefaultStagesConfig() StagesConfig {
+	return StagesConfig{
+		FetcherEnabled:   true,
+		ParserEnabled:    true,
+		ValidateEnabled:  true,
+		SchedulerEnabled: true,
+	}
+}
+
+// LoadStages 는 .env 를 로드한 후 환경변수로 StagesConfig 를 구성합니다.
+//
+// 모든 stage 가 false 인 구성은 의미 없음 — LoadStages 가 에러로 거부.
+func LoadStages(envFiles ...string) (StagesConfig, error) {
+	if len(envFiles) == 0 {
+		envFiles = []string{".env"}
+	}
+	if err := godotenv.Load(envFiles...); err != nil && !errors.Is(err, os.ErrNotExist) {
+		return StagesConfig{}, fmt.Errorf("failed to load env files %v: %w", envFiles, err)
+	}
+
+	cfg := DefaultStagesConfig()
+
+	for _, op := range []error{
+		parse.Bool("STAGES_FETCHER_ENABLED", &cfg.FetcherEnabled),
+		parse.Bool("STAGES_PARSER_ENABLED", &cfg.ParserEnabled),
+		parse.Bool("STAGES_VALIDATE_ENABLED", &cfg.ValidateEnabled),
+		parse.Bool("STAGES_SCHEDULER_ENABLED", &cfg.SchedulerEnabled),
+	} {
+		if op != nil {
+			return StagesConfig{}, op
+		}
+	}
+
+	if !cfg.FetcherEnabled && !cfg.ParserEnabled && !cfg.ValidateEnabled && !cfg.SchedulerEnabled {
+		return StagesConfig{}, fmt.Errorf("all stages disabled — at least one of STAGES_FETCHER_ENABLED/STAGES_PARSER_ENABLED/STAGES_VALIDATE_ENABLED/STAGES_SCHEDULER_ENABLED must be true")
+	}
+
+	return cfg, nil
+}

--- a/pkg/config/runtime/stages.go
+++ b/pkg/config/runtime/stages.go
@@ -72,7 +72,11 @@ func LoadStages(envFiles ...string) (StagesConfig, error) {
 	}
 
 	if !cfg.FetcherEnabled && !cfg.ParserEnabled && !cfg.ValidateEnabled && !cfg.SchedulerEnabled {
-		return StagesConfig{}, fmt.Errorf("all stages disabled — at least one of STAGES_FETCHER_ENABLED/STAGES_PARSER_ENABLED/STAGES_VALIDATE_ENABLED/STAGES_SCHEDULER_ENABLED must be true")
+		return StagesConfig{}, fmt.Errorf(
+			"all stages disabled — at least one of " +
+				"STAGES_FETCHER_ENABLED/STAGES_PARSER_ENABLED/" +
+				"STAGES_VALIDATE_ENABLED/STAGES_SCHEDULER_ENABLED must be true",
+		)
 	}
 
 	return cfg, nil

--- a/test/pkg/config/stages_test.go
+++ b/test/pkg/config/stages_test.go
@@ -1,0 +1,62 @@
+package config_test
+
+import (
+	runtimecfg "issuetracker/pkg/config/runtime"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestLoadStages_DefaultValues(t *testing.T) {
+	t.Setenv("STAGES_FETCHER_ENABLED", "")
+	t.Setenv("STAGES_PARSER_ENABLED", "")
+	t.Setenv("STAGES_VALIDATE_ENABLED", "")
+	t.Setenv("STAGES_SCHEDULER_ENABLED", "")
+	cfg, err := runtimecfg.LoadStages("/tmp/nonexistent-env-file.env")
+	require.NoError(t, err)
+	require.True(t, cfg.FetcherEnabled)
+	require.True(t, cfg.ParserEnabled)
+	require.True(t, cfg.ValidateEnabled)
+	require.True(t, cfg.SchedulerEnabled)
+}
+
+func TestLoadStages_FetcherOnly(t *testing.T) {
+	t.Setenv("STAGES_FETCHER_ENABLED", "true")
+	t.Setenv("STAGES_PARSER_ENABLED", "false")
+	t.Setenv("STAGES_VALIDATE_ENABLED", "false")
+	t.Setenv("STAGES_SCHEDULER_ENABLED", "false")
+	cfg, err := runtimecfg.LoadStages("/tmp/nonexistent-env-file.env")
+	require.NoError(t, err)
+	require.True(t, cfg.FetcherEnabled)
+	require.False(t, cfg.ParserEnabled)
+	require.False(t, cfg.ValidateEnabled)
+	require.False(t, cfg.SchedulerEnabled)
+}
+
+func TestLoadStages_ValidateOnly(t *testing.T) {
+	t.Setenv("STAGES_FETCHER_ENABLED", "false")
+	t.Setenv("STAGES_PARSER_ENABLED", "false")
+	t.Setenv("STAGES_VALIDATE_ENABLED", "true")
+	t.Setenv("STAGES_SCHEDULER_ENABLED", "false")
+	cfg, err := runtimecfg.LoadStages("/tmp/nonexistent-env-file.env")
+	require.NoError(t, err)
+	require.False(t, cfg.FetcherEnabled)
+	require.False(t, cfg.ParserEnabled)
+	require.True(t, cfg.ValidateEnabled)
+	require.False(t, cfg.SchedulerEnabled)
+}
+
+func TestLoadStages_AllDisabled_Rejected(t *testing.T) {
+	t.Setenv("STAGES_FETCHER_ENABLED", "false")
+	t.Setenv("STAGES_PARSER_ENABLED", "false")
+	t.Setenv("STAGES_VALIDATE_ENABLED", "false")
+	t.Setenv("STAGES_SCHEDULER_ENABLED", "false")
+	_, err := runtimecfg.LoadStages("/tmp/nonexistent-env-file.env")
+	require.Error(t, err, "모두 false 면 의미 없으므로 명시적 거부")
+}
+
+func TestLoadStages_InvalidValue(t *testing.T) {
+	t.Setenv("STAGES_FETCHER_ENABLED", "not-a-bool")
+	_, err := runtimecfg.LoadStages("/tmp/nonexistent-env-file.env")
+	require.Error(t, err)
+}


### PR DESCRIPTION
## 연관 이슈
- Closes #443

<br>

## 구현 내용

`cmd/issuetracker` 가 단일 프로세스에서 fetcher / parser / validate / scheduler 4개 단계를 동시 기동하는 구조에 stage 별 활성/비활성 env toggle 도입. 같은 바이너리로 fetcher-only / parser-only / validate-only / scheduler-only 노드를 배포 가능.

### 1. `pkg/config/runtime/stages.go` (신규)
- `StagesConfig` + `LoadStages()` (parse.Bool 사용)
- 4개 stage 모두 default `true` — env 미설정 시 동작 100% 보존
- 모두 `false` 인 구성은 `LoadStages` 가 fatal 에러로 거부 (의미 없는 구성)
- 단위 테스트: default / fetcher-only / validate-only / all-disabled / invalid value

### 2. `cmd/issuetracker/main.go`
- 로그에 활성 stage 명시 ("stage toggles loaded")
- scheduler: `SchedulerEnabled=false` 면 `Start` / `StartRefreshLoop` skip
- fetcher / parser / validate: `stages` 슬라이스에 enabled 인 것만 append
- fetcher auto-downgrade: fetcher stage 비활성 시 함께 skip

### 3. `.env.example`
- 4개 `STAGES_*` 변수 문서화 (default true, all-false 거부 명시)

### 설계 메모: minimal-invasion
구성요소 (consumer / producer / publisher / worker) 는 stage 비활성에도 그대로 생성됨. kafka-go Reader 가 `FetchMessage` 호출 전까지 consumer group 에 미참여하므로 phantom consumer / lag 누적 우려 없음. Start 호출만 gating 하는 **최소 침투 변경** — 구성 단계 전반을 stage-aware refactor 하는 대신 안전·작은 diff 선호.

추후 stage 별 리소스 절감이 필요해지면 (예: 메모리 1GB 차이) 구성 자체를 gating 하는 후속 PR 가능.

<br>

## CI / 머지 게이트 점검

### 변경 영향 범위
- 영향 패키지/모듈: `pkg/config/runtime` (신규 stages.go), `cmd/issuetracker/main.go`, `.env.example`
- 위험도: `Low` — default 모두 true 이므로 env 미설정 시 동작 변화 0. 기존 배포는 영향 없음.

### Required Status Checks
- [ ] `Commit Lint`
- [ ] `PR Title Lint`
- [ ] `Linked Issue Check`
- [ ] `Format Check`
- [ ] `Build`
- [ ] `Test`
- [ ] `Lint`

### 롤백 계획
- revert PR 단일 작업 — 신규 config + main.go 의 gating 만 영향. 의존 코드 변경 없음.

<br>

## TODO
- [x] `runtimecfg.StagesConfig` + 단위 테스트
- [x] `cmd/issuetracker/main.go` 4개 stage toggle wiring
- [x] `.env.example` 문서화
- [x] gofmt / vet / build / `go test -race ./...` 그린

<br>

## 논의 사항
- `cmd/processor` (validate-only standalone) 와 기능 중복 — 본 PR 후 `cmd/processor` 는 `cmd/issuetracker` + `STAGES_*=false except validate` 로 대체 가능. deprecate 여부는 후속 이슈에서 결정.
- 현재는 Start 호출만 gating — 구성요소 (Kafka consumer / producer 등) 는 늘 생성됨. 메모리·startup 시간이 큰 문제가 되면 구성 자체를 gating 하는 후속 작업 가능.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added stage-level toggles via environment variables (`STAGES_FETCHER_ENABLED`, `STAGES_PARSER_ENABLED`, `STAGES_VALIDATE_ENABLED`, `STAGES_SCHEDULER_ENABLED`) to control which processing stages run at startup. All stages default to enabled to preserve existing behavior.

* **Tests**
  * Added comprehensive tests for stage configuration loading and validation, including invalid value and disabled-stage scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/EinSofINTEREST/IssueTracker/pull/444)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->