### PR TITLE
[FEAT#446] enricher 스켈레톤 — Kafka 토픽 + worker passthrough + stage toggle

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -183,15 +183,20 @@ FETCHER_NORMAL_WORKER_COUNT=6
 FETCHER_LOW_WORKER_COUNT=2
 PARSER_WORKER_COUNT=6
 VALIDATE_WORKER_COUNT=8
+# ENRICH_WORKER_COUNT: enricher worker 수 (이슈 #446). LLM 호출 비용이 큰 단계라
+# validate 보다 작게 (4) 시작. 후속 sub-issue 에서 backlog 모니터링 후 조정.
+ENRICH_WORKER_COUNT=4
 
 # Stage toggle (이슈 #443) — 단일 issuetracker 바이너리에서 stage 별 활성/비활성 제어.
 # 모두 true 가 default — env 미설정 시 동작 100% 보존.
-# 운영자가 같은 바이너리를 fetcher-only / parser-only / validate-only / scheduler-only
-# 노드로 배포할 수 있도록. Kafka consumer group 이 partition 분배를 처리하므로 stage 간
-# 결합은 토픽 경유로 유지됨. 모두 false 면 fatal — 의미 없으므로 명시적 거부.
+# 운영자가 같은 바이너리를 fetcher-only / parser-only / validate-only / enricher-only /
+# scheduler-only 노드로 배포할 수 있도록. Kafka consumer group 이 partition 분배를
+# 처리하므로 stage 간 결합은 토픽 경유로 유지됨. 모두 false 면 fatal — 의미 없으므로
+# 명시적 거부.
 STAGES_FETCHER_ENABLED=true
 STAGES_PARSER_ENABLED=true
 STAGES_VALIDATE_ENABLED=true
+STAGES_ENRICH_ENABLED=true
 STAGES_SCHEDULER_ENABLED=true
 
 # Chromedp pool 설정 (이슈 #230) — JS heavy 사이트 크롤링용 headless Chrome pool

--- a/cmd/issuetracker/main.go
+++ b/cmd/issuetracker/main.go
@@ -16,6 +16,8 @@ import (
 	"issuetracker/internal/bus"
 	"issuetracker/internal/locks"
 	"issuetracker/internal/processor"
+	"issuetracker/internal/processor/enrich"
+	enrichWorkerPkg "issuetracker/internal/processor/enrich/worker"
 	"issuetracker/internal/processor/fetcher"
 	"issuetracker/internal/processor/fetcher/core"
 	"issuetracker/internal/processor/fetcher/domain/general/sources"
@@ -99,6 +101,7 @@ func main() {
 		"fetcher":   stagesCfg.FetcherEnabled,
 		"parser":    stagesCfg.ParserEnabled,
 		"validate":  stagesCfg.ValidateEnabled,
+		"enrich":    stagesCfg.EnrichEnabled,
 		"scheduler": stagesCfg.SchedulerEnabled,
 	}).Info("stage toggles loaded")
 
@@ -871,6 +874,42 @@ func main() {
 	}).Info("validate worker constructed")
 
 	// ══════════════════════════════════════════════════════════════════════════
+	// Processor (Enrich) — sub-issue #446 skeleton (passthrough only)
+	// ══════════════════════════════════════════════════════════════════════════
+
+	enrichKafkaCfg := queue.DefaultConfig()
+	enrichKafkaCfg.GroupID = queue.GroupEnrichers
+
+	enrichConsumer := queue.NewConsumer(enrichKafkaCfg, queue.TopicValidated)
+	defer enrichConsumer.Close()
+
+	enrichProducer := queue.NewProducer(enrichKafkaCfg)
+	defer enrichProducer.Close()
+
+	// publisher facade — enrich 는 Forward (validated → enriched) 만 사용.
+	enrichPublisher := bus.New(enrichProducer, nil, log)
+
+	enrichCap := runtimecfg.CapPerStage(workerCountsCfg.Enrich, stageGateCfg.EnrichMaxConcurrentPerStage)
+	enrichGate := locks.BuildStageGate(locks.StageEnricher, enrichCap, procLock, log)
+	if procLock != nil {
+		log.WithFields(map[string]interface{}{
+			"worker_count": workerCountsCfg.Enrich,
+			"capacity":     enrichCap,
+			"configured":   stageGateCfg.EnrichMaxConcurrentPerStage,
+		}).Info("enrich stage gate enabled (ProcessingLock + Semaphore)")
+	} else {
+		log.Warn("processing lock unavailable, enrich stage gate falls back to noop")
+	}
+
+	enrichW := enrichWorkerPkg.NewWorker(enrichConsumer, enrichPublisher, enrichGate, workerCountsCfg.Enrich)
+
+	log.WithFields(map[string]interface{}{
+		"worker_count": workerCountsCfg.Enrich,
+		"input_topic":  queue.TopicValidated,
+		"output_topic": queue.TopicEnriched,
+	}).Info("enrich worker constructed (passthrough skeleton — #446)")
+
+	// ══════════════════════════════════════════════════════════════════════════
 	// Stage 통합 — processor.Stage 인터페이스로 모든 단계 균일 관리
 	// ══════════════════════════════════════════════════════════════════════════
 
