### PR TITLE
[FEAT#449] enrich 외부 맥락 — Contextualizer + WebFetch background/timeline/implications

### DIFF
--- a/cmd/issuetracker/main.go
+++ b/cmd/issuetracker/main.go
@@ -933,13 +933,28 @@ func main() {
 		log.Info("enrich verifier: noop (claudegen pool or prompt loader unavailable)")
 	}
 
-	enrichW := enrichWorkerPkg.NewWorker(enrichConsumer, enrichPublisher, contentSvc, enrichExtractor, enrichVerifier, enrichGate, workerCountsCfg.Enrich)
+	// 이슈 #449 — claudegen 기반 enricher contextualizer (외부 맥락 수집) wiring.
+	// extractor / verifier 와 동일 fallback 정책.
+	var enrichContextualizer enrichextractor.Contextualizer = enrichextractor.NewNoopContextualizer()
+	if claudegenPool != nil && promptLoader != nil {
+		cc, ccErr := enrichextractor.NewClaudegenContextualizer(claudegenPool, promptLoader)
+		if ccErr != nil {
+			log.WithError(ccErr).Warn("claudegen enrich contextualizer construction failed, using noop")
+		} else {
+			enrichContextualizer = cc
+			log.Info("enrich contextualizer: claudegen-backed")
+		}
+	} else {
+		log.Info("enrich contextualizer: noop (claudegen pool or prompt loader unavailable)")
+	}
+
+	enrichW := enrichWorkerPkg.NewWorker(enrichConsumer, enrichPublisher, contentSvc, enrichExtractor, enrichVerifier, enrichContextualizer, enrichGate, workerCountsCfg.Enrich)
 
 	log.WithFields(map[string]interface{}{
 		"worker_count": workerCountsCfg.Enrich,
 		"input_topic":  queue.TopicValidated,
 		"output_topic": queue.TopicEnriched,
-	}).Info("enrich worker constructed (#447 extractor + #448 verifier)")
+	}).Info("enrich worker constructed (#447 extractor + #448 verifier + #449 contextualizer)")
 
 	// ══════════════════════════════════════════════════════════════════════════
 	// Stage 통합 — processor.Stage 인터페이스로 모든 단계 균일 관리

--- a/internal/processor/enrich/extractor/contextualizer.go
+++ b/internal/processor/enrich/extractor/contextualizer.go
@@ -78,11 +78,12 @@ func (c *ClaudegenContextualizer) Provide(ctx context.Context, in ContextInput) 
 		return nil, fmt.Errorf("load context prompt %q: %w", contextPromptName, err)
 	}
 
-	entitiesJSON, err := marshalEntitiesForPrompt(in.Entities)
+	entitiesJSON, err := marshalSliceForPrompt(in.Entities)
 	if err != nil {
 		return nil, fmt.Errorf("marshal entities: %w", err)
 	}
-	claimsJSON, err := marshalClaimsForPrompt(in.Claims)
+	// context prompt 는 idx 가 불필요 — 단순 직렬화 사용 (verifier 와 다른 점).
+	claimsJSON, err := marshalSliceForPrompt(in.Claims)
 	if err != nil {
 		return nil, fmt.Errorf("marshal claims: %w", err)
 	}
@@ -148,15 +149,4 @@ func (c *PageContext) IsEmpty() bool {
 		return true
 	}
 	return len(c.Background) == 0 && len(c.Timeline) == 0 && c.Implications == nil
-}
-
-func marshalEntitiesForPrompt(entities []Entity) (string, error) {
-	if len(entities) == 0 {
-		return "[]", nil
-	}
-	b, err := json.Marshal(entities)
-	if err != nil {
-		return "", err
-	}
-	return string(b), nil
 }

