### PR TITLE
[FEAT#457] enriched_contents.rationale + factors 컬럼화 — scorer 진단 정보 영속화

### DIFF
--- a/internal/processor/enrich/core/model.go
+++ b/internal/processor/enrich/core/model.go
@@ -64,11 +64,15 @@ type EnrichedFacts struct {
 	Topics    []string  `json:"topics"`
 	Sentiment Sentiment `json:"sentiment"`
 
-	// Verifications / Context / TrustScore: 후속 sub-issue 에서 채움 (#448 / #449 / #450).
-	// 본 sub-issue 에서는 nil/empty 로 출발.
+	// Verifications / Context / TrustScore: sub-issue #448 / #449 / #450 에서 채움.
 	Verifications []Verification `json:"verifications,omitempty"`
 	Context       *PageContext   `json:"context,omitempty"`
 	TrustScore    *float64       `json:"trust_score,omitempty"`
+
+	// Rationale / TrustFactors: 이슈 #457 — scorer 진단 정보 영속화.
+	// TrustScore 가 nil 이면 두 필드도 zero-value (omitempty 로 wire 생략).
+	Rationale    string        `json:"rationale,omitempty"`
+	TrustFactors *ScoreFactors `json:"trust_factors,omitempty"`
 }
 
 // Verification 은 claim 별 외부 소스 대조 결과입니다 (#448 에서 사용).

--- a/internal/processor/enrich/worker/worker.go
+++ b/internal/processor/enrich/worker/worker.go
@@ -481,6 +481,10 @@ func (w *Worker) runScoring(
 	}
 	score := res.TrustScore
 	facts.TrustScore = &score
+	// 이슈 #457: scorer 진단 정보 (rationale + factors) 도 facts 에 첨부 → 후속 persistEnriched 가 DB 영속화.
+	facts.Rationale = res.Rationale
+	factors := res.Factors
+	facts.TrustFactors = &factors
 	log.WithFields(map[string]interface{}{
 		"job_id":      pm.ID,
 		"ref_id":      ref.ID,
@@ -518,12 +522,27 @@ func (w *Worker) persistEnriched(
 		return
 	}
 
+	// 이슈 #457 — scorer 진단 정보 영속화. TrustFactors 가 nil 이면 빈 객체.
+	var factorsJSON []byte
+	if facts.TrustFactors != nil {
+		factorsJSON, err = json.Marshal(facts.TrustFactors)
+		if err != nil {
+			log.WithFields(map[string]interface{}{
+				"job_id": pm.ID,
+				"ref_id": ref.ID,
+			}).WithError(err).Warn("marshal trust factors failed, persisting with empty factors")
+			factorsJSON = nil
+		}
+	}
+
 	rec := &model.EnrichedContentRecord{
 		ContentID:     ref.ID,
 		TrustScore:    *facts.TrustScore,
 		Facts:         factsJSON,
 		Verifications: verificationsJSON,
 		Context:       contextJSON,
+		Rationale:     facts.Rationale,
+		Factors:       factorsJSON,
 	}
 	if err := w.enrichedRepo.Upsert(ctx, rec); err != nil {
 		log.WithFields(map[string]interface{}{

--- a/internal/storage/model/enriched_content.go
+++ b/internal/storage/model/enriched_content.go
@@ -4,8 +4,10 @@ import "time"
 
 // EnrichedContentRecord 는 enriched_contents 테이블의 row 표현입니다 (이슈 #450).
 //
-// JSONB 필드 (Facts / Verifications / Context) 는 raw byte slice 로 보관 — DB 와 wire format
-// 양쪽에서 동일하게 다루기 위함. 호출자가 필요 시 json.Unmarshal 로 강타입 구조체로 변환.
+// JSONB 필드 (Facts / Verifications / Context / Factors) 는 raw byte slice 로 보관 — DB 와
+// wire format 양쪽에서 동일하게 다루기 위함. 호출자가 필요 시 json.Unmarshal 로 강타입 구조체로 변환.
+//
+// Rationale / Factors 는 이슈 #457 (migration 030) 으로 추가된 scorer 진단 필드.
 type EnrichedContentRecord struct {
 	ID            int64
 	ContentID     string
@@ -13,5 +15,7 @@ type EnrichedContentRecord struct {
 	Facts         []byte // JSONB
 	Verifications []byte // JSONB
 	Context       []byte // JSONB
+	Rationale     string // TEXT — scorer 가 산출한 trust_score 근거 텍스트 (이슈 #457)
+	Factors       []byte // JSONB — {claim_support_ratio, source_diversity, context_completeness} (이슈 #457)
 	EnrichedAt    time.Time
 }

--- a/internal/storage/postgres/enriched_content.go
+++ b/internal/storage/postgres/enriched_content.go
@@ -29,15 +29,18 @@ func NewEnrichedContentRepository(pool *pgxpool.Pool, log *logger.Logger) reposi
 // Upsert SQL — content_id UNIQUE 충돌 시 ON CONFLICT 로 UPDATE (재처리 안전).
 //
 // enriched_at 은 항상 NOW() 로 refresh — 마지막 enrich 시점 추적.
-// trust_score / facts / verifications / context 는 caller 가 매번 전달한 값으로 덮어쓰기.
+// trust_score / facts / verifications / context / rationale / factors 는 caller 가 매번 전달한 값으로 덮어쓰기.
+// rationale / factors 는 이슈 #457 (migration 030) 에서 추가된 scorer 진단 컬럼.
 const sqlUpsertEnrichedContent = `
-INSERT INTO enriched_contents (content_id, trust_score, facts, verifications, context)
-VALUES ($1, $2, $3, $4, $5)
+INSERT INTO enriched_contents (content_id, trust_score, facts, verifications, context, rationale, factors)
+VALUES ($1, $2, $3, $4, $5, $6, $7)
 ON CONFLICT (content_id) DO UPDATE
 SET trust_score   = EXCLUDED.trust_score,
     facts         = EXCLUDED.facts,
     verifications = EXCLUDED.verifications,
     context       = EXCLUDED.context,
+    rationale     = EXCLUDED.rationale,
+    factors       = EXCLUDED.factors,
     enriched_at   = NOW()
 RETURNING id, enriched_at
 `
@@ -49,9 +52,10 @@ func (r *pgEnrichedContentRepository) Upsert(ctx context.Context, rec *model.Enr
 	facts := nonNilJSONB(rec.Facts, "{}")
 	verifications := nonNilJSONB(rec.Verifications, "[]")
 	contextJSON := nonNilJSONB(rec.Context, "{}")
+	factors := nonNilJSONB(rec.Factors, "{}")
 
 	row := r.pool.QueryRow(ctx, sqlUpsertEnrichedContent,
-		rec.ContentID, rec.TrustScore, facts, verifications, contextJSON,
+		rec.ContentID, rec.TrustScore, facts, verifications, contextJSON, rec.Rationale, factors,
 	)
 	if err := row.Scan(&rec.ID, &rec.EnrichedAt); err != nil {
 		return fmt.Errorf("upsert enriched_content: %w", err)
@@ -60,7 +64,7 @@ func (r *pgEnrichedContentRepository) Upsert(ctx context.Context, rec *model.Enr
 }
 
 const sqlGetEnrichedContentByContentID = `
-SELECT id, content_id, trust_score, facts, verifications, context, enriched_at
+SELECT id, content_id, trust_score, facts, verifications, context, rationale, factors, enriched_at
 FROM enriched_contents
 WHERE content_id = $1
 `
@@ -71,6 +75,7 @@ func (r *pgEnrichedContentRepository) GetByContentID(ctx context.Context, conten
 	if err := row.Scan(
 		&rec.ID, &rec.ContentID, &rec.TrustScore,
 		&rec.Facts, &rec.Verifications, &rec.Context,
+		&rec.Rationale, &rec.Factors,
 		&rec.EnrichedAt,
 	); err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {

--- a/migrations/down/030_enriched_contents_rationale_factors.sql
+++ b/migrations/down/030_enriched_contents_rationale_factors.sql
@@ -1,0 +1,6 @@
+-- 030 (down): scorer 진단 컬럼 제거.
+-- 데이터 손실 주의 — 운영 환경에서 rollback 시 rationale/factors 영구 손실.
+
+ALTER TABLE enriched_contents
+  DROP COLUMN IF EXISTS rationale,
+  DROP COLUMN IF EXISTS factors;

--- a/migrations/up/030_enriched_contents_rationale_factors.sql
+++ b/migrations/up/030_enriched_contents_rationale_factors.sql
@@ -1,0 +1,22 @@
+-- 030_enriched_contents_rationale_factors: scorer 진단 정보 영속화 (이슈 #457)
+--
+-- 배경:
+--   PR #455 (이슈 #450) 가 scorer trust_score 만 enriched_contents 에 영속화하고
+--   rationale (점수 근거 텍스트) + factors (claim_support_ratio / source_diversity /
+--   context_completeness JSONB) 는 ProcessingMessage.Metadata 에만 임시 첨부.
+--   본 migration 으로 두 필드를 DB 컬럼으로 영속화 — 운영 진단 / 신뢰도 이상치 회고 /
+--   점수 회귀 분석에 활용 가능.
+--
+-- 운영 영향:
+--   ALTER TABLE ADD COLUMN ... DEFAULT 는 PostgreSQL 11+ 에서 metadata-only — full table
+--   rewrite 없이 빠르게 적용. 기존 row 는 default value (rationale='' / factors='{}') 를
+--   가지게 됨.
+
+ALTER TABLE enriched_contents
+  ADD COLUMN rationale TEXT NOT NULL DEFAULT '',
+  ADD COLUMN factors   JSONB NOT NULL DEFAULT '{}'::jsonb;
+
+COMMENT ON COLUMN enriched_contents.rationale IS
+  'Scorer 가 산출한 trust_score 근거 텍스트 (운영 진단용, 이슈 #457).';
+COMMENT ON COLUMN enriched_contents.factors IS
+  '{claim_support_ratio, source_diversity, context_completeness} JSONB — 점수 구성 진단 필드 (이슈 #457).';

--- a/test/internal/processor/enrich/worker/worker_test.go
+++ b/test/internal/processor/enrich/worker/worker_test.go
@@ -803,7 +803,7 @@ func TestEnrichWorker_Scoring_PersistsToEnrichedContents(t *testing.T) {
 		assert.NotEmpty(t, in.Facts)
 	}
 
-	// DB upsert 호출 검증
+	// DB upsert 호출 검증 — 이슈 #457: rationale + factors 도 함께 영속화 확인.
 	if assert.Len(t, repo.upsertCalls, 1) {
 		rec := repo.upsertCalls[0]
 		assert.Equal(t, "c-score", rec.ContentID)
@@ -811,9 +811,17 @@ func TestEnrichWorker_Scoring_PersistsToEnrichedContents(t *testing.T) {
 		assert.NotEmpty(t, rec.Facts)
 		assert.NotEmpty(t, rec.Verifications)
 		assert.NotEmpty(t, rec.Context)
+		assert.Equal(t, "Two sources corroborate.", rec.Rationale)
+		assert.NotEmpty(t, rec.Factors, "factors JSONB should be marshaled")
+		// factors JSON 의 내부 구조 검증
+		var factorsMap map[string]float64
+		require.NoError(t, json.Unmarshal(rec.Factors, &factorsMap))
+		assert.InDelta(t, 1.0, factorsMap["claim_support_ratio"], 1e-9)
+		assert.InDelta(t, 0.8, factorsMap["source_diversity"], 1e-9)
+		assert.InDelta(t, 0.6, factorsMap["context_completeness"], 1e-9)
 	}
 
-	// metadata.enriched_facts.trust_score 첨부 검증
+	// metadata.enriched_facts.trust_score / rationale / trust_factors 첨부 검증
 	var pm core.ProcessingMessage
 	require.NoError(t, json.Unmarshal(published.Value, &pm))
 	rawFacts, ok := pm.Metadata["enriched_facts"].(map[string]interface{})
@@ -821,6 +829,10 @@ func TestEnrichWorker_Scoring_PersistsToEnrichedContents(t *testing.T) {
 		ts, tsOK := rawFacts["trust_score"].(float64)
 		assert.True(t, tsOK)
 		assert.InDelta(t, 0.85, ts, 1e-9)
+		assert.Equal(t, "Two sources corroborate.", rawFacts["rationale"])
+		// trust_factors 도 metadata 에 동행
+		_, factorsOK := rawFacts["trust_factors"].(map[string]interface{})
+		assert.True(t, factorsOK, "trust_factors should be attached to metadata")
 	}
 }
 


### PR DESCRIPTION
## 연관 이슈
- Closes #457

<br>

## 구현 내용

PR #455 (이슈 #450) 가 `scorer.TrustScoreResult` 의 `TrustScore` 만 DB 에 영속화하고 `Rationale` (근거 텍스트) + `Factors` (구성 진단) 는 ProcessingMessage.Metadata 에만 임시 첨부했던 한계 해소.

### 1. DB migration 030

```sql
ALTER TABLE enriched_contents
  ADD COLUMN rationale TEXT NOT NULL DEFAULT '',
  ADD COLUMN factors   JSONB NOT NULL DEFAULT '{}'::jsonb;
```

- PostgreSQL 11+ metadata-only ALTER — full table rewrite 없이 빠른 적용
- 기존 row 는 default value (`rationale=''`, `factors='{}'`) 로 backfill
- down: `DROP COLUMN` (데이터 손실 주의)

### 2. Storage layer

- `model.EnrichedContentRecord` 에 `Rationale string` + `Factors []byte` 추가
- `pgEnrichedContentRepository`:
  - `sqlUpsertEnrichedContent` INSERT/UPDATE 컬럼 목록에 rationale / factors 추가
  - `sqlGetEnrichedContentByContentID` SELECT 컬럼 추가
  - factors JSONB nil fallback `"{}"` — `nonNilJSONB` 재사용

### 3. Enrich worker chain

- `EnrichedFacts` schema 확장:
  - `Rationale string`
  - `TrustFactors *ScoreFactors`
- `runScoring`: `TrustScoreResult` 의 Rationale + Factors 를 facts 에 첨부 (기존: TrustScore 만)
- `persistEnriched`: factors marshal → JSONB → `EnrichedContentRecord.Factors`. marshal 실패 시 best-effort (warn 로깅 + 빈 factors 진행)

### 4. 테스트 확장

기존 `TestEnrichWorker_Scoring_PersistsToEnrichedContents` 에 assertion 추가:
- DB upsert record 의 `Rationale` / `Factors` 검증
- factors JSONB 내부 구조 (claim_support_ratio / source_diversity / context_completeness)
- metadata.enriched_facts.rationale + trust_factors 첨부

<br>

## CI / 머지 게이트 점검

### 변경 영향 범위
- migration 030 신설
- 신규 model field 2개, postgres SQL 갱신
- worker chain 확장 (forward-first 정책 보존)
- 위험도: Low — schema 가법적 변경, 동작 변화 없음 (기존 trust_score 처리 그대로 + 진단 필드 추가)

### Required Status Checks
- [ ] Commit Lint / PR Title Lint / Linked Issue Check / Format Check / Build / Test / Lint

### 배포 절차
1. migration 030 apply (`make migrate`)
2. issuetracker 재배포 — 새 worker 가 rationale + factors 채움
3. 기존 row 는 default '' / '{}' 로 backfill — 다음 enrich 호출 시 자연스럽게 정상 값으로 교체

### 롤백 계획
- migration revert (030 down) — DROP COLUMN
- 코드 revert 시 EnrichedFacts.Rationale / TrustFactors 사용 사이트만 영향

<br>

## TODO
- [x] migration 030 up/down
- [x] EnrichedContentRecord + repository 확장
- [x] worker runScoring + persistEnriched chain
- [x] EnrichedFacts schema 확장
- [x] 테스트 assertion 추가
- [x] gofmt / vet / build / `go test -race ./...` 그린

<br>

## 후속 (별도)

- rationale / factors 기반 운영 쿼리 도구 (예: trust_score 낮은 케이스의 rationale 분포 / factor 별 평균 등) — 별도 이슈
- factors 의 개별 컬럼화 (JSONB → 3 컬럼) — 현재 JSONB 단일 컬럼으로 schema evolution 유연성 확보, 필요 시 후속

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Trust-scoring diagnostics have been enhanced to capture and store detailed information including rationale explanations and key scoring factors (claim support ratio, source diversity, and context completeness), enabling improved visibility into how content trust assessments are calculated and providing a clearer audit trail for scoring decisions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/EinSofINTEREST/IssueTracker/pull/467)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->