### PR TITLE
[FEAT#447] enrich 요소 추출 — claudegen prompt 로 entity/claim/facts JSON 구조화

### DIFF
--- a/cmd/issuetracker/main.go
+++ b/cmd/issuetracker/main.go
@@ -17,6 +17,7 @@ import (
 	"issuetracker/internal/locks"
 	"issuetracker/internal/processor"
 	"issuetracker/internal/processor/enrich"
+	enrichextractor "issuetracker/internal/processor/enrich/extractor"
 	enrichWorkerPkg "issuetracker/internal/processor/enrich/worker"
 	"issuetracker/internal/processor/fetcher"
 	"issuetracker/internal/processor/fetcher/core"
@@ -901,13 +902,29 @@ func main() {
 		log.Warn("processing lock unavailable, enrich stage gate falls back to noop")
 	}
 
-	enrichW := enrichWorkerPkg.NewWorker(enrichConsumer, enrichPublisher, enrichGate, workerCountsCfg.Enrich)
+	// 이슈 #447 — claudegen 기반 enricher extractor wiring. claudegen pool 이 미활성이거나
+	// prompt loader 가 없으면 NoopExtractor 로 fallback (worker 는 항상 forward 보장 — extract
+	// 실패가 파이프라인을 막지 않음).
+	var enrichExtractor enrichextractor.Extractor = enrichextractor.NewNoopExtractor()
+	if claudegenPool != nil && promptLoader != nil {
+		ce, ceErr := enrichextractor.NewClaudegenExtractor(claudegenPool, promptLoader)
+		if ceErr != nil {
+			log.WithError(ceErr).Warn("claudegen enrich extractor construction failed, using noop")
+		} else {
+			enrichExtractor = ce
+			log.Info("enrich extractor: claudegen-backed")
+		}
+	} else {
+		log.Info("enrich extractor: noop (claudegen pool or prompt loader unavailable)")
+	}
+
+	enrichW := enrichWorkerPkg.NewWorker(enrichConsumer, enrichPublisher, contentSvc, enrichExtractor, enrichGate, workerCountsCfg.Enrich)
 
 	log.WithFields(map[string]interface{}{
 		"worker_count": workerCountsCfg.Enrich,
 		"input_topic":  queue.TopicValidated,
 		"output_topic": queue.TopicEnriched,
-	}).Info("enrich worker constructed (passthrough skeleton — #446)")
+	}).Info("enrich worker constructed (#447 — claudegen extractor)")
 
 	// ══════════════════════════════════════════════════════════════════════════
 	// Stage 통합 — processor.Stage 인터페이스로 모든 단계 균일 관리

--- a/internal/processor/enrich/extractor/claudegen.go
+++ b/internal/processor/enrich/extractor/claudegen.go
@@ -126,19 +126,35 @@ func parseEnrichOutput(output string) (*EnrichedFacts, error) {
 	return &raw, nil
 }
 