--- a/internal/processor/enrich/extractor/contextualizer.go
+++ b/internal/processor/enrich/extractor/contextualizer.go
@@ -1,0 +1,162 @@
+// 본 파일은 enrich 단계의 외부 맥락 수집기 (Contextualizer) 를 정의합니다 (이슈 #449).
+//
+// Contextualizer 는 추출된 entities / claims 를 입력으로 받아 page 외부의 배경·타임라인·
+// 함의 정보를 PageContext 로 반환합니다. Claude WebFetch 도구를 적극 활용하도록 prompt 가
+// 유도 — 위키피디아 / 공식 페이지 / 정책 문서 등에서 직접 페치.
+
+package extractor
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	"issuetracker/pkg/llm/prompt"
+)
+
+// ContextInput 은 Contextualizer.Provide 의 입력입니다.
+type ContextInput struct {
+	URL      string
+	Host     string
+	Title    string
+	Entities []Entity
+	Claims   []Claim
+}
+
+// Contextualizer 는 page 외부의 맥락 정보를 PageContext 로 반환합니다.
+//
+// 실패 시 worker 가 nil context 로 fallback — forward 보장 (forward-first 정책).
+type Contextualizer interface {
+	Provide(ctx context.Context, in ContextInput) (*PageContext, error)
+}
+
+// NoopContextualizer 는 항상 nil context 를 반환합니다 (claudegen 미configured fallback).
+type NoopContextualizer struct{}
+
+// NewNoopContextualizer 는 NoopContextualizer 인스턴스를 반환합니다.
+func NewNoopContextualizer() *NoopContextualizer { return &NoopContextualizer{} }
+
+// Provide 는 항상 nil 반환 — context 미첨부.
+func (c *NoopContextualizer) Provide(_ context.Context, _ ContextInput) (*PageContext, error) {
+	return nil, nil
+}
+
+// 컴파일 타임 인터페이스 만족 검증.
+var _ Contextualizer = (*NoopContextualizer)(nil)
+
+// contextPromptName 은 외부 맥락 수집 prompt asset 경로입니다.
+const contextPromptName = "claudegen/enricher_context"
+
+// ClaudegenContextualizer 는 claudegen.ClaudeWorkerPool 로 context session 을 실행합니다.
+type ClaudegenContextualizer struct {
+	runner SessionRunner
+	loader prompt.Loader
+}
+
+// NewClaudegenContextualizer 는 claudegen-backed Contextualizer 를 생성합니다.
+func NewClaudegenContextualizer(runner SessionRunner, loader prompt.Loader) (*ClaudegenContextualizer, error) {
+	if runner == nil {
+		return nil, errors.New("extractor: claudegen runner must not be nil")
+	}
+	if loader == nil {
+		return nil, errors.New("extractor: prompt loader must not be nil")
+	}
+	return &ClaudegenContextualizer{runner: runner, loader: loader}, nil
+}
+
+// Provide 는 claudegen 세션을 실행하고 stdout 을 PageContext 로 파싱합니다.
+//
+// entities + claims 가 모두 비어있으면 호출 skip — context 산출 근거가 없음.
+func (c *ClaudegenContextualizer) Provide(ctx context.Context, in ContextInput) (*PageContext, error) {
+	if len(in.Entities) == 0 && len(in.Claims) == 0 {
+		return nil, nil
+	}
+
+	tpl, err := c.loader.Load(contextPromptName)
+	if err != nil {
+		return nil, fmt.Errorf("load context prompt %q: %w", contextPromptName, err)
+	}
+
+	entitiesJSON, err := marshalEntitiesForPrompt(in.Entities)
+	if err != nil {
+		return nil, fmt.Errorf("marshal entities: %w", err)
+	}
+	claimsJSON, err := marshalClaimsForPrompt(in.Claims)
+	if err != nil {
+		return nil, fmt.Errorf("marshal claims: %w", err)
+	}
+
+	promptText := prompt.Render(tpl,
+		"{{URL}}", in.URL,
+		"{{HOST}}", in.Host,
+		"{{TITLE}}", in.Title,
+		"{{ENTITIES_JSON}}", entitiesJSON,
+		"{{CLAIMS_JSON}}", claimsJSON,
+	)
+
+	stdout, err := c.runner.RunEnrichSession(ctx, "enrich-context", nil, promptText)
+	if err != nil {
+		return nil, fmt.Errorf("claudegen context session: %w", err)
+	}
+
+	pageCtx, err := parseContextOutput(stdout)
+	if err != nil {
+		return nil, fmt.Errorf("parse context output: %w", err)
+	}
+	return pageCtx, nil
+}
+
+// 컴파일 타임 인터페이스 만족 검증.
+var _ Contextualizer = (*ClaudegenContextualizer)(nil)
+
+// parseContextOutput 는 claudegen stdout JSON 을 PageContext 로 파싱합니다.
+//
+// 응답이 비어있거나 모든 sub-field 가 비어있어도 *PageContext 자체는 반환 — 호출자가
+// 명시적으로 nil/non-nil 을 통해 "수집 시도 완료" 신호로 활용 가능.
+// 다만 모든 sub-field 가 empty 면 호출자 (worker) 가 attach skip 결정 가능 (helper IsEmpty).
+func parseContextOutput(output string) (*PageContext, error) {
+	body := stripFences(output)
+	if body == "" {
+		return nil, errors.New("empty output")
+	}
+	var pc PageContext
+	if err := json.Unmarshal([]byte(body), &pc); err != nil {
+		return nil, fmt.Errorf("unmarshal: %w", err)
+	}
+	// nil slice → empty slice 정규화 (downstream 일관성).
+	if pc.Background == nil {
+		pc.Background = []BackgroundItem{}
+	}
+	if pc.Timeline == nil {
+		pc.Timeline = []TimelineEvent{}
+	}
+	// Implications 가 모두 빈 문자열이면 객체 자체를 nil 로 — JSON output 의 noise 제거.
+	if pc.Implications != nil &&
+		pc.Implications.Political == "" &&
+		pc.Implications.Social == "" &&
+		pc.Implications.Technical == "" {
+		pc.Implications = nil
+	}
+	return &pc, nil
+}
+
+// IsEmpty 는 PageContext 의 모든 필드가 empty 인지 검사합니다.
+// worker 가 빈 context 첨부를 skip 할 때 사용.
+func (c *PageContext) IsEmpty() bool {
+	if c == nil {
+		return true
+	}
+	return len(c.Background) == 0 && len(c.Timeline) == 0 && c.Implications == nil
+}
+
+func marshalEntitiesForPrompt(entities []Entity) (string, error) {
+	if len(entities) == 0 {
+		return "[]", nil
+	}
+	b, err := json.Marshal(entities)
+	if err != nil {
+		return "", err
+	}
+	return string(b), nil
+}

--- a/internal/processor/enrich/extractor/verifier.go
+++ b/internal/processor/enrich/extractor/verifier.go
@@ -85,11 +85,11 @@ func (v *ClaudegenVerifier) Verify(ctx context.Context, in VerifyInput) ([]Verif
 		return nil, fmt.Errorf("load verifier prompt %q: %w", verifierPromptName, err)
 	}
 
-	claimsJSON, err := marshalClaimsForPrompt(in.Claims)
+	claimsJSON, err := marshalIndexedClaimsForPrompt(in.Claims)
 	if err != nil {
 		return nil, fmt.Errorf("marshal claims: %w", err)
 	}
-	candidatesJSON, err := marshalCandidatesForPrompt(in.Candidates)
+	candidatesJSON, err := marshalSliceForPrompt(in.Candidates)
 	if err != nil {
 		return nil, fmt.Errorf("marshal candidates: %w", err)
 	}
