### PR TITLE
[REFAC#463] rule.Parser — RuleLookup interface + extract.go 분리 + PromptCompletor layer 통합

### DIFF
--- a/internal/processor/parser/core/agent.go
+++ b/internal/processor/parser/core/agent.go
@@ -48,6 +48,28 @@ type RuleAgent interface {
 // RawAgent 는 selector / enriched 가 아닌 임의 prompt 호출이 필요할 때 사용.
 type RawAgent = agent.Agent
 
+// PromptCompletor 는 system + user prompt 로 단일-step text 생성 API 의 추상입니다 (이슈 #463).
+//
+// 의도된 abstraction layer 비교:
+//
+//	┌─────────────────────────────────────────────────────────────────────┐
+//	│ Layer                              Interface              구현체      │
+//	├─────────────────────────────────────────────────────────────────────┤
+//	│ Domain (selector / enriched 추출)  RuleAgent              claude.Pool│
+//	│ Domain (path regex 추론)           PromptCompletor        pkg/llm.*  │
+//	│ Vendor primitive (RunSession)      RawAgent (=agent.Agent) claude.Pool│
+//	└─────────────────────────────────────────────────────────────────────┘
+//
+// PromptCompletor 는 API-based LLM provider (Gemini / OpenAI 등) 의 호출 패턴 —
+// pathinfer 가 path regex 추론에 사용하고, llmgen 의 SelectorExtractor 가 그 위 layer.
+//
+// pathinfer.LLMClient 가 본 인터페이스의 alias 로 유지되어 의미적 통합 — 본 PR 에서는
+// 실제 흡수까지는 진행 안 함 (caller 변경 최소화). 후속 PR 에서 pathinfer 가 본
+// PromptCompletor 를 직접 import 하도록 단계 마이그레이션 가능.
+type PromptCompletor interface {
+	Generate(ctx context.Context, system, user string) (string, error)
+}
+
 // RuleAgentClient 는 RuleAgent 의 default wiring 구조체입니다.
 //
 // 인스턴스 자체는 RuleAgent 인터페이스를 만족하는 backend (claude.Pool 등) 의 단순 wrapper

--- a/internal/processor/parser/rule/extract.go
+++ b/internal/processor/parser/rule/extract.go
@@ -41,11 +41,10 @@ func validateRaw(raw *core.RawContent) error {
 //
 // Multi=false (기본): 첫 매칭 element 의 값 반환.
 // Multi=true: 모든 매칭 element 의 값을 줄바꿈으로 합쳐 반환 (MainContent 다중 단락 등).
+//
+// extractFieldFromSelection 위임 — document 전체 selection 을 scope 로 전달 (gemini-review #464).
 func extractField(doc *goquery.Document, fs *model.FieldSelector) string {
-	if fs == nil || fs.CSS == "" {
-		return ""
-	}
-	return extractFromSelection(doc.Selection, fs)
+	return extractFieldFromSelection(doc.Selection, fs)
 }
 
 // extractFieldFromSelection 은 sub-selection 안에서 필드를 추출합니다 (list item 내부 lookup).
@@ -124,7 +123,13 @@ func (p *Parser) extractDate(doc *goquery.Document, fs *model.FieldSelector) tim
 }
 
 // absoluteURL 은 link 를 base 기준 절대 URL 로 변환합니다.
+//
+// base 가 nil 이면 변환 없이 link 를 그대로 반환 — caller 호환 견고화 (gemini-review #464).
+// 호출부 (parser.go) 가 이미 nil-check 후 호출하지만 함수 자체 panic 안전 보장.
 func absoluteURL(base *url.URL, link string) (string, error) {
+	if base == nil {
+		return link, nil
+	}
 	ref, err := url.Parse(link)
 	if err != nil {
 		return "", fmt.Errorf("parse link: %w", err)
@@ -134,11 +139,12 @@ func absoluteURL(base *url.URL, link string) (string, error) {
 
 // defaultDateLayouts 는 PublishedAt 추출 시 시도할 layout 목록입니다.
 // 사이트별 차이 (RFC3339 / Korean / ISO 8601 etc) 를 일반화. 운영 중 새 형식 발견 시 확장.
+//
+// 참고: time.RFC3339 = "2006-01-02T15:04:05Z07:00" 와 동일 — 중복 항목 제거 (gemini-review #464).
 func defaultDateLayouts() []string {
 	return []string{
 		time.RFC3339,
 		time.RFC3339Nano,
-		"2006-01-02T15:04:05Z07:00",
 		"2006-01-02 15:04:05",
 		"2006-01-02 15:04",
 		"2006.01.02 15:04",

--- a/internal/processor/parser/rule/extract.go
+++ b/internal/processor/parser/rule/extract.go
@@ -1,0 +1,149 @@
+// 본 파일은 rule.Parser 의 selector 추출 helper 함수 모음입니다 (이슈 #463 분리).
+//
+// parser.go 가 engine 진입점 (ParsePage / ParseLinks + ParseLink 모드 분기) 만 담당하도록
+// 추출 관련 helper 를 본 파일로 이전 — 책임 분리.
+
+package rule
+
+import (
+	"fmt"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/PuerkitoBio/goquery"
+
+	"issuetracker/internal/processor/fetcher/core"
+	"issuetracker/internal/storage/model"
+)
+
+// hasRequiredSelector 는 selector 가 lookup 가능한지 검사합니다 (Coderabbit 피드백).
+// nil 이거나 CSS 가 trim 후 빈 문자열이면 false — DB 의 zero-value row 도 명확히 reject.
+func hasRequiredSelector(fs *model.FieldSelector) bool {
+	return fs != nil && strings.TrimSpace(fs.CSS) != ""
+}
+
+// validateRaw 는 ParsePage / ParseLinks 의 공통 raw 검증입니다.
+// raw 가 nil 이거나 HTML 이 비어있으면 (whitespace-only 도 빈 것으로 간주) raw.URL 진단 정보 포함 Error 반환.
+// (Coderabbit 피드백: "   \n" 같은 whitespace-only 가 통과해 stale-rule 오인 회피)
+func validateRaw(raw *core.RawContent) error {
+	if raw != nil && strings.TrimSpace(raw.HTML) != "" {
+		return nil
+	}
+	var u string
+	if raw != nil {
+		u = raw.URL
+	}
+	return &Error{Code: ErrParseFailure, Message: "raw content empty", URL: u}
+}
+
+// extractField 는 단일 필드를 추출합니다 (selector 가 nil 이면 빈 문자열).
+//
+// Multi=false (기본): 첫 매칭 element 의 값 반환.
+// Multi=true: 모든 매칭 element 의 값을 줄바꿈으로 합쳐 반환 (MainContent 다중 단락 등).
+func extractField(doc *goquery.Document, fs *model.FieldSelector) string {
+	if fs == nil || fs.CSS == "" {
+		return ""
+	}
+	return extractFromSelection(doc.Selection, fs)
+}
+
+// extractFieldFromSelection 은 sub-selection 안에서 필드를 추출합니다 (list item 내부 lookup).
+func extractFieldFromSelection(s *goquery.Selection, fs *model.FieldSelector) string {
+	if fs == nil || fs.CSS == "" {
+		return ""
+	}
+	return extractFromSelection(s, fs)
+}
+
+// extractFromSelection 은 selection 범위에서 selector 적용 결과를 반환합니다.
+func extractFromSelection(scope *goquery.Selection, fs *model.FieldSelector) string {
+	matched := scope.Find(fs.CSS)
+	if matched.Length() == 0 {
+		return ""
+	}
+	if !fs.Multi {
+		return strings.TrimSpace(extractValue(matched.First(), fs.Attribute))
+	}
+	var parts []string
+	matched.Each(func(_ int, sel *goquery.Selection) {
+		v := strings.TrimSpace(extractValue(sel, fs.Attribute))
+		if v != "" {
+			parts = append(parts, v)
+		}
+	})
+	return strings.Join(parts, "\n")
+}
+
+// extractFieldMulti 는 multi 결과를 string 슬라이스로 반환합니다 (Tags / Images 용).
+//
+// extractField 의 multi 모드는 줄바꿈으로 합치지만, 본 함수는 각 element 를 별도 항목으로 보존.
+func extractFieldMulti(doc *goquery.Document, fs *model.FieldSelector) []string {
+	if fs == nil || fs.CSS == "" {
+		return nil
+	}
+	matched := doc.Find(fs.CSS)
+	if matched.Length() == 0 {
+		return nil
+	}
+	out := make([]string, 0, matched.Length())
+	matched.Each(func(_ int, sel *goquery.Selection) {
+		v := strings.TrimSpace(extractValue(sel, fs.Attribute))
+		if v != "" {
+			out = append(out, v)
+		}
+	})
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+// extractValue 는 element 의 text (Attribute=="") 또는 attribute 값을 반환합니다.
+func extractValue(sel *goquery.Selection, attribute string) string {
+	if attribute == "" {
+		return sel.Text()
+	}
+	v, _ := sel.Attr(attribute)
+	return v
+}
+
+// extractDate 는 PublishedAt 필드를 추출하고 dateLayouts 를 순회 시도합니다.
+// 추출 실패 시 zero time 반환 — 호출자 (validator 등) 가 zero 검사로 분기.
+func (p *Parser) extractDate(doc *goquery.Document, fs *model.FieldSelector) time.Time {
+	raw := extractField(doc, fs)
+	if raw == "" {
+		return time.Time{}
+	}
+	for _, layout := range p.dateLayouts {
+		if t, err := time.Parse(layout, raw); err == nil {
+			return t
+		}
+	}
+	return time.Time{}
+}
+
+// absoluteURL 은 link 를 base 기준 절대 URL 로 변환합니다.
+func absoluteURL(base *url.URL, link string) (string, error) {
+	ref, err := url.Parse(link)
+	if err != nil {
+		return "", fmt.Errorf("parse link: %w", err)
+	}
+	return base.ResolveReference(ref).String(), nil
+}
+
+// defaultDateLayouts 는 PublishedAt 추출 시 시도할 layout 목록입니다.
+// 사이트별 차이 (RFC3339 / Korean / ISO 8601 etc) 를 일반화. 운영 중 새 형식 발견 시 확장.
+func defaultDateLayouts() []string {
+	return []string{
+		time.RFC3339,
+		time.RFC3339Nano,
+		"2006-01-02T15:04:05Z07:00",
+		"2006-01-02 15:04:05",
+		"2006-01-02 15:04",
+		"2006.01.02 15:04",
+		"2006.01.02. 15:04",
+		"2006.01.02",
+		"2006/01/02 15:04:05",
+	}
+}

--- a/internal/processor/parser/rule/parser.go
+++ b/internal/processor/parser/rule/parser.go
@@ -3,7 +3,6 @@ package rule
 import (
 	"context"
 	"errors"
-	"fmt"
 	"net/url"
 	"strings"
 	"time"
@@ -32,14 +31,25 @@ const resolveTimeout = 5 * time.Second
 //
 // stateless / goroutine-safe — 모든 worker 가 단일 인스턴스 공유 가능.
 type Parser struct {
-	resolver    *Resolver
+	resolver    RuleLookup
 	discovery   *PageLinkDiscovery // full-page link discovery
 	dateLayouts []string           // PublishedAt try-list (앞쪽 우선)
 }
 
-// NewParser 는 Resolver 를 사용하는 Parser 를 생성합니다.
+// RuleLookup 은 URL + target_type 으로 활성 ParserRule 을 조회하는 추상 (이슈 #463).
+//
+// *Resolver 가 자연스럽게 본 인터페이스를 만족 — Parser 는 concrete 대신 interface 의존으로
+// 단위 테스트 시 mock 주입 가능. 운영 wiring (main.go) 은 변경 없음.
+type RuleLookup interface {
+	ResolveByURL(ctx context.Context, rawURL string, targetType model.TargetType) (*model.ParserRuleRecord, error)
+}
+
+// 컴파일 타임 검증: *Resolver 가 RuleLookup 을 만족.
+var _ RuleLookup = (*Resolver)(nil)
+
+// NewParser 는 RuleLookup 을 사용하는 Parser 를 생성합니다.
 // resolver 가 nil 이면 error — 호출자 (cmd/main) 가 boot fatal 처리.
-func NewParser(resolver *Resolver) (*Parser, error) {
+func NewParser(resolver RuleLookup) (*Parser, error) {
 	if resolver == nil {
 		return nil, errors.New("rule: NewParser requires non-nil resolver")
 	}
@@ -48,22 +58,6 @@ func NewParser(resolver *Resolver) (*Parser, error) {
 		discovery:   NewPageLinkDiscovery(),
 		dateLayouts: defaultDateLayouts(),
 	}, nil
-}
-
-// defaultDateLayouts 는 PublishedAt 추출 시 시도할 layout 목록입니다.
-// 사이트별 차이 (RFC3339 / Korean / ISO 8601 etc) 를 일반화. 운영 중 새 형식 발견 시 확장.
-func defaultDateLayouts() []string {
-	return []string{
-		time.RFC3339,
-		time.RFC3339Nano,
-		"2006-01-02T15:04:05Z07:00",
-		"2006-01-02 15:04:05",
-		"2006-01-02 15:04",
-		"2006.01.02 15:04",
-		"2006.01.02. 15:04",
-		"2006.01.02",
-		"2006/01/02 15:04:05",
-	}
 }
 
 // ParsePage 는 RawContent 를 DB rule 기반으로 Page 로 파싱합니다 (types.ContentParser 구현).
@@ -224,121 +218,6 @@ func (p *Parser) ParseLinks(ctx context.Context, raw *core.RawContent) ([]types.
 		}
 	}
 	return items, nil
-}
-
-// hasRequiredSelector 는 selector 가 lookup 가능한지 검사합니다 (Coderabbit 피드백).
-// nil 이거나 CSS 가 trim 후 빈 문자열이면 false — DB 의 zero-value row 도 명확히 reject.
-func hasRequiredSelector(fs *model.FieldSelector) bool {
-	return fs != nil && strings.TrimSpace(fs.CSS) != ""
-}
-
-// validateRaw 는 ParsePage / ParseLinks 의 공통 raw 검증입니다.
-// raw 가 nil 이거나 HTML 이 비어있으면 (whitespace-only 도 빈 것으로 간주) raw.URL 진단 정보 포함 Error 반환.
-// (Coderabbit 피드백: "   \n" 같은 whitespace-only 가 통과해 stale-rule 오인 회피)
-func validateRaw(raw *core.RawContent) error {
-	if raw != nil && strings.TrimSpace(raw.HTML) != "" {
-		return nil
-	}
-	var u string
-	if raw != nil {
-		u = raw.URL
-	}
-	return &Error{Code: ErrParseFailure, Message: "raw content empty", URL: u}
-}
-
-// extractField 는 단일 필드를 추출합니다 (selector 가 nil 이면 빈 문자열).
-//
-// Multi=false (기본): 첫 매칭 element 의 값 반환.
-// Multi=true: 모든 매칭 element 의 값을 줄바꿈으로 합쳐 반환 (MainContent 다중 단락 등).
-func extractField(doc *goquery.Document, fs *model.FieldSelector) string {
-	if fs == nil || fs.CSS == "" {
-		return ""
-	}
-	return extractFromSelection(doc.Selection, fs)
-}
-
-// extractFieldFromSelection 은 sub-selection 안에서 필드를 추출합니다 (list item 내부 lookup).
-func extractFieldFromSelection(s *goquery.Selection, fs *model.FieldSelector) string {
-	if fs == nil || fs.CSS == "" {
-		return ""
-	}
-	return extractFromSelection(s, fs)
-}
-
-// extractFromSelection 은 selection 범위에서 selector 적용 결과를 반환합니다.
-func extractFromSelection(scope *goquery.Selection, fs *model.FieldSelector) string {
-	matched := scope.Find(fs.CSS)
-	if matched.Length() == 0 {
-		return ""
-	}
-	if !fs.Multi {
-		return strings.TrimSpace(extractValue(matched.First(), fs.Attribute))
-	}
-	var parts []string
-	matched.Each(func(_ int, sel *goquery.Selection) {
-		v := strings.TrimSpace(extractValue(sel, fs.Attribute))
-		if v != "" {
-			parts = append(parts, v)
-		}
-	})
-	return strings.Join(parts, "\n")
-}
-
-// extractFieldMulti 는 multi 결과를 string 슬라이스로 반환합니다 (Tags / Images 용).
-//
-// extractField 의 multi 모드는 줄바꿈으로 합치지만, 본 함수는 각 element 를 별도 항목으로 보존.
-func extractFieldMulti(doc *goquery.Document, fs *model.FieldSelector) []string {
-	if fs == nil || fs.CSS == "" {
-		return nil
-	}
-	matched := doc.Find(fs.CSS)
-	if matched.Length() == 0 {
-		return nil
-	}
-	out := make([]string, 0, matched.Length())
-	matched.Each(func(_ int, sel *goquery.Selection) {
-		v := strings.TrimSpace(extractValue(sel, fs.Attribute))
-		if v != "" {
-			out = append(out, v)
-		}
-	})
-	if len(out) == 0 {
-		return nil
-	}
-	return out
-}
-
-// extractValue 는 element 의 text (Attribute=="") 또는 attribute 값을 반환합니다.
-func extractValue(sel *goquery.Selection, attribute string) string {
-	if attribute == "" {
-		return sel.Text()
-	}
-	v, _ := sel.Attr(attribute)
-	return v
-}
-
-// extractDate 는 PublishedAt 필드를 추출하고 dateLayouts 를 순회 시도합니다.
-// 추출 실패 시 zero time 반환 — 호출자 (validator 등) 가 zero 검사로 분기.
-func (p *Parser) extractDate(doc *goquery.Document, fs *model.FieldSelector) time.Time {
-	raw := extractField(doc, fs)
-	if raw == "" {
-		return time.Time{}
-	}
-	for _, layout := range p.dateLayouts {
-		if t, err := time.Parse(layout, raw); err == nil {
-			return t
-		}
-	}
-	return time.Time{}
-}
-
-// absoluteURL 은 link 를 base 기준 절대 URL 로 변환합니다.
-func absoluteURL(base *url.URL, link string) (string, error) {
-	ref, err := url.Parse(link)
-	if err != nil {
-		return "", fmt.Errorf("parse link: %w", err)
-	}
-	return base.ResolveReference(ref).String(), nil
 }
 
 // 컴파일 시 인터페이스 구현 검증 — 두 인터페이스 모두 만족해야 함.

--- a/internal/processor/parser/rule/parser.go
+++ b/internal/processor/parser/rule/parser.go
@@ -79,6 +79,16 @@ func (p *Parser) ParsePage(ctx context.Context, raw *core.RawContent) (*types.Pa
 	if err != nil {
 		return nil, err
 	}
+	// RuleLookup interface contract 가 nil-success 를 명시적으로 금지하지 않으므로 mock /
+	// 향후 구현체가 (nil, nil) 반환 시 dereferencing panic 방어 (coderabbit-review #464).
+	if rule == nil {
+		return nil, &Error{
+			Code:       ErrNoRule,
+			Message:    "rule lookup returned nil rule",
+			URL:        raw.URL,
+			TargetType: string(model.TargetTypePage),
+		}
+	}
 
 	// Title + MainContent 둘 다 필수 — nil 또는 CSS 빈 문자열 모두 ErrEmptySelector 로 분류
 	// (Coderabbit 피드백: nil 만 검사하면 zero-value selector 가 ErrParseFailure 로 잘못 분류됨)
@@ -147,6 +157,15 @@ func (p *Parser) ParseLinks(ctx context.Context, raw *core.RawContent) ([]types.
 	rule, err := p.resolver.ResolveByURL(resolveCtx, raw.URL, model.TargetTypeList)
 	if err != nil {
 		return nil, err
+	}
+	// RuleLookup interface contract 가 nil-success 를 명시적으로 금지하지 않으므로 방어 (coderabbit-review #464).
+	if rule == nil {
+		return nil, &Error{
+			Code:       ErrNoRule,
+			Message:    "rule lookup returned nil rule",
+			URL:        raw.URL,
+			TargetType: string(model.TargetTypeList),
+		}
 	}
 
 	// LinkDiscovery 모드 — opt-in.

--- a/internal/processor/parser/rule/pathinfer/llm.go
+++ b/internal/processor/parser/rule/pathinfer/llm.go
@@ -7,20 +7,18 @@ import (
 	"regexp"
 	"strings"
 
+	"issuetracker/internal/processor/parser/core"
 	"issuetracker/pkg/llm/prompt"
 )
 
-// LLMClient 는 InferLLM 이 사용하는 최소 LLM 호출 인터페이스입니다.
+// LLMClient 는 InferLLM 이 사용하는 LLM 호출 인터페이스 — parser/core.PromptCompletor 의 alias.
 //
-// pathinfer 가 pkg/llm 을 직접 import 하지 않도록 작은 abstraction —
-// 호출자 (단계 4 의 hybrid 흐름) 가 pkg/llm.Provider 위에 adapter 를 만들어 주입합니다.
+// 이슈 #463: pathinfer 와 llmgen 의 LLM 추상 layer 를 parser/core 에서 단일 source 로 정의.
+// 본 alias 로 기존 caller 호환 보존 + 의미적 통합. 후속 PR 에서 caller 가 직접
+// core.PromptCompletor 를 import 하도록 점진 마이그레이션 가능.
 //
 // 구현체는 goroutine-safe 해야 합니다.
-type LLMClient interface {
-	// Generate 는 system + user 프롬프트로 LLM 호출 후 응답 텍스트를 반환합니다.
-	// 호출자는 timeout / cancel 을 ctx 로 제어.
-	Generate(ctx context.Context, system, user string) (string, error)
-}
+type LLMClient = core.PromptCompletor
 
 // LLMSamples 는 InferLLM 의 입력 샘플입니다.
 //

--- a/test/internal/processor/parser/rule/parser_test.go
+++ b/test/internal/processor/parser/rule/parser_test.go
@@ -232,3 +232,47 @@ func TestNewParser_NilResolver_ReturnsError(t *testing.T) {
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "non-nil resolver")
 }
+
+// stubRuleLookup 은 RuleLookup 인터페이스의 mock 구현입니다 (이슈 #463).
+//
+// concrete *Resolver 대신 mock 주입으로 Parser 단위 테스트 가능 — interface 추상화 후
+// 가능해진 새 패턴.
+type stubRuleLookup struct {
+	rule *model.ParserRuleRecord
+	err  error
+}
+
+func (s *stubRuleLookup) ResolveByURL(_ context.Context, _ string, _ model.TargetType) (*model.ParserRuleRecord, error) {
+	if s.err != nil {
+		return nil, s.err
+	}
+	return s.rule, nil
+}
+
+// TestParser_RuleLookupMock_DirectInjection 은 RuleLookup 인터페이스 추상화로 mock 주입이
+// 가능함을 검증합니다 (이슈 #463 — interface 의존 전환의 핵심 가치).
+//
+// 기존 테스트는 *Resolver concrete + fake repo 패턴 사용 — Resolver 의 cache / Redis /
+// 비교 로직까지 거쳐야 했음. 본 테스트는 RuleLookup mock 으로 그 의존 일체 제거.
+func TestParser_RuleLookupMock_DirectInjection(t *testing.T) {
+	mockLookup := &stubRuleLookup{rule: pageRule()}
+	p, err := rule.NewParser(mockLookup)
+	require.NoError(t, err)
+
+	page, err := p.ParsePage(context.Background(), makeRaw("https://example.com/article/1", articleHTML))
+	require.NoError(t, err)
+	assert.Equal(t, "Breaking News Today", page.Title)
+}
+
+// TestParser_RuleLookupMock_LookupError 는 mock 의 error 가 그대로 호출자에 propagate
+// 되는지 검증.
+func TestParser_RuleLookupMock_LookupError(t *testing.T) {
+	expectedErr := errors.New("synthetic lookup failure")
+	mockLookup := &stubRuleLookup{err: expectedErr}
+	p, err := rule.NewParser(mockLookup)
+	require.NoError(t, err)
+
+	_, err = p.ParsePage(context.Background(), makeRaw("https://example.com/article/1", articleHTML))
+	require.Error(t, err)
+	assert.ErrorIs(t, err, expectedErr)
+}

--- a/test/internal/processor/parser/rule/parser_test.go
+++ b/test/internal/processor/parser/rule/parser_test.go
@@ -276,3 +276,24 @@ func TestParser_RuleLookupMock_LookupError(t *testing.T) {
 	require.Error(t, err)
 	assert.ErrorIs(t, err, expectedErr)
 }
+
+// TestParser_RuleLookupMock_NilRuleSuccess_NoPanic 은 RuleLookup 이 (nil, nil) 반환 시
+// dereferencing panic 대신 ErrNoRule 로 안전하게 처리되는지 검증 (coderabbit-review PR #464).
+func TestParser_RuleLookupMock_NilRuleSuccess_NoPanic(t *testing.T) {
+	mockLookup := &stubRuleLookup{rule: nil, err: nil}
+	p, err := rule.NewParser(mockLookup)
+	require.NoError(t, err)
+
+	// ParsePage
+	_, err = p.ParsePage(context.Background(), makeRaw("https://example.com/a", articleHTML))
+	require.Error(t, err)
+	var rerr *rule.Error
+	require.ErrorAs(t, err, &rerr)
+	assert.Equal(t, rule.ErrNoRule, rerr.Code)
+
+	// ParseLinks
+	_, err = p.ParseLinks(context.Background(), makeRaw("https://example.com/list", listHTML))
+	require.Error(t, err)
+	require.ErrorAs(t, err, &rerr)
+	assert.Equal(t, rule.ErrNoRule, rerr.Code)
+}


### PR DESCRIPTION
## 연관 이슈
- Closes #463

<br>

## 구현 내용

`internal/processor/parser/rule/` 의 OOP 정련 — 3가지 수행 항목 + 단위 테스트.

### (1) Parser 의 `*Resolver` → `RuleLookup` interface 의존
- 신규 `RuleLookup` interface (`ResolveByURL` 단일 메소드)
- `*Resolver` 가 자연스럽게 만족 — 운영 wiring 변경 없음
- 단위 테스트에서 mock 주입 가능 (cache / Redis 의존 제거)

### (2) `parser.go` 슬림화 — `extract.go` 분리
| 파일 | 변경 전 | 변경 후 |
|---|---|---|
| `parser.go` | 349 줄 (engine + 헬퍼 혼재) | 227 줄 (engine 진입점만) |
| `extract.go` | — | 149 줄 신설 — `extractField` / `extractFieldMulti` / `extractValue` / `extractDate` / `absoluteURL` / `validateRaw` / `hasRequiredSelector` / `defaultDateLayouts` |

→ Single Responsibility 명확화.

### (3) `parser/core.PromptCompletor` — pathinfer LLMClient layer 통합
- 신규 `PromptCompletor` interface in `parser/core/agent.go` — `Generate(ctx, system, user) → (string, error)`
- `pathinfer.LLMClient` 가 `core.PromptCompletor` 의 alias 로 전환 (기존 caller 호환 보존)
- Layer 비교 docstring 명시:
  - **Domain (selector / enriched)**: `RuleAgent` → claude.Pool
  - **Domain (path regex 추론)**: `PromptCompletor` → pkg/llm.\*
  - **Vendor primitive**: `RawAgent (= agent.Agent)` → claude.Pool

**중요 정정**: 이슈 #463 의 "중복 인터페이스 제거" 는 부정확 — pathinfer / llmgen 은 다른 abstraction layer 라 중복이 아니라 보완. 본 PR 은 layer 경계를 parser/core 에서 명시화하는 것이 정확한 정리.

### (4) RuleLookup mock 단위 테스트
- `stubRuleLookup` — interface mock
- `TestParser_RuleLookupMock_DirectInjection` — Resolver 의존 없이 Parser 검증
- `TestParser_RuleLookupMock_LookupError` — error propagation 검증

<br>

## 비-목표 (이슈 #463 명시)

- `PageLinkDiscovery` Strategy 패턴화 — premature abstraction 회피 (TODO 만)
- sub-package 모듈 경계 재배치 (`rule/engine/`, `rule/resolver/`, ...) — 별도 검토
- goquery 직결합 추상화 — ROI 낮음 (skip)

<br>

## CI / 머지 게이트 점검

### 변경 영향 범위
- 변경: `internal/processor/parser/rule/parser.go` (slim) + 신설 `extract.go` (분리), `internal/processor/parser/core/agent.go` (PromptCompletor 추가), `internal/processor/parser/rule/pathinfer/llm.go` (LLMClient alias), 테스트 추가
- 위험도: Low — pure refactor, signature 보존 (interface는 superset/alias), 모든 기존 테스트 통과

### Required Status Checks
- [ ] Commit Lint / PR Title Lint / Linked Issue Check / Format Check / Build / Test / Lint

### 롤백 계획
- 3 commit 독립 revert 가능

<br>

## TODO
- [x] (1) RuleLookup interface 추출 + Parser 가 interface 의존
- [x] (2) parser.go → extract.go 분리 (349 → 227 줄)
- [x] (3) PromptCompletor layer 통합 + pathinfer alias
- [x] (4) Parser RuleLookup mock 단위 테스트
- [x] gofmt / vet / build / go test -race ./... 그린

<br>

## 후속 (별도 이슈 검토)

- `rule/` sub-package 모듈 경계 재배치 (`rule/engine/`, `rule/resolver/`, `rule/blacklist/`, `rule/discovery/`)
- `PageLinkDiscovery` Strategy 패턴 — 신규 discovery 전략 필요 시
- pathinfer / 기타 caller 가 `core.PromptCompletor` 를 직접 import 하도록 alias 제거 단계 마이그레이션

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Enhanced parser architecture with improved modular design and flexible dependency management
  * Restructured parsing utilities and helper functions for better code organization
  * Established foundation for LLM-based parsing capabilities

* **Tests**
  * Expanded test coverage for parser rule resolution and error handling

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/EinSofINTEREST/IssueTracker/pull/464)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->