-// stripFences 는 markdown code fence (```json ... ```) 를 제거합니다.
+// stripFences 는 응답에서 markdown code fence (```json ... ```) 를 견고하게 제거합니다.
+//
+// 처리 시나리오 (gemini-review PR #452 반영):
+//   - prompt 위반으로 fence 외부에 대화 텍스트 (예: "Here is the JSON:") 가 있어도
+//     첫 fence 의 시작점을 찾아 그 이전 텍스트는 버림.
+//   - 언어 식별자 (json/javascript 등) 가 newline 없이 붙어 있어도 ('json{"k":1}')
+//     JSON 시작 토큰 ({ 또는 [) 까지 skip.
+//   - 닫는 fence 뒤 텍스트가 있어도 last `\x60\x60\x60` 위치로 자름.
+//   - fence 가 전혀 없는 응답은 그대로 trim 만 적용.
 func stripFences(s string) string {
-	if !strings.HasPrefix(s, "```") {
+	s = strings.TrimSpace(s)
+	startIdx := strings.Index(s, "```")
+	if startIdx == -1 {
 		return s
 	}
-	// 첫 줄 (```json 등) 제거
-	if idx := strings.Index(s, "\n"); idx > 0 {
+	// 첫 fence 진입 — 그 이전 텍스트는 무시.
+	s = s[startIdx+3:]
+
+	// 언어 식별자 처리: newline 까지 skip. newline 없으면 JSON 시작 토큰 위치로 점프.
+	if idx := strings.Index(s, "\n"); idx >= 0 {
 		s = s[idx+1:]
-	} else {
-		s = strings.TrimPrefix(s, "```")
+	} else if start := strings.IndexAny(s, "{["); start != -1 {
+		s = s[start:]
 	}
-	// 마지막 ``` 제거
-	s = strings.TrimSuffix(strings.TrimSpace(s), "```")
+
+	// 닫는 fence 위치 (최근 발견) — 뒤쪽 텍스트 제거.
+	if idx := strings.LastIndex(s, "```"); idx != -1 {
+		s = s[:idx]
+	}
 	return strings.TrimSpace(s)
 }
 

--- a/internal/processor/enrich/extractor/claudegen.go
+++ b/internal/processor/enrich/extractor/claudegen.go
@@ -1,0 +1,146 @@
+package extractor
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+
+	"issuetracker/pkg/llm/prompt"
+)
+
+// SessionRunner 는 claudegen.ClaudeWorkerPool 의 RunEnrichSession 시그니처와 일치하는 추상.
+//
+// 본 패키지가 claudegen 패키지를 직접 import 하면 enrich → claudegen 의존이 추가됨.
+// 인터페이스로 추상화하여 enrich 패키지가 claudegen 을 모르도록 — 테스트도 mock 으로 간단.
+type SessionRunner interface {
+	RunEnrichSession(
+		ctx context.Context,
+		sessionLabel string,
+		files map[string][]byte,
+		promptText string,
+	) (string, error)
+}
+
+// promptName 은 enrich extraction 에 사용할 prompt asset 경로입니다.
+const promptName = "claudegen/enricher_extract"
+
+// ClaudegenExtractor 는 claudegen.ClaudeWorkerPool 을 통해 EnrichedFacts 를 추출합니다.
+type ClaudegenExtractor struct {
+	runner SessionRunner
+	loader prompt.Loader
+}
+
+// NewClaudegenExtractor 는 claudegen-backed Extractor 를 생성합니다.
+//
+// runner 가 nil 이면 error — 호출자 (main.go) 가 claudegen pool 부재 시 NoopExtractor 사용.
+// loader 가 nil 이면 error — prompt asset 로드 불가.
+func NewClaudegenExtractor(runner SessionRunner, loader prompt.Loader) (*ClaudegenExtractor, error) {
+	if runner == nil {
+		return nil, errors.New("extractor: claudegen runner must not be nil")
+	}
+	if loader == nil {
+		return nil, errors.New("extractor: prompt loader must not be nil")
+	}
+	return &ClaudegenExtractor{runner: runner, loader: loader}, nil
+}
+
+// Extract 는 claudegen 으로 session 을 실행하고 stdout 을 EnrichedFacts 로 파싱합니다.
+//
+// 실패 시 error 를 반환 — 호출자 (enrich worker) 는 빈 facts 로 fallback 결정.
+func (e *ClaudegenExtractor) Extract(ctx context.Context, in Input) (*EnrichedFacts, error) {
+	tpl, err := e.loader.Load(promptName)
+	if err != nil {
+		return nil, fmt.Errorf("load enrich prompt %q: %w", promptName, err)
+	}
+
+	// 본 sub-issue 에서는 session_path 가 컨테이너 내부 경로로 직접 노출 — claudegen Worker 의
+	// 세션 디렉토리는 /workspace/<sessionID> 에 마운트. 본 path 를 caller 가 알 필요 없도록
+	// claudegen 내부에서 처리하고, prompt 안에서는 sessionPath placeholder 를 사용.
+	//
+	// 다만 RunEnrichSession 은 sessionPath 를 반환하지 않으므로, prompt template 의
+	// {{SESSION_PATH}} 가 컨테이너 표준 경로로 치환되도록 caller 가 placeholder 를 미리 알아야 함.
+	// 현재 단계: prompt 안에서 page.html 을 직접 절대 경로로 참조하는 대신 "Read the HTML file
+	// in your session workspace" 식으로 묶어 처리 가능. 본 sub-issue 는 ExtractEnriched 와
+	// 동일하게 /workspace/<sessionID>/page.html 컨테이너 path 를 사용하나, RunEnrichSession
+	// 이 sessionID 를 외부로 노출하지 않으므로 prompt 에는 상대 경로만 기록한다.
+	//
+	// 단순화: prompt 에서 {{SESSION_PATH}} 를 그대로 두지 않고, page.html 만 사용한다고 명시 →
+	// claude 가 cwd 의 page.html 을 읽도록 한다. RunEnrichSession 은 컨테이너 cwd 를
+	// 세션 디렉토리로 두므로 동일 효과.
+	//
+	// 향후 (#448 의 cross-verify) 가 sessionPath 가 필요하면 RunEnrichSession 시그니처 확장.
+	promptText := prompt.Render(tpl,
+		"{{SESSION_PATH}}", ".", // 컨테이너 cwd 가 세션 디렉토리이므로 상대경로
+		"{{HOST}}", in.Host,
+		"{{URL}}", in.URL,
+		"{{TITLE}}", in.Title,
+	)
+
+	files := map[string][]byte{
+		"page.html": []byte(in.HTML),
+	}
+
+	stdout, err := e.runner.RunEnrichSession(ctx, "enrich-extract", files, promptText)
+	if err != nil {
+		return nil, fmt.Errorf("claudegen enrich session: %w", err)
+	}
+
+	facts, err := parseEnrichOutput(stdout)
+	if err != nil {
+		return nil, fmt.Errorf("parse enrich output: %w", err)
+	}
+	return facts, nil
+}
+
+// parseEnrichOutput 는 claudegen stdout JSON 을 EnrichedFacts 로 파싱합니다.
+//
+// 응답이 markdown code fence 로 감싸진 경우도 견고하게 처리 — claude 가 prompt 지시에도
+// 가끔 ```json ... ``` 로 감싸 반환.
+func parseEnrichOutput(output string) (*EnrichedFacts, error) {
+	body := stripFences(strings.TrimSpace(output))
+	if body == "" {
+		return nil, errors.New("empty output")
+	}
+	var raw EnrichedFacts
+	if err := json.Unmarshal([]byte(body), &raw); err != nil {
+		return nil, fmt.Errorf("unmarshal: %w", err)
+	}
+	// nil slice → empty slice 정규화 (downstream 코드의 nil/empty 분기 단순화).
+	if raw.Entities == nil {
+		raw.Entities = []Entity{}
+	}
+	if raw.Claims == nil {
+		raw.Claims = []Claim{}
+	}
+	if raw.Facts == nil {
+		raw.Facts = []Fact{}
+	}
+	if raw.Topics == nil {
+		raw.Topics = []string{}
+	}
+	if raw.Sentiment == "" {
+		raw.Sentiment = SentimentNeutral
+	}
+	return &raw, nil
+}
+
+// stripFences 는 markdown code fence (```json ... ```) 를 제거합니다.
+func stripFences(s string) string {
+	if !strings.HasPrefix(s, "```") {
+		return s
+	}
+	// 첫 줄 (```json 등) 제거
+	if idx := strings.Index(s, "\n"); idx > 0 {
+		s = s[idx+1:]
+	} else {
+		s = strings.TrimPrefix(s, "```")
+	}
+	// 마지막 ``` 제거
+	s = strings.TrimSuffix(strings.TrimSpace(s), "```")
+	return strings.TrimSpace(s)
+}
+
+// 컴파일 타임 인터페이스 만족 검증.
+var _ Extractor = (*ClaudegenExtractor)(nil)

--- a/internal/processor/enrich/extractor/extractor.go
+++ b/internal/processor/enrich/extractor/extractor.go
@@ -1,0 +1,32 @@
+// Package extractor 는 enrich 단계의 LLM 추출기 인터페이스 + 구현체를 제공합니다 (이슈 #447).
+//
+// Extractor 는 page 메타데이터를 받아 EnrichedFacts 를 반환하는 단일 메소드 인터페이스입니다.
+// 구현체:
+//   - NoopExtractor: 빈 EnrichedFacts 반환. claudegen 미configured / disabled 환경의 fallback.
+//   - ClaudegenExtractor: claudegen.ClaudeWorkerPool 을 통해 Claude Code 호출 (실제 추출).
+package extractor
+
+import (
+	"context"
+)
+
+// Input 은 Extractor.Extract 입력 — page 식별 + 본문.
+type Input struct {
+	// URL 은 page 의 canonical URL — prompt 에 직접 주입되어 claudegen 이 검증 등에 사용.
+	URL string
+	// Host 는 URL 의 host portion (예: cnn.com). prompt 에 주입.
+	Host string
+	// Title 은 페이지 제목 (선택) — prompt 에 주입되어 context 제공.
+	Title string
+	// HTML 은 page 본문 (parser 가 추출한 정제된 텍스트 또는 raw HTML).
+	// claudegen container 의 세션 디렉토리에 page.html 파일로 기록됩니다.
+	HTML string
+}
+
+// Extractor 는 page 입력으로부터 EnrichedFacts 를 추출합니다.
+//
+// 호출자 (enrich worker) 는 ctx timeout 을 적용하여 호출. error 반환 시 worker 는 빈 facts 로
+// fallback 하고 forward 를 계속 진행 — enrichment 실패가 파이프라인을 멈추지 않도록.
+type Extractor interface {
+	Extract(ctx context.Context, in Input) (*EnrichedFacts, error)
+}

--- a/internal/processor/enrich/extractor/model.go
+++ b/internal/processor/enrich/extractor/model.go
@@ -1,0 +1,109 @@
+// 본 파일은 enrichment 단계의 도메인 schema 를 정의합니다 (이슈 #447).
+//
+// EnrichedFacts 는 page 에서 추출한 구조화된 facts (entities / claims / numeric facts /
+// topics / sentiment) 를 담습니다. 후속 sub-issue (#448 / #449 / #450) 가 verifications /
+// context / trust_score 필드를 추가합니다.
+//
+// 본 타입을 extractor 패키지에 배치한 이유: extractor 가 본 타입의 producer 이며,
+// enrich/worker 도 extractor 만 import 하면 facts 타입에 접근 가능. enrich 루트
+// 패키지 (Stage wrapper) 가 worker 를 import 하므로 본 model 을 enrich 루트에 두면
+// import cycle 발생. extractor 가 cycle-free leaf 위치.
+package extractor
+
+// EntityType 은 추출된 entity 의 분류입니다.
+type EntityType string
+
+const (
+	EntityTypePerson   EntityType = "person"
+	EntityTypeOrg      EntityType = "org"
+	EntityTypeLocation EntityType = "location"
+	EntityTypeEvent    EntityType = "event"
+	EntityTypeProduct  EntityType = "product"
+)
+
+// Sentiment 는 page 전체의 감정 톤입니다.
+type Sentiment string
+
+const (
+	SentimentPositive Sentiment = "positive"
+	SentimentNegative Sentiment = "negative"
+	SentimentNeutral  Sentiment = "neutral"
+)
+
+// Entity 는 page 에서 추출된 named entity 입니다.
+type Entity struct {
+	Type     EntityType `json:"type"`
+	Name     string     `json:"name"`
+	Mentions int        `json:"mentions"`
+}
+
+// Claim 은 page 가 단언하는 한 가지 선언적 진술입니다.
+// subject-predicate-object 분해는 후속 단계 (#448 교차 검증) 에서 활용됩니다.
+type Claim struct {
+	Text      string `json:"text"`
+	Subject   string `json:"subject,omitempty"`
+	Predicate string `json:"predicate,omitempty"`
+	Object    string `json:"object,omitempty"`
+}
+
+// Fact 는 page 의 수치·날짜·정량적 사실입니다.
+type Fact struct {
+	Key   string `json:"key"`
+	Value string `json:"value"`
+	Unit  string `json:"unit,omitempty"`
+}
+
+// EnrichedFacts 는 enrichment 단계의 종합 결과입니다.
+//
+// 본 sub-issue (#447) 는 extraction 결과만 채웁니다. Verifications / Context / TrustScore
+// 필드는 schema 만 reserve — 후속 sub-issue 가 점진적으로 채웁니다.
+type EnrichedFacts struct {
+	Entities  []Entity  `json:"entities"`
+	Claims    []Claim   `json:"claims"`
+	Facts     []Fact    `json:"facts"`
+	Topics    []string  `json:"topics"`
+	Sentiment Sentiment `json:"sentiment"`
+
+	// Verifications / Context / TrustScore: 후속 sub-issue 에서 채움 (#448 / #449 / #450).
+	// 본 sub-issue 에서는 nil/empty 로 출발.
+	Verifications []Verification `json:"verifications,omitempty"`
+	Context       *PageContext   `json:"context,omitempty"`
+	TrustScore    *float64       `json:"trust_score,omitempty"`
+}
+
+// Verification 은 claim 별 외부 소스 대조 결과입니다 (#448 에서 사용).
+type Verification struct {
+	ClaimIdx int      `json:"claim_idx"`
+	Verdict  string   `json:"verdict"` // "supported" | "contradicted" | "unverified"
+	Sources  []string `json:"sources,omitempty"`
+	Note     string   `json:"note,omitempty"`
+}
+
+// PageContext 는 외부 맥락 (사회·정치·공학 배경) 정보입니다 (#449 에서 사용).
+type PageContext struct {
+	Background   []BackgroundItem `json:"background,omitempty"`
+	Timeline     []TimelineEvent  `json:"timeline,omitempty"`
+	Implications *Implications    `json:"implications,omitempty"`
+}
+
+// BackgroundItem 은 entity / topic 별 배경 요약입니다.
+type BackgroundItem struct {
+	Subject  string   `json:"subject"`
+	Category string   `json:"category"` // person | event | tech | policy
+	Summary  string   `json:"summary"`
+	Sources  []string `json:"sources,omitempty"`
+}
+
+// TimelineEvent 는 사건 타임라인 항목입니다.
+type TimelineEvent struct {
+	Date   string `json:"date"` // ISO 8601
+	Event  string `json:"event"`
+	Source string `json:"source,omitempty"`
+}
+
+// Implications 은 사회·정치·공학적 함의 요약입니다.
+type Implications struct {
+	Political string `json:"political,omitempty"`
+	Social    string `json:"social,omitempty"`
+	Technical string `json:"technical,omitempty"`
+}

--- a/internal/processor/enrich/extractor/noop.go
+++ b/internal/processor/enrich/extractor/noop.go
@@ -1,0 +1,30 @@
+package extractor
+
+import (
+	"context"
+)
+
+// NoopExtractor 는 빈 EnrichedFacts 를 반환하는 placeholder 입니다.
+//
+// 용도: claudegen 비활성 환경 / 테스트 / 단계적 rollout 첫 단계에서 사용. enrich worker 는
+// 항상 Extractor 의존을 받으므로 nil 대신 NoopExtractor 를 주입 → nil-check 분기 제거.
+type NoopExtractor struct{}
+
+// NewNoopExtractor 는 NoopExtractor 인스턴스를 반환합니다.
+func NewNoopExtractor() *NoopExtractor {
+	return &NoopExtractor{}
+}
+
+// Extract 는 항상 빈 (zero-value 필드) EnrichedFacts 를 반환합니다.
+func (e *NoopExtractor) Extract(_ context.Context, _ Input) (*EnrichedFacts, error) {
+	return &EnrichedFacts{
+		Entities:  []Entity{},
+		Claims:    []Claim{},
+		Facts:     []Fact{},
+		Topics:    []string{},
+		Sentiment: SentimentNeutral,
+	}, nil
+}
+
+// 컴파일 타임 인터페이스 만족 검증.
+var _ Extractor = (*NoopExtractor)(nil)

--- a/internal/processor/enrich/worker/worker.go
+++ b/internal/processor/enrich/worker/worker.go
@@ -218,7 +218,15 @@ func (w *Worker) runExtraction(ctx context.Context, pm *core.ProcessingMessage, 
 	}
 
 	host := ""
-	if u, perr := url.Parse(ref.URL); perr == nil {
+	// url.Parse 실패 시 host 가 빈 문자열로 남고 extractor 가 degraded 입력을 받는데,
+	// 이는 forward-first 정책 일관 — 다만 진단을 위해 DEBUG 로깅 (coderabbit-review PR #452).
+	if u, perr := url.Parse(ref.URL); perr != nil {
+		log.WithFields(map[string]interface{}{
+			"job_id": pm.ID,
+			"ref_id": ref.ID,
+			"url":    ref.URL,
+		}).WithError(perr).Debug("url parse failed for host extraction, using empty host")
+	} else {
 		host = u.Host
 	}
 

--- a/internal/processor/enrich/worker/worker.go
+++ b/internal/processor/enrich/worker/worker.go
@@ -12,11 +12,15 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"net/url"
 	"time"
 
 	"issuetracker/internal/bus"
 	"issuetracker/internal/locks"
+	"issuetracker/internal/processor/enrich/extractor"
 	"issuetracker/internal/processor/fetcher/core"
+	"issuetracker/internal/storage"
+	"issuetracker/internal/storage/service"
 	"issuetracker/internal/workerpool"
 	"issuetracker/pkg/logger"
 	"issuetracker/pkg/queue"
@@ -31,12 +35,18 @@ const drainTimeout = workerpool.DefaultDrainTimeout
 
 // Worker 는 issuetracker.validated 토픽을 소비하여 enrich 후 issuetracker.enriched 에 발행합니다.
 //
-// 본 sub-issue (#446) 에서는 enrichment 미적용 — passthrough 로 메시지를 그대로 forward.
-// 후속 sub-issue 에서 claudegen 호출 / DB 조회 / 신뢰도 산출이 process 메소드 내부에 점진적으로
-// 추가됩니다.
+// 이슈 #447 에서 추가된 동작:
+//   - ContentService 로 ref.ID 의 Content (Title/Body 포함) 조회
+//   - extractor.Extract 로 EnrichedFacts 추출
+//   - 결과를 ProcessingMessage.Metadata["enriched_facts"] 에 JSON 으로 첨부 후 forward
+//
+// 추출 실패는 파이프라인을 멈추지 않습니다 — warn 로깅 + 빈 facts 로 fallback + forward 진행.
+// content 조회 실패 (ErrNotFound) 는 idempotent 정상 분기 — 이미 처리된 메시지로 보고 commit.
 type Worker struct {
 	consumer    bus.Consumer
 	pub         *bus.Publisher
+	contentSvc  service.ContentService
+	extractor   extractor.Extractor
 	gate        locks.StageGate // nil 허용 → NoopStageGate 로 fallback
 	workerCount int
 
@@ -44,15 +54,25 @@ type Worker struct {
 }
 
 // NewWorker 는 새로운 Worker 를 생성합니다.
-// pub 이 nil 이면 panic — validate worker 패턴과 일관 (fail-fast).
+//
+// pub / contentSvc / extractor 가 nil 이면 panic — fail-fast (silent failure 회피).
+// gate 가 nil 이면 NoopStageGate 로 fallback.
 func NewWorker(
 	consumer bus.Consumer,
 	pub *bus.Publisher,
+	contentSvc service.ContentService,
+	ex extractor.Extractor,
 	gate locks.StageGate,
 	workerCount int,
 ) *Worker {
 	if pub == nil {
 		panic("enrich.NewWorker: pub must not be nil")
+	}
+	if contentSvc == nil {
+		panic("enrich.NewWorker: contentSvc must not be nil")
+	}
+	if ex == nil {
+		panic("enrich.NewWorker: extractor must not be nil (use extractor.NoopExtractor for disabled enrichment)")
 	}
 	if gate == nil {
 		gate = locks.NewNoopStageGate()
@@ -60,6 +80,8 @@ func NewWorker(
 	return &Worker{
 		consumer:    consumer,
 		pub:         pub,
+		contentSvc:  contentSvc,
+		extractor:   ex,
 		gate:        gate,
 		workerCount: workerCount,
 	}
@@ -151,7 +173,13 @@ func (w *Worker) process(ctx context.Context, msg *queue.Message) error {
 		defer release()
 	}
 
-	// 이슈 #446 — 본 sub-issue 는 passthrough 만. enrichment 로직은 후속 sub-issue 에서 삽입.
+	// 이슈 #447 — Content 조회 + extractor 호출 + facts 첨부.
+	// 본 단계 어떤 실패도 forward 를 막지 않음 — pipeline 진행이 enrichment 보다 우선.
+	facts := w.runExtraction(ctx, &pm, &ref)
+	if facts != nil {
+		w.attachFacts(&pm, facts)
+	}
+
 	if err := w.publishEnriched(ctx, &ref, &pm, msg); err != nil {
 		if errors.Is(err, context.Canceled) {
 			drainCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), drainTimeout)
@@ -167,8 +195,74 @@ func (w *Worker) process(ctx context.Context, msg *queue.Message) error {
 	return w.commit(ctx, msg)
 }
 
+// runExtraction 은 content 를 조회하고 extractor 를 호출합니다.
+// 모든 실패 경로는 nil 을 반환 — 호출자가 facts 첨부 skip 하고 forward 진행.
+// 즉 enrichment 실패는 pipeline 을 멈추지 않음 (forward-first 정책).
+func (w *Worker) runExtraction(ctx context.Context, pm *core.ProcessingMessage, ref *core.ContentRef) *extractor.EnrichedFacts {
+	log := logger.FromContext(ctx)
+
+	content, err := w.contentSvc.GetByID(ctx, ref.ID)
+	if err != nil {
+		if errors.Is(err, storage.ErrNotFound) {
+			log.WithFields(map[string]interface{}{
+				"job_id": pm.ID,
+				"ref_id": ref.ID,
+			}).Info("content not found, skipping enrichment (already deleted or duplicate)")
+			return nil
+		}
+		log.WithFields(map[string]interface{}{
+			"job_id": pm.ID,
+			"ref_id": ref.ID,
+		}).WithError(err).Warn("failed to fetch content for enrichment, forwarding without facts")
+		return nil
+	}
+
+	host := ""
+	if u, perr := url.Parse(ref.URL); perr == nil {
+		host = u.Host
+	}
+
+	in := extractor.Input{
+		URL:   ref.URL,
+		Host:  host,
+		Title: content.Title,
+		HTML:  content.Body,
+	}
+
+	facts, err := w.extractor.Extract(ctx, in)
+	if err != nil {
+		log.WithFields(map[string]interface{}{
+			"job_id": pm.ID,
+			"ref_id": ref.ID,
+			"host":   host,
+		}).WithError(err).Warn("enrichment extraction failed, forwarding without facts")
+		return nil
+	}
+
+	log.WithFields(map[string]interface{}{
+		"job_id":       pm.ID,
+		"ref_id":       ref.ID,
+		"entity_count": len(facts.Entities),
+		"claim_count":  len(facts.Claims),
+		"fact_count":   len(facts.Facts),
+	}).Debug("enrichment extraction completed")
+	return facts
+}
+
+// attachFacts 는 추출된 facts 를 ProcessingMessage.Metadata 에 JSON 으로 저장합니다.
+//
+// 본 sub-issue 는 wire format 으로 metadata 활용 — 후속 #450 sub-issue 가 별도
+// enriched_contents 테이블에 영속화하면 metadata 의존을 줄일 수 있음.
+//
+// 직렬화 실패 시 best-effort — 메시지는 그대로 forward (warn 로깅 후 skip).
+func (w *Worker) attachFacts(pm *core.ProcessingMessage, facts *extractor.EnrichedFacts) {
+	if pm.Metadata == nil {
+		pm.Metadata = map[string]interface{}{}
+	}
+	pm.Metadata["enriched_facts"] = facts
+}
+
 // publishEnriched 는 ContentRef 를 TopicEnriched 에 발행합니다.
-// 본 sub-issue 에서는 payload 가 입력 ref 와 동일 — 후속 sub-issue 가 EnrichedFacts 등을 첨부.
 func (w *Worker) publishEnriched(ctx context.Context, ref *core.ContentRef, pm *core.ProcessingMessage, orig *queue.Message) error {
 	data, err := json.Marshal(ref)
 	if err != nil {

--- a/internal/processor/parser/rule/claudegen/enrich.go
+++ b/internal/processor/parser/rule/claudegen/enrich.go
@@ -1,0 +1,99 @@
+// 본 파일은 enrich 단계 (이슈 #447) 가 사용할 generic session primitive 를 제공합니다.
+//
+// ExtractEnriched 는 parser-rule extraction 전용 시그니처 (host/targetType/html →
+// llmgen.ExtractResult) 라 enrich 의 다른 prompt / 다른 출력 schema 에는 직접 재사용
+// 불가. 본 파일의 RunEnrichSession 은 한 단계 더 generic 한 primitive:
+// (files + promptText) → raw stdout. enrich 패키지가 자체 prompt template 을 빌드해서
+// 넘기고 자체 출력 schema 로 파싱.
+//
+// ExtractEnriched 의 session lifecycle 과 의도적으로 분리 — 기존 parser 경로에 무영향.
+
+package claudegen
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// RunEnrichSession 은 새 세션을 만들어 files 를 세션 디렉토리에 기록한 뒤 promptText 로
+// claude code 를 호출하고 stdout 을 반환합니다.
+//
+// 매개변수:
+//   - sessionLabel: 로그·디버그용 라벨 (예: "enrich-extract"). 컨테이너 동작에는 영향 없음.
+//   - files: 세션 디렉토리에 기록할 파일들 — filename (확장자 포함) → contents.
+//     prompt 안에서 {{SESSION_PATH}}/<filename> 으로 참조됩니다.
+//   - promptText: claude code 에 -p 로 전달할 최종 프롬프트 (caller 가 이미 placeholder 치환 완료).
+//
+// 세션 디렉토리는 호출 종료 시 자동 삭제됩니다 (성공/실패 무관).
+//
+// 본 메소드는 ExtractEnriched 와 동일하게 wg.Add/Done 으로 진행 중 호출을 추적 — Stop() 의
+// wg.Wait() 이 본 호출을 놓치지 않음.
+//
+// 호출자 역할: stdout 을 자체 schema 로 파싱. RunEnrichSession 은 JSON 파싱 / blacklist 분기
+// 등을 일체 수행하지 않습니다 (parser-specific 인 ExtractEnriched 와 다른 점).
+func (w *ClaudeWorker) RunEnrichSession(
+	ctx context.Context,
+	sessionLabel string,
+	files map[string][]byte,
+	promptText string,
+) (string, error) {
+	w.wg.Add(1)
+	defer w.wg.Done()
+
+	w.mu.RLock()
+	containerID := w.containerID
+	workDir := w.workDir
+	w.mu.RUnlock()
+
+	if containerID == "" {
+		return "", errors.New("claudegen: worker not started — call Start() first")
+	}
+
+	sessionID, err := newSessionID()
+	if err != nil {
+		return "", fmt.Errorf("generate session id: %w", err)
+	}
+
+	sessionHostDir := filepath.Join(workDir, sessionID)
+	if err := os.MkdirAll(sessionHostDir, 0o755); err != nil {
+		return "", fmt.Errorf("create session dir: %w", err)
+	}
+	defer os.RemoveAll(sessionHostDir)
+
+	for name, data := range files {
+		// name 검증: 호출자가 ".." 같은 path traversal 을 넣지 못하도록 baseName 만 허용.
+		if name == "" || name != filepath.Base(name) {
+			return "", fmt.Errorf("invalid session file name %q", name)
+		}
+		if err := os.WriteFile(filepath.Join(sessionHostDir, name), data, 0o644); err != nil {
+			return "", fmt.Errorf("write session file %q: %w", name, err)
+		}
+	}
+
+	runCtx, cancel := context.WithTimeout(ctx, w.sessionTimeout)
+	defer cancel()
+
+	args := []string{
+		"claude",
+		"--model", w.model,
+		"-p", promptText,
+	}
+
+	w.log.WithFields(map[string]interface{}{
+		"session_label": sessionLabel,
+		"container_id":  containerID,
+		"session_id":    sessionID,
+		"file_count":    len(files),
+	}).Debug("starting claude code enrich session")
+
+	stdout, stderr, err := w.runner.ExecSession(runCtx, containerID, args)
+	if err != nil {
+		return "", fmt.Errorf("claude code enrich session: %w (stderr: %s)",
+			err, truncate(stderr, truncateStderrLen))
+	}
+
+	return stdout, nil
+}

--- a/internal/processor/parser/rule/claudegen/pool.go
+++ b/internal/processor/parser/rule/claudegen/pool.go
@@ -242,6 +242,18 @@ func (p *ClaudeWorkerPool) ExtractEnriched(ctx context.Context, host string, tar
 	return p.pick().ExtractEnriched(ctx, host, targetType, html)
 }
 
+// RunEnrichSession 은 round-robin worker 선택 후 RunEnrichSession 위임 (이슈 #447).
+//
+// enrich.Extractor 구현체 (extractor/claudegen.go) 가 호출하는 진입점.
+func (p *ClaudeWorkerPool) RunEnrichSession(
+	ctx context.Context,
+	sessionLabel string,
+	files map[string][]byte,
+	promptText string,
+) (string, error) {
+	return p.pick().RunEnrichSession(ctx, sessionLabel, files, promptText)
+}
+
 // pick 는 round-robin 분배로 다음 worker 를 선택합니다.
 //
 // atomic.Uint64 의 ADD-AND-MODULO 패턴 — lock-free + counter wrap-around 시 modulo 정상 동작.

--- a/pkg/llm/prompt/assets/claudegen/enricher_extract.user.txt
+++ b/pkg/llm/prompt/assets/claudegen/enricher_extract.user.txt
@@ -1,0 +1,32 @@
+Read the HTML file at {{SESSION_PATH}}/page.html from the {{HOST}} website.
+
+Your task: extract structured facts from this page. Return a single JSON object — no explanation, no markdown, no code blocks.
+
+Page URL: {{URL}}
+Page title: {{TITLE}}
+
+Output schema:
+{
+  "entities": [
+    {"type": "person" | "org" | "location" | "event" | "product", "name": "<entity name>", "mentions": <int — number of times referenced>}
+  ],
+  "claims": [
+    {"text": "<full claim as written in the page>", "subject": "<who/what>", "predicate": "<verb/action>", "object": "<target/result>"}
+  ],
+  "facts": [
+    {"key": "<machine-readable key, e.g., death_toll>", "value": "<extracted value>", "unit": "<optional unit, e.g., people, %, USD>"}
+  ],
+  "topics": ["<top-level topic, e.g., politics, technology, environment>", ...],
+  "sentiment": "positive" | "negative" | "neutral"
+}
+
+Extraction rules:
+1. entities — only those clearly named in the page. Aggregate mentions across the body (case-insensitive). Skip generic terms (e.g., "the president" without a name).
+2. claims — declarative statements the page makes (not quotes from interviewees unless presented as fact). 3-10 most central claims. Keep "text" verbatim from the page (truncate to 300 chars).
+3. facts — numerical / quantitative / dated / measurable claims. Extract value as the page presents it (e.g., "32", "1.5 million", "2024-03-15"). Unit is optional.
+4. topics — 1-5 high-level topics. Lowercase. Prefer broad categories (politics, economy, technology, society, environment, culture, sports, health).
+5. sentiment — overall tone of the page towards its subject. neutral by default; positive/negative only when clearly biased.
+
+Empty arrays are acceptable when the page lacks signal. Do not invent.
+
+Return ONLY the JSON object.

--- a/test/internal/processor/enrich/extractor/claudegen_test.go
+++ b/test/internal/processor/enrich/extractor/claudegen_test.go
@@ -86,6 +86,45 @@ func TestClaudegenExtractor_StripsMarkdownFence(t *testing.T) {
 	assert.Equal(t, extractor.SentimentPositive, got.Sentiment)
 }
 
+// TestClaudegenExtractor_StripsFenceVariants — gemini-review PR #452 반영.
+// stripFences 가 다양한 LLM 응답 변형 (preamble / 언어 ID 무 newline / trailing 텍스트) 에서
+// 견고하게 동작하는지 검증.
+func TestClaudegenExtractor_StripsFenceVariants(t *testing.T) {
+	cases := []struct {
+		name   string
+		stdout string
+	}{
+		{
+			name:   "preamble before fence",
+			stdout: "Here is the JSON:\n```json\n{\"sentiment\":\"positive\"}\n```",
+		},
+		{
+			name:   "language id without newline",
+			stdout: "```json{\"sentiment\":\"positive\"}```",
+		},
+		{
+			name:   "trailing text after closing fence",
+			stdout: "```json\n{\"sentiment\":\"positive\"}\n```\nThanks for asking!",
+		},
+		{
+			name:   "no fence at all",
+			stdout: `{"sentiment":"positive"}`,
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			ex, err := extractor.NewClaudegenExtractor(
+				&stubRunner{stdout: c.stdout},
+				&stubLoader{tpl: "t"},
+			)
+			require.NoError(t, err)
+			got, err := ex.Extract(context.Background(), extractor.Input{})
+			require.NoError(t, err)
+			assert.Equal(t, extractor.SentimentPositive, got.Sentiment, "case %q", c.name)
+		})
+	}
+}
+
 func TestClaudegenExtractor_NilFieldsNormalized(t *testing.T) {
 	// 응답에 entities / claims / facts / topics 가 모두 누락 — empty slice 로 정규화.
 	stdout := `{"sentiment": "neutral"}`

--- a/test/internal/processor/enrich/extractor/claudegen_test.go
+++ b/test/internal/processor/enrich/extractor/claudegen_test.go
@@ -1,0 +1,150 @@
+package extractor_test
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"issuetracker/internal/processor/enrich/extractor"
+)
+
+// stubLoader 는 항상 같은 template 을 반환하는 prompt.Loader stub.
+type stubLoader struct {
+	tpl string
+}
+
+func (s *stubLoader) Load(_ string) (string, error) { return s.tpl, nil }
+
+// stubRunner 는 미리 정의한 stdout 또는 error 를 반환하는 SessionRunner stub.
+type stubRunner struct {
+	stdout string
+	err    error
+	calls  int
+}
+
+func (s *stubRunner) RunEnrichSession(
+	_ context.Context,
+	_ string,
+	_ map[string][]byte,
+	_ string,
+) (string, error) {
+	s.calls++
+	if s.err != nil {
+		return "", s.err
+	}
+	return s.stdout, nil
+}
+
+func TestClaudegenExtractor_Success(t *testing.T) {
+	stdout := `{
+		"entities": [{"type": "person", "name": "Alice", "mentions": 2}],
+		"claims":   [{"text": "Alice did X", "subject": "Alice", "predicate": "did", "object": "X"}],
+		"facts":    [{"key": "casualties", "value": "32", "unit": "people"}],
+		"topics":   ["politics", "society"],
+		"sentiment": "neutral"
+	}`
+
+	ex, err := extractor.NewClaudegenExtractor(
+		&stubRunner{stdout: stdout},
+		&stubLoader{tpl: "page at {{HOST}}"},
+	)
+	require.NoError(t, err)
+
+	got, err := ex.Extract(context.Background(), extractor.Input{
+		URL:   "https://example.com/a",
+		Host:  "example.com",
+		Title: "Hi",
+		HTML:  "<html/>",
+	})
+	require.NoError(t, err)
+
+	assert.Len(t, got.Entities, 1)
+	assert.Equal(t, "Alice", got.Entities[0].Name)
+	assert.Equal(t, extractor.EntityTypePerson, got.Entities[0].Type)
+	assert.Len(t, got.Claims, 1)
+	assert.Len(t, got.Facts, 1)
+	assert.Equal(t, "32", got.Facts[0].Value)
+	assert.Equal(t, []string{"politics", "society"}, got.Topics)
+	assert.Equal(t, extractor.SentimentNeutral, got.Sentiment)
+}
+
+func TestClaudegenExtractor_StripsMarkdownFence(t *testing.T) {
+	stdout := "```json\n" + `{"entities":[],"claims":[],"facts":[],"topics":[],"sentiment":"positive"}` + "\n```"
+
+	ex, err := extractor.NewClaudegenExtractor(
+		&stubRunner{stdout: stdout},
+		&stubLoader{tpl: "t"},
+	)
+	require.NoError(t, err)
+
+	got, err := ex.Extract(context.Background(), extractor.Input{})
+	require.NoError(t, err)
+	assert.Equal(t, extractor.SentimentPositive, got.Sentiment)
+}
+
+func TestClaudegenExtractor_NilFieldsNormalized(t *testing.T) {
+	// 응답에 entities / claims / facts / topics 가 모두 누락 — empty slice 로 정규화.
+	stdout := `{"sentiment": "neutral"}`
+
+	ex, err := extractor.NewClaudegenExtractor(
+		&stubRunner{stdout: stdout},
+		&stubLoader{tpl: "t"},
+	)
+	require.NoError(t, err)
+
+	got, err := ex.Extract(context.Background(), extractor.Input{})
+	require.NoError(t, err)
+	assert.NotNil(t, got.Entities)
+	assert.NotNil(t, got.Claims)
+	assert.NotNil(t, got.Facts)
+	assert.NotNil(t, got.Topics)
+	assert.Empty(t, got.Entities)
+	assert.Empty(t, got.Claims)
+	assert.Empty(t, got.Facts)
+	assert.Empty(t, got.Topics)
+}
+
+func TestClaudegenExtractor_MalformedOutput_ReturnsError(t *testing.T) {
+	ex, err := extractor.NewClaudegenExtractor(
+		&stubRunner{stdout: "not json"},
+		&stubLoader{tpl: "t"},
+	)
+	require.NoError(t, err)
+
+	_, err = ex.Extract(context.Background(), extractor.Input{})
+	assert.Error(t, err)
+}
+
+func TestClaudegenExtractor_SessionError_Propagates(t *testing.T) {
+	ex, err := extractor.NewClaudegenExtractor(
+		&stubRunner{err: errors.New("docker exec failed")},
+		&stubLoader{tpl: "t"},
+	)
+	require.NoError(t, err)
+
+	_, err = ex.Extract(context.Background(), extractor.Input{})
+	require.Error(t, err)
+	assert.Contains(t, strings.ToLower(err.Error()), "session")
+}
+
+func TestNoopExtractor_ReturnsEmpty(t *testing.T) {
+	got, err := extractor.NewNoopExtractor().Extract(context.Background(), extractor.Input{})
+	require.NoError(t, err)
+	assert.Empty(t, got.Entities)
+	assert.Empty(t, got.Claims)
+	assert.Empty(t, got.Facts)
+	assert.Empty(t, got.Topics)
+	assert.Equal(t, extractor.SentimentNeutral, got.Sentiment)
+}
+
+func TestNewClaudegenExtractor_NilArgs(t *testing.T) {
+	_, err := extractor.NewClaudegenExtractor(nil, &stubLoader{tpl: "t"})
+	assert.Error(t, err)
+
+	_, err = extractor.NewClaudegenExtractor(&stubRunner{stdout: "{}"}, nil)
+	assert.Error(t, err)
+}

--- a/test/internal/processor/enrich/worker/worker_test.go
+++ b/test/internal/processor/enrich/worker/worker_test.go
@@ -15,8 +15,12 @@ import (
 
 	"issuetracker/internal/bus"
 	"issuetracker/internal/locks"
+	"issuetracker/internal/processor/enrich/extractor"
 	"issuetracker/internal/processor/enrich/worker"
 	"issuetracker/internal/processor/fetcher/core"
+	"issuetracker/internal/storage"
+	"issuetracker/internal/storage/model"
+	"issuetracker/internal/storage/service"
 	"issuetracker/pkg/logger"
 	"issuetracker/pkg/queue"
 )
@@ -70,8 +74,50 @@ func newTestPublisher(producer queue.Producer) *bus.Publisher {
 	return bus.New(producer, nil, logger.New(logger.DefaultConfig()))
 }
 
+// stubContentService 는 항상 ErrNotFound 를 반환하는 ContentService stub 입니다.
+// 본 worker 의 enrichment 분기는 ErrNotFound 시 skip + forward 이므로 passthrough
+// 시나리오에 적합 — content body 가 필요한 별도 테스트는 별도 stub 사용.
+type stubContentService struct {
+	service.ContentService
+	content *core.Content
+}
+
+func (s *stubContentService) GetByID(_ context.Context, id string) (*core.Content, error) {
+	if s.content != nil && s.content.ID == id {
+		return s.content, nil
+	}
+	return nil, storage.ErrNotFound
+}
+
+// stub 의 다른 메소드는 본 테스트에서 미사용 — interface embedded 로 default nil-impl.
+// 정적 검사 만족용 어서션:
+var _ service.ContentService = (*stubContentService)(nil)
+var _ = model.ValidationStatusPassed // model import keep — 외부 테스트가 향후 사용 시 보존
+
+// fakeExtractor 는 호출 카운트를 추적하는 간단한 Extractor 입니다.
+type fakeExtractor struct {
+	facts    *extractor.EnrichedFacts
+	err      error
+	callsLog []extractor.Input
+}
+
+func (f *fakeExtractor) Extract(_ context.Context, in extractor.Input) (*extractor.EnrichedFacts, error) {
+	f.callsLog = append(f.callsLog, in)
+	if f.err != nil {
+		return nil, f.err
+	}
+	return f.facts, nil
+}
+
 func newEnrichWorker(consumer queue.Consumer, producer queue.Producer) *worker.Worker {
-	return worker.NewWorker(consumer, newTestPublisher(producer), locks.NewNoopStageGate(), 1)
+	return worker.NewWorker(
+		consumer,
+		newTestPublisher(producer),
+		&stubContentService{},
+		extractor.NewNoopExtractor(),
+		locks.NewNoopStageGate(),
+		1,
+	)
 }
 
 func makeValidatedMessage(t *testing.T, refID, url, country, sourceName string) *queue.Message {
@@ -207,6 +253,112 @@ func TestEnrichWorker_Passthrough_PreservesOriginalHeaders(t *testing.T) {
 	assert.Equal(t, "example-kr", published.Headers["source"])
 	assert.Equal(t, "KR", published.Headers["country"])
 }
+
+// TestEnrichWorker_Extraction_AttachesFactsToMetadata — 추출 성공 시 EnrichedFacts 가
+// ProcessingMessage.Metadata["enriched_facts"] 로 첨부되어 forward 되는지 검증.
+func TestEnrichWorker_Extraction_AttachesFactsToMetadata(t *testing.T) {
+	consumer := new(mockConsumer)
+	producer := new(mockProducer)
+
+	contentSvc := &stubContentService{content: &core.Content{
+		ID:    "content-extract",
+		Title: "Sample article",
+		Body:  "Body text of the article",
+		URL:   "https://example.com/a",
+	}}
+	expectedFacts := &extractor.EnrichedFacts{
+		Entities: []extractor.Entity{{Type: extractor.EntityTypeOrg, Name: "ACME", Mentions: 3}},
+		Claims:   []extractor.Claim{{Text: "ACME announced X"}},
+		Facts:    []extractor.Fact{{Key: "amount", Value: "100", Unit: "USD"}},
+		Topics:   []string{"business"},
+	}
+	fake := &fakeExtractor{facts: expectedFacts}
+
+	w := worker.NewWorker(
+		consumer,
+		newTestPublisher(producer),
+		contentSvc,
+		fake,
+		locks.NewNoopStageGate(),
+		1,
+	)
+
+	msg := makeValidatedMessage(t, "content-extract", "https://example.com/a", "US", "example")
+
+	var published queue.Message
+	producer.On("Publish", mock.Anything, mock.MatchedBy(func(m queue.Message) bool {
+		if m.Topic != queue.TopicEnriched {
+			return false
+		}
+		published = m
+		return true
+	})).Return(nil).Once()
+	producer.On("Close").Return(nil).Maybe()
+	consumer.On("CommitMessages", mock.Anything, mock.Anything).Return(nil).Maybe()
+
+	runWorker(t, consumer, w, msg)
+
+	// extractor 호출 검증
+	if assert.Len(t, fake.callsLog, 1) {
+		in := fake.callsLog[0]
+		assert.Equal(t, "https://example.com/a", in.URL)
+		assert.Equal(t, "example.com", in.Host)
+		assert.Equal(t, "Sample article", in.Title)
+		assert.Equal(t, "Body text of the article", in.HTML)
+	}
+
+	// metadata 첨부 검증
+	var pm core.ProcessingMessage
+	if err := json.Unmarshal(published.Value, &pm); err != nil {
+		t.Fatalf("unmarshal pm: %v", err)
+	}
+	if assert.NotNil(t, pm.Metadata) {
+		facts, ok := pm.Metadata["enriched_facts"]
+		assert.True(t, ok, "metadata should contain enriched_facts")
+		_ = facts // type 은 map[string]interface{} 로 decode 됨 — 필드 존재만 검증
+	}
+}
+
+// TestEnrichWorker_ExtractionFailure_StillForwards — 추출 실패는 pipeline 진행을 막지 않음.
+// extractor 가 error 를 반환해도 forward 가 수행되어 다음 단계로 메시지가 전달되어야 함.
+func TestEnrichWorker_ExtractionFailure_StillForwards(t *testing.T) {
+	consumer := new(mockConsumer)
+	producer := new(mockProducer)
+
+	contentSvc := &stubContentService{content: &core.Content{
+		ID:    "content-fail",
+		Title: "T",
+		Body:  "B",
+	}}
+	fake := &fakeExtractor{err: assertAnError()}
+
+	w := worker.NewWorker(
+		consumer,
+		newTestPublisher(producer),
+		contentSvc,
+		fake,
+		locks.NewNoopStageGate(),
+		1,
+	)
+	msg := makeValidatedMessage(t, "content-fail", "https://example.com/b", "KR", "example-kr")
+
+	producer.On("Publish", mock.Anything, mock.MatchedBy(func(m queue.Message) bool {
+		return m.Topic == queue.TopicEnriched
+	})).Return(nil).Once()
+	producer.On("Close").Return(nil).Maybe()
+	consumer.On("CommitMessages", mock.Anything, mock.Anything).Return(nil).Maybe()
+
+	runWorker(t, consumer, w, msg)
+
+	consumer.AssertExpectations(t)
+	producer.AssertExpectations(t)
+}
+
+func assertAnError() error { return assertError{} }
+
+type assertError struct{}
+
+func (assertError) Error() string { return "extractor failure" }
 
 // TestEnrichWorker_MalformedMessage_SendsToDLQ — 잘못된 JSON 은 DLQ 로 라우팅.
 func TestEnrichWorker_MalformedMessage_SendsToDLQ(t *testing.T) {


### PR DESCRIPTION
## 연관 이슈
- Closes #447
- Parent: #445

<br>

## 구현 내용

Enricher 의 첫 실제 로직. validate 통과 article 의 본문에서 page 핵심 요소 (entities / claims / numeric facts / topics / sentiment) 를 claudegen 으로 추출.

### 1. claudegen 패키지 — RunEnrichSession primitive
- 기존 ExtractEnriched 가 parser-rule extraction 전용 시그니처라 enrich 의 다른 schema 에 직접 재사용 불가
- 한 단계 더 generic 한 primitive 추가: `RunEnrichSession(ctx, sessionLabel, files, promptText) -> stdout`
- caller 가 files (filename→bytes) + 렌더된 prompt 전달, claudegen 은 세션 lifecycle 만 관리
- ClaudeWorkerPool 에도 round-robin 위임 메소드 추가

### 2. enrich/extractor 패키지 (신규)
- model.go — EnrichedFacts + Entity/Claim/Fact/Topics/Sentiment 스키마
  - Verifications/Context/TrustScore 필드는 schema 만 reserve (#448/#449/#450)
- extractor.go — Extractor 인터페이스 + Input
- noop.go — NoopExtractor (claudegen 미configured fallback)
- claudegen.go — ClaudegenExtractor
  - SessionRunner 추상으로 claudegen 패키지 직접 의존 회피
  - markdown fence 자동 제거, nil slice → empty slice 정규화

### 3. Prompt 템플릿
- `pkg/llm/prompt/assets/claudegen/enricher_extract.user.txt`
- entities/claims/facts/topics/sentiment JSON 출력 schema
- 추출 규칙 명시 (생성 금지, 명시적 자료만, 수치 page 표기 그대로)

### 4. Worker 확장
- ContentService + Extractor 의존 추가 (모두 not-nil 강제)
- process() 흐름:
  1. contentSvc.GetByID(ref.ID) — Title/Body 조회 (ErrNotFound → skip + forward)
  2. extractor.Extract(URL, Host, Title, HTML=Body) — LLM 호출
  3. pm.Metadata["enriched_facts"] = EnrichedFacts → forward
- **forward-first 정책**: enrichment 실패 (DB 조회 실패 / extractor 에러) 가 pipeline 을 막지 않음

### 5. main.go wiring
- claudegenPool + promptLoader 모두 가용 시 ClaudegenExtractor 사용
- 부재 시 NoopExtractor 로 graceful fallback

### 6. 테스트
- 신규: `test/internal/processor/enrich/extractor/claudegen_test.go`
  - 성공 파싱 / markdown fence / nil slice 정규화 / malformed / session error / Noop
- 확장: `test/internal/processor/enrich/worker/worker_test.go`
  - stubContentService + fakeExtractor 도입
  - 추출 성공 → metadata 첨부 + extractor 호출 입력 검증
  - 추출 실패 → 여전히 forward (forward-first 검증)

### 설계 메모: import cycle 회피
EnrichedFacts model 은 `enrich/extractor` 패키지에 배치. 이유:
- enrich 루트가 worker 를 import (Stage wrapper)
- worker 는 extractor 를 import
- model 을 enrich 루트에 두면 cycle (extractor → enrich → worker → extractor)
- extractor 는 leaf 위치 — 모든 의존 가능

<br>

## CI / 머지 게이트 점검

### 변경 영향 범위
- 신규: `internal/processor/enrich/extractor/`, `pkg/llm/prompt/assets/claudegen/enricher_extract.user.txt`, `internal/processor/parser/rule/claudegen/enrich.go`
- 변경: `internal/processor/enrich/worker/worker.go` (signature 확장), `cmd/issuetracker/main.go` (wiring), `internal/processor/parser/rule/claudegen/pool.go` (pool delegate)
- 위험도: Medium — claudegen pool 의 새 method 가 ExtractEnriched 와 독립적이라 parser 경로 무영향. 단, claudegen 미configured 환경에서는 NoopExtractor fallback 이라 enrichment 미적용 (이미 forward 만 하던 sub#446 동등)

### Required Status Checks
- [ ] Commit Lint / PR Title Lint / Linked Issue Check / Format Check / Build / Test / Lint

### 롤백 계획
- STAGES_ENRICH_ENABLED=false 로 단계 자체 비활성 가능
- revert 시 worker NewWorker 호환성 깨짐 → 본 PR 전체 revert 필요

<br>

## TODO
- [x] EnrichedFacts model + prompt asset
- [x] Extractor interface + NoopExtractor + ClaudegenExtractor
- [x] claudegen RunEnrichSession primitive + pool delegate
- [x] Worker 통합 (ContentService + Extractor) + main.go wiring
- [x] 단위 테스트 (extractor parsing + worker integration)
- [x] gofmt / vet / build / go test -race ./... 그린

<br>

## 논의 사항
- 다음 sub-issue (#448) 가 cross-verification 단계 — claim 별 다른 소스 대조 + WebFetch 활용
- 현재는 metadata 로 facts 전달 — #450 sub-issue 에서 enriched_contents 테이블에 영속화
- claudegen container 가 아직 enrich용 작업공간 layout (cwd=세션 디렉토리) 을 명시적으로 사용. prompt 에서 `./page.html` 로 참조하나, 컨테이너 cwd 가 세션 디렉토리가 아니면 작동 안 함 — live 검증 시 추가 조정 필요할 수 있음

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added intelligent fact extraction from processed content, extracting entities, claims, topics, and sentiment analysis using LLM-powered enrichment.
  * Enriched facts are now embedded in message metadata for downstream processing.
  * Extractor supports graceful fallback with no-op implementation when AI extraction is unavailable.

* **Tests**
  * Added comprehensive test coverage for enrichment extraction and worker integration.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/EinSofINTEREST/IssueTracker/pull/452)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->