### PR TITLE
[FEAT#450] enrich 신뢰도 점수 + enriched_contents 영속화 (메인 #445 완료)

### DIFF
--- a/cmd/issuetracker/main.go
+++ b/cmd/issuetracker/main.go
@@ -948,13 +948,32 @@ func main() {
 		log.Info("enrich contextualizer: noop (claudegen pool or prompt loader unavailable)")
 	}
 
-	enrichW := enrichWorkerPkg.NewWorker(enrichConsumer, enrichPublisher, contentSvc, enrichExtractor, enrichVerifier, enrichContextualizer, enrichGate, workerCountsCfg.Enrich)
+	// 이슈 #450 — claudegen 기반 enricher scorer (trust_score) + enriched_contents 영속화 wiring.
+	var enrichScorer enrichextractor.Scorer = enrichextractor.NewNoopScorer()
+	if claudegenPool != nil && promptLoader != nil {
+		cs, csErr := enrichextractor.NewClaudegenScorer(claudegenPool, promptLoader)
+		if csErr != nil {
+			log.WithError(csErr).Warn("claudegen enrich scorer construction failed, using noop")
+		} else {
+			enrichScorer = cs
+			log.Info("enrich scorer: claudegen-backed")
+		}
+	} else {
+		log.Info("enrich scorer: noop (claudegen pool or prompt loader unavailable)")
+	}
+
+	// enriched_contents repository — pgxpool 사용. nil 허용 (Worker 가 nil 시 DB write skip).
+	enrichedRepo := decorator.WrapEnrichedContentWithTimeout(
+		pgstore.NewEnrichedContentRepository(pool, log), dbCfg.QueryTimeout,
+	)
+
+	enrichW := enrichWorkerPkg.NewWorker(enrichConsumer, enrichPublisher, contentSvc, enrichExtractor, enrichVerifier, enrichContextualizer, enrichScorer, enrichedRepo, enrichGate, workerCountsCfg.Enrich)
 
 	log.WithFields(map[string]interface{}{
 		"worker_count": workerCountsCfg.Enrich,
 		"input_topic":  queue.TopicValidated,
 		"output_topic": queue.TopicEnriched,
-	}).Info("enrich worker constructed (#447 extractor + #448 verifier + #449 contextualizer)")
+	}).Info("enrich worker constructed (#447 extractor + #448 verifier + #449 contextualizer + #450 scorer/persistence)")
 
 	// ══════════════════════════════════════════════════════════════════════════
 	// Stage 통합 — processor.Stage 인터페이스로 모든 단계 균일 관리

--- a/internal/processor/enrich/extractor/scorer.go
+++ b/internal/processor/enrich/extractor/scorer.go
@@ -1,0 +1,178 @@
+// 본 파일은 enrich 단계의 신뢰도 점수 산출기 (Scorer) 를 정의합니다 (이슈 #450).
+//
+// Scorer 는 추출 + 검증 + 외부 맥락 결과를 종합하여 page 단위 0.0 ~ 1.0 신뢰도 점수와
+// rationale / factors 를 반환합니다. claudegen 의 LLM 추론을 활용.
+
+package extractor
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	"issuetracker/pkg/llm/prompt"
+)
+
+// TrustScoreResult 는 Scorer.Score 의 출력입니다.
+//
+// TrustScore 는 [0.0, 1.0] — 호출자 (worker) 가 EnrichedFacts.TrustScore 에 첨부 +
+// DB enriched_contents.trust_score 에 영속화.
+// Rationale / Factors 는 진단·운영 가시성용 메타데이터 — 본 sub-issue 범위에서는 metadata 첨부만,
+// DB 영속화는 schema 단순화를 위해 생략 (필요 시 후속 schema evolution).
+type TrustScoreResult struct {
+	TrustScore float64
+	Rationale  string
+	Factors    ScoreFactors
+}
+
+// ScoreFactors 는 trust_score 구성 진단 필드들입니다.
+type ScoreFactors struct {
+	ClaimSupportRatio   float64 `json:"claim_support_ratio"`
+	SourceDiversity     float64 `json:"source_diversity"`
+	ContextCompleteness float64 `json:"context_completeness"`
+}
+
+// ScoreInput 은 Scorer.Score 의 입력입니다.
+type ScoreInput struct {
+	URL           string
+	Host          string
+	Title         string
+	Facts         []byte // JSON 직렬화된 facts (entities/claims/...)
+	Verifications []byte // JSON 직렬화된 verifications
+	Context       []byte // JSON 직렬화된 context
+}
+
+// Scorer 는 종합 신뢰도 점수를 산출합니다.
+//
+// 실패 시 worker 가 score 미첨부 + DB write skip 으로 fallback — forward 보장.
+type Scorer interface {
+	Score(ctx context.Context, in ScoreInput) (*TrustScoreResult, error)
+}
+
+// NoopScorer 는 항상 (nil, nil) 을 반환합니다 — claudegen 미configured fallback.
+type NoopScorer struct{}
+
+// NewNoopScorer 는 NoopScorer 인스턴스를 반환합니다.
+func NewNoopScorer() *NoopScorer { return &NoopScorer{} }
+
+// Score 는 항상 (nil, nil) 을 반환합니다 — 점수 미첨부.
+func (s *NoopScorer) Score(_ context.Context, _ ScoreInput) (*TrustScoreResult, error) {
+	return nil, nil
+}
+
+// 컴파일 타임 인터페이스 만족 검증.
+var _ Scorer = (*NoopScorer)(nil)
+
+// scorerPromptName 은 신뢰도 점수 prompt asset 경로입니다.
+const scorerPromptName = "claudegen/enricher_score"
+
+// ClaudegenScorer 는 claudegen.ClaudeWorkerPool 로 scoring session 을 실행합니다.
+type ClaudegenScorer struct {
+	runner SessionRunner
+	loader prompt.Loader
+}
+
+// NewClaudegenScorer 는 claudegen-backed Scorer 를 생성합니다.
+func NewClaudegenScorer(runner SessionRunner, loader prompt.Loader) (*ClaudegenScorer, error) {
+	if runner == nil {
+		return nil, errors.New("extractor: claudegen runner must not be nil")
+	}
+	if loader == nil {
+		return nil, errors.New("extractor: prompt loader must not be nil")
+	}
+	return &ClaudegenScorer{runner: runner, loader: loader}, nil
+}
+
+// Score 는 claudegen 세션을 실행하고 stdout 을 TrustScoreResult 로 파싱합니다.
+//
+// 모든 입력 (facts/verifications/context) 이 빈 JSON 이면 runner skip — 점수 산출 근거 부족.
+func (s *ClaudegenScorer) Score(ctx context.Context, in ScoreInput) (*TrustScoreResult, error) {
+	if isEmptyJSON(in.Facts) && isEmptyJSON(in.Verifications) && isEmptyJSON(in.Context) {
+		return nil, nil
+	}
+
+	tpl, err := s.loader.Load(scorerPromptName)
+	if err != nil {
+		return nil, fmt.Errorf("load scorer prompt %q: %w", scorerPromptName, err)
+	}
+
+	promptText := prompt.Render(tpl,
+		"{{URL}}", in.URL,
+		"{{HOST}}", in.Host,
+		"{{TITLE}}", in.Title,
+		"{{FACTS_JSON}}", jsonOrEmptyObject(in.Facts),
+		"{{VERIFICATIONS_JSON}}", jsonOrEmptyArray(in.Verifications),
+		"{{CONTEXT_JSON}}", jsonOrEmptyObject(in.Context),
+	)
+
+	stdout, err := s.runner.RunEnrichSession(ctx, "enrich-score", nil, promptText)
+	if err != nil {
+		return nil, fmt.Errorf("claudegen score session: %w", err)
+	}
+
+	res, err := parseScoreOutput(stdout)
+	if err != nil {
+		return nil, fmt.Errorf("parse score output: %w", err)
+	}
+	return res, nil
+}
+
+// 컴파일 타임 인터페이스 만족 검증.
+var _ Scorer = (*ClaudegenScorer)(nil)
+
+// scoreResponse 는 claudegen scorer 응답의 wire format 입니다.
+type scoreResponse struct {
+	TrustScore float64      `json:"trust_score"`
+	Rationale  string       `json:"rationale"`
+	Factors    ScoreFactors `json:"factors"`
+}
+
+// parseScoreOutput 는 claudegen stdout JSON 을 TrustScoreResult 로 파싱합니다.
+//
+// trust_score 가 [0.0, 1.0] 밖이면 error — DB CHECK constraint 위반 회피 (caller 에서 미첨부 결정).
+func parseScoreOutput(output string) (*TrustScoreResult, error) {
+	body := stripFences(output)
+	if body == "" {
+		return nil, errors.New("empty output")
+	}
+	var raw scoreResponse
+	if err := json.Unmarshal([]byte(body), &raw); err != nil {
+		return nil, fmt.Errorf("unmarshal: %w", err)
+	}
+	if raw.TrustScore < 0 || raw.TrustScore > 1 {
+		return nil, fmt.Errorf("trust_score %v out of range [0.0, 1.0]", raw.TrustScore)
+	}
+	return &TrustScoreResult{
+		TrustScore: raw.TrustScore,
+		Rationale:  raw.Rationale,
+		Factors:    raw.Factors,
+	}, nil
+}
+
+// isEmptyJSON 는 byte slice 가 비어있거나 빈 JSON ({}, [], null) 인지 검사합니다.
+func isEmptyJSON(b []byte) bool {
+	if len(b) == 0 {
+		return true
+	}
+	s := string(b)
+	switch s {
+	case "{}", "[]", "null":
+		return true
+	}
+	return false
+}
+
+func jsonOrEmptyObject(b []byte) string {
+	if len(b) == 0 {
+		return "{}"
+	}
+	return string(b)
+}
+
+func jsonOrEmptyArray(b []byte) string {
+	if len(b) == 0 {
+		return "[]"
+	}
+	return string(b)
+}