@@ -153,8 +153,28 @@ func parseVerifyOutput(output string) ([]Verification, error) {
 	return res.Verifications, nil
 }
 
-func marshalClaimsForPrompt(claims []Claim) (string, error) {
-	// claim_idx 명시 — prompt 가 idx 기반 verdict 를 반환하므로 caller 가 알기 쉬운 배열로 직렬화.
+// marshalSliceForPrompt 는 임의의 슬라이스를 prompt 용 JSON 문자열로 직렬화합니다 (이슈 #449, gemini-review PR #454).
+//
+// 입력 슬라이스가 비어있으면 "[]" 반환. Entities / Candidates / Claims(no-idx) 등 idx 가공이
+// 필요 없는 케이스에서 공통으로 사용. idx 부착이 필요한 claims (verifier 입력) 는
+// marshalIndexedClaimsForPrompt 별도 사용.
+func marshalSliceForPrompt[T any](v []T) (string, error) {
+	if len(v) == 0 {
+		return "[]", nil
+	}
+	b, err := json.Marshal(v)
+	if err != nil {
+		return "", err
+	}
+	return string(b), nil
+}
+
+// marshalIndexedClaimsForPrompt 는 claims 를 verifier prompt 용으로 idx 부착 직렬화합니다.
+//
+// verifier prompt 의 출력 (verifications) 이 claim_idx 로 입력 claim 을 가리키므로 호출자
+// (verifier) 에게 idx 명시 형태가 필수. contextualizer 처럼 idx 가 불필요한 경로는
+// marshalSliceForPrompt(claims) 직접 사용 가능.
+func marshalIndexedClaimsForPrompt(claims []Claim) (string, error) {
 	type indexedClaim struct {
 		Idx       int    `json:"idx"`
 		Text      string `json:"text"`
@@ -169,17 +189,6 @@ func marshalClaimsForPrompt(claims []Claim) (string, error) {
 		})
 	}
 	b, err := json.Marshal(out)
-	if err != nil {
-		return "", err
-	}
-	return string(b), nil
-}
-
-func marshalCandidatesForPrompt(cs []CandidateRef) (string, error) {
-	if len(cs) == 0 {
-		return "[]", nil
-	}
-	b, err := json.Marshal(cs)
 	if err != nil {
 		return "", err
 	}

--- a/internal/processor/enrich/worker/worker.go
+++ b/internal/processor/enrich/worker/worker.go
@@ -401,20 +401,13 @@ func (w *Worker) runContextEnrichment(
 	}
 	facts.Context = pageCtx
 
-	bgCount := 0
-	tlCount := 0
-	hasImpl := false
-	if pageCtx != nil {
-		bgCount = len(pageCtx.Background)
-		tlCount = len(pageCtx.Timeline)
-		hasImpl = pageCtx.Implications != nil
-	}
+	// pageCtx 는 위 IsEmpty() 가 false → 도달 시점에 non-nil 보장 (gemini-review PR #454).
 	log.WithFields(map[string]interface{}{
 		"job_id":           pm.ID,
 		"ref_id":           ref.ID,
-		"background_count": bgCount,
-		"timeline_count":   tlCount,
-		"has_implications": hasImpl,
+		"background_count": len(pageCtx.Background),
+		"timeline_count":   len(pageCtx.Timeline),
+		"has_implications": pageCtx.Implications != nil,
 	}).Debug("enrichment context completed")
 }
 

--- a/internal/processor/enrich/worker/worker.go
+++ b/internal/processor/enrich/worker/worker.go
@@ -51,20 +51,21 @@ const drainTimeout = workerpool.DefaultDrainTimeout
 // 추출/검증 실패는 파이프라인을 멈추지 않습니다 — warn 로깅 + 빈 결과로 fallback + forward 진행.
 // content 조회 실패 (ErrNotFound) 는 idempotent 정상 분기 — 이미 처리된 메시지로 보고 commit.
 type Worker struct {
-	consumer    bus.Consumer
-	pub         *bus.Publisher
-	contentSvc  service.ContentService
-	extractor   extractor.Extractor
-	verifier    extractor.Verifier
-	gate        locks.StageGate // nil 허용 → NoopStageGate 로 fallback
-	workerCount int
+	consumer       bus.Consumer
+	pub            *bus.Publisher
+	contentSvc     service.ContentService
+	extractor      extractor.Extractor
+	verifier       extractor.Verifier
+	contextualizer extractor.Contextualizer
+	gate           locks.StageGate // nil 허용 → NoopStageGate 로 fallback
+	workerCount    int
 
 	pool *workerpool.ConsumerPool
 }
 
 // NewWorker 는 새로운 Worker 를 생성합니다.
 //
