### PR TITLE
[FEAT#448] enrich 교차 검증 — DB 후보 + WebFetch 로 claim 별 verdict

### DIFF
--- a/cmd/issuetracker/main.go
+++ b/cmd/issuetracker/main.go
@@ -918,13 +918,28 @@ func main() {
 		log.Info("enrich extractor: noop (claudegen pool or prompt loader unavailable)")
 	}
 
-	enrichW := enrichWorkerPkg.NewWorker(enrichConsumer, enrichPublisher, contentSvc, enrichExtractor, enrichGate, workerCountsCfg.Enrich)
+	// 이슈 #448 — claudegen 기반 enricher verifier (cross-verification) wiring. extractor 와
+	// 동일 fallback 정책.
+	var enrichVerifier enrichextractor.Verifier = enrichextractor.NewNoopVerifier()
+	if claudegenPool != nil && promptLoader != nil {
+		cv, cvErr := enrichextractor.NewClaudegenVerifier(claudegenPool, promptLoader)
+		if cvErr != nil {
+			log.WithError(cvErr).Warn("claudegen enrich verifier construction failed, using noop")
+		} else {
+			enrichVerifier = cv
+			log.Info("enrich verifier: claudegen-backed")
+		}
+	} else {
+		log.Info("enrich verifier: noop (claudegen pool or prompt loader unavailable)")
+	}
+
+	enrichW := enrichWorkerPkg.NewWorker(enrichConsumer, enrichPublisher, contentSvc, enrichExtractor, enrichVerifier, enrichGate, workerCountsCfg.Enrich)
 
 	log.WithFields(map[string]interface{}{
 		"worker_count": workerCountsCfg.Enrich,
 		"input_topic":  queue.TopicValidated,
 		"output_topic": queue.TopicEnriched,
-	}).Info("enrich worker constructed (#447 — claudegen extractor)")
+	}).Info("enrich worker constructed (#447 extractor + #448 verifier)")
 
 	// ══════════════════════════════════════════════════════════════════════════
 	// Stage 통합 — processor.Stage 인터페이스로 모든 단계 균일 관리

