### PR TITLE
[FIX#470] claude — tool 권한 자동 허가 + enrich prompt output 예시

### DIFF
--- a/pkg/agent/claude/enrich.go
+++ b/pkg/agent/claude/enrich.go
@@ -79,6 +79,10 @@ func (w *Worker) RunSession(
 	args := []string{
 		"claude",
 		"--model", w.model,
+		// 이슈 #470 — 컨테이너 내 도구 권한 자동 허가. enrich worker 는 WebFetch / WebSearch 가
+		// 핵심 동작 의존성 (cross-verify / context 단계). 라이브 (2026-05-16) 에서 권한 부재로
+		// 14건 모두 검증 실패 확인 → 본 플래그로 일괄 허가.
+		"--dangerously-skip-permissions",
 		"-p", promptText,
 	}
 

--- a/pkg/agent/claude/worker.go
+++ b/pkg/agent/claude/worker.go
@@ -382,8 +382,10 @@ func (w *Worker) ExtractEnriched(ctx context.Context, host string, targetType mo
 	args := []string{
 		"claude",
 		"--model", w.model,
-		// --dangerously-skip-permissions 는 root user 환경에서 동작하지 않고, OAuth 인증 + -p 모드는
-		// 본 플래그 없이 정상 동작 — 라이브 검증 시 발견.
+		// 이슈 #470 — 도구 권한 자동 허가. 컨테이너 환경이므로 모든 tool 사용 허가.
+		// 라이브 검증 (2026-05-16) 에서 WebFetch / WebSearch 권한 부재로 enrich verification /
+		// context 단계가 무력화되는 케이스 확인 — 본 플래그로 자동 허가.
+		"--dangerously-skip-permissions",
 		"-p", promptText,
 	}
 

--- a/pkg/agent/claude/worker.go
+++ b/pkg/agent/claude/worker.go
@@ -382,9 +382,10 @@ func (w *Worker) ExtractEnriched(ctx context.Context, host string, targetType mo
 	args := []string{
 		"claude",
 		"--model", w.model,
-		// 이슈 #470 — 도구 권한 자동 허가. 컨테이너 환경이므로 모든 tool 사용 허가.
-		// 라이브 검증 (2026-05-16) 에서 WebFetch / WebSearch 권한 부재로 enrich verification /
-		// context 단계가 무력화되는 케이스 확인 — 본 플래그로 자동 허가.
+		// 이슈 #470 — 컨테이너 내 도구 권한 자동 허가. ExtractEnriched 자체는 selector 추출
+		// 단계라 외부 도구 호출이 적지만, 동일 컨테이너 / 동일 CLI 호출 패턴을 enrich 경로
+		// (RunSession) 와 일관되게 유지하기 위해 본 단계도 동일 플래그 적용. 격리된 docker
+		// 컨테이너 환경이므로 권한 prompt 가 prompt 만큼 자율 동작을 막는 비용이 더 크다.
 		"--dangerously-skip-permissions",
 		"-p", promptText,
 	}

--- a/pkg/llm/prompt/assets/enrich/claude/context.user.txt
+++ b/pkg/llm/prompt/assets/enrich/claude/context.user.txt
@@ -52,4 +52,31 @@ Output rules:
 - Source article's host is acceptable in `sources` only when it is the canonical source (e.g., official corporate site). Prefer external authoritative sources where possible.
 - All summaries / events / implications must be factually grounded in cited sources. When in doubt, omit.
 
-Return ONLY the JSON object.
+Example output (illustrative — your values will differ. Note: starts immediately with `{`, no preamble like "Based on..." or "Here is...":
+{
+  "background": [
+    {
+      "subject": "Acme Corp",
+      "category": "organization",
+      "summary": "Acme Corp is a publicly traded US logistics firm founded in 1987, headquartered in Ohio. It operated regional warehousing across the Midwest until rising debt prompted restructuring efforts in 2024.",
+      "sources": ["https://en.wikipedia.org/wiki/Acme_Corp"]
+    },
+    {
+      "subject": "Jane Doe",
+      "category": "person",
+      "summary": "Jane Doe served as Acme Corp's CEO since 2019 after a career at FedEx. She previously oversaw the 2022 Midwest expansion that is now cited as a major driver of the company's debt load.",
+      "sources": ["https://www.acmecorp.com/leadership/jane-doe"]
+    }
+  ],
+  "timeline": [
+    {"date": "2024-11", "event": "Acme Corp issued profit warning citing rising fuel costs.", "source": "https://www.reuters.com/business/acme-warning-2024-11"},
+    {"date": "2026-05-15", "event": "Acme Corp filed for Chapter 11 bankruptcy protection.", "source": "https://www.reuters.com/business/acme-bankruptcy-filing-2026-05-15"}
+  ],
+  "implications": {
+    "political": "",
+    "social": "1200 affected employees concentrated in three Midwest counties may strain local unemployment services.",
+    "technical": ""
+  }
+}
+
+Return ONLY the JSON object — no preamble, no markdown fences, no trailing prose. Begin your response with `{` and end with `}`.

--- a/pkg/llm/prompt/assets/enrich/claude/context.user.txt
+++ b/pkg/llm/prompt/assets/enrich/claude/context.user.txt
@@ -52,7 +52,7 @@ Output rules:
 - Source article's host is acceptable in `sources` only when it is the canonical source (e.g., official corporate site). Prefer external authoritative sources where possible.
 - All summaries / events / implications must be factually grounded in cited sources. When in doubt, omit.
 
-Example output (illustrative — your values will differ. Note: starts immediately with `{`, no preamble like "Based on..." or "Here is...":
+Example output (illustrative — your values will differ; starts immediately with `{`, no preamble like "Based on..." or "Here is..."):
 {
   "background": [
     {

--- a/pkg/llm/prompt/assets/enrich/claude/cross_verify.user.txt
+++ b/pkg/llm/prompt/assets/enrich/claude/cross_verify.user.txt
@@ -40,4 +40,28 @@ Source rules:
 
 Be honest about uncertainty — when in doubt, prefer "unverified" with a short note explaining what you searched and why it was inconclusive.
 
-Return ONLY the JSON object.
+Example output (illustrative — your values will differ):
+{
+  "verifications": [
+    {
+      "claim_idx": 0,
+      "verdict": "supported",
+      "sources": ["https://www.reuters.com/business/acme-bankruptcy-filing-2026-05-15", "https://www.bloomberg.com/news/articles/2026-05-15/acme-chapter-11"],
+      "note": "Both Reuters and Bloomberg confirm the May 15 Chapter 11 filing."
+    },
+    {
+      "claim_idx": 1,
+      "verdict": "contradicted",
+      "sources": ["https://www.sec.gov/cgi-bin/browse-edgar?action=getcompany&CIK=acme"],
+      "note": "SEC filing shows CEO transition announced May 12, not the bankruptcy date."
+    },
+    {
+      "claim_idx": 2,
+      "verdict": "unverified",
+      "sources": [],
+      "note": "Searched Reuters, AP, and local press; no independent coverage of the 1200 employee figure."
+    }
+  ]
+}
+
+Return ONLY the JSON object — no preamble, no markdown fences, no trailing prose.

--- a/pkg/llm/prompt/assets/enrich/claude/extract.user.txt
+++ b/pkg/llm/prompt/assets/enrich/claude/extract.user.txt
@@ -29,4 +29,22 @@ Extraction rules:
 
 Empty arrays are acceptable when the page lacks signal. Do not invent.
 
-Return ONLY the JSON object.
+Example output (illustrative — your values will differ):
+{
+  "entities": [
+    {"type": "person", "name": "Jane Doe", "mentions": 4},
+    {"type": "org", "name": "Acme Corp", "mentions": 2}
+  ],
+  "claims": [
+    {"text": "Acme Corp filed for bankruptcy on May 15.", "subject": "Acme Corp", "predicate": "filed for", "object": "bankruptcy"},
+    {"text": "The CEO Jane Doe stepped down the same day.", "subject": "Jane Doe", "predicate": "stepped down", "object": "CEO role"}
+  ],
+  "facts": [
+    {"key": "filing_date", "value": "2026-05-15"},
+    {"key": "employees_affected", "value": "1200", "unit": "people"}
+  ],
+  "topics": ["business", "economy"],
+  "sentiment": "negative"
+}
+
+Return ONLY the JSON object — no preamble, no markdown fences, no trailing prose.

--- a/pkg/llm/prompt/assets/enrich/claude/score.user.txt
+++ b/pkg/llm/prompt/assets/enrich/claude/score.user.txt
@@ -42,4 +42,15 @@ Output rules:
 - factors fields MUST also be in [0.0, 1.0] — they are diagnostic only, do not have to combine linearly to trust_score.
 - rationale is required and must be non-empty. No invented citations.
 
-Return ONLY the JSON object.
+Example output (illustrative — your values will differ):
+{
+  "trust_score": 0.72,
+  "rationale": "5 of 7 claims supported by independent reputable sources (Reuters, Bloomberg, SEC). One claim contradicted by SEC filing pulls the score down. Context has rich background on Acme Corp and Jane Doe with citations to Wikipedia and the official site. Source diversity moderate — 4 distinct domains across verifications and context.",
+  "factors": {
+    "claim_support_ratio":  0.71,
+    "source_diversity":     0.6,
+    "context_completeness": 0.8
+  }
+}
+
+Return ONLY the JSON object — no preamble, no markdown fences, no trailing prose.


### PR DESCRIPTION
## 연관 이슈
- Closes #470

<br>

## 구현 내용

### 1. claude CLI tool 권한 자동 허가 ([FIX])
- `pkg/agent/claude/worker.go` (ExtractEnriched) 와 `pkg/agent/claude/enrich.go` (RunSession) 의 `args` 양쪽에 `--dangerously-skip-permissions` 추가
- 라이브 (2026-05-16) 에서 enrich verification / context 단계 14건 모두 WebFetch 권한 부재로 실패 — 본 플래그로 컨테이너 격리 환경의 도구 사용 일괄 허가

### 2. 4 enrich prompt 에 output JSON 예시 추가 ([FEAT])
- `assets/enrich/claude/extract.user.txt` — entities / claims / facts / topics / sentiment 예시
- `assets/enrich/claude/cross_verify.user.txt` — supported / contradicted / unverified verdict 예시
- `assets/enrich/claude/context.user.txt` — background / timeline / implications 예시 + "`{` 로 시작" 강조 (라이브에서 context 만 0% 파싱)
- `assets/enrich/claude/score.user.txt` — trust_score / rationale / factors 예시

<br>

## CI / 머지 게이트 점검

### 변경 영향 범위
- 영향 패키지/모듈: `pkg/agent/claude`, `pkg/llm/prompt/assets/enrich/claude`
- 위험도: `Low` — 동작 토글 1개 + prompt 텍스트 변경. Go 코드 로직 변경 없음

### Required Status Checks
- [x] `Commit Lint`
- [x] `PR Title Lint`
- [x] `Linked Issue Check`
- [x] `Format Check`
- [x] `Build`
- [x] `Test`
- [x] `Lint`

### 롤백 계획
- `--dangerously-skip-permissions` 가 root 사용자 컨테이너에서 거부될 경우 → 본 PR revert 후 별도 `--allowedTools` allowlist 방식으로 재시도 (이슈 #470 follow-up)
- prompt 예시는 단순 텍스트 추가 — revert 영향 없음

<br>

## 비-목표 (별도 이슈)
- 인덱스 페이지 자동 블랙리스트 (#468)
- DB candidate_count=0 버그 (#469)
- 라이브 재검증 (본 PR 머지 후 별도 작업)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced permission handling for the Claude enrichment agent to ensure proper authorization behavior across environments.

* **Documentation**
  * Refined enrichment prompts with clearer output specifications and illustrative examples to improve consistency and detail in extracted entities, claims, facts, topics, and verification results.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/EinSofINTEREST/IssueTracker/pull/471?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->