-// pub / contentSvc / extractor / verifier 가 nil 이면 panic — fail-fast (silent failure 회피).
+// pub / contentSvc / extractor / verifier / contextualizer 가 nil 이면 panic — fail-fast.
 // gate 가 nil 이면 NoopStageGate 로 fallback.
 func NewWorker(
 	consumer bus.Consumer,
@@ -72,6 +73,7 @@ func NewWorker(
 	contentSvc service.ContentService,
 	ex extractor.Extractor,
 	vr extractor.Verifier,
+	cz extractor.Contextualizer,
 	gate locks.StageGate,
 	workerCount int,
 ) *Worker {
@@ -87,17 +89,21 @@ func NewWorker(
 	if vr == nil {
 		panic("enrich.NewWorker: verifier must not be nil (use extractor.NoopVerifier for disabled verification)")
 	}
+	if cz == nil {
+		panic("enrich.NewWorker: contextualizer must not be nil (use extractor.NoopContextualizer for disabled context)")
+	}
 	if gate == nil {
 		gate = locks.NewNoopStageGate()
 	}
 	return &Worker{
-		consumer:    consumer,
-		pub:         pub,
-		contentSvc:  contentSvc,
-		extractor:   ex,
-		verifier:    vr,
-		gate:        gate,
-		workerCount: workerCount,
+		consumer:       consumer,
+		pub:            pub,
+		contentSvc:     contentSvc,
+		extractor:      ex,
+		verifier:       vr,
+		contextualizer: cz,
+		gate:           gate,
+		workerCount:    workerCount,
 	}
 }
 
@@ -187,11 +193,12 @@ func (w *Worker) process(ctx context.Context, msg *queue.Message) error {
 		defer release()
 	}
 
-	// 이슈 #447 / #448 — Content 조회 + extractor 호출 + cross-verify + facts 첨부.
+	// 이슈 #447 / #448 / #449 — Content 조회 + extractor 호출 + cross-verify + context + facts 첨부.
 	// 본 단계 어떤 실패도 forward 를 막지 않음 — pipeline 진행이 enrichment 보다 우선.
 	content, facts := w.runExtraction(ctx, &pm, &ref)
 	if facts != nil {
 		w.runVerification(ctx, &pm, &ref, content, facts)
+		w.runContextEnrichment(ctx, &pm, &ref, content, facts)
 		w.attachFacts(&pm, facts)
 	}
 
@@ -341,6 +348,74 @@ func (w *Worker) runVerification(
 		"candidate_count":    len(candidates),
 		"verification_count": len(verifications),
 	}).Debug("enrichment verification completed")
+}
+
+// runContextEnrichment 는 entities + claims 를 입력으로 외부 맥락을 수집하고
+// facts.Context 에 첨부합니다 (이슈 #449).
+//
+// entities/claims 가 모두 비어있으면 skip. contextualizer error / 빈 결과는 미첨부 — forward 보장.
+func (w *Worker) runContextEnrichment(
+	ctx context.Context,
+	pm *core.ProcessingMessage,
+	ref *core.ContentRef,
+	content *core.Content,
+	facts *extractor.EnrichedFacts,
+) {
+	log := logger.FromContext(ctx)
+
+	if facts == nil {
+		return
+	}
+	if len(facts.Entities) == 0 && len(facts.Claims) == 0 {
+		return
+	}
+
+	title := ""
+	if content != nil {
+		title = content.Title
+	}
+	in := extractor.ContextInput{
+		URL:      ref.URL,
+		Host:     hostOf(ref.URL),
+		Title:    title,
+		Entities: facts.Entities,
+		Claims:   facts.Claims,
+	}
+
+	pageCtx, err := w.contextualizer.Provide(ctx, in)
+	if err != nil {
+		log.WithFields(map[string]interface{}{
+			"job_id":       pm.ID,
+			"ref_id":       ref.ID,
+			"entity_count": len(facts.Entities),
+			"claim_count":  len(facts.Claims),
+		}).WithError(err).Warn("enrichment context provider failed, forwarding without context")
+		return
+	}
+	if pageCtx.IsEmpty() {
+		log.WithFields(map[string]interface{}{
+			"job_id": pm.ID,
+			"ref_id": ref.ID,
+		}).Debug("context provider returned empty result, skipping attach")
+		return
+	}
+	facts.Context = pageCtx
+
+	bgCount := 0
+	tlCount := 0
+	hasImpl := false
+	if pageCtx != nil {
+		bgCount = len(pageCtx.Background)
+		tlCount = len(pageCtx.Timeline)
+		hasImpl = pageCtx.Implications != nil
+	}
+	log.WithFields(map[string]interface{}{
+		"job_id":           pm.ID,
+		"ref_id":           ref.ID,
+		"background_count": bgCount,
+		"timeline_count":   tlCount,
+		"has_implications": hasImpl,
+	}).Debug("enrichment context completed")
 }
 
 // findCandidates 는 본 content 와 같은 country + 시간 윈도우의 후보 article 들을 조회하고

--- a/pkg/llm/prompt/assets/claudegen/enricher_context.user.txt
+++ b/pkg/llm/prompt/assets/claudegen/enricher_context.user.txt
@@ -21,31 +21,34 @@ Your task — **use the WebFetch tool aggressively**:
 4. Build a short timeline of dated events relevant to the article (if applicable).
 5. Summarize political / social / technical implications (only when supported by sources — do not speculate).
 
-Output a single JSON object — no explanation, no markdown, no code blocks:
+Output a single JSON object — no explanation, no markdown, no code blocks. The example below shows the schema; all field values must be concrete strings/arrays — no `|` union syntax, no placeholder brackets in the output:
+
 {
   "background": [
     {
       "subject": "<entity or topic name>",
-      "category": "person" | "event" | "tech" | "policy",
+      "category": "<one of: person, organization, location, event, tech, policy>",
       "summary": "<1-3 sentences of factual background>",
-      "sources": ["<url1>", "<url2>", ...]
+      "sources": ["<url1>"]
     }
   ],
   "timeline": [
     {"date": "<ISO 8601 date or YYYY-MM>", "event": "<short factual description>", "source": "<url>"}
   ],
   "implications": {
-    "political": "<short paragraph, only if applicable, otherwise empty>",
-    "social":    "<short paragraph, only if applicable, otherwise empty>",
-    "technical": "<short paragraph, only if applicable, otherwise empty>"
+    "political": "<short paragraph, empty string if not applicable>",
+    "social":    "<short paragraph, empty string if not applicable>",
+    "technical": "<short paragraph, empty string if not applicable>"
   }
 }
 
 Output rules:
 - Cite real URLs you actually fetched. Do not invent sources.