--- a/internal/processor/enrich/extractor/verifier.go
+++ b/internal/processor/enrich/extractor/verifier.go
@@ -1,0 +1,187 @@
+// 본 파일은 enrich 단계의 교차 검증기 (Verifier) 인터페이스 + 구현체를 정의합니다 (이슈 #448).
+//
+// Verifier 는 추출된 claims 와 후보 reference URL 들을 받아 claim 별 verdict 를 산출합니다.
+// Claude WebFetch 도구를 적극 활용하도록 prompt 가 유도 — 후보 URL 외에도 추가 신규 페치
+// 가능. Extractor 와 마찬가지로 실패 시 빈 verifications 로 fallback 하고 pipeline 진행.
+
+package extractor
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	"issuetracker/pkg/llm/prompt"
+)
+
+// CandidateRef 는 DB 에서 추출한 동일 국가·시간 윈도우 후보 article 의 lightweight ref 입니다.
+type CandidateRef struct {
+	URL   string
+	Title string
+	Host  string
+}
+
+// VerifyInput 은 Verifier.Verify 의 입력 — source URL + 검증 대상 claims + DB 후보.
+type VerifyInput struct {
+	URL        string
+	Host       string
+	Title      string
+	Claims     []Claim
+	Candidates []CandidateRef
+}
+
+// Verifier 는 claims 의 외부 소스 대조 결과 (Verification 리스트) 를 산출합니다.
+//
+// 실패 시 worker 가 빈 verifications 로 fallback — forward 보장 (forward-first 정책).
+type Verifier interface {
+	Verify(ctx context.Context, in VerifyInput) ([]Verification, error)
+}
+
+// NoopVerifier 는 항상 빈 verifications 를 반환합니다 — claudegen 미configured 환경 fallback.
+type NoopVerifier struct{}
+
+// NewNoopVerifier 는 NoopVerifier 인스턴스를 반환합니다.
+func NewNoopVerifier() *NoopVerifier { return &NoopVerifier{} }
+
+// Verify 는 항상 빈 []Verification 을 반환합니다.
+func (v *NoopVerifier) Verify(_ context.Context, _ VerifyInput) ([]Verification, error) {
+	return []Verification{}, nil
+}
+
+// 컴파일 타임 인터페이스 만족 검증.
+var _ Verifier = (*NoopVerifier)(nil)
+
+// verifierPromptName 은 cross-verify prompt asset 경로입니다.
+const verifierPromptName = "claudegen/enricher_cross_verify"
+
+// ClaudegenVerifier 는 claudegen.ClaudeWorkerPool 로 cross-verify session 을 실행합니다.
+type ClaudegenVerifier struct {
+	runner SessionRunner
+	loader prompt.Loader
+}
+
+// NewClaudegenVerifier 는 claudegen-backed Verifier 를 생성합니다.
+func NewClaudegenVerifier(runner SessionRunner, loader prompt.Loader) (*ClaudegenVerifier, error) {
+	if runner == nil {
+		return nil, errors.New("extractor: claudegen runner must not be nil")
+	}
+	if loader == nil {
+		return nil, errors.New("extractor: prompt loader must not be nil")
+	}
+	return &ClaudegenVerifier{runner: runner, loader: loader}, nil
+}
+
+// Verify 는 claudegen 세션을 실행하고 stdout 을 []Verification 으로 파싱합니다.
+//
+// 입력 claims 가 비어있으면 LLM 호출 skip — 빈 verifications 반환.
+func (v *ClaudegenVerifier) Verify(ctx context.Context, in VerifyInput) ([]Verification, error) {
+	if len(in.Claims) == 0 {
+		return []Verification{}, nil
+	}
+
+	tpl, err := v.loader.Load(verifierPromptName)
+	if err != nil {
+		return nil, fmt.Errorf("load verifier prompt %q: %w", verifierPromptName, err)
+	}
+
+	claimsJSON, err := marshalClaimsForPrompt(in.Claims)
+	if err != nil {
+		return nil, fmt.Errorf("marshal claims: %w", err)
+	}
+	candidatesJSON, err := marshalCandidatesForPrompt(in.Candidates)
+	if err != nil {
+		return nil, fmt.Errorf("marshal candidates: %w", err)
+	}
+
+	promptText := prompt.Render(tpl,
+		"{{URL}}", in.URL,
+		"{{HOST}}", in.Host,
+		"{{TITLE}}", in.Title,
+		"{{CLAIMS_JSON}}", claimsJSON,
+		"{{CANDIDATES_JSON}}", candidatesJSON,
+	)
+
+	stdout, err := v.runner.RunEnrichSession(ctx, "enrich-verify", nil, promptText)
+	if err != nil {
+		return nil, fmt.Errorf("claudegen verify session: %w", err)
+	}
+
+	verifications, err := parseVerifyOutput(stdout)
+	if err != nil {
+		return nil, fmt.Errorf("parse verify output: %w", err)
+	}
+	return verifications, nil
+}
+
+// 컴파일 타임 인터페이스 만족 검증.
+var _ Verifier = (*ClaudegenVerifier)(nil)
+
+// verifyResponse 는 claudegen verify 응답의 wire format 입니다.
+type verifyResponse struct {
+	Verifications []Verification `json:"verifications"`
+}
+
+// parseVerifyOutput 는 claudegen stdout JSON 을 []Verification 으로 파싱합니다.
+//
+// 응답 schema:
+//
+//	{ "verifications": [ {claim_idx, verdict, sources, note}, ... ] }
+//
+// markdown code fence 도 stripFences 로 자동 제거 (Extractor 와 동일).
+func parseVerifyOutput(output string) ([]Verification, error) {
+	body := stripFences(output)
+	if body == "" {
+		return nil, errors.New("empty output")
+	}
+	var res verifyResponse
+	if err := json.Unmarshal([]byte(body), &res); err != nil {
+		return nil, fmt.Errorf("unmarshal: %w", err)
+	}
+	if res.Verifications == nil {
+		res.Verifications = []Verification{}
+	}
+	// verdict 정규화 — LLM 이 임의 string 을 반환할 수 있으므로 unknown 값은 "unverified" 로 폴백.
+	for i := range res.Verifications {
+		switch res.Verifications[i].Verdict {
+		case "supported", "contradicted", "unverified":
+			// OK
+		default:
+			res.Verifications[i].Verdict = "unverified"
+		}
+	}
+	return res.Verifications, nil
+}
+
+func marshalClaimsForPrompt(claims []Claim) (string, error) {
+	// claim_idx 명시 — prompt 가 idx 기반 verdict 를 반환하므로 caller 가 알기 쉬운 배열로 직렬화.
+	type indexedClaim struct {
+		Idx       int    `json:"idx"`
+		Text      string `json:"text"`
+		Subject   string `json:"subject,omitempty"`
+		Predicate string `json:"predicate,omitempty"`
+		Object    string `json:"object,omitempty"`
+	}
+	out := make([]indexedClaim, 0, len(claims))
+	for i, c := range claims {
+		out = append(out, indexedClaim{
+			Idx: i, Text: c.Text, Subject: c.Subject, Predicate: c.Predicate, Object: c.Object,
+		})
+	}
+	b, err := json.Marshal(out)
+	if err != nil {
+		return "", err
+	}
+	return string(b), nil
+}
+
+func marshalCandidatesForPrompt(cs []CandidateRef) (string, error) {
+	if len(cs) == 0 {
+		return "[]", nil
+	}
+	b, err := json.Marshal(cs)
+	if err != nil {
+		return "", err
+	}
+	return string(b), nil
+}