--- a/internal/processor/enrich/extractor/scorer.go
+++ b/internal/processor/enrich/extractor/scorer.go
@@ -10,6 +10,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"strings"
 
 	"issuetracker/pkg/llm/prompt"
 )
@@ -122,15 +123,22 @@ func (s *ClaudegenScorer) Score(ctx context.Context, in ScoreInput) (*TrustScore
 var _ Scorer = (*ClaudegenScorer)(nil)
 
 // scoreResponse 는 claudegen scorer 응답의 wire format 입니다.
+//
+// TrustScore 는 pointer 타입 — 응답에서 필드가 누락되면 0 으로 fallback 되지 않고 nil 로 잡혀
+// 명시적 missing 검출 가능 (coderabbit-review PR #455). DB 에 fabricated 0 점수가 저장되는
+// 사고 회피.
 type scoreResponse struct {
-	TrustScore float64      `json:"trust_score"`
+	TrustScore *float64     `json:"trust_score"`
 	Rationale  string       `json:"rationale"`
 	Factors    ScoreFactors `json:"factors"`
 }
 
 // parseScoreOutput 는 claudegen stdout JSON 을 TrustScoreResult 로 파싱합니다.
 //
-// trust_score 가 [0.0, 1.0] 밖이면 error — DB CHECK constraint 위반 회피 (caller 에서 미첨부 결정).
+// 필수 필드 검증:
+//   - trust_score 필드 누락 → error (zero-value fabricated score 회피)
+//   - rationale 누락 또는 whitespace-only → error (운영자 진단 정보 결핍 회피)
+//   - trust_score 범위 [0.0, 1.0] 위반 → error (DB CHECK 와 일관)
 func parseScoreOutput(output string) (*TrustScoreResult, error) {
 	body := stripFences(output)
 	if body == "" {
@@ -140,22 +148,30 @@ func parseScoreOutput(output string) (*TrustScoreResult, error) {
 	if err := json.Unmarshal([]byte(body), &raw); err != nil {
 		return nil, fmt.Errorf("unmarshal: %w", err)
 	}
-	if raw.TrustScore < 0 || raw.TrustScore > 1 {
-		return nil, fmt.Errorf("trust_score %v out of range [0.0, 1.0]", raw.TrustScore)
+	if raw.TrustScore == nil {
+		return nil, errors.New("missing trust_score")
+	}
+	if strings.TrimSpace(raw.Rationale) == "" {
+		return nil, errors.New("missing rationale")
+	}
+	if *raw.TrustScore < 0 || *raw.TrustScore > 1 {
+		return nil, fmt.Errorf("trust_score %v out of range [0.0, 1.0]", *raw.TrustScore)
 	}
 	return &TrustScoreResult{
-		TrustScore: raw.TrustScore,
+		TrustScore: *raw.TrustScore,
 		Rationale:  raw.Rationale,
 		Factors:    raw.Factors,
 	}, nil
 }
 
 // isEmptyJSON 는 byte slice 가 비어있거나 빈 JSON ({}, [], null) 인지 검사합니다.
+//
+// whitespace 도 흡수 — `" {}\n"` 같은 변형도 empty 로 인식 (coderabbit-review PR #455).
 func isEmptyJSON(b []byte) bool {
-	if len(b) == 0 {
+	s := strings.TrimSpace(string(b))
+	if s == "" {
 		return true
 	}
-	s := string(b)
 	switch s {
 	case "{}", "[]", "null":
 		return true

--- a/internal/processor/enrich/worker/worker.go
+++ b/internal/processor/enrich/worker/worker.go
@@ -446,17 +446,13 @@ func (w *Worker) runScoring(
 		return
 	}
 
-	factsJSON, _ := json.Marshal(struct {
-		Entities  []extractor.Entity  `json:"entities,omitempty"`
-		Claims    []extractor.Claim   `json:"claims,omitempty"`
-		Facts     []extractor.Fact    `json:"facts,omitempty"`
-		Topics    []string            `json:"topics,omitempty"`
-		Sentiment extractor.Sentiment `json:"sentiment,omitempty"`
-	}{facts.Entities, facts.Claims, facts.Facts, facts.Topics, facts.Sentiment})
-	verificationsJSON, _ := json.Marshal(facts.Verifications)
-	var contextJSON []byte
-	if facts.Context != nil {
-		contextJSON, _ = json.Marshal(facts.Context)
+	factsJSON, verificationsJSON, contextJSON, err := marshalFactsTriple(facts)
+	if err != nil {
+		log.WithFields(map[string]interface{}{
+			"job_id": pm.ID,
+			"ref_id": ref.ID,
+		}).WithError(err).Warn("marshal facts triple for scoring failed, forwarding without trust_score")
+		return
 	}
 
 	title := ""
@@ -513,29 +509,13 @@ func (w *Worker) persistEnriched(
 		return
 	}
 
-	factsJSON, err := json.Marshal(struct {
-		Entities  []extractor.Entity  `json:"entities"`
-		Claims    []extractor.Claim   `json:"claims"`
-		Facts     []extractor.Fact    `json:"facts"`
-		Topics    []string            `json:"topics"`
-		Sentiment extractor.Sentiment `json:"sentiment"`
-	}{facts.Entities, facts.Claims, facts.Facts, facts.Topics, facts.Sentiment})
+	factsJSON, verificationsJSON, contextJSON, err := marshalFactsTriple(facts)
 	if err != nil {
-		log.WithError(err).Warn("marshal facts for persistence failed, skipping enriched upsert")
+		log.WithFields(map[string]interface{}{
+			"job_id": pm.ID,
+			"ref_id": ref.ID,
+		}).WithError(err).Warn("marshal facts triple for persistence failed, skipping enriched upsert")
 		return
-	}
-	verificationsJSON, err := json.Marshal(facts.Verifications)
-	if err != nil {
-		log.WithError(err).Warn("marshal verifications for persistence failed, skipping enriched upsert")
-		return
-	}
-	var contextJSON []byte
-	if facts.Context != nil {
-		contextJSON, err = json.Marshal(facts.Context)
-		if err != nil {
-			log.WithError(err).Warn("marshal context for persistence failed, skipping enriched upsert")
-			return
-		}
 	}
 
 	rec := &model.EnrichedContentRecord{
@@ -759,4 +739,47 @@ func (w *Worker) commit(ctx context.Context, msg *queue.Message) error {
 		return workerpool.CommitWithDrain(ctx, w.consumer, msg, drainTimeout)
 	}
 	return w.pool.Commit(ctx, msg)
+}
+
+// promptFactsPayload 는 facts 의 LLM/DB 직렬화 공통 wire format 입니다 (이슈 #450).
+//
+// runScoring (LLM 입력) / persistEnriched (DB JSONB) 두 곳에서 동일한 facts schema 를
+// 사용해야 하므로 익명 구조체 중복을 제거하고 본 타입으로 통합 (gemini-review PR #455).
+//
+// json 태그는 omitempty 미사용 — DB 영속화 시 일관된 schema (모든 필드 항상 존재) 보장.
+// LLM 입력 측에서도 빈 배열이 명시적으로 보여 prompt 가 부재 vs zero-count 를 구분 가능.
+type promptFactsPayload struct {
+	Entities  []extractor.Entity  `json:"entities"`
+	Claims    []extractor.Claim   `json:"claims"`
+	Facts     []extractor.Fact    `json:"facts"`
+	Topics    []string            `json:"topics"`
+	Sentiment extractor.Sentiment `json:"sentiment"`
+}
+
+// marshalFactsTriple 은 facts / verifications / context 를 LLM 입력 + DB 영속화에 공통으로
+// 쓰이는 JSON triple 로 직렬화합니다 (gemini-review PR #455).
+//
+// 직렬화 실패 시 첫 에러 즉시 반환 — caller (runScoring / persistEnriched) 는 forward 만 진행.
+func marshalFactsTriple(facts *extractor.EnrichedFacts) (factsJSON, verificationsJSON, contextJSON []byte, err error) {
+	factsJSON, err = json.Marshal(promptFactsPayload{
+		Entities:  facts.Entities,
+		Claims:    facts.Claims,
+		Facts:     facts.Facts,
+		Topics:    facts.Topics,
+		Sentiment: facts.Sentiment,
+	})
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("marshal facts: %w", err)
+	}
+	verificationsJSON, err = json.Marshal(facts.Verifications)
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("marshal verifications: %w", err)
+	}
+	if facts.Context != nil {
+		contextJSON, err = json.Marshal(facts.Context)
+		if err != nil {
+			return nil, nil, nil, fmt.Errorf("marshal context: %w", err)
+		}
+	}
+	return factsJSON, verificationsJSON, contextJSON, nil
 }

--- a/internal/processor/enrich/worker/worker.go
+++ b/internal/processor/enrich/worker/worker.go
@@ -23,6 +23,7 @@ import (
 	"issuetracker/internal/processor/fetcher/core"
 	"issuetracker/internal/storage"
 	"issuetracker/internal/storage/model"
+	"issuetracker/internal/storage/repository"
 	"issuetracker/internal/storage/service"
 	"issuetracker/internal/workerpool"
 	"issuetracker/pkg/logger"
@@ -57,6 +58,8 @@ type Worker struct {
 	extractor      extractor.Extractor
 	verifier       extractor.Verifier
 	contextualizer extractor.Contextualizer
+	scorer         extractor.Scorer
+	enrichedRepo   repository.EnrichedContentRepository
 	gate           locks.StageGate // nil 허용 → NoopStageGate 로 fallback
 	workerCount    int
 
@@ -65,7 +68,8 @@ type Worker struct {
 
 // NewWorker 는 새로운 Worker 를 생성합니다.
 //
-// pub / contentSvc / extractor / verifier / contextualizer 가 nil 이면 panic — fail-fast.
+// pub / contentSvc / extractor / verifier / contextualizer / scorer 가 nil 이면 panic — fail-fast.
+// enrichedRepo 는 nil 허용 — nil 이면 DB write skip + metadata 첨부만 (sub-issue #450 도입 전 동작 호환).
 // gate 가 nil 이면 NoopStageGate 로 fallback.
 func NewWorker(
 	consumer bus.Consumer,
@@ -74,6 +78,8 @@ func NewWorker(
 	ex extractor.Extractor,
 	vr extractor.Verifier,
 	cz extractor.Contextualizer,
+	sc extractor.Scorer,
+	enrichedRepo repository.EnrichedContentRepository,
 	gate locks.StageGate,
 	workerCount int,
 ) *Worker {
@@ -92,6 +98,9 @@ func NewWorker(
 	if cz == nil {
 		panic("enrich.NewWorker: contextualizer must not be nil (use extractor.NoopContextualizer for disabled context)")
 	}
+	if sc == nil {
+		panic("enrich.NewWorker: scorer must not be nil (use extractor.NoopScorer for disabled scoring)")
+	}
 	if gate == nil {
 		gate = locks.NewNoopStageGate()
 	}
@@ -102,6 +111,8 @@ func NewWorker(
 		extractor:      ex,
 		verifier:       vr,
 		contextualizer: cz,
+		scorer:         sc,
+		enrichedRepo:   enrichedRepo,
 		gate:           gate,
 		workerCount:    workerCount,
 	}
@@ -193,12 +204,14 @@ func (w *Worker) process(ctx context.Context, msg *queue.Message) error {
 		defer release()
 	}
 
-	// 이슈 #447 / #448 / #449 — Content 조회 + extractor 호출 + cross-verify + context + facts 첨부.
+	// 이슈 #447 / #448 / #449 / #450 — Content 조회 + extractor + cross-verify + context + score + DB upsert + facts 첨부.
 	// 본 단계 어떤 실패도 forward 를 막지 않음 — pipeline 진행이 enrichment 보다 우선.
 	content, facts := w.runExtraction(ctx, &pm, &ref)
 	if facts != nil {
 		w.runVerification(ctx, &pm, &ref, content, facts)
 		w.runContextEnrichment(ctx, &pm, &ref, content, facts)
+		w.runScoring(ctx, &pm, &ref, content, facts)
+		w.persistEnriched(ctx, &pm, &ref, facts)
 		w.attachFacts(&pm, facts)
 	}
 
@@ -409,6 +422,143 @@ func (w *Worker) runContextEnrichment(
 		"timeline_count":   len(pageCtx.Timeline),
 		"has_implications": pageCtx.Implications != nil,
 	}).Debug("enrichment context completed")
+}
+
+// runScoring 은 추출 + 검증 + 외부 맥락 결과를 종합하여 trust_score 를 산출하고 facts.TrustScore
+// 에 첨부합니다 (이슈 #450).
+//
+// facts 가 nil 이거나 facts 가 모두 empty (claims / verifications / context 부재) 면 skip.
+// scorer error 시 미첨부 + forward 계속 (forward-first 정책).
+func (w *Worker) runScoring(
+	ctx context.Context,
+	pm *core.ProcessingMessage,
+	ref *core.ContentRef,
+	content *core.Content,
+	facts *extractor.EnrichedFacts,
+) {
+	log := logger.FromContext(ctx)
+
+	if facts == nil {
+		return
+	}
+	// 점수 산출 근거가 전혀 없으면 skip — extractor 가 빈 facts 만 반환한 경우 등.
+	if len(facts.Claims) == 0 && len(facts.Verifications) == 0 && facts.Context.IsEmpty() {
+		return
+	}
+
+	factsJSON, _ := json.Marshal(struct {
+		Entities  []extractor.Entity  `json:"entities,omitempty"`
+		Claims    []extractor.Claim   `json:"claims,omitempty"`
+		Facts     []extractor.Fact    `json:"facts,omitempty"`
+		Topics    []string            `json:"topics,omitempty"`
+		Sentiment extractor.Sentiment `json:"sentiment,omitempty"`
+	}{facts.Entities, facts.Claims, facts.Facts, facts.Topics, facts.Sentiment})
+	verificationsJSON, _ := json.Marshal(facts.Verifications)
+	var contextJSON []byte
+	if facts.Context != nil {
+		contextJSON, _ = json.Marshal(facts.Context)
+	}
+
+	title := ""
+	if content != nil {
+		title = content.Title
+	}
+	in := extractor.ScoreInput{
+		URL:           ref.URL,
+		Host:          hostOf(ref.URL),
+		Title:         title,
+		Facts:         factsJSON,
+		Verifications: verificationsJSON,
+		Context:       contextJSON,
+	}
+
+	res, err := w.scorer.Score(ctx, in)
+	if err != nil {
+		log.WithFields(map[string]interface{}{
+			"job_id": pm.ID,
+			"ref_id": ref.ID,
+		}).WithError(err).Warn("enrichment scoring failed, forwarding without trust_score")
+		return
+	}
+	if res == nil {
+		return
+	}
+	score := res.TrustScore
+	facts.TrustScore = &score
+	log.WithFields(map[string]interface{}{
+		"job_id":      pm.ID,
+		"ref_id":      ref.ID,
+		"trust_score": score,
+	}).Debug("enrichment scoring completed")
+}
+
+// persistEnriched 는 facts 결과를 enriched_contents 테이블에 UPSERT 합니다 (이슈 #450).
+//
+// 다음 조건들에서는 skip (forward 만 계속):
+//   - enrichedRepo 가 nil (미configured 환경)
+//   - facts.TrustScore 가 nil (scoring 실패 / Noop)
+//
+// DB 쓰기 실패는 warn 로깅 후 forward — DB 일시 장애가 pipeline 을 막지 않도록 (forward-first).
+func (w *Worker) persistEnriched(
+	ctx context.Context,
+	pm *core.ProcessingMessage,
+	ref *core.ContentRef,
+	facts *extractor.EnrichedFacts,
+) {
+	log := logger.FromContext(ctx)
+	if w.enrichedRepo == nil {
+		return
+	}
+	if facts == nil || facts.TrustScore == nil {
+		return
+	}
+
+	factsJSON, err := json.Marshal(struct {
+		Entities  []extractor.Entity  `json:"entities"`
+		Claims    []extractor.Claim   `json:"claims"`
+		Facts     []extractor.Fact    `json:"facts"`
+		Topics    []string            `json:"topics"`
+		Sentiment extractor.Sentiment `json:"sentiment"`
+	}{facts.Entities, facts.Claims, facts.Facts, facts.Topics, facts.Sentiment})
+	if err != nil {
+		log.WithError(err).Warn("marshal facts for persistence failed, skipping enriched upsert")
+		return
+	}
+	verificationsJSON, err := json.Marshal(facts.Verifications)
+	if err != nil {
+		log.WithError(err).Warn("marshal verifications for persistence failed, skipping enriched upsert")
+		return
+	}
+	var contextJSON []byte
+	if facts.Context != nil {
+		contextJSON, err = json.Marshal(facts.Context)
+		if err != nil {
+			log.WithError(err).Warn("marshal context for persistence failed, skipping enriched upsert")
+			return
+		}
+	}
+
+	rec := &model.EnrichedContentRecord{
+		ContentID:     ref.ID,
+		TrustScore:    *facts.TrustScore,
+		Facts:         factsJSON,
+		Verifications: verificationsJSON,
+		Context:       contextJSON,
+	}
+	if err := w.enrichedRepo.Upsert(ctx, rec); err != nil {
+		log.WithFields(map[string]interface{}{
+			"job_id":      pm.ID,
+			"ref_id":      ref.ID,
+			"trust_score": *facts.TrustScore,
+		}).WithError(err).Warn("enriched_contents upsert failed, forwarding anyway")
+		return
+	}
+	log.WithFields(map[string]interface{}{
+		"job_id":      pm.ID,
+		"ref_id":      ref.ID,
+		"enriched_id": rec.ID,
+		"trust_score": *facts.TrustScore,
+	}).Debug("enriched_contents upsert completed")
 }
 
 // findCandidates 는 본 content 와 같은 country + 시간 윈도우의 후보 article 들을 조회하고

--- a/internal/storage/decorator/timeout.go
+++ b/internal/storage/decorator/timeout.go
@@ -452,3 +452,29 @@ func (t *timeoutFetcherRuleRepo) BulkDowngradeAutoUpgraded(ctx context.Context) 
 	defer cancel()
 	return t.inner.BulkDowngradeAutoUpgraded(ctx)
 }
+
+// ─────────────────────────────────────────────────────────────────────────────
+// repository.EnrichedContentRepository (이슈 #450)
+// ─────────────────────────────────────────────────────────────────────────────
+
+type timeoutEnrichedContentRepo struct {
+	inner   repository.EnrichedContentRepository
+	timeout time.Duration
+}
+
+// WrapEnrichedContentWithTimeout 은 repository.EnrichedContentRepository 의 모든 메서드 진입에 timeout 을 적용합니다.
+func WrapEnrichedContentWithTimeout(r repository.EnrichedContentRepository, d time.Duration) repository.EnrichedContentRepository {
+	return &timeoutEnrichedContentRepo{inner: r, timeout: d}
+}
+
+func (t *timeoutEnrichedContentRepo) Upsert(ctx context.Context, rec *model.EnrichedContentRecord) error {
+	ctx, cancel := withTimeout(ctx, t.timeout)
+	defer cancel()
+	return t.inner.Upsert(ctx, rec)
+}
+
+func (t *timeoutEnrichedContentRepo) GetByContentID(ctx context.Context, contentID string) (*model.EnrichedContentRecord, error) {
+	ctx, cancel := withTimeout(ctx, t.timeout)
+	defer cancel()
+	return t.inner.GetByContentID(ctx, contentID)
+}

--- a/internal/storage/model/enriched_content.go
+++ b/internal/storage/model/enriched_content.go
@@ -1,0 +1,17 @@
+package model
+
+import "time"
+
+// EnrichedContentRecord 는 enriched_contents 테이블의 row 표현입니다 (이슈 #450).
+//
+// JSONB 필드 (Facts / Verifications / Context) 는 raw byte slice 로 보관 — DB 와 wire format
+// 양쪽에서 동일하게 다루기 위함. 호출자가 필요 시 json.Unmarshal 로 강타입 구조체로 변환.
+type EnrichedContentRecord struct {
+	ID            int64
+	ContentID     string
+	TrustScore    float64
+	Facts         []byte // JSONB
+	Verifications []byte // JSONB
+	Context       []byte // JSONB
+	EnrichedAt    time.Time
+}

--- a/internal/storage/postgres/enriched_content.go
+++ b/internal/storage/postgres/enriched_content.go
@@ -1,0 +1,91 @@
+package postgres
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"issuetracker/internal/storage"
+	"issuetracker/internal/storage/model"
+	"issuetracker/internal/storage/repository"
+	"issuetracker/pkg/logger"
+)
+
+// pgEnrichedContentRepository 는 pgx/v5 기반 EnrichedContentRepository 구현체입니다 (이슈 #450).
+type pgEnrichedContentRepository struct {
+	pool *pgxpool.Pool
+}
+
+// NewEnrichedContentRepository 는 pgxpool 기반 EnrichedContentRepository 를 생성합니다.
+// log 인자는 시그니처 일관성용 — 현재 미사용.
+func NewEnrichedContentRepository(pool *pgxpool.Pool, log *logger.Logger) repository.EnrichedContentRepository {
+	_ = log
+	return &pgEnrichedContentRepository{pool: pool}
+}
+
+// Upsert SQL — content_id UNIQUE 충돌 시 ON CONFLICT 로 UPDATE (재처리 안전).
+//
+// enriched_at 은 항상 NOW() 로 refresh — 마지막 enrich 시점 추적.
+// trust_score / facts / verifications / context 는 caller 가 매번 전달한 값으로 덮어쓰기.
+const sqlUpsertEnrichedContent = `
+INSERT INTO enriched_contents (content_id, trust_score, facts, verifications, context)
+VALUES ($1, $2, $3, $4, $5)
+ON CONFLICT (content_id) DO UPDATE
+SET trust_score   = EXCLUDED.trust_score,
+    facts         = EXCLUDED.facts,
+    verifications = EXCLUDED.verifications,
+    context       = EXCLUDED.context,
+    enriched_at   = NOW()
+RETURNING id, enriched_at
+`
+
+func (r *pgEnrichedContentRepository) Upsert(ctx context.Context, rec *model.EnrichedContentRecord) error {
+	if rec == nil {
+		return errors.New("enriched_contents upsert: rec must not be nil")
+	}
+	facts := nonNilJSONB(rec.Facts, "{}")
+	verifications := nonNilJSONB(rec.Verifications, "[]")
+	contextJSON := nonNilJSONB(rec.Context, "{}")
+
+	row := r.pool.QueryRow(ctx, sqlUpsertEnrichedContent,
+		rec.ContentID, rec.TrustScore, facts, verifications, contextJSON,
+	)
+	if err := row.Scan(&rec.ID, &rec.EnrichedAt); err != nil {
+		return fmt.Errorf("upsert enriched_content: %w", err)
+	}
+	return nil
+}
+
+const sqlGetEnrichedContentByContentID = `
+SELECT id, content_id, trust_score, facts, verifications, context, enriched_at
+FROM enriched_contents
+WHERE content_id = $1
+`
+
+func (r *pgEnrichedContentRepository) GetByContentID(ctx context.Context, contentID string) (*model.EnrichedContentRecord, error) {
+	var rec model.EnrichedContentRecord
+	row := r.pool.QueryRow(ctx, sqlGetEnrichedContentByContentID, contentID)
+	if err := row.Scan(
+		&rec.ID, &rec.ContentID, &rec.TrustScore,
+		&rec.Facts, &rec.Verifications, &rec.Context,
+		&rec.EnrichedAt,
+	); err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, storage.ErrNotFound
+		}
+		return nil, fmt.Errorf("get enriched_content by content_id %q: %w", contentID, err)
+	}
+	return &rec, nil
+}
+
+// nonNilJSONB 는 JSONB 필드의 nil 입력을 fallback 으로 대체합니다.
+// 호출자가 JSON marshal 실패 등으로 nil 을 전달해도 DB schema (NOT NULL) 위반 회피.
+func nonNilJSONB(v []byte, fallback string) []byte {
+	if len(v) == 0 {
+		return []byte(fallback)
+	}
+	return v
+}

--- a/internal/storage/repository/enriched_content.go
+++ b/internal/storage/repository/enriched_content.go
@@ -1,0 +1,20 @@
+package repository
+
+import (
+	"context"
+
+	"issuetracker/internal/storage/model"
+)
+
+// EnrichedContentRepository 는 enriched_contents 테이블 CRUD 인터페이스입니다 (이슈 #450).
+//
+// 모든 구현체는 goroutine-safe 해야 합니다.
+// pgx/v5 구현체: internal/storage/postgres/enriched_content.go
+type EnrichedContentRepository interface {
+	// Upsert 는 enriched_contents row 를 저장합니다. content_id 충돌 시 UPDATE (재처리 안전).
+	// rec.ID / rec.EnrichedAt 는 호출 후 DB 값으로 갱신됩니다.
+	Upsert(ctx context.Context, rec *model.EnrichedContentRecord) error
+
+	// GetByContentID 는 content_id 로 row 를 조회합니다. 미존재 시 storage.ErrNotFound.
+	GetByContentID(ctx context.Context, contentID string) (*model.EnrichedContentRecord, error)
+}

--- a/migrations/down/029_enriched_contents.sql
+++ b/migrations/down/029_enriched_contents.sql
@@ -1,0 +1,4 @@
+-- 029_enriched_contents (down): 테이블 + 인덱스 일괄 삭제.
+-- DROP TABLE 이 idx_enriched_trust / idx_enriched_at 도 함께 정리.
+
+DROP TABLE IF EXISTS enriched_contents;

--- a/migrations/up/029_enriched_contents.sql
+++ b/migrations/up/029_enriched_contents.sql
@@ -1,0 +1,40 @@
+-- 029_enriched_contents: enrich 단계 결과 영속화 테이블 (이슈 #450)
+--
+-- 배경:
+--   enricher worker 는 #447 ~ #449 단계에서 추출/검증/외부 맥락을 산출하고 ProcessingMessage.Metadata
+--   에 임시 첨부했음. 본 migration 으로 별도 테이블에 영속화 — schema evolution + 재처리 안전.
+--
+-- 스키마 결정:
+--   - content_id: contents.id (VARCHAR(255)) 의 FK. ON DELETE CASCADE 로 컨텐츠 삭제 시 동반 정리
+--   - trust_score: NUMERIC(4,3) — 0.000 ~ 1.000 정밀도, CHECK constraint 로 범위 강제
+--   - facts/verifications/context: JSONB — 향후 schema evolution 시 컬럼 추가 없이 필드 확장
+--   - UNIQUE(content_id): 한 content 당 enriched record 1개 — 재처리 시 UPSERT
+--   - idx_enriched_trust: trust_score 기반 필터링 쿼리 (예: 신뢰도 >= 0.8) 지원
+
+CREATE TABLE IF NOT EXISTS enriched_contents (
+  id            BIGSERIAL     NOT NULL,
+  content_id    VARCHAR(255)  NOT NULL,
+  trust_score   NUMERIC(4,3)  NOT NULL,
+  facts         JSONB         NOT NULL DEFAULT '{}'::jsonb,
+  verifications JSONB         NOT NULL DEFAULT '[]'::jsonb,
+  context       JSONB         NOT NULL DEFAULT '{}'::jsonb,
+  enriched_at   TIMESTAMPTZ   NOT NULL DEFAULT NOW(),
+
+  CONSTRAINT enriched_contents_pkey PRIMARY KEY (id),
+  CONSTRAINT enriched_contents_content_fk
+    FOREIGN KEY (content_id) REFERENCES contents(id) ON DELETE CASCADE,
+  CONSTRAINT enriched_contents_trust_score_range
+    CHECK (trust_score >= 0 AND trust_score <= 1),
+  CONSTRAINT enriched_contents_content_id_unique UNIQUE (content_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_enriched_trust
+  ON enriched_contents (trust_score);
+
+CREATE INDEX IF NOT EXISTS idx_enriched_at
+  ON enriched_contents (enriched_at DESC);
+
+COMMENT ON TABLE enriched_contents IS
+  '컨텐츠 enrichment 결과 (이슈 #445/#450) — LLM 추출 facts + cross-verify verdicts + 외부 context + 종합 신뢰도 점수.';
+COMMENT ON COLUMN enriched_contents.trust_score IS
+  'page 단위 신뢰도 0.000-1.000 — claim 지지율 / 소스 다양성 / 맥락 완전성 종합. CHECK constraint 로 범위 강제.';

--- a/pkg/llm/prompt/assets/claudegen/enricher_score.user.txt
+++ b/pkg/llm/prompt/assets/claudegen/enricher_score.user.txt
@@ -1,0 +1,45 @@
+You are computing a single page-level trust score (0.0 ~ 1.0) for an enriched article.
+
+Source article:
+- URL: {{URL}}
+- Host: {{HOST}}
+- Title: {{TITLE}}
+
+Inputs from earlier enrichment steps:
+
+Facts (extraction):
+{{FACTS_JSON}}
+
+Verifications (cross-verification):
+{{VERIFICATIONS_JSON}}
+
+Context (external background):
+{{CONTEXT_JSON}}
+
+Your task:
+Produce a single float trust score in [0.0, 1.0] based on the combined evidence.
+
+Scoring guidance (rationale-driven, not a formula):
+- claim_support_ratio: among claims, the fraction with verdict="supported" pushes the score up; "contradicted" pushes it down sharply; "unverified" is mild signal.
+- source_diversity: how many distinct domains appear across verifications and context sources (more independent sources = higher).
+- context_completeness: presence of background + timeline + implications grounded in cited sources (richer context = higher).
+- Apply penalties for: zero claims (cannot assess), zero verifications (no corroboration possible), zero external sources, contradictory verdicts.
+
+Output a single JSON object — no explanation, no markdown, no code blocks:
+
+{
+  "trust_score": <float between 0.0 and 1.0 inclusive>,
+  "rationale": "<short paragraph explaining the score, max 400 chars>",
+  "factors": {
+    "claim_support_ratio":   <float between 0.0 and 1.0>,
+    "source_diversity":      <float between 0.0 and 1.0>,
+    "context_completeness":  <float between 0.0 and 1.0>
+  }
+}
+
+Output rules:
+- trust_score MUST be a number in [0.0, 1.0] (inclusive). Out-of-range values are rejected upstream.
+- factors fields MUST also be in [0.0, 1.0] — they are diagnostic only, do not have to combine linearly to trust_score.
+- rationale is required and must be non-empty. No invented citations.
+
+Return ONLY the JSON object.

--- a/test/internal/processor/enrich/extractor/claudegen_test.go
+++ b/test/internal/processor/enrich/extractor/claudegen_test.go
@@ -435,23 +435,55 @@ func TestClaudegenScorer_OutOfRange_ReturnsError(t *testing.T) {
 	}
 }
 
-func TestClaudegenScorer_AllEmpty_SkipsRunner(t *testing.T) {
-	runner := &stubRunner{stdout: "this should never be parsed"}
+func TestClaudegenScorer_MissingTrustScore_ReturnsError(t *testing.T) {
+	// trust_score 누락 → 0 으로 fabricated 안 되도록 error.
 	s, err := extractor.NewClaudegenScorer(
-		runner,
+		&stubRunner{stdout: `{"rationale": "ok"}`},
 		&stubLoader{tpl: "t"},
 	)
 	require.NoError(t, err)
+	_, err = s.Score(context.Background(), extractor.ScoreInput{Facts: []byte(`{"a":1}`)})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "trust_score")
+}
 
-	// 모든 input 이 empty/null
-	got, err := s.Score(context.Background(), extractor.ScoreInput{
-		Facts:         []byte(`{}`),
-		Verifications: []byte(`[]`),
-		Context:       []byte(`null`),
-	})
+func TestClaudegenScorer_MissingRationale_ReturnsError(t *testing.T) {
+	s, err := extractor.NewClaudegenScorer(
+		&stubRunner{stdout: `{"trust_score": 0.5}`},
+		&stubLoader{tpl: "t"},
+	)
 	require.NoError(t, err)
-	assert.Nil(t, got)
-	assert.Equal(t, 0, runner.calls)
+	_, err = s.Score(context.Background(), extractor.ScoreInput{Facts: []byte(`{"a":1}`)})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "rationale")
+}
+
+func TestClaudegenScorer_AllEmpty_SkipsRunner(t *testing.T) {
+	cases := []struct {
+		name                      string
+		facts, verifications, ctx []byte
+	}{
+		{"exact empty", []byte(`{}`), []byte(`[]`), []byte(`null`)},
+		{"whitespace empty", []byte(" {}\n"), []byte(" [] "), []byte("  null  ")},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			runner := &stubRunner{stdout: "this should never be parsed"}
+			s, err := extractor.NewClaudegenScorer(
+				runner,
+				&stubLoader{tpl: "t"},
+			)
+			require.NoError(t, err)
+			got, err := s.Score(context.Background(), extractor.ScoreInput{
+				Facts:         c.facts,
+				Verifications: c.verifications,
+				Context:       c.ctx,
+			})
+			require.NoError(t, err)
+			assert.Nil(t, got)
+			assert.Equal(t, 0, runner.calls, "case %q", c.name)
+		})
+	}
 }
 
 func TestClaudegenScorer_SessionError_Propagates(t *testing.T) {

--- a/test/internal/processor/enrich/extractor/claudegen_test.go
+++ b/test/internal/processor/enrich/extractor/claudegen_test.go
@@ -392,6 +392,103 @@ func TestNewClaudegenContextualizer_NilArgs(t *testing.T) {
 	assert.Error(t, err)
 }
 
+// ─────────────────────────────────────────────────────────────────────────────
+// Scorer (이슈 #450)
+// ─────────────────────────────────────────────────────────────────────────────
+
+func TestClaudegenScorer_Success(t *testing.T) {
+	stdout := `{
+		"trust_score": 0.78,
+		"rationale": "Two independent sources corroborate the main claim.",
+		"factors": {
+			"claim_support_ratio":  0.8,
+			"source_diversity":     0.7,
+			"context_completeness": 0.6
+		}
+	}`
+	runner := &stubRunner{stdout: stdout}
+	s, err := extractor.NewClaudegenScorer(runner, &stubLoader{tpl: "score {{FACTS_JSON}}"})
+	require.NoError(t, err)
+
+	got, err := s.Score(context.Background(), extractor.ScoreInput{
+		URL:           "https://example.com/p",
+		Facts:         []byte(`{"entities":[]}`),
+		Verifications: []byte(`[]`),
+		Context:       []byte(`{}`),
+	})
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	assert.InDelta(t, 0.78, got.TrustScore, 1e-9)
+	assert.Contains(t, got.Rationale, "Two independent sources")
+	assert.InDelta(t, 0.8, got.Factors.ClaimSupportRatio, 1e-9)
+}
+
+func TestClaudegenScorer_OutOfRange_ReturnsError(t *testing.T) {
+	for _, sc := range []string{`{"trust_score": 1.5}`, `{"trust_score": -0.1}`} {
+		s, err := extractor.NewClaudegenScorer(
+			&stubRunner{stdout: sc},
+			&stubLoader{tpl: "t"},
+		)
+		require.NoError(t, err)
+		_, err = s.Score(context.Background(), extractor.ScoreInput{Facts: []byte(`{"a":1}`)})
+		require.Error(t, err, "stdout=%q", sc)
+	}
+}
+
+func TestClaudegenScorer_AllEmpty_SkipsRunner(t *testing.T) {
+	runner := &stubRunner{stdout: "this should never be parsed"}
+	s, err := extractor.NewClaudegenScorer(
+		runner,
+		&stubLoader{tpl: "t"},
+	)
+	require.NoError(t, err)
+
+	// 모든 input 이 empty/null
+	got, err := s.Score(context.Background(), extractor.ScoreInput{
+		Facts:         []byte(`{}`),
+		Verifications: []byte(`[]`),
+		Context:       []byte(`null`),
+	})
+	require.NoError(t, err)
+	assert.Nil(t, got)
+	assert.Equal(t, 0, runner.calls)
+}
+
+func TestClaudegenScorer_SessionError_Propagates(t *testing.T) {
+	s, err := extractor.NewClaudegenScorer(
+		&stubRunner{err: errors.New("exec failure")},
+		&stubLoader{tpl: "t"},
+	)
+	require.NoError(t, err)
+	_, err = s.Score(context.Background(), extractor.ScoreInput{Facts: []byte(`{"a":1}`)})
+	require.Error(t, err)
+}
+
+func TestClaudegenScorer_MalformedOutput_ReturnsError(t *testing.T) {
+	s, err := extractor.NewClaudegenScorer(
+		&stubRunner{stdout: "not json"},
+		&stubLoader{tpl: "t"},
+	)
+	require.NoError(t, err)
+	_, err = s.Score(context.Background(), extractor.ScoreInput{Facts: []byte(`{"a":1}`)})
+	require.Error(t, err)
+}
+
+func TestNoopScorer_ReturnsNil(t *testing.T) {
+	got, err := extractor.NewNoopScorer().Score(context.Background(), extractor.ScoreInput{
+		Facts: []byte(`{"a":1}`),
+	})
+	require.NoError(t, err)
+	assert.Nil(t, got)
+}
+
+func TestNewClaudegenScorer_NilArgs(t *testing.T) {
+	_, err := extractor.NewClaudegenScorer(nil, &stubLoader{tpl: "t"})
+	assert.Error(t, err)
+	_, err = extractor.NewClaudegenScorer(&stubRunner{stdout: "{}"}, nil)
+	assert.Error(t, err)
+}
+
 func TestPageContext_IsEmpty(t *testing.T) {
 	// nil receiver
 	var nilPC *extractor.PageContext

--- a/test/internal/processor/enrich/worker/worker_test.go
+++ b/test/internal/processor/enrich/worker/worker_test.go
@@ -133,6 +133,8 @@ func newEnrichWorker(consumer queue.Consumer, producer queue.Producer) *worker.W
 		extractor.NewNoopExtractor(),
 		extractor.NewNoopVerifier(),
 		extractor.NewNoopContextualizer(),
+		extractor.NewNoopScorer(),
+		nil,
 		locks.NewNoopStageGate(),
 		1,
 	)
@@ -151,6 +153,40 @@ func (c *fakeContextualizer) Provide(_ context.Context, in extractor.ContextInpu
 		return nil, c.err
 	}
 	return c.page, nil
+}
+
+// fakeScorer 는 score 입력 추적 + 미리 정의된 result / err 반환.
+type fakeScorer struct {
+	result   *extractor.TrustScoreResult
+	err      error
+	callsLog []extractor.ScoreInput
+}
+
+func (s *fakeScorer) Score(_ context.Context, in extractor.ScoreInput) (*extractor.TrustScoreResult, error) {
+	s.callsLog = append(s.callsLog, in)
+	if s.err != nil {
+		return nil, s.err
+	}
+	return s.result, nil
+}
+
+// fakeEnrichedRepo 는 EnrichedContentRepository stub — Upsert 호출 캡쳐 + err 반환.
+type fakeEnrichedRepo struct {
+	upsertCalls []*model.EnrichedContentRecord
+	upsertErr   error
+}
+
+func (r *fakeEnrichedRepo) Upsert(_ context.Context, rec *model.EnrichedContentRecord) error {
+	r.upsertCalls = append(r.upsertCalls, rec)
+	if r.upsertErr != nil {
+		return r.upsertErr
+	}
+	rec.ID = 42 // pretend assigned by DB
+	return nil
+}
+
+func (r *fakeEnrichedRepo) GetByContentID(_ context.Context, _ string) (*model.EnrichedContentRecord, error) {
+	return nil, storage.ErrNotFound
 }
 
 func makeValidatedMessage(t *testing.T, refID, url, country, sourceName string) *queue.Message {
@@ -314,6 +350,8 @@ func TestEnrichWorker_Extraction_AttachesFactsToMetadata(t *testing.T) {
 		fake,
 		extractor.NewNoopVerifier(),
 		extractor.NewNoopContextualizer(),
+		extractor.NewNoopScorer(),
+		nil,
 		locks.NewNoopStageGate(),
 		1,
 	)
@@ -374,6 +412,8 @@ func TestEnrichWorker_ExtractionFailure_StillForwards(t *testing.T) {
 		fake,
 		extractor.NewNoopVerifier(),
 		extractor.NewNoopContextualizer(),
+		extractor.NewNoopScorer(),
+		nil,
 		locks.NewNoopStageGate(),
 		1,
 	)
@@ -456,6 +496,8 @@ func TestEnrichWorker_Verification_AttachesVerificationsToFacts(t *testing.T) {
 		fakeExt,
 		fakeVer,
 		extractor.NewNoopContextualizer(),
+		extractor.NewNoopScorer(),
+		nil,
 		locks.NewNoopStageGate(),
 		1,
 	)
@@ -518,6 +560,8 @@ func TestEnrichWorker_NoClaims_SkipsVerifier(t *testing.T) {
 		&fakeExtractor{facts: emptyFacts},
 		fakeVer,
 		extractor.NewNoopContextualizer(),
+		extractor.NewNoopScorer(),
+		nil,
 		locks.NewNoopStageGate(),
 		1,
 	)
@@ -549,6 +593,8 @@ func TestEnrichWorker_VerificationFailure_StillForwards(t *testing.T) {
 		&fakeExtractor{facts: facts},
 		&fakeVerifier{err: assertAnError()},
 		extractor.NewNoopContextualizer(),
+		extractor.NewNoopScorer(),
+		nil,
 		locks.NewNoopStageGate(),
 		1,
 	)
@@ -590,6 +636,8 @@ func TestEnrichWorker_Context_AttachesPageContext(t *testing.T) {
 		&fakeExtractor{facts: facts},
 		&fakeVerifier{},
 		fakeCtx,
+		extractor.NewNoopScorer(),
+		nil,
 		locks.NewNoopStageGate(),
 		1,
 	)
@@ -647,6 +695,8 @@ func TestEnrichWorker_NoEntitiesOrClaims_SkipsContext(t *testing.T) {
 		&fakeExtractor{facts: facts},
 		&fakeVerifier{},
 		fakeCtx,
+		extractor.NewNoopScorer(),
+		nil,
 		locks.NewNoopStageGate(),
 		1,
 	)
@@ -680,6 +730,8 @@ func TestEnrichWorker_ContextFailure_StillForwards(t *testing.T) {
 		&fakeExtractor{facts: facts},
 		&fakeVerifier{},
 		&fakeContextualizer{err: assertAnError()},
+		extractor.NewNoopScorer(),
+		nil,
 		locks.NewNoopStageGate(),
 		1,
 	)
@@ -695,6 +747,183 @@ func TestEnrichWorker_ContextFailure_StillForwards(t *testing.T) {
 
 	consumer.AssertExpectations(t)
 	producer.AssertExpectations(t)
+}
+
+// TestEnrichWorker_Scoring_PersistsToEnrichedContents — score 산출 후 enriched_contents
+// 에 upsert 되고 metadata 에 trust_score 가 첨부되는지 검증 (이슈 #450).
+func TestEnrichWorker_Scoring_PersistsToEnrichedContents(t *testing.T) {
+	consumer := new(mockConsumer)
+	producer := new(mockProducer)
+	contentSvc := &listingStubContentService{primary: &core.Content{
+		ID: "c-score", Title: "T", Body: "B", URL: "https://example.com/s", Country: "US",
+		PublishedAt: time.Now(),
+	}}
+	facts := &extractor.EnrichedFacts{
+		Entities: []extractor.Entity{{Name: "Acme"}},
+		Claims:   []extractor.Claim{{Text: "Acme did X"}},
+	}
+	scorer := &fakeScorer{result: &extractor.TrustScoreResult{
+		TrustScore: 0.85,
+		Rationale:  "Two sources corroborate.",
+		Factors: extractor.ScoreFactors{
+			ClaimSupportRatio: 1.0, SourceDiversity: 0.8, ContextCompleteness: 0.6,
+		},
+	}}
+	repo := &fakeEnrichedRepo{}
+
+	w := worker.NewWorker(
+		consumer, newTestPublisher(producer), contentSvc,
+		&fakeExtractor{facts: facts},
+		&fakeVerifier{verifications: []extractor.Verification{{ClaimIdx: 0, Verdict: "supported"}}},
+		&fakeContextualizer{page: &extractor.PageContext{Background: []extractor.BackgroundItem{{Subject: "Acme"}}}},
+		scorer,
+		repo,
+		locks.NewNoopStageGate(),
+		1,
+	)
+	msg := makeValidatedMessage(t, "c-score", "https://example.com/s", "US", "example")
+
+	var published queue.Message
+	producer.On("Publish", mock.Anything, mock.MatchedBy(func(m queue.Message) bool {
+		if m.Topic != queue.TopicEnriched {
+			return false
+		}
+		published = m
+		return true
+	})).Return(nil).Once()
+	producer.On("Close").Return(nil).Maybe()
+	consumer.On("CommitMessages", mock.Anything, mock.Anything).Return(nil).Maybe()
+
+	runWorker(t, consumer, w, msg)
+
+	// scorer 호출 입력 검증
+	if assert.Len(t, scorer.callsLog, 1) {
+		in := scorer.callsLog[0]
+		assert.Equal(t, "https://example.com/s", in.URL)
+		assert.NotEmpty(t, in.Facts)
+	}
+
+	// DB upsert 호출 검증
+	if assert.Len(t, repo.upsertCalls, 1) {
+		rec := repo.upsertCalls[0]
+		assert.Equal(t, "c-score", rec.ContentID)
+		assert.InDelta(t, 0.85, rec.TrustScore, 1e-9)
+		assert.NotEmpty(t, rec.Facts)
+		assert.NotEmpty(t, rec.Verifications)
+		assert.NotEmpty(t, rec.Context)
+	}
+
+	// metadata.enriched_facts.trust_score 첨부 검증
+	var pm core.ProcessingMessage
+	require.NoError(t, json.Unmarshal(published.Value, &pm))
+	rawFacts, ok := pm.Metadata["enriched_facts"].(map[string]interface{})
+	if assert.True(t, ok) {
+		ts, tsOK := rawFacts["trust_score"].(float64)
+		assert.True(t, tsOK)
+		assert.InDelta(t, 0.85, ts, 1e-9)
+	}
+}
+
+// TestEnrichWorker_NoScorer_NoPersistence — scorer Noop 또는 score result nil 이면 DB 미저장.
+func TestEnrichWorker_NoScorerResult_SkipsPersistence(t *testing.T) {
+	consumer := new(mockConsumer)
+	producer := new(mockProducer)
+	contentSvc := &listingStubContentService{primary: &core.Content{
+		ID: "c-noscore", Title: "T", Body: "B", URL: "https://example.com/n", Country: "US",
+		PublishedAt: time.Now(),
+	}}
+	facts := &extractor.EnrichedFacts{Claims: []extractor.Claim{{Text: "x"}}}
+	repo := &fakeEnrichedRepo{}
+
+	w := worker.NewWorker(
+		consumer, newTestPublisher(producer), contentSvc,
+		&fakeExtractor{facts: facts},
+		&fakeVerifier{},
+		&fakeContextualizer{},
+		extractor.NewNoopScorer(), // result nil
+		repo,
+		locks.NewNoopStageGate(),
+		1,
+	)
+	msg := makeValidatedMessage(t, "c-noscore", "https://example.com/n", "US", "example")
+
+	producer.On("Publish", mock.Anything, mock.MatchedBy(func(m queue.Message) bool {
+		return m.Topic == queue.TopicEnriched
+	})).Return(nil).Once()
+	producer.On("Close").Return(nil).Maybe()
+	consumer.On("CommitMessages", mock.Anything, mock.Anything).Return(nil).Maybe()
+
+	runWorker(t, consumer, w, msg)
+
+	assert.Empty(t, repo.upsertCalls, "no score → no DB upsert")
+}
+
+// TestEnrichWorker_NilRepo_StillForwards — enrichedRepo 가 nil 이어도 forward 보장.
+func TestEnrichWorker_NilRepo_StillForwards(t *testing.T) {
+	consumer := new(mockConsumer)
+	producer := new(mockProducer)
+	contentSvc := &listingStubContentService{primary: &core.Content{
+		ID: "c-nilrepo", Title: "T", Body: "B", URL: "https://example.com/r", Country: "US",
+		PublishedAt: time.Now(),
+	}}
+	facts := &extractor.EnrichedFacts{Claims: []extractor.Claim{{Text: "x"}}}
+
+	w := worker.NewWorker(
+		consumer, newTestPublisher(producer), contentSvc,
+		&fakeExtractor{facts: facts},
+		&fakeVerifier{},
+		&fakeContextualizer{},
+		&fakeScorer{result: &extractor.TrustScoreResult{TrustScore: 0.5}},
+		nil, // enrichedRepo nil
+		locks.NewNoopStageGate(),
+		1,
+	)
+	msg := makeValidatedMessage(t, "c-nilrepo", "https://example.com/r", "US", "example")
+
+	producer.On("Publish", mock.Anything, mock.MatchedBy(func(m queue.Message) bool {
+		return m.Topic == queue.TopicEnriched
+	})).Return(nil).Once()
+	producer.On("Close").Return(nil).Maybe()
+	consumer.On("CommitMessages", mock.Anything, mock.Anything).Return(nil).Maybe()
+
+	runWorker(t, consumer, w, msg)
+
+	consumer.AssertExpectations(t)
+	producer.AssertExpectations(t)
+}
+
+// TestEnrichWorker_RepoUpsertFailure_StillForwards — DB upsert 실패도 forward 보장.
+func TestEnrichWorker_RepoUpsertFailure_StillForwards(t *testing.T) {
+	consumer := new(mockConsumer)
+	producer := new(mockProducer)
+	contentSvc := &listingStubContentService{primary: &core.Content{
+		ID: "c-dberr", Title: "T", Body: "B", URL: "https://example.com/d", Country: "US",
+		PublishedAt: time.Now(),
+	}}
+	facts := &extractor.EnrichedFacts{Claims: []extractor.Claim{{Text: "x"}}}
+	repo := &fakeEnrichedRepo{upsertErr: assertAnError()}
+
+	w := worker.NewWorker(
+		consumer, newTestPublisher(producer), contentSvc,
+		&fakeExtractor{facts: facts},
+		&fakeVerifier{},
+		&fakeContextualizer{},
+		&fakeScorer{result: &extractor.TrustScoreResult{TrustScore: 0.5}},
+		repo,
+		locks.NewNoopStageGate(),
+		1,
+	)
+	msg := makeValidatedMessage(t, "c-dberr", "https://example.com/d", "US", "example")
+
+	producer.On("Publish", mock.Anything, mock.MatchedBy(func(m queue.Message) bool {
+		return m.Topic == queue.TopicEnriched
+	})).Return(nil).Once()
+	producer.On("Close").Return(nil).Maybe()
+	consumer.On("CommitMessages", mock.Anything, mock.Anything).Return(nil).Maybe()
+
+	runWorker(t, consumer, w, msg)
+
+	assert.Len(t, repo.upsertCalls, 1, "upsert should still be attempted")
 }
 
 // TestEnrichWorker_MalformedMessage_SendsToDLQ — 잘못된 JSON 은 DLQ 로 라우팅.


### PR DESCRIPTION
## 연관 이슈
- Closes #450
- **Closes #445** (메인 이슈 — enricher stage 전체 완성)
- Parent: #445

<br>

## 구현 내용

enrichment 의 마지막 단계 — 추출 + 검증 + 외부 맥락을 종합한 신뢰도 점수 산출 + DB 영속화. 본 PR 머지 시 메인 이슈 #445 도 함께 close (enricher 5단계 #446~#450 완성).

### 1. DB migration (`migrations/up/029_enriched_contents.sql` + down)
- `enriched_contents` 테이블 신설
  - id BIGSERIAL PK
  - content_id VARCHAR(255) FK ON DELETE CASCADE
  - trust_score NUMERIC(4,3) CHECK [0,1]
  - facts / verifications / context JSONB (NOT NULL DEFAULT)
  - enriched_at TIMESTAMPTZ DEFAULT NOW()
  - UNIQUE(content_id) — 재처리 시 UPSERT
  - idx_enriched_trust / idx_enriched_at

### 2. Storage layer
- `model.EnrichedContentRecord` — 테이블 row 표현 (JSONB raw bytes)
- `repository.EnrichedContentRepository` — Upsert / GetByContentID 인터페이스
- `postgres.NewEnrichedContentRepository` — pgx/v5 구현
  - ON CONFLICT (content_id) DO UPDATE — UNIQUE 충돌 시 UPDATE (재처리 안전)
  - JSONB nil fallback ("{}", "[]") — NOT NULL DEFAULT 위반 회피
- `decorator.WrapEnrichedContentWithTimeout` — 기존 timeout decorator 패턴 일관

### 3. Scorer + prompt
- `pkg/llm/prompt/assets/claudegen/enricher_score.user.txt`
  - 입력: source URL/host/title + facts/verifications/context JSON
  - 출력: `{trust_score, rationale, factors{claim_support_ratio, source_diversity, context_completeness}}`
  - rationale-driven scoring (가중합 아님)
- `Scorer` 인터페이스 + `NoopScorer` + `ClaudegenScorer`
  - 모든 입력이 empty/null JSON 이면 runner skip
  - trust_score [0,1] 범위 강제 (DB CHECK 와 일관, 위반 시 error)

### 4. Worker chain
- `NewWorker` 시그니처 확장 — Scorer (not-nil 강제) + EnrichedRepo (nil 허용) 추가
- `runScoring` 신규: 종합 facts → Scorer → `facts.TrustScore` 첨부
- `persistEnriched` 신규: TrustScore 있으면 `repo.Upsert` → `enriched_contents` 저장
- **forward-first 정책 유지** — scorer / DB 실패 모두 forward 진행

### 5. main.go wiring
- claudegenPool + promptLoader 가용 시 ClaudegenScorer, 부재 시 NoopScorer
- enriched_contents repo 는 pgxpool + WrapEnrichedContentWithTimeout

### 6. 테스트
- extractor: 성공 파싱 / 범위 초과 reject / empty input skip / session error / malformed / Noop / nil-arg
- worker: scoring → DB upsert + metadata 첨부 / Noop result nil → DB skip / repo nil → forward / upsert error → forward

<br>

## 메인 이슈 #445 완성 요약

| Sub-issue | PR | 산출물 |
|---|---|---|
| #446 | merged | 스켈레톤 (Kafka 토픽, passthrough worker, stage toggle) |
| #447 | merged | 요소 추출 (EnrichedFacts, claudegen prompt, Extractor) |
| #448 | merged | 교차 검증 (Verifier, WebFetch claim 검증) |
| #449 | merged | 외부 맥락 (Contextualizer, WebFetch background/timeline/implications) |
| **#450** | **본 PR** | **신뢰도 점수 + enriched_contents 영속화** |

<br>

## CI / 머지 게이트 점검

### 변경 영향 범위
- 신규: migration 029, `model.EnrichedContentRecord`, `repository.EnrichedContentRepository`, `postgres.NewEnrichedContentRepository`, `extractor.Scorer` + 구현체, scorer prompt
- 변경: `decorator.WrapEnrichedContentWithTimeout` 추가, `enrich.NewWorker` 시그니처 확장, `cmd/issuetracker/main.go` wiring, 테스트
- 위험도: Medium — 새 DB 테이블 + worker.NewWorker breaking change (Scorer + Repo 추가). 호출자는 main.go + 테스트만 통제됨

### Required Status Checks
- [ ] Commit Lint / PR Title Lint / Linked Issue Check / Format Check / Build / Test / Lint

### 배포 절차
1. migration 029 apply (`make migrate` 또는 `cmd/migrate`)
2. issuetracker 배포 — STAGES_ENRICH_ENABLED=true 환경
3. claudegen 환경에서는 자동으로 scoring + persistence 활성, NoopScorer 환경은 metadata 첨부만 (DB write skip)

### 롤백 계획
- STAGES_ENRICH_ENABLED=false 로 단계 비활성
- DB migration revert (029 down) — DROP TABLE enriched_contents
- 코드 revert 시 sub-issue #449 동작 (context 까지) 으로 복귀

<br>

## TODO
- [x] Migration 029 up/down
- [x] EnrichedContentRepository (model / interface / pgx / decorator)
- [x] Scorer interface + NoopScorer + ClaudegenScorer + prompt template
- [x] Worker chain (score + persist) + main.go wiring
- [x] 단위 테스트 (scorer + worker score/persist)
- [x] gofmt / vet / build / go test -race ./... 그린

<br>

## 논의 사항
- rationale / factors 는 metadata 로 첨부되나 DB schema 에는 미저장 — 운영 가시성용 진단 데이터로 사용, 필요 시 후속 schema evolution 으로 컬럼 추가 가능
- 점수가 NoopScorer 환경에서는 0 으로 잡히지 않고 nil 로 남음 — DB write skip 으로 일관 처리 (CHECK constraint 회피)
- 비용 cap (claudegen 호출 회수 / token budget) 은 본 PR scope 외 — 별도 운영 이슈 대상

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added trust scoring system for enriched content, with optional AI-powered scoring when available.
  * Implemented persistence of enriched content results, including trust scores, extracted facts, verifications, and contextual data.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/EinSofINTEREST/IssueTracker/pull/455)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->