### PR TITLE
[FEAT#476] parser index-only 휴리스틱 모듈 + 단위 테스트

### DIFF
--- a/internal/processor/parser/rule/indexonly/indexonly.go
+++ b/internal/processor/parser/rule/indexonly/indexonly.go
@@ -1,0 +1,230 @@
+// Package indexonly 은 ParsePage 결과가 카테고리/링크 hub 페이지 (index-only)
+// 처럼 보이는지 휴리스틱으로 판정합니다 (이슈 #468, sub-issue #476).
+//
+// 호출 측 (parser engine 또는 worker) 가 본 결과를 받아 parser_blacklist 자동
+// 강등 등의 액션을 수행합니다 — 본 패키지는 pure-logic 만 담당.
+//
+// 판정 기준 (AND):
+//
+//   - 본문이 짧음            : Page.MainContent rune 길이가 MinBodyRunes 미만
+//   - PublishedAt zero-value : 본문은 article 이 아닌 카테고리/목록
+//   - 링크 hub 신호 (둘 중 하나):
+//   - 링크 텍스트 비율이 MinLinkRatio 이상 — 페이지 텍스트의 대부분이 anchor
+//   - article-like link 가 MinArticleLinks 이상 — 카테고리/목록 페이지에 흔한 패턴
+//
+// 조건 결합을 AND 로 잡아 false-positive 회피.
+package indexonly
+
+import (
+	"net/url"
+	"strings"
+	"unicode/utf8"
+
+	"github.com/PuerkitoBio/goquery"
+
+	"issuetracker/internal/processor/parser/types"
+)
+
+// 기본 임계값. 호출자가 Config 로 override 하지 않으면 본 값 적용.
+const (
+	DefaultMinBodyRunes    = 200
+	DefaultMinLinkRatio    = 0.8
+	DefaultMinArticleLinks = 5
+)
+
+// Config 는 휴리스틱 임계값. zero 값은 default 로 보정.
+type Config struct {
+	MinBodyRunes    int     // Page.MainContent rune 길이 임계값
+	MinLinkRatio    float64 // link 텍스트 비율 임계값 (0.0~1.0)
+	MinArticleLinks int     // article-like link 수 임계값
+}
+
+// withDefaults 는 zero 필드를 default 로 채웁니다.
+func (c Config) withDefaults() Config {
+	if c.MinBodyRunes <= 0 {
+		c.MinBodyRunes = DefaultMinBodyRunes
+	}
+	if c.MinLinkRatio <= 0 {
+		c.MinLinkRatio = DefaultMinLinkRatio
+	}
+	if c.MinArticleLinks <= 0 {
+		c.MinArticleLinks = DefaultMinArticleLinks
+	}
+	return c
+}
+
+// Score 는 각 휴리스틱 조건의 결과를 풀어 담습니다. 로그/디버깅 / metric label 용.
+type Score struct {
+	BodyRunes        int     // Page.MainContent rune 길이
+	BodyShort        bool    // BodyRunes < cfg.MinBodyRunes
+	NoPublishedAt    bool    // Page.PublishedAt.IsZero()
+	LinkRatio        float64 // 페이지 전체 텍스트 대비 anchor 텍스트 비율 (0~1)
+	HighLinkRatio    bool    // LinkRatio >= cfg.MinLinkRatio
+	ArticleLinks     int     // article-like <a href> 수
+	ManyArticleLinks bool    // ArticleLinks >= cfg.MinArticleLinks
+}
+
+// IsIndexOnly 는 page 가 index-only 페이지로 보이는지 판정합니다.
+//
+// 인자:
+//   - page    : ParsePage 결과 (nil 이면 false + zero Score 반환 — defensive)
+//   - rawHTML : 원본 HTML — anchor 비율 및 article-like link 수 계산에 사용. 빈 문자열이면 HTML 의존 신호는 false.
+//   - cfg     : 임계값. zero 값은 default 사용.
+//
+// 반환:
+//   - ok    : true 면 index-only. false 면 article 등 일반 페이지.
+//   - score : 디버깅/로그 용 풀어쓴 판정 결과.
+func IsIndexOnly(page *types.Page, rawHTML string, cfg Config) (bool, Score) {
+	cfg = cfg.withDefaults()
+	if page == nil {
+		return false, Score{}
+	}
+
+	score := Score{
+		BodyRunes:     utf8.RuneCountInString(page.MainContent),
+		NoPublishedAt: page.PublishedAt.IsZero(),
+	}
+	score.BodyShort = score.BodyRunes < cfg.MinBodyRunes
+
+	score.LinkRatio, score.ArticleLinks = analyzeAnchors(rawHTML, page.URL)
+	score.HighLinkRatio = score.LinkRatio >= cfg.MinLinkRatio
+	score.ManyArticleLinks = score.ArticleLinks >= cfg.MinArticleLinks
+
+	// AND: 본문 부족 + 게시일 부재 + (링크 hub OR article-like link 다수)
+	ok := score.BodyShort && score.NoPublishedAt && (score.HighLinkRatio || score.ManyArticleLinks)
+	return ok, score
+}
+
+// analyzeAnchors 는 HTML 의 anchor 텍스트 비율과 article-like link 수를 계산합니다.
+// rawHTML 이 비었거나 parse 실패면 (0, 0) 반환 — 호출자는 HTML 의존 신호를 모두 false 로 인식.
+func analyzeAnchors(rawHTML, pageURL string) (linkRatio float64, articleLinks int) {
+	rawHTML = strings.TrimSpace(rawHTML)
+	if rawHTML == "" {
+		return 0, 0
+	}
+	doc, err := goquery.NewDocumentFromReader(strings.NewReader(rawHTML))
+	if err != nil {
+		return 0, 0
+	}
+
+	// 페이지 전체 텍스트는 <body> 의 텍스트로 측정 — html/head 부분은 제외해야 anchor 비율이 의미 있음.
+	bodySel := doc.Find("body")
+	if bodySel.Length() == 0 {
+		bodySel = doc.Selection
+	}
+	totalLen := utf8.RuneCountInString(collapseWhitespace(bodySel.Text()))
+	if totalLen == 0 {
+		return 0, 0
+	}
+
+	// LinkRatio / ArticleLinks 모두 same-host anchor 만 카운트 — 본 휴리스틱의 의도가
+	// "사이트 내부 hub 페이지" 탐지이므로 외부 도메인 anchor 는 양 신호 모두에서 제외.
+	// 외부 광고 / "관련 사이트" 영역이 ratio 를 부풀리는 false-positive 차단.
+	pageHost := hostOf(pageURL)
+	var linkTextLen int
+	seen := make(map[string]struct{})
+	bodySel.Find("a[href]").Each(func(_ int, a *goquery.Selection) {
+		href, ok := a.Attr("href")
+		if !ok {
+			return
+		}
+		if !isSameHostOrRelative(href, pageHost) {
+			return
+		}
+		linkTextLen += utf8.RuneCountInString(collapseWhitespace(a.Text()))
+		if !isArticleLike(href, pageHost) {
+			return
+		}
+		// 중복 href 는 한 번만 카운트 — 카테고리 페이지의 "더보기" 등 반복 anchor 보정.
+		if _, dup := seen[href]; dup {
+			return
+		}
+		seen[href] = struct{}{}
+		articleLinks++
+	})
+	if linkTextLen > totalLen {
+		// 안전장치 — 중첩 anchor 등 비정상 케이스에서 비율이 1 을 넘지 않도록 clamp.
+		linkTextLen = totalLen
+	}
+	linkRatio = float64(linkTextLen) / float64(totalLen)
+	return linkRatio, articleLinks
+}
+
+// isSameHostOrRelative 는 href 가 same-host (절대 URL) 이거나 상대 URL 인지 판정합니다.
+// 외부 도메인 anchor 를 LinkRatio 계산에서 제외하기 위한 사전 필터.
+func isSameHostOrRelative(href, pageHost string) bool {
+	href = strings.TrimSpace(href)
+	if href == "" || strings.HasPrefix(href, "#") || strings.HasPrefix(href, "javascript:") || strings.HasPrefix(href, "mailto:") {
+		return false
+	}
+	u, err := url.Parse(href)
+	if err != nil {
+		return false
+	}
+	if u.Host == "" {
+		return true // 상대 URL — same-host 로 간주
+	}
+	return pageHost != "" && strings.EqualFold(u.Host, pageHost)
+}
+
+// isArticleLike 는 href 가 article 후보로 보이는지 판정합니다.
+//
+// 기준:
+//   - 절대 URL 이면 host 가 pageHost 와 동일해야 함 (외부 도메인 제외)
+//   - 상대 URL 도 허용 (대다수 카테고리 페이지 내부 link)
+//   - path 가 "/" 만 있거나 fragment / anchor 만이면 제외
+//   - path 가 적어도 1 개의 segment 를 가지며 단순 "/" 가 아님
+func isArticleLike(href, pageHost string) bool {
+	href = strings.TrimSpace(href)
+	if href == "" || strings.HasPrefix(href, "#") || strings.HasPrefix(href, "javascript:") || strings.HasPrefix(href, "mailto:") {
+		return false
+	}
+	u, err := url.Parse(href)
+	if err != nil {
+		return false
+	}
+	if u.Host != "" && pageHost != "" && !strings.EqualFold(u.Host, pageHost) {
+		return false
+	}
+	p := strings.TrimSpace(u.Path)
+	if p == "" || p == "/" {
+		return false
+	}
+	// path 가 최소 1 개의 non-empty segment 를 가져야 함.
+	for _, seg := range strings.Split(p, "/") {
+		if seg != "" {
+			return true
+		}
+	}
+	return false
+}
+
+// hostOf 는 URL 의 host 만 추출합니다 (parse 실패 시 빈 문자열).
+func hostOf(rawURL string) string {
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return ""
+	}
+	return u.Host
+}
+
+// collapseWhitespace 는 연속된 공백 문자열을 단일 공백으로 변환합니다.
+// goquery.Text() 가 들여쓰기/줄바꿈 포함 텍스트를 반환하므로 텍스트 길이 측정의 노이즈를 제거.
+func collapseWhitespace(s string) string {
+	var b strings.Builder
+	b.Grow(len(s))
+	prevSpace := true // leading whitespace 무시
+	for _, r := range s {
+		if r == ' ' || r == '\t' || r == '\n' || r == '\r' {
+			if !prevSpace {
+				b.WriteByte(' ')
+				prevSpace = true
+			}
+			continue
+		}
+		b.WriteRune(r)
+		prevSpace = false
+	}
+	out := b.String()
+	return strings.TrimRight(out, " ")
+}