@@ -885,6 +924,10 @@ func main() {
 	validateStage, err := validate.NewStage(validateWorker)
 	if err != nil {
 		log.WithError(err).Fatal("failed to construct validate stage")
+	}
+	enrichStage, err := enrich.NewStage(enrichW)
+	if err != nil {
+		log.WithError(err).Fatal("failed to construct enrich stage")
 	}
 
 	// 이슈 #443 — stage 별 활성 플래그에 따라 selective Start.
@@ -905,6 +948,11 @@ func main() {
 		stages = append(stages, validateStage)
 	} else {
 		log.Info("validate stage disabled by STAGES_VALIDATE_ENABLED=false")
+	}
+	if stagesCfg.EnrichEnabled {
+		stages = append(stages, enrichStage)
+	} else {
+		log.Info("enrich stage disabled by STAGES_ENRICH_ENABLED=false")
 	}
 
 	// chromedp 자동 upgrade 의 자가 회복 안전장치 — interval 마다 reason='auto_upgrade_validation'

--- a/internal/locks/processing_lock.go
+++ b/internal/locks/processing_lock.go
@@ -47,6 +47,7 @@ const (
 	StageFetcher   = "fetcher"
 	StageParser    = "parser"
 	StageValidator = "validator"
+	StageEnricher  = "enricher"
 )
 
 // ProcessingKey 는 (stage, normalized_url) 페어로 ProcessingLock 의 Redis 키를 생성합니다.

--- a/internal/processor/enrich/enrich.go
+++ b/internal/processor/enrich/enrich.go
@@ -1,0 +1,43 @@
+// Package enrich 는 enrich 단계의 processor.Stage 래퍼를 제공합니다 (이슈 #445/#446).
+//
+// Stage 인터페이스는 fetcher / parser / validate 와 동일한 패턴 (Name / Start / Stop).
+// 본 sub-issue (#446) 는 스켈레톤 — 실제 enrichment 로직은 후속 sub-issue 가 worker 내부에 채움.
+package enrich
+
+import (
+	"context"
+	"errors"
+
+	"issuetracker/internal/processor"
+	"issuetracker/internal/processor/enrich/worker"
+)
+
+// Stage 는 enrich worker 를 processor.Stage 인터페이스로 wrapping 합니다.
+type Stage struct {
+	worker *worker.Worker
+}
+
+// NewStage 는 wired Worker 를 받아 enrich.Stage 를 반환합니다.
+// worker 가 nil 이면 error — 호출자 (cmd/main) 가 boot fatal 처리.
+func NewStage(w *worker.Worker) (*Stage, error) {
+	if w == nil {
+		return nil, errors.New("enrich: NewStage requires non-nil Worker")
+	}
+	return &Stage{worker: w}, nil
+}
+
+// Name 은 stage 식별자 ("enricher") 를 반환합니다.
+func (s *Stage) Name() string { return worker.StageName }
+
+// Start 는 enrich worker pool 을 기동합니다.
+func (s *Stage) Start(ctx context.Context) {
+	s.worker.Start(ctx)
+}
+
+// Stop 은 enrich worker 의 graceful shutdown 을 수행합니다.
+func (s *Stage) Stop(ctx context.Context) error {
+	return s.worker.Stop(ctx)
+}
+
+// 컴파일 타임 인터페이스 만족 검증.
+var _ processor.Stage = (*Stage)(nil)

--- a/internal/processor/enrich/worker/worker.go
+++ b/internal/processor/enrich/worker/worker.go
@@ -189,15 +189,21 @@ func (w *Worker) publishEnriched(ctx context.Context, ref *core.ContentRef, pm *
 		return fmt.Errorf("marshal processing message: %w", err)
 	}
 
+	// 원본 메시지 헤더 (trace ID / request ID 등 observability 메타데이터) 를 base 로 복사 후
+	// stage-specific 키만 덮어쓰기 — sendToDLQ 패턴과 일관 (gemini-review #451 반영).
+	headers := make(map[string]string, len(orig.Headers)+3)
+	for k, v := range orig.Headers {
+		headers[k] = v
+	}
+	headers["source"] = ref.SourceInfo.Name
+	headers["country"] = ref.Country
+	headers["stage"] = "enriched"
+
 	outMsg := queue.Message{
-		Topic: queue.TopicEnriched,
-		Key:   orig.Key,
-		Value: outBytes,
-		Headers: map[string]string{
-			"source":  ref.SourceInfo.Name,
-			"country": ref.Country,
-			"stage":   "enriched",
-		},
+		Topic:   queue.TopicEnriched,
+		Key:     orig.Key,
+		Value:   outBytes,
+		Headers: headers,
 	}
 
 	return w.pub.Forward(ctx, outMsg)

--- a/internal/processor/enrich/worker/worker.go
+++ b/internal/processor/enrich/worker/worker.go
@@ -1,0 +1,243 @@
+// Package worker 는 enrich 단계의 Kafka consumer worker 를 제공합니다 (이슈 #446).
+//
+// 본 sub-issue 는 스켈레톤 단계 — 입력 (TopicValidated) 메시지를 그대로 TopicEnriched 로
+// forward 만 수행. 실제 enrichment 로직 (claudegen 호출, 교차 검증, 외부 맥락, 신뢰도 점수) 은
+// 후속 sub-issue (#447 ~ #450) 에서 점진적으로 채워집니다.
+//
+// 패키지 구조는 validate worker (internal/processor/validate/worker) 를 미러링.
+package worker
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"time"
+
+	"issuetracker/internal/bus"
+	"issuetracker/internal/locks"
+	"issuetracker/internal/processor/fetcher/core"
+	"issuetracker/internal/workerpool"
+	"issuetracker/pkg/logger"
+	"issuetracker/pkg/queue"
+)
+
+// StageName 은 enrich 단계의 식별자입니다 (locks.StageEnricher 와 일치).
+const StageName = "enricher"
+
+// drainTimeout 은 graceful shutdown 후 Kafka publish 를 한 번 더 시도할 때 사용하는 별도
+// context 의 타임아웃입니다 (at-least-once).
+const drainTimeout = workerpool.DefaultDrainTimeout
+
+// Worker 는 issuetracker.validated 토픽을 소비하여 enrich 후 issuetracker.enriched 에 발행합니다.
+//
+// 본 sub-issue (#446) 에서는 enrichment 미적용 — passthrough 로 메시지를 그대로 forward.
+// 후속 sub-issue 에서 claudegen 호출 / DB 조회 / 신뢰도 산출이 process 메소드 내부에 점진적으로
+// 추가됩니다.
+type Worker struct {
+	consumer    bus.Consumer
+	pub         *bus.Publisher
+	gate        locks.StageGate // nil 허용 → NoopStageGate 로 fallback
+	workerCount int
+
+	pool *workerpool.ConsumerPool
+}
+
+// NewWorker 는 새로운 Worker 를 생성합니다.
+// pub 이 nil 이면 panic — validate worker 패턴과 일관 (fail-fast).
+func NewWorker(
+	consumer bus.Consumer,
+	pub *bus.Publisher,
+	gate locks.StageGate,
+	workerCount int,
+) *Worker {
+	if pub == nil {
+		panic("enrich.NewWorker: pub must not be nil")
+	}
+	if gate == nil {
+		gate = locks.NewNoopStageGate()
+	}
+	return &Worker{
+		consumer:    consumer,
+		pub:         pub,
+		gate:        gate,
+		workerCount: workerCount,
+	}
+}
+
+// Start 는 workerpool harness 를 기동합니다. 인스턴스당 1회만 호출 (2회차는 panic).
+func (w *Worker) Start(ctx context.Context) {
+	if w.pool != nil {
+		panic("enrich worker: Start called more than once on the same instance")
+	}
+	plainLog := logger.FromContext(ctx)
+	ctx = plainLog.WithField("worker_pool", StageName).ToContext(ctx)
+
+	w.pool = workerpool.New(workerpool.Config{
+		Consumer:     w.consumer,
+		Handler:      w,
+		WorkerCount:  w.workerCount,
+		DrainTimeout: drainTimeout,
+		Log:          plainLog,
+		Name:         StageName,
+	})
+	w.pool.Start(ctx)
+}
+
+// Stop 은 workerpool harness 의 정상 종료를 수행합니다.
+// 미기동 (Start 미호출) 상태에서는 consumer.Close 만 수행.
+func (w *Worker) Stop(ctx context.Context) error {
+	if w.pool == nil {
+		return w.consumer.Close()
+	}
+	return w.pool.Stop(ctx)
+}
+
+// Handle 은 workerpool.Handler 구현 — 각 메시지마다 호출됩니다.
+func (w *Worker) Handle(ctx context.Context, msg *queue.Message) {
+	log := logger.FromContext(ctx)
+	if err := w.process(ctx, msg); err != nil {
+		if errors.Is(err, context.Canceled) {
+			log.WithError(err).Debug("enrich worker canceled during shutdown")
+		} else {
+			log.WithError(err).Error("enrich worker failed to process message")
+		}
+	}
+}
+
+// process 는 단일 메시지를 처리합니다.
+//
+// 본 sub-issue 의 동작: 메시지 deserialize → ContentRef.URL 기반 StageGate acquire → passthrough
+// publish (TopicEnriched) → commit. 후속 sub-issue 가 acquire 이후 enrichment 로직을 삽입.
+func (w *Worker) process(ctx context.Context, msg *queue.Message) error {
+	log := logger.FromContext(ctx)
+
+	var pm core.ProcessingMessage
+	if err := json.Unmarshal(msg.Value, &pm); err != nil {
+		log.WithError(err).Error("failed to unmarshal processing message, sending to dlq")
+		if dlqErr := w.sendToDLQ(ctx, msg, err); dlqErr != nil {
+			return fmt.Errorf("send to dlq (unmarshal): %w", dlqErr)
+		}
+		return w.commit(ctx, msg)
+	}
+
+	var ref core.ContentRef
+	if err := json.Unmarshal(pm.Data, &ref); err != nil {
+		log.WithFields(map[string]interface{}{
+			"job_id": pm.ID,
+		}).WithError(err).Error("failed to unmarshal content ref, sending to dlq")
+		if dlqErr := w.sendToDLQ(ctx, msg, err); dlqErr != nil {
+			return fmt.Errorf("send to dlq (ref unmarshal): %w", dlqErr)
+		}
+		return w.commit(ctx, msg)
+	}
+
+	release, acquired, gateErr := w.gate.Acquire(ctx, ref.URL)
+	if gateErr != nil {
+		if ctx.Err() != nil {
+			return fmt.Errorf("enricher stage gate acquire aborted by ctx: %w", gateErr)
+		}
+		log.WithFields(map[string]interface{}{
+			"job_id": pm.ID,
+			"ref_id": ref.ID,
+		}).WithError(gateErr).Warn("failed to acquire enricher stage gate, proceeding without gate")
+	} else if !acquired {
+		log.WithFields(map[string]interface{}{
+			"job_id": pm.ID,
+			"ref_id": ref.ID,
+		}).Debug("enricher processing lock already held by another worker, skipping")
+		return nil
+	} else {
+		defer release()
+	}
+
+	// 이슈 #446 — 본 sub-issue 는 passthrough 만. enrichment 로직은 후속 sub-issue 에서 삽입.
+	if err := w.publishEnriched(ctx, &ref, &pm, msg); err != nil {
+		if errors.Is(err, context.Canceled) {
+			drainCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), drainTimeout)
+			defer cancel()
+			if drainErr := w.publishEnriched(drainCtx, &ref, &pm, msg); drainErr != nil {
+				return fmt.Errorf("publish enriched ref %s (drain retry failed): %w", ref.ID, drainErr)
+			}
+			return w.commit(drainCtx, msg)
+		}
+		return fmt.Errorf("publish enriched ref %s: %w", ref.ID, err)
+	}
+
+	return w.commit(ctx, msg)
+}
+
+// publishEnriched 는 ContentRef 를 TopicEnriched 에 발행합니다.
+// 본 sub-issue 에서는 payload 가 입력 ref 와 동일 — 후속 sub-issue 가 EnrichedFacts 등을 첨부.
+func (w *Worker) publishEnriched(ctx context.Context, ref *core.ContentRef, pm *core.ProcessingMessage, orig *queue.Message) error {
+	data, err := json.Marshal(ref)
+	if err != nil {
+		return fmt.Errorf("marshal content ref: %w", err)
+	}
+
+	out := core.ProcessingMessage{
+		ID:        pm.ID,
+		Timestamp: time.Now(),
+		Country:   ref.Country,
+		Stage:     "enriched",
+		Data:      data,
+		Metadata:  pm.Metadata,
+	}
+
+	outBytes, err := json.Marshal(out)
+	if err != nil {
+		return fmt.Errorf("marshal processing message: %w", err)
+	}
+
+	outMsg := queue.Message{
+		Topic: queue.TopicEnriched,
+		Key:   orig.Key,
+		Value: outBytes,
+		Headers: map[string]string{
+			"source":  ref.SourceInfo.Name,
+			"country": ref.Country,
+			"stage":   "enriched",
+		},
+	}
+
+	return w.pub.Forward(ctx, outMsg)
+}
+
+// sendToDLQ 는 메시지를 DLQ 토픽으로 발행합니다.
+func (w *Worker) sendToDLQ(ctx context.Context, msg *queue.Message, reason error) error {
+	log := logger.FromContext(ctx)
+
+	headers := make(map[string]string, len(msg.Headers)+2)
+	for k, v := range msg.Headers {
+		headers[k] = v
+	}
+	headers["original-topic"] = msg.Topic
+	headers["error"] = reason.Error()
+
+	dlqMsg := queue.Message{
+		Topic:   queue.TopicDLQ,
+		Key:     msg.Key,
+		Value:   msg.Value,
+		Headers: headers,
+	}
+
+	err := w.pub.Forward(ctx, dlqMsg)
+	if err != nil && errors.Is(err, context.Canceled) {
+		drainCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), drainTimeout)
+		defer cancel()
+		err = w.pub.Forward(drainCtx, dlqMsg)
+	}
+	if err != nil {
+		log.WithError(err).Error("failed to send message to dlq")
+		return err
+	}
+	return nil
+}
+
+// commit 은 Kafka offset 을 commit 합니다 (drain 재시도 포함).
+func (w *Worker) commit(ctx context.Context, msg *queue.Message) error {
+	if w.pool == nil {
+		return workerpool.CommitWithDrain(ctx, w.consumer, msg, drainTimeout)
+	}
+	return w.pool.Commit(ctx, msg)
+}