-- 0-5 background items is enough. Skip entities with no findings.
+- 0-5 background items. Skip entities with no findings.
+- If ENTITIES_JSON or CLAIMS_JSON is non-empty, include at least 1 external source URL across background/timeline. If no external source can be found after reasonable search, return all arrays empty (background=[], timeline=[], implications with all-empty strings).
+- Every `background` item's `sources` array MUST contain at least one URL — do not emit background items without sources.
 - timeline 0-10 events. Use exact dates when available; YYYY-MM when only month known; otherwise skip.
-- implications: each field optional. Leave empty string when the article does not warrant that angle.
+- implications: each field optional. Use empty string when the article does not warrant that angle.
 - Source article's host is acceptable in `sources` only when it is the canonical source (e.g., official corporate site). Prefer external authoritative sources where possible.
 - All summaries / events / implications must be factually grounded in cited sources. When in doubt, omit.
 

--- a/pkg/llm/prompt/assets/claudegen/enricher_context.user.txt
+++ b/pkg/llm/prompt/assets/claudegen/enricher_context.user.txt
@@ -1,0 +1,52 @@
+You are gathering external context for a news/community article. Go beyond the page itself — find background, timeline, and broader implications for the entities, events, and topics it covers.
+
+Source article:
+- URL: {{URL}}
+- Host: {{HOST}}
+- Title: {{TITLE}}
+
+Extracted entities (from previous step):
+{{ENTITIES_JSON}}
+
+Extracted claims (from previous step):
+{{CLAIMS_JSON}}
+
+Your task — **use the WebFetch tool aggressively**:
+1. For each named entity (person / organization / location), look up authoritative background. Examples:
+   - Person: Wikipedia / official bio page → role, prior history, recent relevant events.
+   - Organization: Wikipedia / official site → founding, scope, recent activity.
+   - Event: Wikipedia / news archive → timeline, related earlier events.
+2. For technical / scientific terms, find official definitions or specs (Wikipedia, standard bodies, RFC, vendor docs).
+3. For policy / legal references, find the official policy doc or governmental source.
+4. Build a short timeline of dated events relevant to the article (if applicable).
+5. Summarize political / social / technical implications (only when supported by sources — do not speculate).
+
+Output a single JSON object — no explanation, no markdown, no code blocks:
+{
+  "background": [
+    {
+      "subject": "<entity or topic name>",
+      "category": "person" | "event" | "tech" | "policy",
+      "summary": "<1-3 sentences of factual background>",
+      "sources": ["<url1>", "<url2>", ...]
+    }
+  ],
+  "timeline": [
+    {"date": "<ISO 8601 date or YYYY-MM>", "event": "<short factual description>", "source": "<url>"}
+  ],
+  "implications": {
+    "political": "<short paragraph, only if applicable, otherwise empty>",
+    "social":    "<short paragraph, only if applicable, otherwise empty>",
+    "technical": "<short paragraph, only if applicable, otherwise empty>"
+  }
+}
+
+Output rules:
+- Cite real URLs you actually fetched. Do not invent sources.
+- 0-5 background items is enough. Skip entities with no findings.
+- timeline 0-10 events. Use exact dates when available; YYYY-MM when only month known; otherwise skip.
+- implications: each field optional. Leave empty string when the article does not warrant that angle.
+- Source article's host is acceptable in `sources` only when it is the canonical source (e.g., official corporate site). Prefer external authoritative sources where possible.
+- All summaries / events / implications must be factually grounded in cited sources. When in doubt, omit.
+
+Return ONLY the JSON object.

