### PR TITLE
[REFAC#458] claudegen → pkg/agent/claude — agent namespace 분리

### DIFF
--- a/cmd/issuetracker/main.go
+++ b/cmd/issuetracker/main.go
@@ -28,7 +28,6 @@ import (
 	crawlerWorker "issuetracker/internal/processor/fetcher/worker"
 	"issuetracker/internal/processor/parser"
 	"issuetracker/internal/processor/parser/rule"
-	"issuetracker/internal/processor/parser/rule/claudegen"
 	llmgenwiring "issuetracker/internal/processor/parser/rule/llmgen/wiring"
 	refinerwiring "issuetracker/internal/processor/parser/rule/refiner/wiring"
 	"issuetracker/internal/processor/parser/rule/validator"
@@ -42,6 +41,7 @@ import (
 	"issuetracker/internal/storage/primitive"
 	redisstore "issuetracker/internal/storage/redis"
 	"issuetracker/internal/storage/service"
+	"issuetracker/pkg/agent/claude"
 	"issuetracker/pkg/links"
 	"issuetracker/pkg/llm/prompt"
 	llmwiring "issuetracker/pkg/llm/wiring"
@@ -719,9 +719,9 @@ func main() {
 	// 미지정 / gemini (기본) 일 때는 buildLLMGenerator 가 설정한 기본 LLM provider 추출.
 	// Start 실패 시 Gemini 경로로 graceful fallback (fatal 아님).
 	// 종료 시 stages.Stop 이후 worker.Stop 호출 — llmGen.Stop 으로 in-flight Extract 완료 보장 후 컨테이너 정리.
-	// 이슈 #352 — 단일 worker → ClaudeWorkerPool (N replica, default 2) 로 throughput 향상.
+	// 이슈 #352 — 단일 worker → Pool (N replica, default 2) 로 throughput 향상.
 	// CLAUDE_CODE_WORKER_COUNT 로 운영자 조정 가능. 기존 단일 worker 동작은 N=1 로 동등 재현 가능.
-	var claudegenPool *claudegen.ClaudeWorkerPool
+	var claudegenPool *claude.Pool
 	llmExtractor := os.Getenv("LLM_EXTRACTOR")
 	switch {
 	case llmExtractor != "claude-code":
@@ -732,7 +732,7 @@ func main() {
 	case promptLoader == nil:
 		log.Warn("LLM_EXTRACTOR=claude-code requested but prompt loader is disabled; claudegen extractor not registered")
 	default:
-		pool, perr := claudegen.NewPoolFromEnv(promptLoader, log)
+		pool, perr := claude.NewPoolFromEnv(promptLoader, log)
 		if perr != nil {
 			log.WithError(perr).Warn("claudegen pool construction failed, falling back to default extractor")
 		} else if serr := pool.Start(ctx); serr != nil {

--- a/internal/processor/enrich/extractor/claudegen.go
+++ b/internal/processor/enrich/extractor/claudegen.go
@@ -10,7 +10,7 @@ import (
 	"issuetracker/pkg/llm/prompt"
 )
 
-// SessionRunner 는 claudegen.ClaudeWorkerPool 의 RunEnrichSession 시그니처와 일치하는 추상.
+// SessionRunner 는 claude.Pool 의 RunEnrichSession 시그니처와 일치하는 추상.
 //
 // 본 패키지가 claudegen 패키지를 직접 import 하면 enrich → claudegen 의존이 추가됨.
 // 인터페이스로 추상화하여 enrich 패키지가 claudegen 을 모르도록 — 테스트도 mock 으로 간단.
@@ -26,7 +26,7 @@ type SessionRunner interface {
 // promptName 은 enrich extraction 에 사용할 prompt asset 경로입니다.
 const promptName = "claudegen/enricher_extract"
 
-// ClaudegenExtractor 는 claudegen.ClaudeWorkerPool 을 통해 EnrichedFacts 를 추출합니다.
+// ClaudegenExtractor 는 claude.Pool 을 통해 EnrichedFacts 를 추출합니다.
 type ClaudegenExtractor struct {
 	runner SessionRunner
 	loader prompt.Loader

--- a/internal/processor/enrich/extractor/contextualizer.go
+++ b/internal/processor/enrich/extractor/contextualizer.go
@@ -48,7 +48,7 @@ var _ Contextualizer = (*NoopContextualizer)(nil)
 // contextPromptName 은 외부 맥락 수집 prompt asset 경로입니다.
 const contextPromptName = "claudegen/enricher_context"
 
-// ClaudegenContextualizer 는 claudegen.ClaudeWorkerPool 로 context session 을 실행합니다.
+// ClaudegenContextualizer 는 claude.Pool 로 context session 을 실행합니다.
 type ClaudegenContextualizer struct {
 	runner SessionRunner
 	loader prompt.Loader

--- a/internal/processor/enrich/extractor/extractor.go
+++ b/internal/processor/enrich/extractor/extractor.go
@@ -3,7 +3,7 @@
 // Extractor 는 page 메타데이터를 받아 EnrichedFacts 를 반환하는 단일 메소드 인터페이스입니다.
 // 구현체:
 //   - NoopExtractor: 빈 EnrichedFacts 반환. claudegen 미configured / disabled 환경의 fallback.
-//   - ClaudegenExtractor: claudegen.ClaudeWorkerPool 을 통해 Claude Code 호출 (실제 추출).
+//   - ClaudegenExtractor: claude.Pool 을 통해 Claude Code 호출 (실제 추출).
 package extractor
 
 import (

--- a/internal/processor/enrich/extractor/scorer.go
+++ b/internal/processor/enrich/extractor/scorer.go
@@ -68,7 +68,7 @@ var _ Scorer = (*NoopScorer)(nil)
 // scorerPromptName 은 신뢰도 점수 prompt asset 경로입니다.
 const scorerPromptName = "claudegen/enricher_score"
 
-// ClaudegenScorer 는 claudegen.ClaudeWorkerPool 로 scoring session 을 실행합니다.
+// ClaudegenScorer 는 claude.Pool 로 scoring session 을 실행합니다.
 type ClaudegenScorer struct {
 	runner SessionRunner
 	loader prompt.Loader

--- a/internal/processor/enrich/extractor/verifier.go
+++ b/internal/processor/enrich/extractor/verifier.go
@@ -55,7 +55,7 @@ var _ Verifier = (*NoopVerifier)(nil)
 // verifierPromptName 은 cross-verify prompt asset 경로입니다.
 const verifierPromptName = "claudegen/enricher_cross_verify"
 
-// ClaudegenVerifier 는 claudegen.ClaudeWorkerPool 로 cross-verify session 을 실행합니다.
+// ClaudegenVerifier 는 claude.Pool 로 cross-verify session 을 실행합니다.
 type ClaudegenVerifier struct {
 	runner SessionRunner
 	loader prompt.Loader

--- a/internal/processor/parser/rule/llmgen/generator.go
+++ b/internal/processor/parser/rule/llmgen/generator.go
@@ -75,7 +75,7 @@ type SelectorValidatorResult struct {
 // SelectorExtractor 는 HTML 에서 CSS 셀렉터를 추출하는 인터페이스입니다.
 //
 // 기본 구현: pkg/llm.Provider 기반 LLM 호출 (Gemini Flash 등).
-// 대체 구현: claudegen.ClaudeWorker (Claude Code 웜 컨테이너).
+// 대체 구현: claude.Worker (Claude Code 웜 컨테이너).
 // SetExtractor 로 교체하면 추출 단계만 대체되고 나머지 흐름 (validation, INSERT) 은 동일.
 type SelectorExtractor interface {
 	Extract(ctx context.Context, host string, targetType model.TargetType, html string) (model.SelectorMap, error)

--- a/internal/processor/parser/worker/worker.go
+++ b/internal/processor/parser/worker/worker.go
@@ -352,7 +352,7 @@ func (w *Worker) ProcessMessage(ctx context.Context, msg *queue.Message) error {
 	// validator → parser 재학습 cycle (이슈 #366):
 	//   1. inbox headers 를 ctx 에 첨부 — publishContents 가 reparse_* 를 normalized 메시지로 전파
 	//   2. validate_reparse_reason 헤더가 있으면 ctx 에 llmgen.WithRejectReason 으로 주입 —
-	//      claudegen.ExtractEnriched 가 prompt 에 reason context 포함 (Sub B #365 메커니즘)
+	//      claude.Worker.ExtractEnriched 가 prompt 에 reason context 포함 (Sub B #365 메커니즘)
 	ctx = core.WithInboxHeaders(ctx, msg.Headers)
 	if reason := msg.Headers[core.HeaderValidateReparseReason]; reason != "" {
 		ctx = llmgen.WithRejectReason(ctx, reason)

--- a/pkg/agent/claude/container.go
+++ b/pkg/agent/claude/container.go
@@ -1,4 +1,4 @@
-package claudegen
+package claude
 
 import (
 	"bytes"

--- a/pkg/agent/claude/enrich.go
+++ b/pkg/agent/claude/enrich.go
@@ -49,7 +49,7 @@ func (w *Worker) RunEnrichSession(
 	w.mu.RUnlock()
 
 	if containerID == "" {
-		return "", errors.New("claudegen: worker not started — call Start() first")
+		return "", errors.New("claude: worker not started — call Start() first")
 	}
 
 	sessionID, err := newSessionID()

--- a/pkg/agent/claude/enrich.go
+++ b/pkg/agent/claude/enrich.go
@@ -8,7 +8,7 @@
 //
 // ExtractEnriched 의 session lifecycle 과 의도적으로 분리 — 기존 parser 경로에 무영향.
 
-package claudegen
+package claude
 
 import (
 	"context"
@@ -34,7 +34,7 @@ import (
 //
 // 호출자 역할: stdout 을 자체 schema 로 파싱. RunEnrichSession 은 JSON 파싱 / blacklist 분기
 // 등을 일체 수행하지 않습니다 (parser-specific 인 ExtractEnriched 와 다른 점).
-func (w *ClaudeWorker) RunEnrichSession(
+func (w *Worker) RunEnrichSession(
 	ctx context.Context,
 	sessionLabel string,
 	files map[string][]byte,

--- a/pkg/agent/claude/pool.go
+++ b/pkg/agent/claude/pool.go
@@ -1,4 +1,4 @@
-package claudegen
+package claude
 
 import (
 	"context"
@@ -15,13 +15,13 @@ import (
 	"issuetracker/pkg/logger"
 )
 
-// 이슈 #352 — claudegen ClaudeWorker pool.
+// 이슈 #352 — claudegen Worker pool.
 //
 // 라이브 분석 (2026-05-11 22:39~) 6시간 누적 검증 실패율 88% 중 핵심 사유는 published_at
 // selector 부재 (1174건 / 83%). LLM rule generator throughput 을 높여 stale/missing selector
 // 의 자동 학습 + 정밀화 속도를 끌어올리는 것이 본 이슈의 목적.
 //
-// 본 파일은 ClaudeWorker 를 N replica pool 로 확장 — concurrent Extract 호출을 round-robin
+// 본 파일은 Worker 를 N replica pool 로 확장 — concurrent Extract 호출을 round-robin
 // 분배하여 단일 컨테이너 직렬화 병목 해소.
 
 const (
@@ -33,7 +33,7 @@ const (
 	maxWorkerCount = 16
 )
 
-// ClaudeWorkerPool 은 ClaudeWorker N replica 를 round-robin 분배로 사용하는 풀입니다.
+// Pool 은 Worker N replica 를 round-robin 분배로 사용하는 풀입니다.
 //
 // 모든 worker 가 동일한 환경 (image / model / authDir / timeout) 을 공유하므로 외부에서
 // 본 풀은 단일 SelectorExtractor / EnrichedExtractor 처럼 보입니다 — interface 호환을 통해
@@ -43,17 +43,17 @@ const (
 // 검증 후 별도 이슈에서 도입.
 //
 // goroutine-safe: nextIdx 가 atomic, 각 worker 가 자체 mu/wg 로 동시 호출 safe.
-type ClaudeWorkerPool struct {
-	workers []*ClaudeWorker
+type Pool struct {
+	workers []*Worker
 	nextIdx atomic.Uint64
 	log     *logger.Logger
 }
 
-// NewPool 은 주어진 worker slice 로 ClaudeWorkerPool 을 생성합니다 (DI 용).
+// NewPool 은 주어진 worker slice 로 Pool 을 생성합니다 (DI 용).
 //
 // workers 빈 slice 시 error. log nil 시 error.
 // 모든 worker 가 동일한 model 사용을 가정 — ModelName() 은 workers[0].ModelName() 반환.
-func NewPool(workers []*ClaudeWorker, log *logger.Logger) (*ClaudeWorkerPool, error) {
+func NewPool(workers []*Worker, log *logger.Logger) (*Pool, error) {
 	if log == nil {
 		return nil, errors.New("claudegen: NewPool requires non-nil logger")
 	}
@@ -65,7 +65,7 @@ func NewPool(workers []*ClaudeWorker, log *logger.Logger) (*ClaudeWorkerPool, er
 			return nil, fmt.Errorf("claudegen: NewPool workers[%d] is nil", i)
 		}
 	}
-	return &ClaudeWorkerPool{workers: workers, log: log}, nil
+	return &Pool{workers: workers, log: log}, nil
 }
 
 // NewPoolFromEnv 는 CLAUDE_CODE_WORKER_COUNT 환경변수 기준으로 pool 을 구성합니다.
@@ -73,7 +73,7 @@ func NewPool(workers []*ClaudeWorker, log *logger.Logger) (*ClaudeWorkerPool, er
 // 기본값: defaultWorkerCount (2). 상한: maxWorkerCount (16) — 운영자 입력값이 더 크면 clamp.
 // 0 / 음수 / parse 실패 시 default 적용 (WARN 로그).
 // 각 worker 는 동일 환경변수 set (image / model / authDir / timeout) 으로 구성.
-func NewPoolFromEnv(loader prompt.Loader, log *logger.Logger) (*ClaudeWorkerPool, error) {
+func NewPoolFromEnv(loader prompt.Loader, log *logger.Logger) (*Pool, error) {
 	if log == nil {
 		return nil, errors.New("claudegen: NewPoolFromEnv requires non-nil logger")
 	}
@@ -81,7 +81,7 @@ func NewPoolFromEnv(loader prompt.Loader, log *logger.Logger) (*ClaudeWorkerPool
 		return nil, errors.New("claudegen: NewPoolFromEnv requires non-nil prompt loader")
 	}
 	count := resolveWorkerCount(log)
-	workers := make([]*ClaudeWorker, 0, count)
+	workers := make([]*Worker, 0, count)
 	for i := 0; i < count; i++ {
 		w, err := NewFromEnv(loader, log)
 		if err != nil {
@@ -130,12 +130,12 @@ func resolveWorkerCount(log *logger.Logger) int {
 }
 
 // ModelName 은 pool 의 첫 worker 모델 ID 를 반환합니다 — 모든 worker 가 동일 환경 가정.
-func (p *ClaudeWorkerPool) ModelName() string {
+func (p *Pool) ModelName() string {
 	return p.workers[0].ModelName()
 }
 
 // WorkerCount 는 pool 크기를 반환합니다 — 운영 진단용.
-func (p *ClaudeWorkerPool) WorkerCount() int {
+func (p *Pool) WorkerCount() int {
 	return len(p.workers)
 }
 
@@ -143,12 +143,12 @@ func (p *ClaudeWorkerPool) WorkerCount() int {
 //
 // 일부 worker 실패 시: 이미 성공한 worker 들을 best-effort 로 Stop 후 첫 에러 반환.
 // 운영자가 부분 기동 상태를 보지 않도록 — 전부 가동 또는 전부 종료의 두 상태만 노출.
-func (p *ClaudeWorkerPool) Start(ctx context.Context) error {
+func (p *Pool) Start(ctx context.Context) error {
 	var wg sync.WaitGroup
 	errs := make([]error, len(p.workers))
 	for i, w := range p.workers {
 		wg.Add(1)
-		go func(idx int, worker *ClaudeWorker) {
+		go func(idx int, worker *Worker) {
 			defer wg.Done()
 			errs[idx] = worker.Start(ctx)
 		}(i, w)
@@ -174,7 +174,7 @@ func (p *ClaudeWorkerPool) Start(ctx context.Context) error {
 		for i, w := range p.workers {
 			if errs[i] == nil {
 				cwg.Add(1)
-				go func(idx int, worker *ClaudeWorker) {
+				go func(idx int, worker *Worker) {
 					defer cwg.Done()
 					cleanupCtx, cleanupCancel := context.WithTimeout(context.WithoutCancel(ctx), defaultSessionTimeout)
 					defer cleanupCancel()
@@ -199,12 +199,12 @@ func (p *ClaudeWorkerPool) Start(ctx context.Context) error {
 //
 // 각 worker.Stop 이 자체 wg.Wait 으로 in-flight Extract 완료를 보장. 일부 실패는 첫 에러
 // 반환 + 나머지는 best-effort 시도.
-func (p *ClaudeWorkerPool) Stop(ctx context.Context) error {
+func (p *Pool) Stop(ctx context.Context) error {
 	var wg sync.WaitGroup
 	errs := make([]error, len(p.workers))
 	for i, w := range p.workers {
 		wg.Add(1)
-		go func(idx int, worker *ClaudeWorker) {
+		go func(idx int, worker *Worker) {
 			defer wg.Done()
 			errs[idx] = worker.Stop(ctx)
 		}(i, w)
@@ -231,21 +231,21 @@ func (p *ClaudeWorkerPool) Stop(ctx context.Context) error {
 // Extract 는 round-robin 으로 worker 를 선택해 Extract 위임합니다.
 //
 // SelectorExtractor 인터페이스 호환 — llmgen.Generator.SetExtractor 가 본 메소드를 호출.
-func (p *ClaudeWorkerPool) Extract(ctx context.Context, host string, targetType model.TargetType, html string) (model.SelectorMap, error) {
+func (p *Pool) Extract(ctx context.Context, host string, targetType model.TargetType, html string) (model.SelectorMap, error) {
 	return p.pick().Extract(ctx, host, targetType, html)
 }
 
 // ExtractEnriched 는 round-robin 으로 worker 를 선택해 ExtractEnriched 위임합니다.
 //
 // EnrichedExtractor 인터페이스 호환 — llmgen.Generator 가 type assertion 으로 자동 분기.
-func (p *ClaudeWorkerPool) ExtractEnriched(ctx context.Context, host string, targetType model.TargetType, html string) (*llmgen.ExtractResult, error) {
+func (p *Pool) ExtractEnriched(ctx context.Context, host string, targetType model.TargetType, html string) (*llmgen.ExtractResult, error) {
 	return p.pick().ExtractEnriched(ctx, host, targetType, html)
 }
 
 // RunEnrichSession 은 round-robin worker 선택 후 RunEnrichSession 위임 (이슈 #447).
 //
 // enrich.Extractor 구현체 (extractor/claudegen.go) 가 호출하는 진입점.
-func (p *ClaudeWorkerPool) RunEnrichSession(
+func (p *Pool) RunEnrichSession(
 	ctx context.Context,
 	sessionLabel string,
 	files map[string][]byte,
@@ -258,13 +258,13 @@ func (p *ClaudeWorkerPool) RunEnrichSession(
 //
 // atomic.Uint64 의 ADD-AND-MODULO 패턴 — lock-free + counter wrap-around 시 modulo 정상 동작.
 // 분배 균등성은 worker 수가 2^N 일 때 가장 좋고 그 외에도 bias 가 최소.
-func (p *ClaudeWorkerPool) pick() *ClaudeWorker {
+func (p *Pool) pick() *Worker {
 	idx := p.nextIdx.Add(1) - 1 // Add 가 갱신 후 값 반환 — 0-base index 로 -1
 	return p.workers[idx%uint64(len(p.workers))]
 }
 
 // 컴파일 타임 contract — pool 이 두 인터페이스 모두 구현하는지 검증.
 var (
-	_ llmgen.SelectorExtractor = (*ClaudeWorkerPool)(nil)
-	_ llmgen.EnrichedExtractor = (*ClaudeWorkerPool)(nil)
+	_ llmgen.SelectorExtractor = (*Pool)(nil)
+	_ llmgen.EnrichedExtractor = (*Pool)(nil)
 )

--- a/pkg/agent/claude/pool.go
+++ b/pkg/agent/claude/pool.go
@@ -15,7 +15,7 @@ import (
 	"issuetracker/pkg/logger"
 )
 
-// 이슈 #352 — claudegen Worker pool.
+// 이슈 #352 — claude Worker pool.
 //
 // 라이브 분석 (2026-05-11 22:39~) 6시간 누적 검증 실패율 88% 중 핵심 사유는 published_at
 // selector 부재 (1174건 / 83%). LLM rule generator throughput 을 높여 stale/missing selector
@@ -55,14 +55,14 @@ type Pool struct {
 // 모든 worker 가 동일한 model 사용을 가정 — ModelName() 은 workers[0].ModelName() 반환.
 func NewPool(workers []*Worker, log *logger.Logger) (*Pool, error) {
 	if log == nil {
-		return nil, errors.New("claudegen: NewPool requires non-nil logger")
+		return nil, errors.New("claude: NewPool requires non-nil logger")
 	}
 	if len(workers) == 0 {
-		return nil, errors.New("claudegen: NewPool requires at least 1 worker")
+		return nil, errors.New("claude: NewPool requires at least 1 worker")
 	}
 	for i, w := range workers {
 		if w == nil {
-			return nil, fmt.Errorf("claudegen: NewPool workers[%d] is nil", i)
+			return nil, fmt.Errorf("claude: NewPool workers[%d] is nil", i)
 		}
 	}
 	return &Pool{workers: workers, log: log}, nil
@@ -75,17 +75,17 @@ func NewPool(workers []*Worker, log *logger.Logger) (*Pool, error) {
 // 각 worker 는 동일 환경변수 set (image / model / authDir / timeout) 으로 구성.
 func NewPoolFromEnv(loader prompt.Loader, log *logger.Logger) (*Pool, error) {
 	if log == nil {
-		return nil, errors.New("claudegen: NewPoolFromEnv requires non-nil logger")
+		return nil, errors.New("claude: NewPoolFromEnv requires non-nil logger")
 	}
 	if loader == nil {
-		return nil, errors.New("claudegen: NewPoolFromEnv requires non-nil prompt loader")
+		return nil, errors.New("claude: NewPoolFromEnv requires non-nil prompt loader")
 	}
 	count := resolveWorkerCount(log)
 	workers := make([]*Worker, 0, count)
 	for i := 0; i < count; i++ {
 		w, err := NewFromEnv(loader, log)
 		if err != nil {
-			return nil, fmt.Errorf("claudegen: NewPoolFromEnv worker[%d]: %w", i, err)
+			return nil, fmt.Errorf("claude: NewPoolFromEnv worker[%d]: %w", i, err)
 		}
 		workers = append(workers, w)
 	}
@@ -96,7 +96,7 @@ func NewPoolFromEnv(loader prompt.Loader, log *logger.Logger) (*Pool, error) {
 	// 생성 시점 — 아직 컨테이너 기동 전. Start() 가 성공해야 warm container 상태가 됨.
 	log.WithFields(map[string]interface{}{
 		"worker_count": count,
-	}).Info("claudegen worker pool constructed (containers not started yet)")
+	}).Info("claude worker pool constructed (containers not started yet)")
 	return pool, nil
 }
 
@@ -160,7 +160,7 @@ func (p *Pool) Start(ctx context.Context) error {
 	failedAny := false
 	for i, err := range errs {
 		if err != nil && firstErr == nil {
-			firstErr = fmt.Errorf("claudegen: pool worker[%d] start failed: %w", i, err)
+			firstErr = fmt.Errorf("claude: pool worker[%d] start failed: %w", i, err)
 		}
 		if err != nil {
 			failedAny = true
@@ -191,7 +191,7 @@ func (p *Pool) Start(ctx context.Context) error {
 	}
 	p.log.WithFields(map[string]interface{}{
 		"worker_count": len(p.workers),
-	}).Info("claudegen worker pool started (warm containers)")
+	}).Info("claude worker pool started (warm containers)")
 	return nil
 }
 
@@ -216,14 +216,14 @@ func (p *Pool) Stop(ctx context.Context) error {
 		if err != nil {
 			p.log.WithFields(map[string]interface{}{
 				"worker_idx": i,
-			}).WithError(err).Warn("claudegen pool worker stop failed")
+			}).WithError(err).Warn("claude pool worker stop failed")
 			if firstErr == nil {
-				firstErr = fmt.Errorf("claudegen: pool worker[%d] stop failed: %w", i, err)
+				firstErr = fmt.Errorf("claude: pool worker[%d] stop failed: %w", i, err)
 			}
 		}
 	}
 	if firstErr == nil {
-		p.log.Info("claudegen worker pool stopped")
+		p.log.Info("claude worker pool stopped")
 	}
 	return firstErr
 }

--- a/pkg/agent/claude/prompt.go
+++ b/pkg/agent/claude/prompt.go
@@ -18,7 +18,7 @@ const rejectReasonPlaceholder = "{{VALIDATION_REJECT_REASON_CONTEXT}}"
 // 운영자가 LLM_PROMPT_DIR 로 외부 prompt 를 override 했는데 본 placeholder 를 추가하지 않은
 // 경우 — reason 블록이 silently drop 되어 reparse cycle 이 reason 없이 LLM 을 호출하는
 // 잠재 버그. fail-fast 로 운영자에게 즉시 알림.
-var ErrRejectReasonPlaceholderMissing = errors.New("claudegen: prompt template missing " + rejectReasonPlaceholder + " placeholder (LLM_PROMPT_DIR override may need update)")
+var ErrRejectReasonPlaceholderMissing = errors.New("claude: prompt template missing " + rejectReasonPlaceholder + " placeholder (LLM_PROMPT_DIR override may need update)")
 
 // buildPrompt 는 Claude Code 에 전달할 프롬프트를 생성합니다.
 // sessionPath 는 컨테이너 내 세션 디렉토리 경로 (예: /workspace/<sessionID>) 입니다.
@@ -32,13 +32,13 @@ func buildPrompt(loader prompt.Loader, host string, targetType model.TargetType,
 	name := promptNameFor(targetType)
 	template, err := loader.Load(name)
 	if err != nil {
-		return "", fmt.Errorf("load claudegen prompt %q: %w", name, err)
+		return "", fmt.Errorf("load claude prompt %q: %w", name, err)
 	}
 
 	// reparse 경로 인데 템플릿에 placeholder 미포함 — silent drop 위험 차단.
 	// 정상 경로 (reason 빈 문자열) 에서는 placeholder 부재여도 결과 동일하므로 검증 skip.
 	if rejectReason != "" && !strings.Contains(template, rejectReasonPlaceholder) {
-		return "", fmt.Errorf("build claudegen prompt %q: %w", name, ErrRejectReasonPlaceholderMissing)
+		return "", fmt.Errorf("build claude prompt %q: %w", name, ErrRejectReasonPlaceholderMissing)
 	}
 
 	return prompt.Render(template,

--- a/pkg/agent/claude/prompt.go
+++ b/pkg/agent/claude/prompt.go
@@ -1,4 +1,4 @@
-package claudegen
+package claude
 
 import (
 	"errors"

--- a/pkg/agent/claude/worker.go
+++ b/pkg/agent/claude/worker.go
@@ -1,4 +1,4 @@
-// Package claudegen 은 상시 기동된 Claude Code Docker 컨테이너에 세션을 생성하여
+// Package claude 는 상시 기동된 Claude Code Docker 컨테이너에 세션을 생성하여
 // HTML 에서 CSS 셀렉터를 추출하는 컴포넌트입니다.
 //
 // 기존 콜드스타트 방식(docker run --rm)과 달리, 컨테이너를 서비스 기동 시 한 번만 띄우고
@@ -104,10 +104,10 @@ func (w *Worker) ModelName() string { return w.model }
 // 인증 디렉토리가 없거나 접근 불가하면 fail-fast — 호스트 `claude` CLI 사전 로그인 필요.
 func NewFromEnv(loader prompt.Loader, log *logger.Logger) (*Worker, error) {
 	if log == nil {
-		return nil, errors.New("claudegen: NewFromEnv requires non-nil logger")
+		return nil, errors.New("claude: NewFromEnv requires non-nil logger")
 	}
 	if loader == nil {
-		return nil, errors.New("claudegen: NewFromEnv requires non-nil prompt loader")
+		return nil, errors.New("claude: NewFromEnv requires non-nil prompt loader")
 	}
 	authDir, err := resolveAuthDir(os.Getenv("CLAUDE_CODE_AUTH_DIR"))
 	if err != nil {
@@ -145,10 +145,10 @@ func NewFromEnv(loader prompt.Loader, log *logger.Logger) (*Worker, error) {
 // authDir 은 validateAuthDir 로 절대 경로 정규화 + 존재/디렉토리/읽기 권한 검증.
 func New(image, model, authDir, containerAuthPath string, timeout time.Duration, loader prompt.Loader, log *logger.Logger) (*Worker, error) {
 	if log == nil {
-		return nil, errors.New("claudegen: New requires non-nil logger")
+		return nil, errors.New("claude: New requires non-nil logger")
 	}
 	if loader == nil {
-		return nil, errors.New("claudegen: New requires non-nil prompt loader")
+		return nil, errors.New("claude: New requires non-nil prompt loader")
 	}
 	resolved, err := validateAuthDir(authDir)
 	if err != nil {
@@ -168,13 +168,13 @@ func New(image, model, authDir, containerAuthPath string, timeout time.Duration,
 // authDir 은 validateAuthDir 로 절대 경로 정규화 + 존재/디렉토리/읽기 권한 검증.
 func NewWithRunner(image, model, authDir, containerAuthPath string, timeout time.Duration, runner ContainerRunner, loader prompt.Loader, log *logger.Logger) (*Worker, error) {
 	if log == nil {
-		return nil, errors.New("claudegen: NewWithRunner requires non-nil logger")
+		return nil, errors.New("claude: NewWithRunner requires non-nil logger")
 	}
 	if runner == nil {
-		return nil, errors.New("claudegen: NewWithRunner requires non-nil runner")
+		return nil, errors.New("claude: NewWithRunner requires non-nil runner")
 	}
 	if loader == nil {
-		return nil, errors.New("claudegen: NewWithRunner requires non-nil prompt loader")
+		return nil, errors.New("claude: NewWithRunner requires non-nil prompt loader")
 	}
 	resolved, err := validateAuthDir(authDir)
 	if err != nil {
@@ -197,7 +197,7 @@ func resolveAuthDir(envValue string) (string, error) {
 	if authDir == "" {
 		home, err := os.UserHomeDir()
 		if err != nil {
-			return "", fmt.Errorf("claudegen: CLAUDE_CODE_AUTH_DIR not set and cannot determine home dir: %w", err)
+			return "", fmt.Errorf("claude: CLAUDE_CODE_AUTH_DIR not set and cannot determine home dir: %w", err)
 		}
 		authDir = filepath.Join(home, ".claude")
 	}
@@ -212,21 +212,21 @@ func resolveAuthDir(envValue string) (string, error) {
 //   - os.ReadDir: 읽기 권한 검증 (mode 만 보지 않고 실제로 읽어봄)
 func validateAuthDir(authDir string) (string, error) {
 	if authDir == "" {
-		return "", errors.New("claudegen: authDir must not be empty")
+		return "", errors.New("claude: authDir must not be empty")
 	}
 	absPath, err := filepath.Abs(authDir)
 	if err != nil {
-		return "", fmt.Errorf("claudegen: failed to resolve absolute path for %q: %w", authDir, err)
+		return "", fmt.Errorf("claude: failed to resolve absolute path for %q: %w", authDir, err)
 	}
 	info, err := os.Stat(absPath)
 	if err != nil {
-		return "", fmt.Errorf("claudegen: auth dir %q not accessible: %w (run `claude` CLI on host to login first)", absPath, err)
+		return "", fmt.Errorf("claude: auth dir %q not accessible: %w (run `claude` CLI on host to login first)", absPath, err)
 	}
 	if !info.IsDir() {
-		return "", fmt.Errorf("claudegen: auth dir %q is not a directory", absPath)
+		return "", fmt.Errorf("claude: auth dir %q is not a directory", absPath)
 	}
 	if _, err := os.ReadDir(absPath); err != nil {
-		return "", fmt.Errorf("claudegen: auth dir %q is not readable: %w", absPath, err)
+		return "", fmt.Errorf("claude: auth dir %q is not readable: %w", absPath, err)
 	}
 	return absPath, nil
 }
@@ -238,7 +238,7 @@ func (w *Worker) Start(ctx context.Context) error {
 	defer w.mu.Unlock()
 
 	if w.containerID != "" {
-		return errors.New("claudegen: worker already started")
+		return errors.New("claude: worker already started")
 	}
 
 	workDir, err := os.MkdirTemp("", "claudegen-workspace-*")
@@ -315,7 +315,7 @@ func (w *Worker) Stop(ctx context.Context) error {
 // Blacklist 결정은 무시 (호출자가 ExtractEnriched 직접 호출하도록 권장).
 //
 // llmgen.Generator 는 EnrichedExtractor 인터페이스 type assertion 으로 자동 분기 —
-// claudegen.Worker 는 두 인터페이스 모두 구현.
+// Worker 는 두 인터페이스 모두 구현.
 func (w *Worker) Extract(ctx context.Context, host string, targetType model.TargetType, html string) (model.SelectorMap, error) {
 	res, err := w.ExtractEnriched(ctx, host, targetType, html)
 	if err != nil {
@@ -349,7 +349,7 @@ func (w *Worker) ExtractEnriched(ctx context.Context, host string, targetType mo
 	w.mu.RUnlock()
 
 	if containerID == "" {
-		return nil, errors.New("claudegen: worker not started — call Start() first")
+		return nil, errors.New("claude: worker not started — call Start() first")
 	}
 
 	sessionID, err := newSessionID()
@@ -377,7 +377,7 @@ func (w *Worker) ExtractEnriched(ctx context.Context, host string, targetType mo
 	rejectReason, _ := llmgen.RejectReasonFromContext(ctx)
 	promptText, err := buildPrompt(w.loader, host, targetType, sessionContainerPath, rejectReason)
 	if err != nil {
-		return nil, fmt.Errorf("build claudegen prompt: %w", err)
+		return nil, fmt.Errorf("build claude prompt: %w", err)
 	}
 	args := []string{
 		"claude",
@@ -426,7 +426,7 @@ func (w *Worker) ExtractEnriched(ctx context.Context, host string, targetType mo
 	return res, nil
 }
 
-// enrichedOutput 은 새 prompt schema 의 응답 구조 (claudegen multi-step extraction).
+// enrichedOutput 은 새 prompt schema 의 응답 구조 (claude multi-step extraction).
 //
 // validity == "blacklist" 일 때 selectors / self_check 는 비어있을 수 있음 — Generator 의
 // 호출자가 Blacklist 분기로 즉시 진입하므로 의미 없음.

--- a/pkg/agent/claude/worker.go
+++ b/pkg/agent/claude/worker.go
@@ -20,7 +20,7 @@
 //   - CLAUDE_CODE_MODEL                : 모델 ID (기본: claude-sonnet-4-6)
 //   - CLAUDE_CODE_IMAGE                : Docker 이미지 (기본: issuetracker-claudegen:local — `make claudegen-build` 필요)
 //   - CLAUDE_CODE_TIMEOUT              : 세션 단위 타임아웃 (기본: 120s, Go duration 형식)
-package claudegen
+package claude
 
 import (
 	"context"
@@ -68,7 +68,7 @@ type ContainerRunner interface {
 	StopContainer(ctx context.Context, containerID string) error
 }
 
-// ClaudeWorker 는 상시 기동된 Claude Code 컨테이너에 세션을 생성해 CSS 셀렉터를 추출합니다.
+// Worker 는 상시 기동된 Claude Code 컨테이너에 세션을 생성해 CSS 셀렉터를 추출합니다.
 //
 // Lifecycle:
 //   - Start(ctx): 컨테이너 기동 + workspace 디렉토리 생성
@@ -77,7 +77,7 @@ type ContainerRunner interface {
 //
 // Extract 는 동시 호출에 안전합니다 — 각 세션이 고유 디렉토리를 사용합니다.
 // Stop 은 진행 중인 모든 Extract 완료를 대기합니다 (graceful shutdown).
-type ClaudeWorker struct {
+type Worker struct {
 	image             string
 	model             string
 	authDir           string // 호스트 인증 디렉토리
@@ -95,14 +95,14 @@ type ClaudeWorker struct {
 
 // ModelName 은 이 Worker 가 사용하는 모델 ID 를 반환합니다.
 // llmgen.Generator 가 DB description 에 기록할 때 사용합니다.
-func (w *ClaudeWorker) ModelName() string { return w.model }
+func (w *Worker) ModelName() string { return w.model }
 
-// NewFromEnv 는 환경변수 기반 ClaudeWorker 를 생성합니다.
+// NewFromEnv 는 환경변수 기반 Worker 를 생성합니다.
 // Start() 를 호출하기 전까지는 컨테이너가 기동되지 않습니다.
 //
 // CLAUDE_CODE_AUTH_DIR 미지정 시 $HOME/.claude 를 사용합니다.
 // 인증 디렉토리가 없거나 접근 불가하면 fail-fast — 호스트 `claude` CLI 사전 로그인 필요.
-func NewFromEnv(loader prompt.Loader, log *logger.Logger) (*ClaudeWorker, error) {
+func NewFromEnv(loader prompt.Loader, log *logger.Logger) (*Worker, error) {
 	if log == nil {
 		return nil, errors.New("claudegen: NewFromEnv requires non-nil logger")
 	}
@@ -126,7 +126,7 @@ func NewFromEnv(loader prompt.Loader, log *logger.Logger) (*ClaudeWorker, error)
 			timeout = d
 		}
 	}
-	return &ClaudeWorker{
+	return &Worker{
 		image:             envOr("CLAUDE_CODE_IMAGE", defaultImage),
 		model:             envOr("CLAUDE_CODE_MODEL", defaultModel),
 		authDir:           authDir,
@@ -138,12 +138,12 @@ func NewFromEnv(loader prompt.Loader, log *logger.Logger) (*ClaudeWorker, error)
 	}, nil
 }
 
-// New 는 명시적 파라미터로 ClaudeWorker 를 생성합니다 (DI 용).
+// New 는 명시적 파라미터로 Worker 를 생성합니다 (DI 용).
 //
 // authDir 은 호스트의 Claude 인증 디렉토리, containerAuthPath 는 컨테이너 내 마운트 대상 경로.
 // containerAuthPath 가 빈 문자열이면 defaultContainerAuthPath 사용.
 // authDir 은 validateAuthDir 로 절대 경로 정규화 + 존재/디렉토리/읽기 권한 검증.
-func New(image, model, authDir, containerAuthPath string, timeout time.Duration, loader prompt.Loader, log *logger.Logger) (*ClaudeWorker, error) {
+func New(image, model, authDir, containerAuthPath string, timeout time.Duration, loader prompt.Loader, log *logger.Logger) (*Worker, error) {
 	if log == nil {
 		return nil, errors.New("claudegen: New requires non-nil logger")
 	}
@@ -157,7 +157,7 @@ func New(image, model, authDir, containerAuthPath string, timeout time.Duration,
 	if containerAuthPath == "" {
 		containerAuthPath = defaultContainerAuthPath
 	}
-	return &ClaudeWorker{
+	return &Worker{
 		image: image, model: model,
 		authDir: resolved, containerAuthPath: containerAuthPath,
 		sessionTimeout: timeout, runner: &execContainerRunner{}, loader: loader, log: log,
@@ -166,7 +166,7 @@ func New(image, model, authDir, containerAuthPath string, timeout time.Duration,
 
 // NewWithRunner 는 ContainerRunner 를 주입하는 생성자입니다 (테스트/DI 용).
 // authDir 은 validateAuthDir 로 절대 경로 정규화 + 존재/디렉토리/읽기 권한 검증.
-func NewWithRunner(image, model, authDir, containerAuthPath string, timeout time.Duration, runner ContainerRunner, loader prompt.Loader, log *logger.Logger) (*ClaudeWorker, error) {
+func NewWithRunner(image, model, authDir, containerAuthPath string, timeout time.Duration, runner ContainerRunner, loader prompt.Loader, log *logger.Logger) (*Worker, error) {
 	if log == nil {
 		return nil, errors.New("claudegen: NewWithRunner requires non-nil logger")
 	}
@@ -183,7 +183,7 @@ func NewWithRunner(image, model, authDir, containerAuthPath string, timeout time
 	if containerAuthPath == "" {
 		containerAuthPath = defaultContainerAuthPath
 	}
-	return &ClaudeWorker{
+	return &Worker{
 		image: image, model: model,
 		authDir: resolved, containerAuthPath: containerAuthPath,
 		sessionTimeout: timeout, runner: runner, loader: loader, log: log,
@@ -233,7 +233,7 @@ func validateAuthDir(authDir string) (string, error) {
 
 // Start 는 Claude Code 컨테이너를 기동하고 workspace 를 준비합니다.
 // 서비스 초기화 시 한 번 호출합니다.
-func (w *ClaudeWorker) Start(ctx context.Context) error {
+func (w *Worker) Start(ctx context.Context) error {
 	w.mu.Lock()
 	defer w.mu.Unlock()
 
@@ -271,7 +271,7 @@ func (w *ClaudeWorker) Start(ctx context.Context) error {
 // Stop 은 진행 중인 Extract 호출 완료를 대기한 뒤 컨테이너를 종료하고 workspace 를 정리합니다.
 // graceful shutdown 시 호출합니다. 멱등(이미 정지된 경우 noop).
 // StopContainer 실패 시 state 를 소거하지 않아 재시도가 가능합니다.
-func (w *ClaudeWorker) Stop(ctx context.Context) error {
+func (w *Worker) Stop(ctx context.Context) error {
 	w.mu.Lock()
 	if w.containerID == "" {
 		w.mu.Unlock()
@@ -315,8 +315,8 @@ func (w *ClaudeWorker) Stop(ctx context.Context) error {
 // Blacklist 결정은 무시 (호출자가 ExtractEnriched 직접 호출하도록 권장).
 //
 // llmgen.Generator 는 EnrichedExtractor 인터페이스 type assertion 으로 자동 분기 —
-// claudegen.ClaudeWorker 는 두 인터페이스 모두 구현.
-func (w *ClaudeWorker) Extract(ctx context.Context, host string, targetType model.TargetType, html string) (model.SelectorMap, error) {
+// claudegen.Worker 는 두 인터페이스 모두 구현.
+func (w *Worker) Extract(ctx context.Context, host string, targetType model.TargetType, html string) (model.SelectorMap, error) {
 	res, err := w.ExtractEnriched(ctx, host, targetType, html)
 	if err != nil {
 		return model.SelectorMap{}, err
@@ -338,7 +338,7 @@ func (w *ClaudeWorker) Extract(ctx context.Context, host string, targetType mode
 //
 // validity == "blacklist" 면 ExtractResult.Blacklist 비-nil — 호출자가 셀렉터 INSERT skip
 // + parser_blacklist Upsert 분기. Selectors / PageType 은 의미 없음.
-func (w *ClaudeWorker) ExtractEnriched(ctx context.Context, host string, targetType model.TargetType, html string) (*llmgen.ExtractResult, error) {
+func (w *Worker) ExtractEnriched(ctx context.Context, host string, targetType model.TargetType, html string) (*llmgen.ExtractResult, error) {
 	// wg.Add 를 락 획득보다 먼저 수행 — Stop() 의 wg.Wait() 이 이 Extract 호출을 놓치지 않도록 함.
 	w.wg.Add(1)
 	defer w.wg.Done()

--- a/test/pkg/agent/claude/parse_enriched_output_test.go
+++ b/test/pkg/agent/claude/parse_enriched_output_test.go
@@ -1,4 +1,4 @@
-package claudegen_test
+package claude_test
 
 // parseEnrichedOutput 은 claudegen 패키지의 unexported 헬퍼라 동일 구조의 동작은 통합 테스트
 // (worker_test.go 의 ExtractEnriched flow) 로 검증됩니다. 본 파일은 ExtractResult 의 schema

--- a/test/pkg/agent/claude/pool_test.go
+++ b/test/pkg/agent/claude/pool_test.go
@@ -1,6 +1,6 @@
-package claudegen_test
+package claude_test
 
-// pool_test.go — 이슈 #352 ClaudeWorkerPool 단위 테스트.
+// pool_test.go — 이슈 #352 Pool 단위 테스트.
 //
 // 검증 항목:
 //  1. Start: 모든 worker 컨테이너 기동 + 부분 실패 시 cleanup
@@ -20,8 +20,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"issuetracker/internal/processor/parser/rule/claudegen"
 	"issuetracker/internal/storage/model"
+	"issuetracker/pkg/agent/claude"
 	"issuetracker/pkg/logger"
 )
 
@@ -60,12 +60,12 @@ func (m *poolMockRunner) StopContainer(_ context.Context, _ string) error {
 	return nil
 }
 
-// newTestPoolWorker 는 ID 가 다른 runner 와 함께 ClaudeWorker 를 생성하는 헬퍼.
-func newTestPoolWorker(t *testing.T, runner *poolMockRunner) *claudegen.ClaudeWorker {
+// newTestPoolWorker 는 ID 가 다른 runner 와 함께 Worker 를 생성하는 헬퍼.
+func newTestPoolWorker(t *testing.T, runner *poolMockRunner) *claude.Worker {
 	t.Helper()
 	log := logger.New(logger.DefaultConfig())
 	authDir := makeAuthDir(t)
-	w, err := claudegen.NewWithRunner(
+	w, err := claude.NewWithRunner(
 		"ghcr.io/anthropics/claude-code:latest",
 		"claude-sonnet-4-6",
 		authDir,
@@ -84,14 +84,14 @@ const successStdout = `{"title":{"css":"h1.article-title"},"main_content":{"css"
 
 // TestPool_NewPool_NilLogger 는 nil logger 입력 시 error 반환.
 func TestPool_NewPool_NilLogger(t *testing.T) {
-	_, err := claudegen.NewPool([]*claudegen.ClaudeWorker{nil}, nil)
+	_, err := claude.NewPool([]*claude.Worker{nil}, nil)
 	require.Error(t, err)
 }
 
 // TestPool_NewPool_EmptyWorkers 는 빈 slice 입력 시 error 반환.
 func TestPool_NewPool_EmptyWorkers(t *testing.T) {
 	log := logger.New(logger.DefaultConfig())
-	_, err := claudegen.NewPool([]*claudegen.ClaudeWorker{}, log)
+	_, err := claude.NewPool([]*claude.Worker{}, log)
 	require.Error(t, err)
 }
 
@@ -100,7 +100,7 @@ func TestPool_NewPool_NilWorker(t *testing.T) {
 	log := logger.New(logger.DefaultConfig())
 	r := &poolMockRunner{id: "c1", execStdout: successStdout}
 	w := newTestPoolWorker(t, r)
-	_, err := claudegen.NewPool([]*claudegen.ClaudeWorker{w, nil}, log)
+	_, err := claude.NewPool([]*claude.Worker{w, nil}, log)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "workers[1] is nil")
 }
@@ -111,12 +111,12 @@ func TestPool_StartStop_AllContainers(t *testing.T) {
 	r1 := &poolMockRunner{id: "c1", execStdout: successStdout}
 	r2 := &poolMockRunner{id: "c2", execStdout: successStdout}
 	r3 := &poolMockRunner{id: "c3", execStdout: successStdout}
-	workers := []*claudegen.ClaudeWorker{
+	workers := []*claude.Worker{
 		newTestPoolWorker(t, r1),
 		newTestPoolWorker(t, r2),
 		newTestPoolWorker(t, r3),
 	}
-	pool, err := claudegen.NewPool(workers, log)
+	pool, err := claude.NewPool(workers, log)
 	require.NoError(t, err)
 
 	require.NoError(t, pool.Start(context.Background()))
@@ -138,12 +138,12 @@ func TestPool_Start_PartialFailure_CleansUpStarted(t *testing.T) {
 	r1 := &poolMockRunner{id: "c1"}
 	r2 := &poolMockRunner{id: "c2", startErr: errors.New("docker daemon down")}
 	r3 := &poolMockRunner{id: "c3"}
-	workers := []*claudegen.ClaudeWorker{
+	workers := []*claude.Worker{
 		newTestPoolWorker(t, r1),
 		newTestPoolWorker(t, r2),
 		newTestPoolWorker(t, r3),
 	}
-	pool, err := claudegen.NewPool(workers, log)
+	pool, err := claude.NewPool(workers, log)
 	require.NoError(t, err)
 
 	err = pool.Start(context.Background())
@@ -162,7 +162,7 @@ func TestPool_Extract_RoundRobin(t *testing.T) {
 	const poolSize = 3
 	const callCount = 9 // 3 worker × 3 call
 	runners := make([]*poolMockRunner, poolSize)
-	workers := make([]*claudegen.ClaudeWorker, poolSize)
+	workers := make([]*claude.Worker, poolSize)
 	for i := 0; i < poolSize; i++ {
 		runners[i] = &poolMockRunner{
 			id:         "c" + string(rune('1'+i)),
@@ -171,7 +171,7 @@ func TestPool_Extract_RoundRobin(t *testing.T) {
 		}
 		workers[i] = newTestPoolWorker(t, runners[i])
 	}
-	pool, err := claudegen.NewPool(workers, log)
+	pool, err := claude.NewPool(workers, log)
 	require.NoError(t, err)
 	require.NoError(t, pool.Start(context.Background()))
 	t.Cleanup(func() { _ = pool.Stop(context.Background()) })
@@ -211,11 +211,11 @@ func TestPool_Extract_SequentialDistributesRoundRobin(t *testing.T) {
 	log := logger.New(logger.DefaultConfig())
 	r1 := &poolMockRunner{id: "c1", execStdout: successStdout}
 	r2 := &poolMockRunner{id: "c2", execStdout: successStdout}
-	workers := []*claudegen.ClaudeWorker{
+	workers := []*claude.Worker{
 		newTestPoolWorker(t, r1),
 		newTestPoolWorker(t, r2),
 	}
-	pool, err := claudegen.NewPool(workers, log)
+	pool, err := claude.NewPool(workers, log)
 	require.NoError(t, err)
 	require.NoError(t, pool.Start(context.Background()))
 	t.Cleanup(func() { _ = pool.Stop(context.Background()) })
@@ -235,8 +235,8 @@ func TestPool_Extract_SequentialDistributesRoundRobin(t *testing.T) {
 func TestPool_ModelName(t *testing.T) {
 	log := logger.New(logger.DefaultConfig())
 	r := &poolMockRunner{id: "c1"}
-	workers := []*claudegen.ClaudeWorker{newTestPoolWorker(t, r)}
-	pool, err := claudegen.NewPool(workers, log)
+	workers := []*claude.Worker{newTestPoolWorker(t, r)}
+	pool, err := claude.NewPool(workers, log)
 	require.NoError(t, err)
 	assert.Equal(t, "claude-sonnet-4-6", pool.ModelName())
 }
@@ -249,7 +249,7 @@ func TestPool_NewPoolFromEnv_DefaultCount(t *testing.T) {
 	t.Setenv("CLAUDE_CODE_WORKER_COUNT", "")
 	t.Setenv("CLAUDE_CODE_AUTH_DIR", makeAuthDir(t))
 
-	pool, err := claudegen.NewPoolFromEnv(claudegenLoader, log)
+	pool, err := claude.NewPoolFromEnv(claudegenLoader, log)
 	require.NoError(t, err)
 	assert.Equal(t, 2, pool.WorkerCount(), "default worker count must be 2")
 }
@@ -260,7 +260,7 @@ func TestPool_NewPoolFromEnv_EnvOverride(t *testing.T) {
 	t.Setenv("CLAUDE_CODE_WORKER_COUNT", "4")
 	t.Setenv("CLAUDE_CODE_AUTH_DIR", makeAuthDir(t))
 
-	pool, err := claudegen.NewPoolFromEnv(claudegenLoader, log)
+	pool, err := claude.NewPoolFromEnv(claudegenLoader, log)
 	require.NoError(t, err)
 	assert.Equal(t, 4, pool.WorkerCount())
 }
@@ -274,7 +274,7 @@ func TestPool_NewPoolFromEnv_InvalidValueFallsBack(t *testing.T) {
 	for _, raw := range []string{"abc", "-1", "0"} {
 		t.Run("raw="+raw, func(t *testing.T) {
 			t.Setenv("CLAUDE_CODE_WORKER_COUNT", raw)
-			pool, err := claudegen.NewPoolFromEnv(claudegenLoader, log)
+			pool, err := claude.NewPoolFromEnv(claudegenLoader, log)
 			require.NoError(t, err)
 			assert.Equal(t, 2, pool.WorkerCount(), "invalid input must fallback to default 2")
 		})
@@ -288,7 +288,7 @@ func TestPool_NewPoolFromEnv_ExceedsMax_ClampsToCap(t *testing.T) {
 	t.Setenv("CLAUDE_CODE_WORKER_COUNT", "999")
 	t.Setenv("CLAUDE_CODE_AUTH_DIR", makeAuthDir(t))
 
-	pool, err := claudegen.NewPoolFromEnv(claudegenLoader, log)
+	pool, err := claude.NewPoolFromEnv(claudegenLoader, log)
 	require.NoError(t, err)
 	assert.LessOrEqual(t, pool.WorkerCount(), 16, "must be clamped to maxWorkerCount")
 }

--- a/test/pkg/agent/claude/reject_reason_test.go
+++ b/test/pkg/agent/claude/reject_reason_test.go
@@ -1,4 +1,4 @@
-package claudegen_test
+package claude_test
 
 // reject_reason_test.go — Sub B (#365) — claudegen prompt 에 reason context 주입 검증.
 //
@@ -16,9 +16,9 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"issuetracker/internal/processor/parser/rule/claudegen"
 	"issuetracker/internal/processor/parser/rule/llmgen"
 	"issuetracker/internal/storage/model"
+	"issuetracker/pkg/agent/claude"
 	"issuetracker/pkg/llm/prompt"
 	"issuetracker/pkg/logger"
 )
@@ -102,7 +102,7 @@ func TestExtractEnriched_TemplateMissingPlaceholder_FailsFast(t *testing.T) {
 	}
 	log := logger.New(logger.DefaultConfig())
 	authDir := makeAuthDir(t)
-	w, err := claudegen.NewWithRunner(
+	w, err := claude.NewWithRunner(
 		"ghcr.io/anthropics/claude-code:latest",
 		"claude-sonnet-4-6",
 		authDir,
@@ -136,7 +136,7 @@ func TestExtractEnriched_TemplateMissingPlaceholder_NoReason_OK(t *testing.T) {
 	runner := &mockContainerRunner{
 		execStdout: `{"validity":"ok","page_type":"news","selectors":{"title":{"css":"h1"},"main_content":{"css":"article","multi":true}},"self_check":{"title_sample":"x","body_word_count_estimate":200}}`,
 	}
-	w, err := claudegen.NewWithRunner(
+	w, err := claude.NewWithRunner(
 		"ghcr.io/anthropics/claude-code:latest",
 		"claude-sonnet-4-6",
 		authDir,

--- a/test/pkg/agent/claude/worker_test.go
+++ b/test/pkg/agent/claude/worker_test.go
@@ -1,4 +1,4 @@
-package claudegen_test
+package claude_test
 
 import (
 	"context"
@@ -12,8 +12,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"issuetracker/internal/processor/parser/rule/claudegen"
 	"issuetracker/internal/storage/model"
+	"issuetracker/pkg/agent/claude"
 	"issuetracker/pkg/llm/prompt"
 	"issuetracker/pkg/logger"
 )
@@ -81,11 +81,11 @@ func makeAuthDir(t *testing.T) string {
 	return dir
 }
 
-func newTestWorker(t *testing.T, runner *mockContainerRunner) *claudegen.ClaudeWorker {
+func newTestWorker(t *testing.T, runner *mockContainerRunner) *claude.Worker {
 	t.Helper()
 	log := logger.New(logger.DefaultConfig())
 	authDir := makeAuthDir(t)
-	w, err := claudegen.NewWithRunner(
+	w, err := claude.NewWithRunner(
 		"ghcr.io/anthropics/claude-code:latest",
 		"claude-sonnet-4-6",
 		authDir,
@@ -288,7 +288,7 @@ func TestClaudeWorker_ModelName(t *testing.T) {
 func TestNewFromEnv_MissingAuthDir(t *testing.T) {
 	t.Setenv("CLAUDE_CODE_AUTH_DIR", "/nonexistent/path/to/claude/auth")
 	log := logger.New(logger.DefaultConfig())
-	_, err := claudegen.NewFromEnv(claudegenLoader, log)
+	_, err := claude.NewFromEnv(claudegenLoader, log)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "auth dir")
 }
@@ -299,7 +299,7 @@ func TestNewFromEnv_AuthDirIsFile(t *testing.T) {
 	require.NoError(t, os.WriteFile(tmpFile, []byte("x"), 0o644))
 	t.Setenv("CLAUDE_CODE_AUTH_DIR", tmpFile)
 	log := logger.New(logger.DefaultConfig())
-	_, err := claudegen.NewFromEnv(claudegenLoader, log)
+	_, err := claude.NewFromEnv(claudegenLoader, log)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "not a directory")
 }
@@ -309,7 +309,7 @@ func TestNewFromEnv_ValidAuthDir(t *testing.T) {
 	authDir := makeAuthDir(t)
 	t.Setenv("CLAUDE_CODE_AUTH_DIR", authDir)
 	log := logger.New(logger.DefaultConfig())
-	w, err := claudegen.NewFromEnv(claudegenLoader, log)
+	w, err := claude.NewFromEnv(claudegenLoader, log)
 	require.NoError(t, err)
 	assert.NotNil(t, w)
 }
@@ -317,7 +317,7 @@ func TestNewFromEnv_ValidAuthDir(t *testing.T) {
 // TestNew_EmptyAuthDir 는 New() 에 빈 authDir 전달 시 에러를 반환하는지 검증합니다.
 func TestNew_EmptyAuthDir(t *testing.T) {
 	log := logger.New(logger.DefaultConfig())
-	_, err := claudegen.New("image", "model", "", "/root/.claude", 10*time.Second, claudegenLoader, log)
+	_, err := claude.New("image", "model", "", "/root/.claude", 10*time.Second, claudegenLoader, log)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "authDir")
 }
@@ -326,7 +326,7 @@ func TestNew_EmptyAuthDir(t *testing.T) {
 func TestNewWithRunner_EmptyAuthDir(t *testing.T) {
 	log := logger.New(logger.DefaultConfig())
 	runner := &mockContainerRunner{}
-	_, err := claudegen.NewWithRunner("image", "model", "", "/root/.claude", 10*time.Second, runner, claudegenLoader, log)
+	_, err := claude.NewWithRunner("image", "model", "", "/root/.claude", 10*time.Second, runner, claudegenLoader, log)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "authDir")
 }
@@ -335,7 +335,7 @@ func TestNewWithRunner_EmptyAuthDir(t *testing.T) {
 func TestNewWithRunner_NilRunner(t *testing.T) {
 	log := logger.New(logger.DefaultConfig())
 	authDir := makeAuthDir(t)
-	_, err := claudegen.NewWithRunner("image", "model", authDir, "/root/.claude", 10*time.Second, nil, claudegenLoader, log)
+	_, err := claude.NewWithRunner("image", "model", authDir, "/root/.claude", 10*time.Second, nil, claudegenLoader, log)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "runner")
 }
@@ -345,7 +345,7 @@ func TestNewWithRunner_DefaultContainerAuthPath(t *testing.T) {
 	log := logger.New(logger.DefaultConfig())
 	authDir := makeAuthDir(t)
 	runner := &mockContainerRunner{}
-	w, err := claudegen.NewWithRunner("image", "model", authDir, "", 10*time.Second, runner, claudegenLoader, log)
+	w, err := claude.NewWithRunner("image", "model", authDir, "", 10*time.Second, runner, claudegenLoader, log)
 	require.NoError(t, err)
 	require.NoError(t, w.Start(t.Context()))
 	t.Cleanup(func() { _ = w.Stop(context.Background()) })


### PR DESCRIPTION
## 연관 이슈
- Closes #458

<br>

## 구현 내용

`internal/processor/parser/rule/claudegen/` 의 Claude Code CLI agent 구현체를 새 `pkg/agent/claude/` 로 이전. Codex CLI 등 추가 agent backend 의 발판.

### 1. 디렉토리 이전
- `internal/processor/parser/rule/claudegen/` → `pkg/agent/claude/`
- `test/internal/processor/parser/rule/claudegen/` → `test/pkg/agent/claude/`
- 패키지: `claudegen` → `claude` (디렉토리명과 일치)
- test 패키지: `claudegen_test` → `claude_test`

### 2. 심볼 rename (패키지 prefix 흡수)
- `ClaudeWorker` → `Worker`
- `ClaudeWorkerPool` → `Pool`
- 생성자 (`NewPool` / `NewPoolFromEnv` / `New` / `NewFromEnv` / `NewWithRunner`) 시그니처 보존

### 3. import 갱신
- `cmd/issuetracker/main.go` — 실 import 경로 + 변수 타입
- `internal/processor/enrich/extractor/*.go` — 주석 references (실 의존은 `SessionRunner` 인터페이스 추상이라 코드 변경 없음)
- `internal/processor/parser/rule/llmgen/generator.go`, `internal/processor/parser/worker/worker.go` — 주석 references

<br>

## CI / 머지 게이트 점검

### 변경 영향 범위
- 이전: `internal/processor/parser/rule/claudegen/` 5 파일 + 테스트 4 파일
- 변경: import 1개 (main.go) + 주석 다수 (실 의존 없음)
- 위험도: Low — pure rename / 이동. 동작 변화 없음. 컨테이너 lifecycle / prompt path / API 보존

### Required Status Checks
- [ ] Commit Lint / PR Title Lint / Linked Issue Check / Format Check / Build / Test / Lint

### 롤백 계획
- `git revert` 단일 commit — 디렉토리 위치 + 패키지명 모두 복원

<br>

## TODO
- [x] git mv 이동 + 패키지명 변경
- [x] ClaudeWorker / ClaudeWorkerPool → Worker / Pool rename
- [x] main.go import + enricher/llmgen/parser worker 주석 갱신
- [x] gofmt / vet / build / `go test -race ./...` 그린

<br>

## 후속 이슈 (별도)

본 PR 의 비-목표 — 다음 이슈에서:
- `pkg/agent/` 의 공통 Agent 인터페이스 정의 (Backend / Session 등)
- `parser/core/` + `enrich/core/` 디렉토리 신설 + 각 stage 가 agent 를 사용하는 부분의 OOP 코드 배치
- `pkg/agent/codex/` — OpenAI Codex CLI backend

## 라이브 발견 별도 hotfix 필요

이번 라이브 (PR #455 머지 후) 에서 발견:
- enricher 4개 prompt const (`"claudegen/enricher_extract"` 등) 가 `.user` 접미사 누락 → 모든 LLM 호출 실패 → enriched_contents 0건
- 본 PR scope 외 — `[FIX]` hotfix 별도 진행 예정 (이슈 신설)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized internal Claude integration code structure for improved maintainability and clarity.
  * Renamed internal types and updated package organization to better reflect the module's purpose.

* **Tests**
  * Updated test suite to reflect internal code reorganization with no impact on test coverage or behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/EinSofINTEREST/IssueTracker/pull/459)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->