--- a/pkg/config/runtime/stage_gate.go
+++ b/pkg/config/runtime/stage_gate.go
@@ -26,6 +26,10 @@ type StageGateConfig struct {
 	// ValidateMaxConcurrentPerStage: validate stage 의 Semaphore capacity 상한.
 	// 0 이하면 worker_count/2 (floor) 사용. 양수면 min(value, worker_count/2) 채택.
 	ValidateMaxConcurrentPerStage int
+
+	// EnrichMaxConcurrentPerStage: enrich stage 의 Semaphore capacity 상한 (이슈 #446).
+	// 0 이하면 worker_count/2 (floor) 사용. 양수면 min(value, worker_count/2) 채택.
+	EnrichMaxConcurrentPerStage int
 }
 
 // DefaultStageGateConfig 는 모든 stage 가 0 (worker_count/2 자동) 인 기본값을 반환합니다.
@@ -34,6 +38,7 @@ func DefaultStageGateConfig() StageGateConfig {
 		FetcherMaxConcurrentPerStage:  0,
 		ParserMaxConcurrentPerStage:   0,
 		ValidateMaxConcurrentPerStage: 0,
+		EnrichMaxConcurrentPerStage:   0,
 	}
 }
 
@@ -61,6 +66,7 @@ func LoadStageGate(envFiles ...string) (StageGateConfig, error) {
 		parseInt("FETCHER_MAX_CONCURRENT_PER_STAGE", &cfg.FetcherMaxConcurrentPerStage),
 		parseInt("PARSER_MAX_CONCURRENT_PER_STAGE", &cfg.ParserMaxConcurrentPerStage),
 		parseInt("VALIDATE_MAX_CONCURRENT_PER_STAGE", &cfg.ValidateMaxConcurrentPerStage),
+		parseInt("ENRICH_MAX_CONCURRENT_PER_STAGE", &cfg.EnrichMaxConcurrentPerStage),
 	} {
 		if op != nil {
 			return StageGateConfig{}, op

--- a/pkg/config/runtime/stages.go
+++ b/pkg/config/runtime/stages.go
@@ -32,6 +32,10 @@ type StagesConfig struct {
 	// 환경변수 STAGES_VALIDATE_ENABLED (default true).
 	ValidateEnabled bool
 
+	// EnrichEnabled: enrich worker (issuetracker.validated consumer) 기동 여부 (이슈 #446).
+	// 환경변수 STAGES_ENRICH_ENABLED (default true).
+	EnrichEnabled bool
+
 	// SchedulerEnabled: scheduler (crawl job emitter) 기동 여부.
 	// 환경변수 STAGES_SCHEDULER_ENABLED (default true).
 	SchedulerEnabled bool
@@ -43,6 +47,7 @@ func DefaultStagesConfig() StagesConfig {
 		FetcherEnabled:   true,
 		ParserEnabled:    true,
 		ValidateEnabled:  true,
+		EnrichEnabled:    true,
 		SchedulerEnabled: true,
 	}
 }
@@ -64,6 +69,7 @@ func LoadStages(envFiles ...string) (StagesConfig, error) {
 		parse.Bool("STAGES_FETCHER_ENABLED", &cfg.FetcherEnabled),
 		parse.Bool("STAGES_PARSER_ENABLED", &cfg.ParserEnabled),
 		parse.Bool("STAGES_VALIDATE_ENABLED", &cfg.ValidateEnabled),
+		parse.Bool("STAGES_ENRICH_ENABLED", &cfg.EnrichEnabled),
 		parse.Bool("STAGES_SCHEDULER_ENABLED", &cfg.SchedulerEnabled),
 	} {
 		if op != nil {
@@ -71,11 +77,12 @@ func LoadStages(envFiles ...string) (StagesConfig, error) {
 		}
 	}
 
-	if !cfg.FetcherEnabled && !cfg.ParserEnabled && !cfg.ValidateEnabled && !cfg.SchedulerEnabled {
+	if !cfg.FetcherEnabled && !cfg.ParserEnabled && !cfg.ValidateEnabled &&
+		!cfg.EnrichEnabled && !cfg.SchedulerEnabled {
 		return StagesConfig{}, fmt.Errorf(
-			"all stages disabled — at least one of " +
-				"STAGES_FETCHER_ENABLED/STAGES_PARSER_ENABLED/" +
-				"STAGES_VALIDATE_ENABLED/STAGES_SCHEDULER_ENABLED must be true",
+			"all stages disabled — at least one of STAGES_FETCHER_ENABLED/" +
+				"STAGES_PARSER_ENABLED/STAGES_VALIDATE_ENABLED/" +
+				"STAGES_ENRICH_ENABLED/STAGES_SCHEDULER_ENABLED must be true",
 		)
 	}
 

--- a/pkg/config/runtime/worker_counts.go
+++ b/pkg/config/runtime/worker_counts.go
@@ -38,6 +38,11 @@ type WorkerCountsConfig struct {
 	// Validate: validate worker (issuetracker.normalized consumer) 의 worker 수.
 	// 환경변수 VALIDATE_WORKER_COUNT (default 8).
 	Validate int
+
+	// Enrich: enrich worker (issuetracker.validated consumer) 의 worker 수 (이슈 #446).
+	// 환경변수 ENRICH_WORKER_COUNT (default 4).
+	// LLM 호출 비용이 큰 단계라 validate 보다 작게 잡음 — 후속 sub-issue 가 backlog 모니터링 후 조정.
+	Enrich int
 }
 
 // DefaultWorkerCountsConfig 는 운영 기본값을 반환합니다.
@@ -49,6 +54,7 @@ func DefaultWorkerCountsConfig() WorkerCountsConfig {
 		FetcherLow:    2,
 		Parser:        6,
 		Validate:      8,
+		Enrich:        4,
 	}
 }
 
@@ -80,6 +86,7 @@ func LoadWorkerCounts(envFiles ...string) (WorkerCountsConfig, error) {
 		{"FETCHER_LOW_WORKER_COUNT", &cfg.FetcherLow},
 		{"PARSER_WORKER_COUNT", &cfg.Parser},
 		{"VALIDATE_WORKER_COUNT", &cfg.Validate},
+		{"ENRICH_WORKER_COUNT", &cfg.Enrich},
 	}
 	for _, b := range bindings {
 		v := os.Getenv(b.envKey)

--- a/test/internal/processor/enrich/worker/worker_test.go
+++ b/test/internal/processor/enrich/worker/worker_test.go
@@ -172,6 +172,42 @@ func TestEnrichWorker_Passthrough_ForwardsToEnrichedTopic(t *testing.T) {
 	assert.Equal(t, "example", published.Headers["source"])
 }
 
+// TestEnrichWorker_Passthrough_PreservesOriginalHeaders — 입력 메시지의 헤더 (trace ID
+// 등 observability 메타데이터) 가 forward 시 보존되는지 검증 (gemini PR #451 피드백).
+func TestEnrichWorker_Passthrough_PreservesOriginalHeaders(t *testing.T) {
+	consumer := new(mockConsumer)
+	producer := new(mockProducer)
+	w := newEnrichWorker(consumer, producer)
+
+	msg := makeValidatedMessage(t, "content-002", "https://example.com/b", "KR", "example-kr")
+	msg.Headers = map[string]string{
+		"x-trace-id":   "trace-abc-123",
+		"x-request-id": "req-xyz-789",
+		"stage":        "validated", // stage-specific 키는 덮어써져야 함
+	}
+
+	var published queue.Message
+	producer.On("Publish", mock.Anything, mock.MatchedBy(func(m queue.Message) bool {
+		if m.Topic != queue.TopicEnriched {
+			return false
+		}
+		published = m
+		return true
+	})).Return(nil).Once()
+	producer.On("Close").Return(nil).Maybe()
+	consumer.On("CommitMessages", mock.Anything, mock.Anything).Return(nil).Maybe()
+
+	runWorker(t, consumer, w, msg)
+
+	// observability 헤더는 보존
+	assert.Equal(t, "trace-abc-123", published.Headers["x-trace-id"])
+	assert.Equal(t, "req-xyz-789", published.Headers["x-request-id"])
+	// stage-specific 헤더는 덮어쓰기
+	assert.Equal(t, "enriched", published.Headers["stage"])
+	assert.Equal(t, "example-kr", published.Headers["source"])
+	assert.Equal(t, "KR", published.Headers["country"])
+}
+
 // TestEnrichWorker_MalformedMessage_SendsToDLQ — 잘못된 JSON 은 DLQ 로 라우팅.
 func TestEnrichWorker_MalformedMessage_SendsToDLQ(t *testing.T) {
 	consumer := new(mockConsumer)

--- a/test/internal/processor/enrich/worker/worker_test.go
+++ b/test/internal/processor/enrich/worker/worker_test.go
@@ -1,0 +1,197 @@
+// 본 sub-issue (#446) 의 enrich worker 는 passthrough 만 — 입력 TopicValidated 메시지를
+// 그대로 TopicEnriched 로 forward. 후속 sub-issue 가 enrichment 로직을 본 worker 에
+// 점진적으로 추가하면 본 테스트의 시그니처 (Forward 1회 + commit) 는 유지되되 추가 assertion
+// 이 늘어남.
+package worker_test
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+
+	"issuetracker/internal/bus"
+	"issuetracker/internal/locks"
+	"issuetracker/internal/processor/enrich/worker"
+	"issuetracker/internal/processor/fetcher/core"
+	"issuetracker/pkg/logger"
+	"issuetracker/pkg/queue"
+)
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Mock 구현체
+// ─────────────────────────────────────────────────────────────────────────────
+
+type mockConsumer struct{ mock.Mock }
+
+func (m *mockConsumer) FetchMessage(ctx context.Context) (*queue.Message, error) {
+	args := m.Called(ctx)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*queue.Message), args.Error(1)
+}
+
+func (m *mockConsumer) CommitMessages(ctx context.Context, msgs ...*queue.Message) error {
+	args := m.Called(ctx, msgs)
+	return args.Error(0)
+}
+
+func (m *mockConsumer) Close() error {
+	args := m.Called()
+	return args.Error(0)
+}
+
+type mockProducer struct{ mock.Mock }
+
+func (m *mockProducer) Publish(ctx context.Context, msg queue.Message) error {
+	args := m.Called(ctx, msg)
+	return args.Error(0)
+}
+
+func (m *mockProducer) PublishBatch(ctx context.Context, msgs []queue.Message) error {
+	args := m.Called(ctx, msgs)
+	return args.Error(0)
+}
+
+func (m *mockProducer) Close() error {
+	args := m.Called()
+	return args.Error(0)
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 헬퍼
+// ─────────────────────────────────────────────────────────────────────────────
+
+func newTestPublisher(producer queue.Producer) *bus.Publisher {
+	return bus.New(producer, nil, logger.New(logger.DefaultConfig()))
+}
+
+func newEnrichWorker(consumer queue.Consumer, producer queue.Producer) *worker.Worker {
+	return worker.NewWorker(consumer, newTestPublisher(producer), locks.NewNoopStageGate(), 1)
+}
+
+func makeValidatedMessage(t *testing.T, refID, url, country, sourceName string) *queue.Message {
+	t.Helper()
+	ref := core.ContentRef{
+		ID:      refID,
+		URL:     url,
+		Country: country,
+		SourceInfo: core.SourceInfo{
+			Country: country,
+			Name:    sourceName,
+		},
+	}
+	data, err := json.Marshal(ref)
+	if err != nil {
+		t.Fatalf("marshal ref: %v", err)
+	}
+	pm := core.ProcessingMessage{
+		ID:        "pm-test-001",
+		Timestamp: time.Now(),
+		Country:   country,
+		Stage:     "validated",
+		Data:      data,
+	}
+	value, err := json.Marshal(pm)
+	if err != nil {
+		t.Fatalf("marshal pm: %v", err)
+	}
+	return &queue.Message{
+		Topic: queue.TopicValidated,
+		Key:   []byte(refID),
+		Value: value,
+	}
+}
+
+func runWorker(t *testing.T, consumer *mockConsumer, w *worker.Worker, msg *queue.Message) {
+	t.Helper()
+	ctx, cancel := context.WithCancel(context.Background())
+
+	consumer.On("FetchMessage", mock.Anything).Return(msg, nil).Once()
+	consumer.On("FetchMessage", mock.Anything).
+		Run(func(_ mock.Arguments) { cancel() }).
+		Return(nil, context.Canceled)
+	consumer.On("Close").Return(nil)
+
+	w.Start(ctx)
+	<-ctx.Done()
+
+	stopCtx, stopCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer stopCancel()
+	_ = w.Stop(stopCtx)
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 테스트
+// ─────────────────────────────────────────────────────────────────────────────
+
+// TestEnrichWorker_Passthrough_ForwardsToEnrichedTopic 는 입력 메시지가 그대로
+// TopicEnriched 로 forward 되는지 검증합니다 (sub-issue #446 스켈레톤 동작).
+func TestEnrichWorker_Passthrough_ForwardsToEnrichedTopic(t *testing.T) {
+	consumer := new(mockConsumer)
+	producer := new(mockProducer)
+	w := newEnrichWorker(consumer, producer)
+
+	msg := makeValidatedMessage(t, "content-001", "https://example.com/a", "US", "example")
+
+	// Publish: 어떤 메시지든 받아서 SUCCESS — 본 sub-issue 는 payload assertion 만 헬퍼.
+	var published queue.Message
+	producer.On("Publish", mock.Anything, mock.MatchedBy(func(m queue.Message) bool {
+		published = m
+		return m.Topic == queue.TopicEnriched
+	})).Return(nil).Once()
+	producer.On("Close").Return(nil).Maybe()
+
+	// Commit: any message
+	consumer.On("CommitMessages", mock.Anything, mock.Anything).Return(nil).Maybe()
+
+	runWorker(t, consumer, w, msg)
+
+	consumer.AssertExpectations(t)
+	producer.AssertExpectations(t)
+
+	// 발행된 메시지의 페이로드도 ProcessingMessage + ContentRef 구조여야 함.
+	var pm core.ProcessingMessage
+	if err := json.Unmarshal(published.Value, &pm); err != nil {
+		t.Fatalf("published value not a ProcessingMessage: %v", err)
+	}
+	assert.Equal(t, "enriched", pm.Stage)
+	assert.Equal(t, "US", pm.Country)
+
+	var ref core.ContentRef
+	if err := json.Unmarshal(pm.Data, &ref); err != nil {
+		t.Fatalf("published data not a ContentRef: %v", err)
+	}
+	assert.Equal(t, "content-001", ref.ID)
+	assert.Equal(t, "https://example.com/a", ref.URL)
+	assert.Equal(t, "enriched", published.Headers["stage"])
+	assert.Equal(t, "example", published.Headers["source"])
+}
+
+// TestEnrichWorker_MalformedMessage_SendsToDLQ — 잘못된 JSON 은 DLQ 로 라우팅.
+func TestEnrichWorker_MalformedMessage_SendsToDLQ(t *testing.T) {
+	consumer := new(mockConsumer)
+	producer := new(mockProducer)
+	w := newEnrichWorker(consumer, producer)
+
+	msg := &queue.Message{
+		Topic: queue.TopicValidated,
+		Key:   []byte("k"),
+		Value: []byte("{not json"),
+	}
+
+	producer.On("Publish", mock.Anything, mock.MatchedBy(func(m queue.Message) bool {
+		return m.Topic == queue.TopicDLQ
+	})).Return(nil).Once()
+	producer.On("Close").Return(nil).Maybe()
+	consumer.On("CommitMessages", mock.Anything, mock.Anything).Return(nil).Maybe()
+
+	runWorker(t, consumer, w, msg)
+
+	consumer.AssertExpectations(t)
+	producer.AssertExpectations(t)
+}

--- a/test/pkg/config/config_test.go
+++ b/test/pkg/config/config_test.go
@@ -908,6 +908,7 @@ func TestLoadWorkerCounts_DefaultValues(t *testing.T) {
 		"FETCHER_LOW_WORKER_COUNT",
 		"PARSER_WORKER_COUNT",
 		"VALIDATE_WORKER_COUNT",
+		"ENRICH_WORKER_COUNT",
 	} {
 		t.Setenv(k, "")
 	}
@@ -931,6 +932,9 @@ func TestLoadWorkerCounts_DefaultValues(t *testing.T) {
 	if cfg.Validate != def.Validate {
 		t.Errorf("Validate: got %d, want %d", cfg.Validate, def.Validate)
 	}
+	if cfg.Enrich != def.Enrich {
+		t.Errorf("Enrich: got %d, want %d", cfg.Enrich, def.Enrich)
+	}
 }
 
 func TestLoadWorkerCounts_EnvOverride(t *testing.T) {
@@ -939,12 +943,13 @@ func TestLoadWorkerCounts_EnvOverride(t *testing.T) {
 	t.Setenv("FETCHER_LOW_WORKER_COUNT", "5")
 	t.Setenv("PARSER_WORKER_COUNT", "12")
 	t.Setenv("VALIDATE_WORKER_COUNT", "16")
+	t.Setenv("ENRICH_WORKER_COUNT", "7")
 
 	cfg, err := runtimecfg.LoadWorkerCounts("/tmp/nonexistent-env-file.env")
 	require.NoError(t, err)
 
 	if cfg.FetcherHigh != 10 || cfg.FetcherNormal != 20 || cfg.FetcherLow != 5 ||
-		cfg.Parser != 12 || cfg.Validate != 16 {
+		cfg.Parser != 12 || cfg.Validate != 16 || cfg.Enrich != 7 {
 		t.Errorf("env override 실패: %+v", cfg)
 	}
 }

--- a/test/pkg/config/stage_gate_test.go
+++ b/test/pkg/config/stage_gate_test.go
@@ -12,22 +12,26 @@ func TestLoadStageGate_DefaultValues(t *testing.T) {
 	t.Setenv("FETCHER_MAX_CONCURRENT_PER_STAGE", "")
 	t.Setenv("PARSER_MAX_CONCURRENT_PER_STAGE", "")
 	t.Setenv("VALIDATE_MAX_CONCURRENT_PER_STAGE", "")
+	t.Setenv("ENRICH_MAX_CONCURRENT_PER_STAGE", "")
 	cfg, err := runtimecfg.LoadStageGate("/tmp/nonexistent-env-file.env")
 	require.NoError(t, err)
 	require.Equal(t, 0, cfg.FetcherMaxConcurrentPerStage)
 	require.Equal(t, 0, cfg.ParserMaxConcurrentPerStage)
 	require.Equal(t, 0, cfg.ValidateMaxConcurrentPerStage)
+	require.Equal(t, 0, cfg.EnrichMaxConcurrentPerStage)
 }
 
 func TestLoadStageGate_EnvOverride(t *testing.T) {
 	t.Setenv("FETCHER_MAX_CONCURRENT_PER_STAGE", "2")
 	t.Setenv("PARSER_MAX_CONCURRENT_PER_STAGE", "4")
 	t.Setenv("VALIDATE_MAX_CONCURRENT_PER_STAGE", "5")
+	t.Setenv("ENRICH_MAX_CONCURRENT_PER_STAGE", "3")
 	cfg, err := runtimecfg.LoadStageGate("/tmp/nonexistent-env-file.env")
 	require.NoError(t, err)
 	require.Equal(t, 2, cfg.FetcherMaxConcurrentPerStage)
 	require.Equal(t, 4, cfg.ParserMaxConcurrentPerStage)
 	require.Equal(t, 5, cfg.ValidateMaxConcurrentPerStage)
+	require.Equal(t, 3, cfg.EnrichMaxConcurrentPerStage)
 }
 
 func TestLoadStageGate_InvalidValue(t *testing.T) {

--- a/test/pkg/config/stages_test.go
+++ b/test/pkg/config/stages_test.go
@@ -11,12 +11,14 @@ func TestLoadStages_DefaultValues(t *testing.T) {
 	t.Setenv("STAGES_FETCHER_ENABLED", "")
 	t.Setenv("STAGES_PARSER_ENABLED", "")
 	t.Setenv("STAGES_VALIDATE_ENABLED", "")
+	t.Setenv("STAGES_ENRICH_ENABLED", "")
 	t.Setenv("STAGES_SCHEDULER_ENABLED", "")
 	cfg, err := runtimecfg.LoadStages("/tmp/nonexistent-env-file.env")
 	require.NoError(t, err)
 	require.True(t, cfg.FetcherEnabled)
 	require.True(t, cfg.ParserEnabled)
 	require.True(t, cfg.ValidateEnabled)
+	require.True(t, cfg.EnrichEnabled)
 	require.True(t, cfg.SchedulerEnabled)
 }
 
@@ -24,12 +26,14 @@ func TestLoadStages_FetcherOnly(t *testing.T) {
 	t.Setenv("STAGES_FETCHER_ENABLED", "true")
 	t.Setenv("STAGES_PARSER_ENABLED", "false")
 	t.Setenv("STAGES_VALIDATE_ENABLED", "false")
+	t.Setenv("STAGES_ENRICH_ENABLED", "false")
 	t.Setenv("STAGES_SCHEDULER_ENABLED", "false")
 	cfg, err := runtimecfg.LoadStages("/tmp/nonexistent-env-file.env")
 	require.NoError(t, err)
 	require.True(t, cfg.FetcherEnabled)
 	require.False(t, cfg.ParserEnabled)
 	require.False(t, cfg.ValidateEnabled)
+	require.False(t, cfg.EnrichEnabled)
 	require.False(t, cfg.SchedulerEnabled)
 }
 
@@ -37,12 +41,29 @@ func TestLoadStages_ValidateOnly(t *testing.T) {
 	t.Setenv("STAGES_FETCHER_ENABLED", "false")
 	t.Setenv("STAGES_PARSER_ENABLED", "false")
 	t.Setenv("STAGES_VALIDATE_ENABLED", "true")
+	t.Setenv("STAGES_ENRICH_ENABLED", "false")
 	t.Setenv("STAGES_SCHEDULER_ENABLED", "false")
 	cfg, err := runtimecfg.LoadStages("/tmp/nonexistent-env-file.env")
 	require.NoError(t, err)
 	require.False(t, cfg.FetcherEnabled)
 	require.False(t, cfg.ParserEnabled)
 	require.True(t, cfg.ValidateEnabled)
+	require.False(t, cfg.EnrichEnabled)
+	require.False(t, cfg.SchedulerEnabled)
+}
+
+func TestLoadStages_EnrichOnly(t *testing.T) {
+	t.Setenv("STAGES_FETCHER_ENABLED", "false")
+	t.Setenv("STAGES_PARSER_ENABLED", "false")
+	t.Setenv("STAGES_VALIDATE_ENABLED", "false")
+	t.Setenv("STAGES_ENRICH_ENABLED", "true")
+	t.Setenv("STAGES_SCHEDULER_ENABLED", "false")
+	cfg, err := runtimecfg.LoadStages("/tmp/nonexistent-env-file.env")
+	require.NoError(t, err)
+	require.False(t, cfg.FetcherEnabled)
+	require.False(t, cfg.ParserEnabled)
+	require.False(t, cfg.ValidateEnabled)
+	require.True(t, cfg.EnrichEnabled)
 	require.False(t, cfg.SchedulerEnabled)
 }
 
@@ -50,6 +71,7 @@ func TestLoadStages_AllDisabled_Rejected(t *testing.T) {
 	t.Setenv("STAGES_FETCHER_ENABLED", "false")
 	t.Setenv("STAGES_PARSER_ENABLED", "false")
 	t.Setenv("STAGES_VALIDATE_ENABLED", "false")
+	t.Setenv("STAGES_ENRICH_ENABLED", "false")
 	t.Setenv("STAGES_SCHEDULER_ENABLED", "false")
 	_, err := runtimecfg.LoadStages("/tmp/nonexistent-env-file.env")
 	require.Error(t, err, "모두 false 면 의미 없으므로 명시적 거부")


### PR DESCRIPTION
## 연관 이슈
- Closes #446
- Parent: #445

<br>

## 구현 내용

Enricher 단계의 골격. 본 PR 은 *enrichment 로직 없음* — TopicValidated 메시지를 그대로 TopicEnriched 로 forward 만. 후속 sub-issue (#447 ~ #450) 가 점진적으로 claudegen 호출 / 교차 검증 / 외부 맥락 / 신뢰도 점수 로직을 worker.process 내부에 삽입.

### 1. `internal/processor/enrich/` (신규)
- `enrich.go` — `processor.Stage` 인터페이스 wrapper (validate.Stage 패턴 미러링)
- `worker/worker.go` — Kafka consumer worker
  - 입력: `TopicValidated` (group `GroupEnrichers`)
  - 출력: `TopicEnriched` (stage="enriched")
  - StageGate (ProcessingLock + Semaphore) 합성 지원 — Kafka rebalance 시 같은 ref 중복 처리 차단
  - DLQ / drain timeout / at-least-once commit 패턴 — validate worker 와 일관
- `internal/locks/processing_lock.go` — `StageEnricher = "enricher"` 상수 추가

### 2. `pkg/config/runtime/` 확장 (이슈 #446 정합)
- `StagesConfig.EnrichEnabled` (default true) + `STAGES_ENRICH_ENABLED` env
- `WorkerCountsConfig.Enrich` (default 4) + `ENRICH_WORKER_COUNT` env — LLM 호출 비용 단계라 validate (8) 보다 작게
- `StageGateConfig.EnrichMaxConcurrentPerStage` + `ENRICH_MAX_CONCURRENT_PER_STAGE` env

### 3. `cmd/issuetracker/main.go`
- enrich Kafka consumer/producer + publisher facade 구성
- enrich StageGate + worker + Stage wrap
- `stages` 슬라이스에 조건부 append (STAGES_ENRICH_ENABLED)
- "stage toggles loaded" 로그에 enrich 필드 추가

### 4. `.env.example`
- `ENRICH_WORKER_COUNT=4` / `STAGES_ENRICH_ENABLED=true` 문서화

### 5. 테스트
- `test/internal/processor/enrich/worker/worker_test.go` (신규)
  - passthrough 발행 검증 (입력 ref 가 stage="enriched" payload 로 forward, header 도 동기화)
  - malformed message → DLQ
- `test/pkg/config/` 갱신
  - StagesConfig: default / enrich-only / all-disabled 케이스
  - WorkerCountsConfig: ENRICH_WORKER_COUNT default + override
  - StageGateConfig: ENRICH_MAX_CONCURRENT_PER_STAGE default + override

<br>

## CI / 머지 게이트 점검

### 변경 영향 범위
- 영향 패키지/모듈: `internal/processor/enrich` (신규), `internal/locks`, `pkg/config/runtime`, `cmd/issuetracker/main.go`, `.env.example`
- 위험도: `Low` — 기본값에서는 새 stage 가 단순 passthrough 로 추가됨 (TopicEnriched 가 비어 있던 상태에서 채워지기 시작). 다음 단계 (embedder 등) 가 아직 없으므로 운영 영향 최소

### Required Status Checks
- [ ] `Commit Lint`
- [ ] `PR Title Lint`
- [ ] `Linked Issue Check`
- [ ] `Format Check`
- [ ] `Build`
- [ ] `Test`
- [ ] `Lint`

### 롤백 계획
- `STAGES_ENRICH_ENABLED=false` 로 즉시 비활성 가능 (revert 없이도)
- 코드 롤백 시 신규 enrich 패키지 + main 의 enrich 블록 제거만 영향 — 기존 stage 호환

<br>

## TODO
- [x] enrich passthrough worker + Stage wrapper
- [x] StagesConfig / WorkerCountsConfig / StageGateConfig Enrich 필드
- [x] main.go wiring + .env.example
- [x] 단위 테스트 (worker passthrough + config 3종)
- [x] gofmt / vet / build / `go test -race ./...` 그린

<br>

## 논의 사항
- 다음 sub-issue (#447) 가 본 worker.process 내부에서 claudegen 호출하여 추출 결과를 ContentRef 와 함께 publish 하도록 확장
- enrich worker 가 publishing facade 만 사용하는 것은 의도적 — validate 처럼 reparse/requeue 가 없는 단방향 forward 구조이므로