--- a/test/internal/processor/enrich/extractor/claudegen_test.go
+++ b/test/internal/processor/enrich/extractor/claudegen_test.go
@@ -277,3 +277,135 @@ func TestNewClaudegenVerifier_NilArgs(t *testing.T) {
 	_, err = extractor.NewClaudegenVerifier(&stubRunner{stdout: "{}"}, nil)
 	assert.Error(t, err)
 }
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Contextualizer (이슈 #449)
+// ─────────────────────────────────────────────────────────────────────────────
+
+func TestClaudegenContextualizer_Success(t *testing.T) {
+	stdout := `{
+		"background": [
+			{"subject": "Acme Corp", "category": "org", "summary": "Founded in 1980 — global manufacturer.", "sources": ["https://en.wikipedia.org/wiki/Acme"]}
+		],
+		"timeline": [
+			{"date": "2025-01-15", "event": "Quarterly results announced", "source": "https://news.example.org/q"}
+		],
+		"implications": {
+			"political": "",
+			"social": "Workforce concerns in two regions.",
+			"technical": ""
+		}
+	}`
+	runner := &stubRunner{stdout: stdout}
+	c, err := extractor.NewClaudegenContextualizer(runner, &stubLoader{tpl: "ctx {{ENTITIES_JSON}} {{CLAIMS_JSON}}"})
+	require.NoError(t, err)
+
+	got, err := c.Provide(context.Background(), extractor.ContextInput{
+		URL:      "https://example.com/p",
+		Host:     "example.com",
+		Title:    "T",
+		Entities: []extractor.Entity{{Type: extractor.EntityTypeOrg, Name: "Acme"}},
+		Claims:   []extractor.Claim{{Text: "Acme announced X"}},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	assert.Len(t, got.Background, 1)
+	assert.Equal(t, "Acme Corp", got.Background[0].Subject)
+	assert.Len(t, got.Timeline, 1)
+	require.NotNil(t, got.Implications)
+	assert.Equal(t, "Workforce concerns in two regions.", got.Implications.Social)
+	assert.Equal(t, 1, runner.calls)
+}
+
+func TestClaudegenContextualizer_EmptyImplications_NormalizedToNil(t *testing.T) {
+	// 모든 implications 필드가 빈 문자열이면 Implications 자체가 nil 로 정규화.
+	stdout := `{
+		"background": [],
+		"timeline": [],
+		"implications": {"political": "", "social": "", "technical": ""}
+	}`
+	c, err := extractor.NewClaudegenContextualizer(
+		&stubRunner{stdout: stdout},
+		&stubLoader{tpl: "t"},
+	)
+	require.NoError(t, err)
+
+	got, err := c.Provide(context.Background(), extractor.ContextInput{
+		Entities: []extractor.Entity{{Name: "X"}},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	assert.Nil(t, got.Implications)
+	assert.True(t, got.IsEmpty())
+}
+
+func TestClaudegenContextualizer_NoEntitiesOrClaims_SkipsRunner(t *testing.T) {
+	runner := &stubRunner{stdout: "should not be parsed"}
+	c, err := extractor.NewClaudegenContextualizer(
+		runner,
+		&stubLoader{tpl: "t"},
+	)
+	require.NoError(t, err)
+
+	got, err := c.Provide(context.Background(), extractor.ContextInput{})
+	require.NoError(t, err)
+	assert.Nil(t, got, "no entities/claims → runner skip, nil context")
+	assert.Equal(t, 0, runner.calls)
+}
+
+func TestClaudegenContextualizer_SessionError_Propagates(t *testing.T) {
+	c, err := extractor.NewClaudegenContextualizer(
+		&stubRunner{err: errors.New("exec failure")},
+		&stubLoader{tpl: "t"},
+	)
+	require.NoError(t, err)
+	_, err = c.Provide(context.Background(), extractor.ContextInput{
+		Entities: []extractor.Entity{{Name: "X"}},
+	})
+	require.Error(t, err)
+}
+
+func TestClaudegenContextualizer_MalformedOutput_ReturnsError(t *testing.T) {
+	c, err := extractor.NewClaudegenContextualizer(
+		&stubRunner{stdout: "not json"},
+		&stubLoader{tpl: "t"},
+	)
+	require.NoError(t, err)
+	_, err = c.Provide(context.Background(), extractor.ContextInput{
+		Entities: []extractor.Entity{{Name: "X"}},
+	})
+	require.Error(t, err)
+}
+
+func TestNoopContextualizer_ReturnsNil(t *testing.T) {
+	got, err := extractor.NewNoopContextualizer().Provide(context.Background(), extractor.ContextInput{
+		Entities: []extractor.Entity{{Name: "X"}},
+	})
+	require.NoError(t, err)
+	assert.Nil(t, got)
+}
+
+func TestNewClaudegenContextualizer_NilArgs(t *testing.T) {
+	_, err := extractor.NewClaudegenContextualizer(nil, &stubLoader{tpl: "t"})
+	assert.Error(t, err)
+	_, err = extractor.NewClaudegenContextualizer(&stubRunner{stdout: "{}"}, nil)
+	assert.Error(t, err)
+}
+
+func TestPageContext_IsEmpty(t *testing.T) {
+	// nil receiver
+	var nilPC *extractor.PageContext
+	assert.True(t, nilPC.IsEmpty())
+
+	// 모두 empty
+	pc := &extractor.PageContext{Background: nil, Timeline: nil, Implications: nil}
+	assert.True(t, pc.IsEmpty())
+
+	// background 있음 → not empty
+	pc2 := &extractor.PageContext{Background: []extractor.BackgroundItem{{Subject: "X"}}}
+	assert.False(t, pc2.IsEmpty())
+
+	// implications 있음 → not empty
+	pc3 := &extractor.PageContext{Implications: &extractor.Implications{Social: "x"}}
+	assert.False(t, pc3.IsEmpty())
+}

--- a/test/internal/processor/enrich/worker/worker_test.go
+++ b/test/internal/processor/enrich/worker/worker_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 
 	"issuetracker/internal/bus"
 	"issuetracker/internal/locks"
@@ -131,9 +132,25 @@ func newEnrichWorker(consumer queue.Consumer, producer queue.Producer) *worker.W
 		&stubContentService{},
 		extractor.NewNoopExtractor(),
 		extractor.NewNoopVerifier(),
+		extractor.NewNoopContextualizer(),
 		locks.NewNoopStageGate(),
 		1,
 	)
+}
+
+// fakeContextualizer 는 context 입력을 캡쳐하고 미리 정의된 PageContext / err 를 반환합니다.
+type fakeContextualizer struct {
+	page     *extractor.PageContext
+	err      error
+	callsLog []extractor.ContextInput
+}
+
+func (c *fakeContextualizer) Provide(_ context.Context, in extractor.ContextInput) (*extractor.PageContext, error) {
+	c.callsLog = append(c.callsLog, in)
+	if c.err != nil {
+		return nil, c.err
+	}
+	return c.page, nil
 }
 
 func makeValidatedMessage(t *testing.T, refID, url, country, sourceName string) *queue.Message {
@@ -296,6 +313,7 @@ func TestEnrichWorker_Extraction_AttachesFactsToMetadata(t *testing.T) {
 		contentSvc,
 		fake,
 		extractor.NewNoopVerifier(),
+		extractor.NewNoopContextualizer(),
 		locks.NewNoopStageGate(),
 		1,
 	)
@@ -355,6 +373,7 @@ func TestEnrichWorker_ExtractionFailure_StillForwards(t *testing.T) {
 		contentSvc,
 		fake,
 		extractor.NewNoopVerifier(),
+		extractor.NewNoopContextualizer(),
 		locks.NewNoopStageGate(),
 		1,
 	)
@@ -436,6 +455,7 @@ func TestEnrichWorker_Verification_AttachesVerificationsToFacts(t *testing.T) {
 		contentSvc,
 		fakeExt,
 		fakeVer,
+		extractor.NewNoopContextualizer(),
 		locks.NewNoopStageGate(),
 		1,
 	)
@@ -497,6 +517,7 @@ func TestEnrichWorker_NoClaims_SkipsVerifier(t *testing.T) {
 		consumer, newTestPublisher(producer), contentSvc,
 		&fakeExtractor{facts: emptyFacts},
 		fakeVer,
+		extractor.NewNoopContextualizer(),
 		locks.NewNoopStageGate(),
 		1,
 	)
@@ -527,10 +548,142 @@ func TestEnrichWorker_VerificationFailure_StillForwards(t *testing.T) {
 		consumer, newTestPublisher(producer), contentSvc,
 		&fakeExtractor{facts: facts},
 		&fakeVerifier{err: assertAnError()},
+		extractor.NewNoopContextualizer(),
 		locks.NewNoopStageGate(),
 		1,
 	)
 	msg := makeValidatedMessage(t, "c-v-fail", "https://example.com/x", "US", "example")
+
+	producer.On("Publish", mock.Anything, mock.MatchedBy(func(m queue.Message) bool {
+		return m.Topic == queue.TopicEnriched
+	})).Return(nil).Once()
+	producer.On("Close").Return(nil).Maybe()
+	consumer.On("CommitMessages", mock.Anything, mock.Anything).Return(nil).Maybe()
+
+	runWorker(t, consumer, w, msg)
+
+	consumer.AssertExpectations(t)
+	producer.AssertExpectations(t)
+}
+
+// TestEnrichWorker_Context_AttachesPageContext — context provider 가 PageContext 를 반환하면
+// facts.Context 에 첨부되어 forward 메시지의 metadata 에 포함 (이슈 #449).
+func TestEnrichWorker_Context_AttachesPageContext(t *testing.T) {
+	consumer := new(mockConsumer)
+	producer := new(mockProducer)
+	contentSvc := &listingStubContentService{primary: &core.Content{
+		ID: "c-ctx", Title: "Sample", Body: "B", URL: "https://example.com/c", Country: "US",
+		PublishedAt: time.Now(),
+	}}
+	facts := &extractor.EnrichedFacts{
+		Entities: []extractor.Entity{{Type: extractor.EntityTypeOrg, Name: "Acme"}},
+		Claims:   []extractor.Claim{{Text: "Acme is global"}},
+	}
+	contextResp := &extractor.PageContext{
+		Background:   []extractor.BackgroundItem{{Subject: "Acme", Category: "org", Summary: "Founded 1980"}},
+		Implications: &extractor.Implications{Social: "Workforce concerns"},
+	}
+	fakeCtx := &fakeContextualizer{page: contextResp}
+
+	w := worker.NewWorker(
+		consumer, newTestPublisher(producer), contentSvc,
+		&fakeExtractor{facts: facts},
+		&fakeVerifier{},
+		fakeCtx,
+		locks.NewNoopStageGate(),
+		1,
+	)
+	msg := makeValidatedMessage(t, "c-ctx", "https://example.com/c", "US", "example")
+
+	var published queue.Message
+	producer.On("Publish", mock.Anything, mock.MatchedBy(func(m queue.Message) bool {
+		if m.Topic != queue.TopicEnriched {
+			return false
+		}
+		published = m
+		return true
+	})).Return(nil).Once()
+	producer.On("Close").Return(nil).Maybe()
+	consumer.On("CommitMessages", mock.Anything, mock.Anything).Return(nil).Maybe()
+
+	runWorker(t, consumer, w, msg)
+
+	// contextualizer 호출 입력 검증
+	if assert.Len(t, fakeCtx.callsLog, 1) {
+		in := fakeCtx.callsLog[0]
+		assert.Equal(t, "https://example.com/c", in.URL)
+		assert.Len(t, in.Entities, 1)
+		assert.Len(t, in.Claims, 1)
+	}
+
+	// metadata.enriched_facts.context 첨부 검증
+	var pm core.ProcessingMessage
+	if err := json.Unmarshal(published.Value, &pm); err != nil {
+		t.Fatalf("unmarshal pm: %v", err)
+	}
+	rawFacts, ok := pm.Metadata["enriched_facts"].(map[string]interface{})
+	require.True(t, ok)
+	pageCtx, ok := rawFacts["context"].(map[string]interface{})
+	if assert.True(t, ok, "context should be attached") {
+		bg, bgOK := pageCtx["background"].([]interface{})
+		assert.True(t, bgOK)
+		assert.Len(t, bg, 1)
+	}
+}
+
+// TestEnrichWorker_NoEntitiesOrClaims_SkipsContext — 둘 다 없으면 contextualizer 미호출.
+func TestEnrichWorker_NoEntitiesOrClaims_SkipsContext(t *testing.T) {
+	consumer := new(mockConsumer)
+	producer := new(mockProducer)
+	contentSvc := &listingStubContentService{primary: &core.Content{
+		ID: "c-skip", Title: "t", Body: "b", URL: "https://example.com/s", Country: "US",
+		PublishedAt: time.Now(),
+	}}
+	facts := &extractor.EnrichedFacts{} // entities + claims 모두 nil/empty
+	fakeCtx := &fakeContextualizer{}
+
+	w := worker.NewWorker(
+		consumer, newTestPublisher(producer), contentSvc,
+		&fakeExtractor{facts: facts},
+		&fakeVerifier{},
+		fakeCtx,
+		locks.NewNoopStageGate(),
+		1,
+	)
+	msg := makeValidatedMessage(t, "c-skip", "https://example.com/s", "US", "example")
+
+	producer.On("Publish", mock.Anything, mock.MatchedBy(func(m queue.Message) bool {
+		return m.Topic == queue.TopicEnriched
+	})).Return(nil).Once()
+	producer.On("Close").Return(nil).Maybe()
+	consumer.On("CommitMessages", mock.Anything, mock.Anything).Return(nil).Maybe()
+
+	runWorker(t, consumer, w, msg)
+
+	assert.Empty(t, fakeCtx.callsLog, "contextualizer must not be called when entities/claims both empty")
+}
+
+// TestEnrichWorker_ContextFailure_StillForwards — context error 도 pipeline 진행 보장.
+func TestEnrichWorker_ContextFailure_StillForwards(t *testing.T) {
+	consumer := new(mockConsumer)
+	producer := new(mockProducer)
+	contentSvc := &listingStubContentService{primary: &core.Content{
+		ID: "c-ctx-fail", Title: "t", Body: "b", URL: "https://example.com/x", Country: "US",
+		PublishedAt: time.Now(),
+	}}
+	facts := &extractor.EnrichedFacts{
+		Entities: []extractor.Entity{{Name: "X"}},
+	}
+
+	w := worker.NewWorker(
+		consumer, newTestPublisher(producer), contentSvc,
+		&fakeExtractor{facts: facts},
+		&fakeVerifier{},
+		&fakeContextualizer{err: assertAnError()},
+		locks.NewNoopStageGate(),
+		1,
+	)
+	msg := makeValidatedMessage(t, "c-ctx-fail", "https://example.com/x", "US", "example")
 
 	producer.On("Publish", mock.Anything, mock.MatchedBy(func(m queue.Message) bool {
 		return m.Topic == queue.TopicEnriched


### PR DESCRIPTION
## 연관 이슈
- Closes #449
- Parent: #445

<br>

## 구현 내용

추출된 entities + claims 를 입력으로 **page 외부의 배경 정보** 를 수집. claudegen 이 WebFetch 도구를 적극 활용하여 Wikipedia / 공식 페이지 / 정책 문서 등에서 직접 페치 → PageContext 산출.

### 1. Contextualizer 인터페이스 + Claudegen 구현
- `Contextualizer.Provide(ctx, ContextInput) → *PageContext`
- `ContextInput`: source URL/host/title + entities + claims
- `NoopContextualizer`: claudegen 미configured fallback
- `ClaudegenContextualizer`:
  - SessionRunner + prompt.Loader 의존
  - entities + claims 모두 empty → runner skip (입력 근거 없음)
  - implications 의 모든 필드 빈 문자열이면 객체 자체 nil 정규화 (noise 제거)
  - `PageContext.IsEmpty()` helper — worker 가 빈 결과 첨부 skip 결정용

### 2. Prompt 템플릿 (`claudegen/enricher_context.user.txt`)
- **WebFetch 적극 활용 유도**:
  - person → Wikipedia / 공식 bio
  - organization → Wikipedia / 공식 사이트
  - event → Wikipedia / 뉴스 아카이브
  - technical/policy → 표준 / 공식 문서
- 출력 schema: `{background[], timeline[], implications{political,social,technical}}`
- sources 인용 강제 — invent 금지, 카논 source 만 허용

### 3. Worker chain 확장
- `NewWorker` 시그니처에 `Contextualizer` 추가 (not-nil 강제)
- `runContextEnrichment` 신규:
  1. entities + claims 모두 empty → skip
  2. ContextInput 구성 → Contextualizer.Provide
  3. `IsEmpty()` 면 attach skip (noise 차단)
  4. facts.Context 에 첨부
- **forward-first 정책 유지** — context provider error / 빈 결과 모두 forward 진행

### 4. main.go wiring
- claudegenPool + promptLoader 가용 시 `ClaudegenContextualizer`, 부재 시 `NoopContextualizer`

### 5. 테스트
- extractor: 성공 파싱 / implications-all-empty 정규화 / entities+claims empty skip / session error / malformed / Noop / IsEmpty helper
- worker: Context 첨부 happy path + metadata 도달 검증 / entities+claims 없으면 contextualizer 미호출 / context error 도 forward

<br>

## CI / 머지 게이트 점검

### 변경 영향 범위
- 신규: `internal/processor/enrich/extractor/contextualizer.go`, `pkg/llm/prompt/assets/claudegen/enricher_context.user.txt`
- 변경: `internal/processor/enrich/worker/worker.go` (signature 확장), `cmd/issuetracker/main.go`, 테스트
- 위험도: Medium — worker.NewWorker breaking change (contextualizer 추가). 호출자는 main.go + 테스트만 — 통제됨. claudegen 미configured 환경은 NoopContextualizer 로 #448 동등 동작 유지

### Required Status Checks
- [ ] Commit Lint / PR Title Lint / Linked Issue Check / Format Check / Build / Test / Lint

### 롤백 계획
- STAGES_ENRICH_ENABLED=false 로 stage 자체 비활성 가능
- revert 시 #448 동작 (extract + verify) 으로 복귀

<br>

## TODO
- [x] Contextualizer interface + NoopContextualizer + ClaudegenContextualizer
- [x] context prompt template (WebFetch 활용 명시)
- [x] Worker chain: extract → verify → context → forward
- [x] main.go wiring
- [x] 단위 테스트 (provider + worker chain)
- [x] gofmt / vet / build / go test -race ./... 그린

<br>

## 논의 사항
- 다음 sub-issue (#450 — 마지막) 가 신뢰도 점수 산출 + `enriched_contents` 테이블 영속화 — 본 PR 의 metadata 첨부에서 DB 영속화로 전환
- WebFetch 호출 비용은 prompt 자체가 0-5 background / 0-10 timeline 제한으로 묶고 있음 — 비용 cap 은 후속 이슈 대상

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enrichment pipeline now attaches contextual information to extracted facts, including background, timeline, and implications gathered during article processing.
  * Context enrichment features graceful error handling to maintain processing flow.

* **Tests**
  * Comprehensive test coverage added for contextual enrichment functionality.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/EinSofINTEREST/IssueTracker/pull/454)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->