--- a/internal/processor/enrich/worker/worker.go
+++ b/internal/processor/enrich/worker/worker.go
@@ -13,6 +13,8 @@ import (
 	"errors"
 	"fmt"
 	"net/url"
+	"sort"
+	"strings"
 	"time"
 
 	"issuetracker/internal/bus"
@@ -20,6 +22,7 @@ import (
 	"issuetracker/internal/processor/enrich/extractor"
 	"issuetracker/internal/processor/fetcher/core"
 	"issuetracker/internal/storage"
+	"issuetracker/internal/storage/model"
 	"issuetracker/internal/storage/service"
 	"issuetracker/internal/workerpool"
 	"issuetracker/pkg/logger"
@@ -38,15 +41,21 @@ const drainTimeout = workerpool.DefaultDrainTimeout
 // 이슈 #447 에서 추가된 동작:
 //   - ContentService 로 ref.ID 의 Content (Title/Body 포함) 조회
 //   - extractor.Extract 로 EnrichedFacts 추출
-//   - 결과를 ProcessingMessage.Metadata["enriched_facts"] 에 JSON 으로 첨부 후 forward
 //
-// 추출 실패는 파이프라인을 멈추지 않습니다 — warn 로깅 + 빈 facts 로 fallback + forward 진행.
+// 이슈 #448 에서 추가된 동작:
+//   - extracted claims 가 있으면 ContentService 로 동일 국가·최근 윈도우 후보 조회
+//   - title token overlap 기반 top-N 후보 선정 후 verifier.Verify 호출
+//   - facts.Verifications 에 결과 첨부
+//
+// 결과는 ProcessingMessage.Metadata["enriched_facts"] 에 JSON 으로 첨부 후 forward.
+// 추출/검증 실패는 파이프라인을 멈추지 않습니다 — warn 로깅 + 빈 결과로 fallback + forward 진행.
 // content 조회 실패 (ErrNotFound) 는 idempotent 정상 분기 — 이미 처리된 메시지로 보고 commit.
 type Worker struct {
 	consumer    bus.Consumer
 	pub         *bus.Publisher
 	contentSvc  service.ContentService
 	extractor   extractor.Extractor
+	verifier    extractor.Verifier
 	gate        locks.StageGate // nil 허용 → NoopStageGate 로 fallback
 	workerCount int
 
@@ -55,13 +64,14 @@ type Worker struct {
 
 // NewWorker 는 새로운 Worker 를 생성합니다.
 //
-// pub / contentSvc / extractor 가 nil 이면 panic — fail-fast (silent failure 회피).
+// pub / contentSvc / extractor / verifier 가 nil 이면 panic — fail-fast (silent failure 회피).
 // gate 가 nil 이면 NoopStageGate 로 fallback.
 func NewWorker(
 	consumer bus.Consumer,
 	pub *bus.Publisher,
 	contentSvc service.ContentService,
 	ex extractor.Extractor,
+	vr extractor.Verifier,
 	gate locks.StageGate,
 	workerCount int,
 ) *Worker {
@@ -74,6 +84,9 @@ func NewWorker(
 	if ex == nil {
 		panic("enrich.NewWorker: extractor must not be nil (use extractor.NoopExtractor for disabled enrichment)")
 	}
+	if vr == nil {
+		panic("enrich.NewWorker: verifier must not be nil (use extractor.NoopVerifier for disabled verification)")
+	}
 	if gate == nil {
 		gate = locks.NewNoopStageGate()
 	}
@@ -82,6 +95,7 @@ func NewWorker(
 		pub:         pub,
 		contentSvc:  contentSvc,
 		extractor:   ex,
+		verifier:    vr,
 		gate:        gate,
 		workerCount: workerCount,
 	}
@@ -173,10 +187,11 @@ func (w *Worker) process(ctx context.Context, msg *queue.Message) error {
 		defer release()
 	}
 
-	// 이슈 #447 — Content 조회 + extractor 호출 + facts 첨부.
+	// 이슈 #447 / #448 — Content 조회 + extractor 호출 + cross-verify + facts 첨부.
 	// 본 단계 어떤 실패도 forward 를 막지 않음 — pipeline 진행이 enrichment 보다 우선.
-	facts := w.runExtraction(ctx, &pm, &ref)
+	content, facts := w.runExtraction(ctx, &pm, &ref)
 	if facts != nil {
+		w.runVerification(ctx, &pm, &ref, content, facts)
 		w.attachFacts(&pm, facts)
 	}
 
@@ -196,9 +211,10 @@ func (w *Worker) process(ctx context.Context, msg *queue.Message) error {
 }
 
 // runExtraction 은 content 를 조회하고 extractor 를 호출합니다.
-// 모든 실패 경로는 nil 을 반환 — 호출자가 facts 첨부 skip 하고 forward 진행.
-// 즉 enrichment 실패는 pipeline 을 멈추지 않음 (forward-first 정책).
-func (w *Worker) runExtraction(ctx context.Context, pm *core.ProcessingMessage, ref *core.ContentRef) *extractor.EnrichedFacts {
+// 모든 실패 경로는 (nil, nil) 을 반환 — 호출자가 facts 첨부 skip 하고 forward 진행.
+// 성공 시 (content, facts) 를 함께 반환 — 호출자가 verification 단계에서 content 메타데이터
+// (Country/PublishedAt) 를 재사용할 수 있도록.
+func (w *Worker) runExtraction(ctx context.Context, pm *core.ProcessingMessage, ref *core.ContentRef) (*core.Content, *extractor.EnrichedFacts) {
 	log := logger.FromContext(ctx)
 
 	content, err := w.contentSvc.GetByID(ctx, ref.ID)
@@ -208,13 +224,13 @@ func (w *Worker) runExtraction(ctx context.Context, pm *core.ProcessingMessage, 
 				"job_id": pm.ID,
 				"ref_id": ref.ID,
 			}).Info("content not found, skipping enrichment (already deleted or duplicate)")
-			return nil
+			return nil, nil
 		}
 		log.WithFields(map[string]interface{}{
 			"job_id": pm.ID,
 			"ref_id": ref.ID,
 		}).WithError(err).Warn("failed to fetch content for enrichment, forwarding without facts")
-		return nil
+		return nil, nil
 	}
 
 	host := ""
@@ -244,7 +260,7 @@ func (w *Worker) runExtraction(ctx context.Context, pm *core.ProcessingMessage, 
 			"ref_id": ref.ID,
 			"host":   host,
 		}).WithError(err).Warn("enrichment extraction failed, forwarding without facts")
-		return nil
+		return content, nil
 	}
 
 	log.WithFields(map[string]interface{}{
@@ -254,7 +270,184 @@ func (w *Worker) runExtraction(ctx context.Context, pm *core.ProcessingMessage, 
 		"claim_count":  len(facts.Claims),
 		"fact_count":   len(facts.Facts),
 	}).Debug("enrichment extraction completed")
-	return facts
+	return content, facts
+}
+
+// 검증 단계 상수 (이슈 #448).
+const (
+	// verificationWindow: 후보 article 시간 윈도우 — 발행 시각 ±N. ±24h 가 일반적인 뉴스 사이클.
+	verificationWindow = 24 * time.Hour
+	// verificationCandidateFetchLimit: DB 후보 조회 fetch limit — 너무 많으면 ranking 비용 증가.
+	verificationCandidateFetchLimit = 50
+	// verificationTopK: 최종 verifier 에 넘기는 후보 수 — prompt context 비용 보호.
+	verificationTopK = 5
+)
+
+// runVerification 은 추출된 claims 에 대해 cross-verification 을 수행하고 facts.Verifications
+// 에 결과를 첨부합니다.
+//
+// 모든 실패 경로는 verifications 미첨부로 fallback — pipeline 진행 보장 (forward-first).
+// claims 가 없으면 skip — verifier 호출 불필요.
+//
+// 후보 선정:
+//  1. ContentService.ListByCountry 로 동일 country + 시간 윈도우 (±24h) 내 최근 발행 article fetch (limit 50)
+//  2. 본인 article (URL 또는 ID 동일) 제외
+//  3. title token overlap 으로 ranking → top 5
+//
+// 그 5개를 CandidateRef 로 verifier 에 전달. verifier (prompt) 가 WebFetch 로 추가 신규
+// 페치 + 검증을 수행.
+func (w *Worker) runVerification(
+	ctx context.Context,
+	pm *core.ProcessingMessage,
+	ref *core.ContentRef,
+	content *core.Content,
+	facts *extractor.EnrichedFacts,
+) {
+	log := logger.FromContext(ctx)
+
+	if facts == nil || len(facts.Claims) == 0 {
+		return
+	}
+	if content == nil {
+		return
+	}
+
+	candidates := w.findCandidates(ctx, content)
+	host := hostOf(ref.URL)
+
+	in := extractor.VerifyInput{
+		URL:        ref.URL,
+		Host:       host,
+		Title:      content.Title,
+		Claims:     facts.Claims,
+		Candidates: candidates,
+	}
+
+	verifications, err := w.verifier.Verify(ctx, in)
+	if err != nil {
+		log.WithFields(map[string]interface{}{
+			"job_id":          pm.ID,
+			"ref_id":          ref.ID,
+			"claim_count":     len(facts.Claims),
+			"candidate_count": len(candidates),
+		}).WithError(err).Warn("enrichment verification failed, forwarding without verifications")
+		return
+	}
+	facts.Verifications = verifications
+	log.WithFields(map[string]interface{}{
+		"job_id":             pm.ID,
+		"ref_id":             ref.ID,
+		"claim_count":        len(facts.Claims),
+		"candidate_count":    len(candidates),
+		"verification_count": len(verifications),
+	}).Debug("enrichment verification completed")
+}
+
+// findCandidates 는 본 content 와 같은 country + 시간 윈도우의 후보 article 들을 조회하고
+// title token overlap 으로 ranking 한 top-K 를 반환합니다. 본인 article 은 제외.
+//
+// 본 메소드는 DB error 시 빈 slice 반환 — verifier 는 DB 후보 없이도 WebFetch 만으로 진행 가능.
+func (w *Worker) findCandidates(ctx context.Context, src *core.Content) []extractor.CandidateRef {
+	log := logger.FromContext(ctx)
+
+	// PublishedAt zero-value 면 시간 윈도우 적용 불가 — 빈 후보로 진행.
+	if src.PublishedAt.IsZero() {
+		return nil
+	}
+
+	after := src.PublishedAt.Add(-verificationWindow)
+	before := src.PublishedAt.Add(verificationWindow)
+	filter := model.ContentFilter{
+		PublishedAfter:  &after,
+		PublishedBefore: &before,
+		Pagination:      model.Pagination{Limit: verificationCandidateFetchLimit},
+	}
+	rows, err := w.contentSvc.ListByCountry(ctx, src.Country, filter)
+	if err != nil {
+		log.WithError(err).Debug("candidate fetch failed, proceeding with empty candidates")
+		return nil
+	}
+
+	srcTokens := tokenize(src.Title)
+	type scored struct {
+		c     *core.Content
+		score int
+	}
+	ranked := make([]scored, 0, len(rows))
+	for _, r := range rows {
+		if r == nil {
+			continue
+		}
+		// 본인 제외 (ID 또는 URL 일치)
+		if r.ID == src.ID || (r.URL != "" && r.URL == src.URL) {
+			continue
+		}
+		s := tokenOverlap(srcTokens, tokenize(r.Title))
+		if s == 0 {
+			continue
+		}
+		ranked = append(ranked, scored{c: r, score: s})
+	}
+	sort.Slice(ranked, func(i, j int) bool { return ranked[i].score > ranked[j].score })
+
+	limit := verificationTopK
+	if len(ranked) < limit {
+		limit = len(ranked)
+	}
+	out := make([]extractor.CandidateRef, 0, limit)
+	for i := 0; i < limit; i++ {
+		c := ranked[i].c
+		out = append(out, extractor.CandidateRef{
+			URL:   c.URL,
+			Title: c.Title,
+			Host:  hostOf(c.URL),
+		})
+	}
+	return out
+}
+
+// hostOf 는 URL 의 host 부분만 추출합니다. parse 실패 시 빈 문자열 반환.
+func hostOf(u string) string {
+	parsed, err := url.Parse(u)
+	if err != nil {
+		return ""
+	}
+	return parsed.Host
+}
+
+// tokenize 는 title 을 소문자 단어 토큰 set 으로 분해합니다. 길이 2 이하 토큰은 stopword 제외.
+func tokenize(s string) map[string]struct{} {
+	out := map[string]struct{}{}
+	cur := make([]rune, 0, 32)
+	flush := func() {
+		if len(cur) > 2 {
+			out[strings.ToLower(string(cur))] = struct{}{}
+		}
+		cur = cur[:0]
+	}
+	for _, r := range s {
+		if (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9') {
+			cur = append(cur, r)
+		} else {
+			flush()
+		}
+	}
+	flush()
+	return out
+}
+
+// tokenOverlap 은 두 토큰 set 의 교집합 크기를 반환합니다.
+func tokenOverlap(a, b map[string]struct{}) int {
+	if len(a) > len(b) {
+		a, b = b, a
+	}
+	n := 0
+	for t := range a {
+		if _, ok := b[t]; ok {
+			n++
+		}
+	}
+	return n
 }
 
 // attachFacts 는 추출된 facts 를 ProcessingMessage.Metadata 에 JSON 으로 저장합니다.

--- a/pkg/llm/prompt/assets/claudegen/enricher_cross_verify.user.txt
+++ b/pkg/llm/prompt/assets/claudegen/enricher_cross_verify.user.txt
@@ -1,0 +1,43 @@
+You are verifying claims extracted from a news/community article. Your goal is to assess each claim against external sources.
+
+Source article:
+- URL: {{URL}}
+- Host: {{HOST}}
+- Title: {{TITLE}}
+
+Claims to verify (each has an idx):
+{{CLAIMS_JSON}}
+
+DB candidate articles (same country / time window, may cover the same topic):
+{{CANDIDATES_JSON}}
+
+Your task:
+1. For each candidate URL, **use the WebFetch tool** to retrieve and read the article. Compare against the claims.
+2. **Use the WebFetch tool to search the open web** for additional independent sources covering the same claims. Prefer reputable / official sources.
+3. For each claim, decide a verdict based on the evidence you find.
+
+Output a single JSON object — no explanation, no markdown, no code blocks:
+{
+  "verifications": [
+    {
+      "claim_idx": <integer matching the idx field of an input claim>,
+      "verdict": "supported" | "contradicted" | "unverified",
+      "sources": ["<url1>", "<url2>", ...],
+      "note": "<short rationale, max 200 chars>"
+    }
+  ]
+}
+
+Verdict rules:
+- "supported": at least one independent source corroborates the same claim (matching subject + predicate + object/value).
+- "contradicted": at least one independent source contradicts the claim outright.
+- "unverified": no external source either way after reasonable search effort.
+
+Source rules:
+- Cite the URLs you actually fetched. Do not invent URLs.
+- Prefer sources different from the source article's host (cross-source corroboration). The source article itself is NOT a valid evidence source.
+- 1-3 sources per claim is usually enough.
+
+Be honest about uncertainty — when in doubt, prefer "unverified" with a short note explaining what you searched and why it was inconclusive.
+
+Return ONLY the JSON object.

--- a/test/internal/processor/enrich/extractor/claudegen_test.go
+++ b/test/internal/processor/enrich/extractor/claudegen_test.go
@@ -187,3 +187,93 @@ func TestNewClaudegenExtractor_NilArgs(t *testing.T) {
 	_, err = extractor.NewClaudegenExtractor(&stubRunner{stdout: "{}"}, nil)
 	assert.Error(t, err)
 }
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Verifier (이슈 #448)
+// ─────────────────────────────────────────────────────────────────────────────
+
+func TestClaudegenVerifier_Success(t *testing.T) {
+	stdout := `{"verifications":[
+		{"claim_idx": 0, "verdict": "supported", "sources": ["https://news.example.com/a"], "note": "matches AP"},
+		{"claim_idx": 1, "verdict": "unverified"}
+	]}`
+	runner := &stubRunner{stdout: stdout}
+	v, err := extractor.NewClaudegenVerifier(runner, &stubLoader{tpl: "verify {{CLAIMS_JSON}} {{CANDIDATES_JSON}}"})
+	require.NoError(t, err)
+
+	got, err := v.Verify(context.Background(), extractor.VerifyInput{
+		URL:    "https://example.com/p",
+		Host:   "example.com",
+		Title:  "T",
+		Claims: []extractor.Claim{{Text: "c0"}, {Text: "c1"}},
+		Candidates: []extractor.CandidateRef{
+			{URL: "https://other.com/x", Title: "other"},
+		},
+	})
+	require.NoError(t, err)
+	require.Len(t, got, 2)
+	assert.Equal(t, 0, got[0].ClaimIdx)
+	assert.Equal(t, "supported", got[0].Verdict)
+	assert.Equal(t, "unverified", got[1].Verdict)
+	assert.Equal(t, 1, runner.calls)
+}
+
+func TestClaudegenVerifier_UnknownVerdict_FallsBackToUnverified(t *testing.T) {
+	stdout := `{"verifications":[
+		{"claim_idx": 0, "verdict": "maybe"}
+	]}`
+	v, err := extractor.NewClaudegenVerifier(
+		&stubRunner{stdout: stdout},
+		&stubLoader{tpl: "t"},
+	)
+	require.NoError(t, err)
+
+	got, err := v.Verify(context.Background(), extractor.VerifyInput{
+		Claims: []extractor.Claim{{Text: "c"}},
+	})
+	require.NoError(t, err)
+	require.Len(t, got, 1)
+	assert.Equal(t, "unverified", got[0].Verdict)
+}
+
+func TestClaudegenVerifier_EmptyClaims_SkipsRunner(t *testing.T) {
+	runner := &stubRunner{stdout: "this should never be parsed"}
+	v, err := extractor.NewClaudegenVerifier(
+		runner,
+		&stubLoader{tpl: "t"},
+	)
+	require.NoError(t, err)
+
+	got, err := v.Verify(context.Background(), extractor.VerifyInput{Claims: nil})
+	require.NoError(t, err)
+	assert.Empty(t, got)
+	assert.Equal(t, 0, runner.calls, "runner must not be called when claims empty")
+}
+
+func TestClaudegenVerifier_SessionError_Propagates(t *testing.T) {
+	v, err := extractor.NewClaudegenVerifier(
+		&stubRunner{err: errors.New("exec failure")},
+		&stubLoader{tpl: "t"},
+	)
+	require.NoError(t, err)
+
+	_, err = v.Verify(context.Background(), extractor.VerifyInput{
+		Claims: []extractor.Claim{{Text: "c"}},
+	})
+	require.Error(t, err)
+}
+
+func TestNoopVerifier_ReturnsEmpty(t *testing.T) {
+	got, err := extractor.NewNoopVerifier().Verify(context.Background(), extractor.VerifyInput{
+		Claims: []extractor.Claim{{Text: "c"}},
+	})
+	require.NoError(t, err)
+	assert.Empty(t, got)
+}
+
+func TestNewClaudegenVerifier_NilArgs(t *testing.T) {
+	_, err := extractor.NewClaudegenVerifier(nil, &stubLoader{tpl: "t"})
+	assert.Error(t, err)
+	_, err = extractor.NewClaudegenVerifier(&stubRunner{stdout: "{}"}, nil)
+	assert.Error(t, err)
+}

--- a/test/internal/processor/enrich/worker/worker_test.go
+++ b/test/internal/processor/enrich/worker/worker_test.go
@@ -109,12 +109,28 @@ func (f *fakeExtractor) Extract(_ context.Context, in extractor.Input) (*extract
 	return f.facts, nil
 }
 
+// fakeVerifier 는 verify 입력 추적 + 미리 정의된 verifications 또는 err 반환.
+type fakeVerifier struct {
+	verifications []extractor.Verification
+	err           error
+	callsLog      []extractor.VerifyInput
+}
+
+func (v *fakeVerifier) Verify(_ context.Context, in extractor.VerifyInput) ([]extractor.Verification, error) {
+	v.callsLog = append(v.callsLog, in)
+	if v.err != nil {
+		return nil, v.err
+	}
+	return v.verifications, nil
+}
+
 func newEnrichWorker(consumer queue.Consumer, producer queue.Producer) *worker.Worker {
 	return worker.NewWorker(
 		consumer,
 		newTestPublisher(producer),
 		&stubContentService{},
 		extractor.NewNoopExtractor(),
+		extractor.NewNoopVerifier(),
 		locks.NewNoopStageGate(),
 		1,
 	)
@@ -279,6 +295,7 @@ func TestEnrichWorker_Extraction_AttachesFactsToMetadata(t *testing.T) {
 		newTestPublisher(producer),
 		contentSvc,
 		fake,
+		extractor.NewNoopVerifier(),
 		locks.NewNoopStageGate(),
 		1,
 	)
@@ -337,6 +354,7 @@ func TestEnrichWorker_ExtractionFailure_StillForwards(t *testing.T) {
 		newTestPublisher(producer),
 		contentSvc,
 		fake,
+		extractor.NewNoopVerifier(),
 		locks.NewNoopStageGate(),
 		1,
 	)
@@ -359,6 +377,172 @@ func assertAnError() error { return assertError{} }
 type assertError struct{}
 
 func (assertError) Error() string { return "extractor failure" }
+
+// listingStubContentService 는 GetByID + ListByCountry 를 모두 stub 합니다 — 이슈 #448 verification.
+type listingStubContentService struct {
+	service.ContentService
+	primary *core.Content
+	listed  []*core.Content
+	listErr error
+}
+
+func (s *listingStubContentService) GetByID(_ context.Context, id string) (*core.Content, error) {
+	if s.primary != nil && s.primary.ID == id {
+		return s.primary, nil
+	}
+	return nil, storage.ErrNotFound
+}
+
+func (s *listingStubContentService) ListByCountry(_ context.Context, _ string, _ model.ContentFilter) ([]*core.Content, error) {
+	if s.listErr != nil {
+		return nil, s.listErr
+	}
+	return s.listed, nil
+}
+
+// TestEnrichWorker_Verification_AttachesVerificationsToFacts — claims 가 있으면 verifier
+// 가 호출되고 결과가 facts.Verifications 에 첨부.
+func TestEnrichWorker_Verification_AttachesVerificationsToFacts(t *testing.T) {
+	consumer := new(mockConsumer)
+	producer := new(mockProducer)
+
+	publishedAt := time.Now().Add(-1 * time.Hour)
+	primary := &core.Content{
+		ID:          "c-primary",
+		Title:       "Election turnout breaks record in city",
+		Body:        "...",
+		URL:         "https://example.com/p",
+		Country:     "US",
+		PublishedAt: publishedAt,
+	}
+	related := []*core.Content{
+		{ID: "c-rel1", Title: "City election turnout sets new record", URL: "https://other.com/a", PublishedAt: publishedAt},
+		{ID: "c-rel2", Title: "Local sports match results", URL: "https://other.com/b", PublishedAt: publishedAt},
+		{ID: "c-primary", Title: "self should be skipped", URL: "https://example.com/p", PublishedAt: publishedAt},
+	}
+	contentSvc := &listingStubContentService{primary: primary, listed: related}
+
+	extractedFacts := &extractor.EnrichedFacts{
+		Claims: []extractor.Claim{{Text: "Turnout reached 60% in city"}},
+	}
+	fakeExt := &fakeExtractor{facts: extractedFacts}
+	fakeVer := &fakeVerifier{verifications: []extractor.Verification{
+		{ClaimIdx: 0, Verdict: "supported", Sources: []string{"https://news.example.org/x"}},
+	}}
+
+	w := worker.NewWorker(
+		consumer,
+		newTestPublisher(producer),
+		contentSvc,
+		fakeExt,
+		fakeVer,
+		locks.NewNoopStageGate(),
+		1,
+	)
+	msg := makeValidatedMessage(t, "c-primary", "https://example.com/p", "US", "example")
+
+	var published queue.Message
+	producer.On("Publish", mock.Anything, mock.MatchedBy(func(m queue.Message) bool {
+		if m.Topic != queue.TopicEnriched {
+			return false
+		}
+		published = m
+		return true
+	})).Return(nil).Once()
+	producer.On("Close").Return(nil).Maybe()
+	consumer.On("CommitMessages", mock.Anything, mock.Anything).Return(nil).Maybe()
+
+	runWorker(t, consumer, w, msg)
+
+	// verifier 호출 검증 — candidate ranking: rel1 (overlap: city,election,turnout,record) 가 rel2 보다 우선
+	if assert.Len(t, fakeVer.callsLog, 1, "verifier should be called once") {
+		in := fakeVer.callsLog[0]
+		assert.Equal(t, "https://example.com/p", in.URL)
+		assert.Len(t, in.Claims, 1)
+		// 본인 (c-primary URL) 은 candidate 에서 제외, rel1 이 rel2 보다 token overlap 높음
+		assert.NotEmpty(t, in.Candidates)
+		topCandidate := in.Candidates[0]
+		assert.Equal(t, "https://other.com/a", topCandidate.URL)
+		// 본인 URL 이 candidate 에 없음
+		for _, c := range in.Candidates {
+			assert.NotEqual(t, "https://example.com/p", c.URL, "source URL must be excluded")
+		}
+	}
+
+	// metadata.enriched_facts.verifications 첨부 검증
+	var pm core.ProcessingMessage
+	if err := json.Unmarshal(published.Value, &pm); err != nil {
+		t.Fatalf("unmarshal pm: %v", err)
+	}
+	rawFacts, ok := pm.Metadata["enriched_facts"].(map[string]interface{})
+	if assert.True(t, ok, "metadata should contain enriched_facts map") {
+		verifs, vok := rawFacts["verifications"].([]interface{})
+		assert.True(t, vok)
+		assert.Len(t, verifs, 1)
+	}
+}
+
+// TestEnrichWorker_NoClaims_SkipsVerifier — claims 가 없으면 verifier 호출 안 함.
+func TestEnrichWorker_NoClaims_SkipsVerifier(t *testing.T) {
+	consumer := new(mockConsumer)
+	producer := new(mockProducer)
+	contentSvc := &listingStubContentService{primary: &core.Content{
+		ID: "c-empty", Title: "t", Body: "b", URL: "https://example.com/e", Country: "US",
+		PublishedAt: time.Now(),
+	}}
+	emptyFacts := &extractor.EnrichedFacts{Claims: []extractor.Claim{}}
+	fakeVer := &fakeVerifier{}
+
+	w := worker.NewWorker(
+		consumer, newTestPublisher(producer), contentSvc,
+		&fakeExtractor{facts: emptyFacts},
+		fakeVer,
+		locks.NewNoopStageGate(),
+		1,
+	)
+	msg := makeValidatedMessage(t, "c-empty", "https://example.com/e", "US", "example")
+
+	producer.On("Publish", mock.Anything, mock.MatchedBy(func(m queue.Message) bool {
+		return m.Topic == queue.TopicEnriched
+	})).Return(nil).Once()
+	producer.On("Close").Return(nil).Maybe()
+	consumer.On("CommitMessages", mock.Anything, mock.Anything).Return(nil).Maybe()
+
+	runWorker(t, consumer, w, msg)
+
+	assert.Empty(t, fakeVer.callsLog, "verifier must not be called when no claims")
+}
+
+// TestEnrichWorker_VerificationFailure_StillForwards — verifier error 도 pipeline 진행 보장.
+func TestEnrichWorker_VerificationFailure_StillForwards(t *testing.T) {
+	consumer := new(mockConsumer)
+	producer := new(mockProducer)
+	contentSvc := &listingStubContentService{primary: &core.Content{
+		ID: "c-v-fail", Title: "t", Body: "b", URL: "https://example.com/x", Country: "US",
+		PublishedAt: time.Now(),
+	}}
+	facts := &extractor.EnrichedFacts{Claims: []extractor.Claim{{Text: "claim A"}}}
+
+	w := worker.NewWorker(
+		consumer, newTestPublisher(producer), contentSvc,
+		&fakeExtractor{facts: facts},
+		&fakeVerifier{err: assertAnError()},
+		locks.NewNoopStageGate(),
+		1,
+	)
+	msg := makeValidatedMessage(t, "c-v-fail", "https://example.com/x", "US", "example")
+
+	producer.On("Publish", mock.Anything, mock.MatchedBy(func(m queue.Message) bool {
+		return m.Topic == queue.TopicEnriched
+	})).Return(nil).Once()
+	producer.On("Close").Return(nil).Maybe()
+	consumer.On("CommitMessages", mock.Anything, mock.Anything).Return(nil).Maybe()
+
+	runWorker(t, consumer, w, msg)
+
+	consumer.AssertExpectations(t)
+	producer.AssertExpectations(t)
+}
 
 // TestEnrichWorker_MalformedMessage_SendsToDLQ — 잘못된 JSON 은 DLQ 로 라우팅.
 func TestEnrichWorker_MalformedMessage_SendsToDLQ(t *testing.T) {


### PR DESCRIPTION
## 연관 이슈
- Closes #448
- Parent: #445

<br>

## 구현 내용

추출된 claims (이슈 #447) 를 외부 소스로 대조 검증. claudegen 이 WebFetch 도구를 적극 활용하여 (1) DB 후보 article 들을 페치, (2) 추가 신규 소스 검색 후 claim 별 verdict 산출.

### 1. Verifier 인터페이스 + Claudegen 구현 (`extractor/verifier.go`)
- `Verifier.Verify(ctx, VerifyInput) → []Verification`
- `VerifyInput`: source URL/host/title + claims + candidates (CandidateRef[])
- `NoopVerifier`: claudegen 미configured fallback
- `ClaudegenVerifier`:
  - SessionRunner + prompt.Loader 의존
  - empty claims → runner skip
  - 응답 verdict unknown 값 → "unverified" 정규화 (LLM hallucination 안전망)
  - markdown fence 자동 제거 (stripFences 재사용)

### 2. Prompt 템플릿 (`claudegen/enricher_cross_verify.user.txt`)
- claims (idx 매핑) + DB candidate JSON 주입
- **WebFetch 도구 적극 활용 유도**: candidate URL 페치 + 신규 검색
- 출력 schema: `{verifications: [{claim_idx, verdict, sources, note}]}`
- 본인 host 소스는 evidence 자격 부정 (cross-source corroboration 강제)

### 3. Worker chain 확장 (`enrich/worker/worker.go`)
- `NewWorker` 시그니처에 `Verifier` 추가 (not-nil 강제)
- `runExtraction` 이 (content, facts) tuple 반환 — verification 단계에서 content 재사용
- `runVerification` 신규:
  1. claims 없으면 skip
  2. `ContentService.ListByCountry` 로 동일 국가 + 시간 윈도우 (±24h, fetch limit 50) 후보 조회
  3. 본인 article (ID/URL 매칭) 제외
  4. title token overlap 으로 ranking → top 5
  5. `Verifier.Verify` 호출 + 결과를 `facts.Verifications` 에 첨부
- **forward-first 정책 유지** — 모든 실패 경로에서 forward 진행 (verifications 만 비워둠)

### 4. main.go wiring
- claudegenPool + promptLoader 가용 시 `ClaudegenVerifier`, 부재 시 `NoopVerifier`

### 5. 테스트
- extractor: 성공 파싱 / unknown verdict fallback / empty claims skip / session error 전파 / Noop
- worker: candidate ranking (token overlap + 본인 제외) / claims 없으면 verifier 미호출 / verifier 실패도 forward

<br>

## CI / 머지 게이트 점검

### 변경 영향 범위
- 신규: `internal/processor/enrich/extractor/verifier.go`, `pkg/llm/prompt/assets/claudegen/enricher_cross_verify.user.txt`
- 변경: `internal/processor/enrich/worker/worker.go` (signature 확장), `cmd/issuetracker/main.go`, 테스트
- 위험도: Medium — worker.NewWorker breaking change (verifier 추가). 호출자는 main.go 와 테스트 두 곳뿐이라 통제 가능. claudegen 미configured 환경은 NoopVerifier fallback 으로 #447 동등 동작 유지

### Required Status Checks
- [ ] Commit Lint / PR Title Lint / Linked Issue Check / Format Check / Build / Test / Lint

### 롤백 계획
- STAGES_ENRICH_ENABLED=false 로 stage 자체 비활성 가능
- revert 시 #447 동작 (extract only) 으로 복귀

<br>

## TODO
- [x] Verifier interface + NoopVerifier + ClaudegenVerifier
- [x] cross-verify prompt template (WebFetch 활용 명시)
- [x] Worker chain: extract → verify → forward
- [x] main.go wiring
- [x] 단위 테스트 (verifier + worker chain)
- [x] gofmt / vet / build / go test -race ./... 그린

<br>

## 논의 사항
- 다음 sub-issue (#449) 가 외부 맥락 (사회·정치·공학 배경) 추가 — 동일 worker chain 에 단계 추가
- DB 후보 ranking 은 in-memory title token overlap 기반 — 한국어 등 비-라틴 토큰화는 단순. 향후 임베딩 기반 ranking 으로 고도화 가능
- ContentRef 의 PublishedAt 부재 article 은 candidate 윈도우 적용 불가 → candidate 빈 상태로 verifier 호출 (verifier 가 WebFetch 만으로 진행)