--- a/internal/processor/parser/rule/indexonly/indexonly.go
+++ b/internal/processor/parser/rule/indexonly/indexonly.go
@@ -18,6 +18,7 @@ package indexonly
 import (
 	"net/url"
 	"strings"
+	"unicode"
 	"unicode/utf8"
 
 	"github.com/PuerkitoBio/goquery"
@@ -120,6 +121,8 @@ func analyzeAnchors(rawHTML, pageURL string) (linkRatio float64, articleLinks in
 	// LinkRatio / ArticleLinks 모두 same-host anchor 만 카운트 — 본 휴리스틱의 의도가
 	// "사이트 내부 hub 페이지" 탐지이므로 외부 도메인 anchor 는 양 신호 모두에서 제외.
 	// 외부 광고 / "관련 사이트" 영역이 ratio 를 부풀리는 false-positive 차단.
+	// href trim / prefix 검사 / url.Parse 는 각 anchor 당 한 번만 수행하고 결과 *url.URL 을
+	// 두 helper 에 전달 — 중복 파싱 회피 (gemini PR #478 피드백).
 	pageHost := hostOf(pageURL)
 	var linkTextLen int
 	seen := make(map[string]struct{})
@@ -128,11 +131,19 @@ func analyzeAnchors(rawHTML, pageURL string) (linkRatio float64, articleLinks in
 		if !ok {
 			return
 		}
-		if !isSameHostOrRelative(href, pageHost) {
+		href = strings.TrimSpace(href)
+		if href == "" || strings.HasPrefix(href, "#") || strings.HasPrefix(href, "javascript:") || strings.HasPrefix(href, "mailto:") {
+			return
+		}
+		u, err := url.Parse(href)
+		if err != nil {
+			return
+		}
+		if !isSameHostOrRelative(u, pageHost) {
 			return
 		}
 		linkTextLen += utf8.RuneCountInString(collapseWhitespace(a.Text()))
-		if !isArticleLike(href, pageHost) {
+		if !isArticleLike(u, pageHost) {
 			return
 		}
 		// 중복 href 는 한 번만 카운트 — 카테고리 페이지의 "더보기" 등 반복 anchor 보정.
@@ -150,53 +161,30 @@ func analyzeAnchors(rawHTML, pageURL string) (linkRatio float64, articleLinks in
 	return linkRatio, articleLinks
 }
 
-// isSameHostOrRelative 는 href 가 same-host (절대 URL) 이거나 상대 URL 인지 판정합니다.
+// isSameHostOrRelative 는 *url.URL 이 same-host (절대 URL) 이거나 상대 URL 인지 판정합니다.
 // 외부 도메인 anchor 를 LinkRatio 계산에서 제외하기 위한 사전 필터.
-func isSameHostOrRelative(href, pageHost string) bool {
-	href = strings.TrimSpace(href)
-	if href == "" || strings.HasPrefix(href, "#") || strings.HasPrefix(href, "javascript:") || strings.HasPrefix(href, "mailto:") {
-		return false
-	}
-	u, err := url.Parse(href)
-	if err != nil {
-		return false
-	}
+func isSameHostOrRelative(u *url.URL, pageHost string) bool {
 	if u.Host == "" {
 		return true // 상대 URL — same-host 로 간주
 	}
 	return pageHost != "" && strings.EqualFold(u.Host, pageHost)
 }
 
-// isArticleLike 는 href 가 article 후보로 보이는지 판정합니다.
+// isArticleLike 는 *url.URL 이 article 후보로 보이는지 판정합니다.
 //
 // 기준:
 //   - 절대 URL 이면 host 가 pageHost 와 동일해야 함 (외부 도메인 제외)
 //   - 상대 URL 도 허용 (대다수 카테고리 페이지 내부 link)
-//   - path 가 "/" 만 있거나 fragment / anchor 만이면 제외
-//   - path 가 적어도 1 개의 segment 를 가지며 단순 "/" 가 아님
-func isArticleLike(href, pageHost string) bool {
-	href = strings.TrimSpace(href)
-	if href == "" || strings.HasPrefix(href, "#") || strings.HasPrefix(href, "javascript:") || strings.HasPrefix(href, "mailto:") {
-		return false
-	}
-	u, err := url.Parse(href)
-	if err != nil {
-		return false
-	}
+//   - path 가 "/" 만 있거나 비어있으면 제외
+//   - path 가 최소 1 개의 non-empty segment 를 가져야 함
+//
+// u.Path 는 url.Parse 가 query 를 RawQuery 로 분리한 뒤의 결과 — query 영향 자동 제거.
+func isArticleLike(u *url.URL, pageHost string) bool {
 	if u.Host != "" && pageHost != "" && !strings.EqualFold(u.Host, pageHost) {
 		return false
 	}
-	p := strings.TrimSpace(u.Path)
-	if p == "" || p == "/" {
-		return false
-	}
-	// path 가 최소 1 개의 non-empty segment 를 가져야 함.
-	for _, seg := range strings.Split(p, "/") {
-		if seg != "" {
-			return true
-		}
-	}
-	return false
+	// strings.Trim 은 앞뒤 "/" 를 모두 제거 — 한 개라도 non-empty segment 가 있으면 결과 non-empty.
+	return strings.Trim(strings.TrimSpace(u.Path), "/") != ""
 }
 
 // hostOf 는 URL 의 host 만 추출합니다 (parse 실패 시 빈 문자열).
@@ -210,12 +198,15 @@ func hostOf(rawURL string) string {
 
 // collapseWhitespace 는 연속된 공백 문자열을 단일 공백으로 변환합니다.
 // goquery.Text() 가 들여쓰기/줄바꿈 포함 텍스트를 반환하므로 텍스트 길이 측정의 노이즈를 제거.
+//
+// unicode.IsSpace 사용 — non-breaking space (U+00A0), ideographic space (U+3000) 등 다양한
+// 유니코드 공백을 정확히 흡수 (i18n 컨텐츠 길이 측정 정확도).
 func collapseWhitespace(s string) string {
 	var b strings.Builder
 	b.Grow(len(s))
 	prevSpace := true // leading whitespace 무시
 	for _, r := range s {
-		if r == ' ' || r == '\t' || r == '\n' || r == '\r' {
+		if unicode.IsSpace(r) {
 			if !prevSpace {
 				b.WriteByte(' ')
 				prevSpace = true

--- a/test/internal/processor/parser/rule/indexonly/indexonly_test.go
+++ b/test/internal/processor/parser/rule/indexonly/indexonly_test.go
@@ -1,0 +1,240 @@
+package indexonly_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"issuetracker/internal/processor/parser/rule/indexonly"
+	"issuetracker/internal/processor/parser/types"
+)
+
+// TestIsIndexOnly_Defaults_PositiveCases 는 카테고리/링크 hub 페이지가 index-only 로 분류되는지 검증합니다.
+func TestIsIndexOnly_Defaults_PositiveCases(t *testing.T) {
+	tests := []struct {
+		name string
+		page *types.Page
+		html string
+	}{
+		{
+			name: "daum 카테고리 — 짧은 본문 + zero published + 다수 article-like link",
+			page: &types.Page{
+				URL:         "https://news.daum.net/breakingnews/politics",
+				Title:       "정치",
+				MainContent: "정치 뉴스",
+				// PublishedAt zero
+			},
+			html: `<html><body>
+				<a href="/news/article-1">기사 1 제목 가나다라마바사</a>
+				<a href="/news/article-2">기사 2 제목 아자차카타파하</a>
+				<a href="/news/article-3">기사 3 제목 일이삼사오육칠</a>
+				<a href="/news/article-4">기사 4 제목 가나다라마바사</a>
+				<a href="/news/article-5">기사 5 제목 가나다라마바사</a>
+				<a href="/news/article-6">기사 6 제목 가나다라마바사</a>
+			</body></html>`,
+		},
+		{
+			name: "링크-허브 — 본문 사실상 anchor 텍스트뿐 → 높은 LinkRatio",
+			page: &types.Page{
+				URL:         "https://example.com/section/tech",
+				Title:       "Tech",
+				MainContent: "Tech",
+				// PublishedAt zero
+			},
+			html: `<html><body>
+				<nav>
+					<a href="/tech/ai">AI 인공지능 관련 최신 기사 모음</a>
+					<a href="/tech/cloud">클라우드 기술 동향 모음</a>
+					<a href="/tech/security">보안 이슈 정리 모음</a>
+					<a href="/tech/devops">DevOps 관련 글 모음</a>
+				</nav>
+			</body></html>`,
+		},
+		{
+			name: "본문 zero + PublishedAt zero + 다수 article-like (절대 URL 동일 호스트)",
+			page: &types.Page{
+				URL:         "https://news.daum.net/breakingnews",
+				Title:       "Breaking",
+				MainContent: "",
+			},
+			html: `<html><body>
+				<a href="https://news.daum.net/article/1">제목 1</a>
+				<a href="https://news.daum.net/article/2">제목 2</a>
+				<a href="https://news.daum.net/article/3">제목 3</a>
+				<a href="https://news.daum.net/article/4">제목 4</a>
+				<a href="https://news.daum.net/article/5">제목 5</a>
+				<a href="https://news.daum.net/article/6">제목 6</a>
+				<a href="https://news.daum.net/article/7">제목 7</a>
+			</body></html>`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ok, score := indexonly.IsIndexOnly(tt.page, tt.html, indexonly.Config{})
+			assert.True(t, ok, "expected index-only, score=%+v", score)
+		})
+	}
+}
+
+// TestIsIndexOnly_Defaults_NegativeCases 는 정상 article 페이지가 index-only 로 잘못 분류되지 않는지 검증합니다.
+func TestIsIndexOnly_Defaults_NegativeCases(t *testing.T) {
+	longBody := ""
+	for i := 0; i < 50; i++ {
+		longBody += "이것은 정상적인 기사 본문이며 충분한 길이를 가집니다. "
+	}
+
+	tests := []struct {
+		name string
+		page *types.Page
+		html string
+	}{
+		{
+			name: "정상 article — 긴 본문 + PublishedAt set",
+			page: &types.Page{
+				URL:         "https://news.daum.net/article/1234",
+				Title:       "정상 기사 제목",
+				MainContent: longBody,
+				PublishedAt: time.Date(2026, 5, 16, 10, 0, 0, 0, time.UTC),
+			},
+			html: `<html><body><article>` + longBody + `</article></body></html>`,
+		},
+		{
+			name: "긴 본문 + zero PublishedAt — published 부재만으로는 미달 (article 외 정적 페이지 보호)",
+			page: &types.Page{
+				URL:         "https://example.com/page",
+				Title:       "정적 페이지",
+				MainContent: longBody,
+				// PublishedAt zero — 그러나 본문 충분히 길어 index-only 아님
+			},
+			html: `<html><body>` + longBody + `</body></html>`,
+		},
+		{
+			name: "짧은 본문 + PublishedAt set — 게시일 있으면 article 로 신뢰",
+			page: &types.Page{
+				URL:         "https://example.com/short",
+				Title:       "짧은 글",
+				MainContent: "짧은 글 본문.",
+				PublishedAt: time.Date(2026, 5, 16, 10, 0, 0, 0, time.UTC),
+			},
+			html: `<html><body>짧은 글 본문.<a href="/x">link</a></body></html>`,
+		},
+		{
+			name: "짧은 본문 + zero PublishedAt — link 신호 없으면 index-only 아님",
+			page: &types.Page{
+				URL:         "https://example.com/blank",
+				Title:       "Blank",
+				MainContent: "짧음.",
+			},
+			html: `<html><body>짧음.</body></html>`,
+		},
+		{
+			name: "외부 도메인 link 만 있는 경우 — article-like 카운트 0",
+			page: &types.Page{
+				URL:         "https://example.com/page",
+				Title:       "Page",
+				MainContent: "짧음.",
+			},
+			html: `<html><body>
+				<a href="https://other.com/article/1">other 1</a>
+				<a href="https://other.com/article/2">other 2</a>
+				<a href="https://other.com/article/3">other 3</a>
+				<a href="https://other.com/article/4">other 4</a>
+				<a href="https://other.com/article/5">other 5</a>
+				<a href="https://other.com/article/6">other 6</a>
+				짧음.
+			</body></html>`,
+		},
+		{
+			name: "anchor 텍스트 비율 낮음 — 본문 위주",
+			page: &types.Page{
+				URL:         "https://example.com/x",
+				Title:       "X",
+				MainContent: "짧음.",
+			},
+			html: `<html><body>` + longBody + `<a href="/x">한줄</a></body></html>`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ok, score := indexonly.IsIndexOnly(tt.page, tt.html, indexonly.Config{})
+			assert.False(t, ok, "expected NOT index-only, score=%+v", score)
+		})
+	}
+}
+
+// TestIsIndexOnly_NilPage 는 nil page 입력 시 false + zero Score 반환을 검증합니다.
+func TestIsIndexOnly_NilPage(t *testing.T) {
+	ok, score := indexonly.IsIndexOnly(nil, "", indexonly.Config{})
+	assert.False(t, ok)
+	assert.Equal(t, indexonly.Score{}, score)
+}
+
+// TestIsIndexOnly_EmptyHTML 는 rawHTML 이 비어있으면 HTML 의존 신호가 모두 false 인지 검증합니다.
+func TestIsIndexOnly_EmptyHTML(t *testing.T) {
+	page := &types.Page{
+		URL:         "https://example.com/empty",
+		Title:       "Empty",
+		MainContent: "짧음.",
+	}
+	ok, score := indexonly.IsIndexOnly(page, "", indexonly.Config{})
+	assert.False(t, ok, "no HTML → 링크 신호 모두 false → AND 미충족")
+	assert.False(t, score.HighLinkRatio)
+	assert.False(t, score.ManyArticleLinks)
+	assert.Equal(t, 0, score.ArticleLinks)
+}
+
+// TestIsIndexOnly_CustomConfig 는 임계값 override 가 동작하는지 검증합니다.
+func TestIsIndexOnly_CustomConfig(t *testing.T) {
+	page := &types.Page{
+		URL:         "https://example.com/page",
+		Title:       "Page",
+		MainContent: "100자 이내의 본문입니다.",
+	}
+	// 비-anchor 텍스트 충분히 많아서 LinkRatio 가 default 0.8 미만 → HighLinkRatio false.
+	// 그리고 article-like link 가 2 개라 default MinArticleLinks=5 미만.
+	html := `<html><body>
+		이 페이지는 비교적 짧지만 anchor 만으로 구성되어 있지 않은 일반 페이지입니다.
+		본문 텍스트가 anchor 텍스트보다 훨씬 많아서 LinkRatio 가 충분히 낮습니다.
+		article-like link 는 두 개뿐이라 default MinArticleLinks 임계값 (5) 미만입니다.
+		<a href="/a/1">link 1</a>
+		<a href="/a/2">link 2</a>
+	</body></html>`
+
+	// default 임계값 (MinArticleLinks=5, MinLinkRatio=0.8) 이면 false
+	ok, score := indexonly.IsIndexOnly(page, html, indexonly.Config{})
+	assert.False(t, ok, "default 임계값에서 false 기대. score=%+v", score)
+
+	// 임계값을 2 로 낮추면 true
+	ok2, score2 := indexonly.IsIndexOnly(page, html, indexonly.Config{MinArticleLinks: 2})
+	assert.True(t, ok2, "score=%+v", score2)
+}
+
+// TestScoreFields 는 Score 구조체가 디버깅 가능한 모든 필드를 채우는지 검증합니다.
+func TestScoreFields(t *testing.T) {
+	page := &types.Page{
+		URL:         "https://example.com/cat",
+		Title:       "카테고리",
+		MainContent: "짧음.",
+	}
+	html := `<html><body>
+		<a href="/article/1">article 1 제목입니다</a>
+		<a href="/article/2">article 2 제목입니다</a>
+		<a href="/article/3">article 3 제목입니다</a>
+		<a href="/article/4">article 4 제목입니다</a>
+		<a href="/article/5">article 5 제목입니다</a>
+		<a href="/article/6">article 6 제목입니다</a>
+	</body></html>`
+
+	ok, score := indexonly.IsIndexOnly(page, html, indexonly.Config{})
+	assert.True(t, ok)
+	assert.Greater(t, score.BodyRunes, 0, "BodyRunes 측정")
+	assert.True(t, score.BodyShort)
+	assert.True(t, score.NoPublishedAt)
+	assert.GreaterOrEqual(t, score.LinkRatio, 0.0)
+	assert.LessOrEqual(t, score.LinkRatio, 1.0)
+	assert.Equal(t, 6, score.ArticleLinks)
+	assert.True(t, score.ManyArticleLinks)
+}


### PR DESCRIPTION
## 연관 이슈
- Closes #476
- Parent: #468

<br>

## 구현 내용

이슈 #468 의 sub-issue #476 — ParsePage 결과가 카테고리/링크 hub 페이지로 보이는지 판정하는 **pure-logic 휴리스틱 모듈** 도입. parser_blacklist 자동 강등 wiring 은 후속 sub-issue #477 에서 처리하여 reviewable diff 분리.

### 1. 신규 패키지: \`internal/processor/parser/rule/indexonly/\`

\`IsIndexOnly(page, rawHTML, cfg) (bool, Score)\` — pure function:

**판정 기준 (AND):**
- 본문이 짧음 — \`Page.MainContent\` rune 길이가 \`MinBodyRunes\` (default 200) 미만
- \`PublishedAt\` zero-value
- 링크 hub 신호 (둘 중 하나):
  - 동일 호스트 anchor 텍스트 비율이 \`MinLinkRatio\` (default 0.8) 이상
  - article-like link 가 \`MinArticleLinks\` (default 5) 이상

**Same-host 필터:** LinkRatio / ArticleLinks 모두 same-host anchor 만 카운트. 외부 광고 / 관련 사이트 영역이 ratio 를 부풀리는 false-positive 차단.

**Score 구조체:** 휴리스틱 개별 판정 결과 풀어쓴 bool 값들 + 측정치. 호출자가 metric 라벨 / WARN 로그에 활용.

### 2. 단위 테스트 (13 케이스)

\`test/internal/processor/parser/rule/indexonly/indexonly_test.go\`:

| 분류 | 케이스 |
|---|---|
| **Positive** (3) | daum 카테고리 / 링크 hub 페이지 / zero body + 다수 article-like link |
| **Negative** (6) | 정상 article / 긴 본문 zero published / 짧은 본문 published / 짧음만 (link 없음) / 외부 도메인 link only / anchor 비율 낮음 |
| **Edge** (4) | nil page / empty HTML / custom config override / Score 모든 필드 채움 |

<br>

## CI / 머지 게이트 점검

> [CI 운영 규약](docs/ci/conventions.md) 및 [Required Status Checks 단일 소스](docs/ci/status-checks.md)에 따라 작성합니다.

### 변경 영향 범위
- 영향 패키지/모듈: \`internal/processor/parser/rule/indexonly\`, \`test/internal/processor/parser/rule/indexonly\`
- 위험도(택1): **Low** — 신규 standalone 모듈 도입. 기존 호출 흐름 변경 없음 (\`IsIndexOnly\` 미호출 상태). 다음 sub-issue #477 의 wiring 머지 전까지는 운영에 영향 없음.

### Required Status Checks
- 통과 확인 대상 (PR Checks 탭에서 확인):
  - [ ] \`Commit Lint\`
  - [ ] \`PR Title Lint\`
  - [ ] \`Linked Issue Check\`
  - [ ] \`Format Check\`
  - [ ] \`Build\`
  - [ ] \`Test\`
  - [ ] \`Lint\`

### 로컬 검증
- ✅ \`make fmt\` 통과
- ✅ \`go build ./...\` 통과
- ✅ \`go test -race ./...\` 통과 (48 packages OK / 0 FAIL)
- ✅ \`go test -v ./test/internal/processor/parser/rule/indexonly/...\` 13/13 PASS

### 롤백 계획
- 본 PR revert — standalone 모듈이라 다른 코드에 영향 없음. revert 만으로 충분.

<br>

## TODO
- [ ] 본 PR 머지 후 sub-issue #477 작업 시작 — ParsePage 흐름에 wiring + 자동 등록 + metric + 로그

<br>

## 논의 사항

### Same-host 필터의 합리성
초기 구현은 모든 anchor 텍스트를 LinkRatio 에 포함했으나, "외부 도메인 link only" 케이스에서 false-positive 발생 (LinkRatio=0.82). 본 휴리스틱의 의도가 \"사이트 내부 hub 페이지\" 탐지이므로 LinkRatio / ArticleLinks 모두 same-host 필터 적용. 외부 ad / related-sites 영역의 영향 차단.

### AND 조건 강도
\`BodyShort && NoPublishedAt && (HighLinkRatio || ManyArticleLinks)\` — 세 layer 의 AND 로 false-positive 회피. 단일 신호만으로는 판정하지 않음 — 짧은 본문 + 게시일 있음 (정적 페이지) / 긴 본문 + 게시일 없음 (블로그) / 짧음 + link 없음 등 정상 케이스가 모두 negative 분류됨을 단위 테스트로 확인.

🤖 Generated with [Claude Code](https://claude.com/claude-code)