### PR TITLE
[FEAT#477] parser ParsePage 결과 index-only 자동 강등 wiring + metric + 로그

### DIFF
--- a/cmd/issuetracker/main.go
+++ b/cmd/issuetracker/main.go
@@ -180,16 +180,14 @@ func main() {
 		service.WithParserRuleQueryTimeout(dbCfg.QueryTimeout),
 		service.WithParserRuleInvalidator(ruleResolver),
 	)
-	ruleParser, err := rule.NewParser(ruleResolver)
-	if err != nil {
-		log.WithError(err).Fatal("failed to construct rule parser")
-	}
-
 	// page-parse 블랙리스트 — 카테고리 → article job 발행 단계에서 매칭 URL 차단.
 	// Enabled=false 시 Matcher 미주입 → parser_worker 가 모든 링크 그대로 발행 (기능 OFF).
 	//
 	// BlacklistService (이슈 #431) 가 decorator chain (timeout + invalidating cache) 을 내부 합성 +
 	// HandleLLMDecision 비즈니스 로직 캡슐화. Matcher 는 별도 구성 — read-only cache + match.
+	//
+	// 이슈 #477 — ruleParser 의 index-only 자동 강등 옵션에 blacklistSvc 를 주입하기 위해
+	// blacklist 구성 후 ruleParser 를 생성하도록 순서 정렬.
 	blacklistCfg, err := processorcfg.LoadBlacklist()
 	if err != nil {
 		log.WithError(err).Fatal("failed to load blacklist config")
@@ -215,6 +213,18 @@ func main() {
 		log.Info("page-parse blacklist enabled (parser_blacklist DB-backed)")
 	} else {
 		log.Info("page-parse blacklist disabled (BLACKLIST_ENABLED=false)")
+	}
+
+	// ruleParser 생성 — blacklistSvc 가 있으면 index-only 자동 강등 옵션 활성 (이슈 #477).
+	// blacklistCfg.Enabled=false 환경에서는 blacklistSvc 가 nil → 옵션이 noop → 기존 동작 유지.
+	autoDemoteMetrics := rule.NewAutoDemoteMetrics(metricsRegistry)
+	parserOpts := []rule.ParserOption{}
+	if blacklistSvc != nil {
+		parserOpts = append(parserOpts, rule.WithBlacklistAutoDemote(blacklistSvc, autoDemoteMetrics, log))
+	}
+	ruleParser, err := rule.NewParser(ruleResolver, parserOpts...)
+	if err != nil {
+		log.WithError(err).Fatal("failed to construct rule parser")
 	}
 
 	// Readiness check: 사이트 등록 전 parser_rules 가 seed 됐는지 검증.

--- a/internal/processor/parser/rule/auto_demote.go
+++ b/internal/processor/parser/rule/auto_demote.go
@@ -17,6 +17,8 @@ import (
 	"errors"
 	"net/url"
 	"regexp"
+	"strings"
+	"sync"
 
 	"issuetracker/internal/processor/parser/rule/indexonly"
 	"issuetracker/internal/storage"
@@ -33,17 +35,37 @@ type AutoDemoteRegisterer interface {
 }
 
 // autoDemoter 는 Parser 내부에 boxing 되는 자동 강등 동작. nil 이면 기능 비활성.
+//
+// wg 는 demoteAsync 가 spawn 한 goroutine 들의 in-flight 트래킹용 — Parser.WaitAutoDemote
+// 가 graceful shutdown / 테스트에서 race 회피로 대기.
 type autoDemoter struct {
 	repo    AutoDemoteRegisterer
 	metrics *AutoDemoteMetrics
 	log     *logger.Logger
+	wg      sync.WaitGroup
 }
 
-// demote 는 index-only 로 판정된 URL 을 parser_blacklist 에 등록합니다.
+// demoteAsync 는 demote 를 별도 goroutine 에서 실행합니다 (gemini PR #479 피드백).
+//
+// ParsePage 의 호출 워커가 DB Insert 지연에 발목 잡히지 않도록 비동기 처리. 부모 ctx 가
+// 호출 종료 시 cancel 되더라도 in-flight Insert 가 완료될 수 있도록 context.WithoutCancel
+// 으로 cancellation 만 분리 — logger fields / trace metadata 는 보존.
+func (d *autoDemoter) demoteAsync(ctx context.Context, rawURL string, score indexonly.Score) {
+	if d == nil {
+		return
+	}
+	d.wg.Add(1)
+	go func() {
+		defer d.wg.Done()
+		d.demote(context.WithoutCancel(ctx), rawURL, score)
+	}()
+}
+
+// demote 는 index-only 로 판정된 URL 을 parser_blacklist 에 동기 등록합니다.
 // 호출자는 score 를 같이 넘겨 로그 가시성 확보.
 //
-// ctx 는 caller (ParsePage) 의 ctx — query timeout / cancellation 전파.
-// 본 함수는 ParsePage 의 호출 후반 단계에서 호출되며 결과가 ParsePage return 값에 영향 X.
+// ctx 는 caller (demoteAsync) 의 ctx — query timeout 전파 (cancellation 은 분리됨).
+// 본 함수는 ParsePage return 값에 영향 X — 실패해도 caller 에 에러 전파 안 함.
 func (d *autoDemoter) demote(ctx context.Context, rawURL string, score indexonly.Score) {
 	if d == nil {
 		return
@@ -108,5 +130,5 @@ func pathPatternFromURL(rawURL string) (host, pathPattern string, ok bool) {
 	if p == "" {
 		p = "/"
 	}
-	return u.Host, "^" + regexp.QuoteMeta(p) + "$", true
+	return strings.ToLower(u.Host), "^" + regexp.QuoteMeta(p) + "$", true
 }

--- a/internal/processor/parser/rule/auto_demote.go
+++ b/internal/processor/parser/rule/auto_demote.go
@@ -1,0 +1,112 @@
+// auto_demote.go 는 ParsePage 결과가 index-only 페이지로 판정될 때 parser_blacklist 에
+// extract_links_only mode 로 자동 등록하는 helper 입니다 (이슈 #477).
+//
+// 본 helper 는 *Parser 의 optional 의존 — WithBlacklistAutoDemote 옵션이 주입되면
+// 활성화되고, 미주입이면 ParsePage 흐름에 영향을 주지 않음 (nil-safe).
+//
+// 정책:
+//   - URL parse 실패 → insert skip (host-wide catch-all over-reach 회피, service.HandleLLMDecision 와 동일)
+//   - Insert 성공 → metric Inc + WARN 로그
+//   - ErrDuplicate (이미 등록) → noop (정상 흡수)
+//   - 그 외 Insert 에러 → WARN 로그 (non-fatal — ParsePage 호출은 정상 결과 그대로 반환)
+
+package rule
+
+import (
+	"context"
+	"errors"
+	"net/url"
+	"regexp"
+
+	"issuetracker/internal/processor/parser/rule/indexonly"
+	"issuetracker/internal/storage"
+	"issuetracker/internal/storage/model"
+	"issuetracker/pkg/logger"
+)
+
+// AutoDemoteRegisterer 는 parser 가 의존하는 좁은 boundary — Insert 만 필요.
+// service.BlacklistService / repository.BlacklistRepository 모두 본 인터페이스를 만족.
+//
+// 좁은 인터페이스로 의존을 명시하여 service 패키지 import 회피 + 테스트 mock 가벼움.
+type AutoDemoteRegisterer interface {
+	Insert(ctx context.Context, rec *model.BlacklistRecord) error
+}
+
+// autoDemoter 는 Parser 내부에 boxing 되는 자동 강등 동작. nil 이면 기능 비활성.
+type autoDemoter struct {
+	repo    AutoDemoteRegisterer
+	metrics *AutoDemoteMetrics
+	log     *logger.Logger
+}
+
+// demote 는 index-only 로 판정된 URL 을 parser_blacklist 에 등록합니다.
+// 호출자는 score 를 같이 넘겨 로그 가시성 확보.
+//
+// ctx 는 caller (ParsePage) 의 ctx — query timeout / cancellation 전파.
+// 본 함수는 ParsePage 의 호출 후반 단계에서 호출되며 결과가 ParsePage return 값에 영향 X.
+func (d *autoDemoter) demote(ctx context.Context, rawURL string, score indexonly.Score) {
+	if d == nil {
+		return
+	}
+	host, pathPattern, ok := pathPatternFromURL(rawURL)
+	if !ok {
+		// URL parse 실패 — host-wide catch-all 회피 (service.HandleLLMDecision 와 동일 정책).
+		d.log.WithFields(map[string]interface{}{"url": rawURL}).
+			Warn("index-only auto-demote skipped — URL parse failed")
+		return
+	}
+
+	rec := &model.BlacklistRecord{
+		HostPattern: host,
+		PathPattern: pathPattern,
+		Reason:      "auto: index-only heuristic detected",
+		Source:      model.BlacklistSourceAuto,
+		Mode:        model.BlacklistModeExtractLinksOnly,
+		Enabled:     true,
+	}
+	if err := d.repo.Insert(ctx, rec); err != nil {
+		if errors.Is(err, storage.ErrDuplicate) {
+			// 이미 등록 — 매칭이 활성화돼 있다는 뜻이라 정상 흡수.
+			return
+		}
+		// non-fatal — ParsePage 자체는 page 결과를 정상 반환.
+		d.log.WithFields(map[string]interface{}{
+			"host": host,
+			"url":  rawURL,
+		}).WithError(err).Warn("index-only auto-demote insert failed (non-fatal)")
+		return
+	}
+
+	d.metrics.RecordAutoDemote(host)
+	d.log.WithFields(map[string]interface{}{
+		"host":             host,
+		"url":              rawURL,
+		"path_pattern":     pathPattern,
+		"body_runes":       score.BodyRunes,
+		"link_ratio":       score.LinkRatio,
+		"article_links":    score.ArticleLinks,
+		"blacklist_id":     rec.ID,
+		"blacklist_mode":   string(model.BlacklistModeExtractLinksOnly),
+		"blacklist_source": string(model.BlacklistSourceAuto),
+	}).Warn("index-only page auto-demoted to extract_links_only")
+}
+
+// pathPatternFromURL 은 sampleURL 의 path 를 ^/$ 로 anchor 한 정확 일치 RE2 regex 로 변환합니다.
+//
+// 반환:
+//   - host        : URL host (lower-case)
+//   - pathPattern : "^" + regexp.QuoteMeta(path) + "$" — 정확 일치
+//   - ok          : URL parse 성공 여부. false 면 host-wide catch-all 회피를 위해 호출자가 skip.
+//
+// 빈 path 는 "/" 로 normalize → "^/$" pattern (service.pathPatternFromURL 와 동일 정책).
+func pathPatternFromURL(rawURL string) (host, pathPattern string, ok bool) {
+	u, err := url.Parse(rawURL)
+	if err != nil || u.Host == "" {
+		return "", "", false
+	}
+	p := u.Path
+	if p == "" {
+		p = "/"
+	}
+	return u.Host, "^" + regexp.QuoteMeta(p) + "$", true
+}

--- a/internal/processor/parser/rule/auto_demote_metrics.go
+++ b/internal/processor/parser/rule/auto_demote_metrics.go
@@ -1,0 +1,66 @@
+// auto_demote_metrics.go 는 index-only 자동 강등 metric collector 입니다 (이슈 #477).
+//
+// Prometheus collector — 본 패키지의 다른 collector (refiner Metrics 등) 와 동일 패턴.
+//
+// Label 정책:
+//   - host: site 호스트명. 카디널리티는 등록된 site 수 (≈수십~수백) — bounded.
+
+package rule
+
+import (
+	"errors"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+// AutoDemoteMetrics 는 index-only 자동 강등의 Prometheus collector 입니다.
+//
+// nil-Metrics 또는 nil 내부 collector 는 모든 Record* 메소드가 noop —
+// 호출자는 nil 검사 없이 항상 호출 가능. NewAutoDemoteMetrics(nil) 또는
+// NewAutoDemoteMetrics(registry) 둘 다 허용.
+type AutoDemoteMetrics struct {
+	autoDemoted *prometheus.CounterVec // labels: host
+}
+
+// NewAutoDemoteMetrics 는 AutoDemoteMetrics 를 생성합니다.
+//
+// registry 가 nil 이면 모든 collector 가 nil — Record* 호출이 noop 으로 동작
+// (METRICS 비활성 환경 cover).
+//
+// 동일 registry 에 두 번 호출돼도 idempotent — 기존 collector 재사용 (panic 회피,
+// pkg/llm.MeasuredFactory / refiner.Metrics 동일 정책).
+func NewAutoDemoteMetrics(registry *prometheus.Registry) *AutoDemoteMetrics {
+	if registry == nil {
+		return &AutoDemoteMetrics{}
+	}
+	return &AutoDemoteMetrics{
+		autoDemoted: registerOrReuseAutoDemoteCounter(registry, prometheus.CounterOpts{
+			Name: "parser_index_page_auto_demoted_total",
+			Help: "Pages auto-demoted to extract_links_only by index-only heuristic, labeled by host.",
+		}, []string{"host"}),
+	}
+}
+
+// RecordAutoDemote 는 host 의 자동 강등 1건을 기록합니다 (Insert 성공 시).
+func (m *AutoDemoteMetrics) RecordAutoDemote(host string) {
+	if m == nil || m.autoDemoted == nil {
+		return
+	}
+	m.autoDemoted.WithLabelValues(host).Inc()
+}
+
+// registerOrReuseAutoDemoteCounter 는 collector 를 등록하거나 기존 collector 를 재사용합니다.
+// 동일 registry 에 두 번 NewAutoDemoteMetrics 호출 시 panic 회피.
+func registerOrReuseAutoDemoteCounter(registry *prometheus.Registry, opts prometheus.CounterOpts, labels []string) *prometheus.CounterVec {
+	counter := prometheus.NewCounterVec(opts, labels)
+	if err := registry.Register(counter); err != nil {
+		var are prometheus.AlreadyRegisteredError
+		if errors.As(err, &are) {
+			if existing, ok := are.ExistingCollector.(*prometheus.CounterVec); ok {
+				return existing
+			}
+		}
+		panic(err) // incompatible collector 충돌 — 운영자 개입 필요
+	}
+	return counter
+}

--- a/internal/processor/parser/rule/parser.go
+++ b/internal/processor/parser/rule/parser.go
@@ -88,9 +88,26 @@ func NewParser(resolver RuleLookup, opts ...ParserOption) (*Parser, error) {
 		dateLayouts: defaultDateLayouts(),
 	}
 	for _, opt := range opts {
+		if opt == nil {
+			continue // nil 옵션은 skip — 호출자 wiring 사고 방어 (coderabbit PR #479 피드백)
+		}
 		opt(p)
 	}
 	return p, nil
+}
+
+// WaitAutoDemote 는 in-flight auto-demote goroutine 들의 완료를 대기합니다.
+//
+// graceful shutdown 또는 테스트에서 race condition 회피용. autoDemoter 가 nil 이면
+// 즉시 반환 (기능 비활성 상태).
+//
+// ParsePage 가 spawn 한 비동기 demote goroutine 들은 본 메소드가 반환할 때까지 in-flight.
+// 호출 시점 이후 시작되는 새 goroutine 은 wait 대상 X — 명시적 barrier 시멘틱.
+func (p *Parser) WaitAutoDemote() {
+	if p.autoDemoter == nil {
+		return
+	}
+	p.autoDemoter.wg.Wait()
 }
 
 // ParsePage 는 RawContent 를 DB rule 기반으로 Page 로 파싱합니다 (types.ContentParser 구현).
@@ -165,9 +182,12 @@ func (p *Parser) ParsePage(ctx context.Context, raw *core.RawContent) (*types.Pa
 	// 이슈 #477 — index-only 페이지 자동 강등. autoDemoter 가 nil 이면 분기 자체 skip
 	// (기능 비활성 시 기존 동작 100% 유지). 본 호출의 page 자체는 정상 반환 — 다음 호출부터
 	// matcher 가 본 URL 을 extract_links_only 로 라우팅 (publisher 직전).
+	//
+	// demoteAsync 는 별도 goroutine — DB Insert 지연이 ParsePage 호출 워커 throughput 에
+	// 영향 X (gemini PR #479 피드백). 테스트는 Parser.WaitAutoDemote 로 in-flight 완료 대기.
 	if p.autoDemoter != nil {
 		if ok, score := indexonly.IsIndexOnly(page, raw.HTML, indexonly.Config{}); ok {
-			p.autoDemoter.demote(ctx, raw.URL, score)
+			p.autoDemoter.demoteAsync(ctx, raw.URL, score)
 		}
 	}
 	return page, nil

--- a/internal/processor/parser/rule/parser.go
+++ b/internal/processor/parser/rule/parser.go
@@ -10,8 +10,10 @@ import (
 	"github.com/PuerkitoBio/goquery"
 
 	"issuetracker/internal/processor/fetcher/core"
+	"issuetracker/internal/processor/parser/rule/indexonly"
 	"issuetracker/internal/processor/parser/types"
 	"issuetracker/internal/storage/model"
+	"issuetracker/pkg/logger"
 )
 
 // resolveTimeout 은 호출자 ctx 가 deadline 없을 때 추가 안전망입니다.
@@ -34,6 +36,31 @@ type Parser struct {
 	resolver    RuleLookup
 	discovery   *PageLinkDiscovery // full-page link discovery
 	dateLayouts []string           // PublishedAt try-list (앞쪽 우선)
+
+	// 이슈 #477 — ParsePage 결과가 index-only 페이지로 판정되면 parser_blacklist 에
+	// extract_links_only mode 로 자동 등록. nil 이면 기능 비활성 (기존 동작 100% 유지).
+	autoDemoter *autoDemoter
+}
+
+// ParserOption 은 NewParser 의 functional option 입니다.
+type ParserOption func(*Parser)
+
+// WithBlacklistAutoDemote 는 ParsePage 가 index-only 페이지로 판정한 URL 을
+// parser_blacklist 에 자동 등록하는 기능을 활성화합니다 (이슈 #477).
+//
+//   - repo    : Insert 만 사용. service.BlacklistService / repository.BlacklistRepository
+//     모두 AutoDemoteRegisterer 를 만족.
+//   - metrics : nil 허용. nil 이면 Record* 가 noop — 기능은 동작하지만 metric 노출 안 됨.
+//   - log     : non-nil 필수. WARN 로그 (auto-demote 발생 / Insert 실패) 출력.
+//
+// 인자 중 repo 또는 log 가 nil 이면 옵션 자체가 noop — 기존 ParsePage 흐름 유지.
+func WithBlacklistAutoDemote(repo AutoDemoteRegisterer, metrics *AutoDemoteMetrics, log *logger.Logger) ParserOption {
+	return func(p *Parser) {
+		if repo == nil || log == nil {
+			return
+		}
+		p.autoDemoter = &autoDemoter{repo: repo, metrics: metrics, log: log}
+	}
 }
 
 // RuleLookup 은 URL + target_type 으로 활성 ParserRule 을 조회하는 추상 (이슈 #463).
@@ -49,15 +76,21 @@ var _ RuleLookup = (*Resolver)(nil)
 
 // NewParser 는 RuleLookup 을 사용하는 Parser 를 생성합니다.
 // resolver 가 nil 이면 error — 호출자 (cmd/main) 가 boot fatal 처리.
-func NewParser(resolver RuleLookup) (*Parser, error) {
+//
+// opts 는 functional option (예: WithBlacklistAutoDemote). 호출자가 미지정하면 기존 동작 유지.
+func NewParser(resolver RuleLookup, opts ...ParserOption) (*Parser, error) {
 	if resolver == nil {
 		return nil, errors.New("rule: NewParser requires non-nil resolver")
 	}
-	return &Parser{
+	p := &Parser{
 		resolver:    resolver,
 		discovery:   NewPageLinkDiscovery(),
 		dateLayouts: defaultDateLayouts(),
-	}, nil
+	}
+	for _, opt := range opts {
+		opt(p)
+	}
+	return p, nil
 }
 
 // ParsePage 는 RawContent 를 DB rule 기반으로 Page 로 파싱합니다 (types.ContentParser 구현).
@@ -126,6 +159,15 @@ func (p *Parser) ParsePage(ctx context.Context, raw *core.RawContent) (*types.Pa
 			Message:    "Title or MainContent selector matched 0 elements (rule may be stale)",
 			URL:        raw.URL,
 			TargetType: string(model.TargetTypePage),
+		}
+	}
+
+	// 이슈 #477 — index-only 페이지 자동 강등. autoDemoter 가 nil 이면 분기 자체 skip
+	// (기능 비활성 시 기존 동작 100% 유지). 본 호출의 page 자체는 정상 반환 — 다음 호출부터
+	// matcher 가 본 URL 을 extract_links_only 로 라우팅 (publisher 직전).
+	if p.autoDemoter != nil {
+		if ok, score := indexonly.IsIndexOnly(page, raw.HTML, indexonly.Config{}); ok {
+			p.autoDemoter.demote(ctx, raw.URL, score)
 		}
 	}
 	return page, nil

--- a/test/internal/processor/parser/rule/auto_demote_test.go
+++ b/test/internal/processor/parser/rule/auto_demote_test.go
@@ -1,0 +1,202 @@
+package rule_test
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"issuetracker/internal/processor/parser/rule"
+	"issuetracker/internal/storage"
+	"issuetracker/internal/storage/model"
+	"issuetracker/pkg/logger"
+)
+
+// ─────────────────────────────────────────────────────────────────────────────
+// fakeAutoDemoteRepo — rule.AutoDemoteRegisterer mock
+// ─────────────────────────────────────────────────────────────────────────────
+
+type fakeAutoDemoteRepo struct {
+	mu        sync.Mutex
+	inserts   []*model.BlacklistRecord
+	insertErr error // 다음 Insert 호출에 반환할 에러 (테스트 케이스별 주입)
+}
+
+func (r *fakeAutoDemoteRepo) Insert(_ context.Context, rec *model.BlacklistRecord) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.insertErr != nil {
+		return r.insertErr
+	}
+	r.inserts = append(r.inserts, rec)
+	return nil
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 테스트 HTML — index-only 페이지 fixture
+// ─────────────────────────────────────────────────────────────────────────────
+
+const indexOnlyHTML = `<html><body>
+  <h1 class="hl">정치</h1>
+  <article>
+    <p>정치 카테고리</p>
+  </article>
+  <a href="/article/1">기사 1 제목입니다 충분히 길게</a>
+  <a href="/article/2">기사 2 제목입니다 충분히 길게</a>
+  <a href="/article/3">기사 3 제목입니다 충분히 길게</a>
+  <a href="/article/4">기사 4 제목입니다 충분히 길게</a>
+  <a href="/article/5">기사 5 제목입니다 충분히 길게</a>
+  <a href="/article/6">기사 6 제목입니다 충분히 길게</a>
+</body></html>`
+
+// indexOnlyPageRule 은 위 indexOnlyHTML 에 맞는 page rule 입니다.
+// PublishedAt selector 부재 → 항상 zero-value → IsIndexOnly 가 NoPublishedAt=true.
+func indexOnlyPageRule() *model.ParserRuleRecord {
+	return &model.ParserRuleRecord{
+		ID:          11,
+		SourceName:  "test",
+		HostPattern: "news.example.com",
+		TargetType:  model.TargetTypePage,
+		Version:     1,
+		Enabled:     true,
+		Selectors: model.SelectorMap{
+			Title:       &model.FieldSelector{CSS: "h1.hl"},
+			MainContent: &model.FieldSelector{CSS: "article p", Multi: true},
+		},
+	}
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// ParsePage + auto-demote 통합 테스트
+// ─────────────────────────────────────────────────────────────────────────────
+
+// TestParser_ParsePage_AutoDemote_TriggersInsert 는 index-only HTML 입력 시
+// blacklist Insert 가 정확히 1회 호출되고 record 가 올바른 mode/source 인지 검증합니다.
+func TestParser_ParsePage_AutoDemote_TriggersInsert(t *testing.T) {
+	repo := &fakeRepo{rules: []*model.ParserRuleRecord{indexOnlyPageRule()}}
+	res, _ := rule.NewResolver(repo)
+	bl := &fakeAutoDemoteRepo{}
+	log := logger.New(logger.DefaultConfig())
+
+	p, err := rule.NewParser(res, rule.WithBlacklistAutoDemote(bl, nil, log))
+	require.NoError(t, err)
+
+	page, err := p.ParsePage(context.Background(),
+		makeRaw("https://news.example.com/breakingnews/politics", indexOnlyHTML))
+	require.NoError(t, err)
+	// page 자체는 정상 반환 — 호출의 결과는 변경되지 않음
+	assert.Equal(t, "정치", page.Title)
+
+	require.Len(t, bl.inserts, 1, "expected exactly 1 Insert call")
+	rec := bl.inserts[0]
+	assert.Equal(t, "news.example.com", rec.HostPattern)
+	assert.Equal(t, "^/breakingnews/politics$", rec.PathPattern)
+	assert.Equal(t, model.BlacklistSourceAuto, rec.Source)
+	assert.Equal(t, model.BlacklistModeExtractLinksOnly, rec.Mode)
+	assert.True(t, rec.Enabled)
+	assert.Contains(t, rec.Reason, "auto: index-only")
+}
+
+// TestParser_ParsePage_AutoDemote_NotTriggeredOnArticle 는 정상 article (긴 본문 +
+// PublishedAt set) 에서 Insert 가 호출되지 않는지 검증합니다.
+func TestParser_ParsePage_AutoDemote_NotTriggeredOnArticle(t *testing.T) {
+	repo := &fakeRepo{rules: []*model.ParserRuleRecord{pageRule()}}
+	res, _ := rule.NewResolver(repo)
+	bl := &fakeAutoDemoteRepo{}
+	log := logger.New(logger.DefaultConfig())
+
+	p, err := rule.NewParser(res, rule.WithBlacklistAutoDemote(bl, nil, log))
+	require.NoError(t, err)
+
+	_, err = p.ParsePage(context.Background(),
+		makeRaw("https://news.example.com/article/1", articleHTML))
+	require.NoError(t, err)
+
+	assert.Empty(t, bl.inserts, "정상 article 에서 Insert 호출되면 안 됨")
+}
+
+// TestParser_ParsePage_AutoDemote_DisabledByDefault 는 옵션을 주지 않으면 Insert 가
+// 호출되지 않는지 (기존 동작 유지) 검증합니다.
+func TestParser_ParsePage_AutoDemote_DisabledByDefault(t *testing.T) {
+	repo := &fakeRepo{rules: []*model.ParserRuleRecord{indexOnlyPageRule()}}
+	res, _ := rule.NewResolver(repo)
+	bl := &fakeAutoDemoteRepo{}
+
+	p, err := rule.NewParser(res) // 옵션 미주입
+	require.NoError(t, err)
+
+	_, err = p.ParsePage(context.Background(),
+		makeRaw("https://news.example.com/breakingnews/politics", indexOnlyHTML))
+	require.NoError(t, err)
+
+	assert.Empty(t, bl.inserts, "옵션 미주입 시 autoDemoter 비활성 — Insert 호출되면 안 됨")
+}
+
+// TestParser_ParsePage_AutoDemote_DuplicateGracefullyAbsorbed 는 Insert 가 ErrDuplicate
+// 반환 시 ParsePage 가 정상 동작 + 호출자 모르게 흡수되는지 검증합니다.
+func TestParser_ParsePage_AutoDemote_DuplicateGracefullyAbsorbed(t *testing.T) {
+	repo := &fakeRepo{rules: []*model.ParserRuleRecord{indexOnlyPageRule()}}
+	res, _ := rule.NewResolver(repo)
+	bl := &fakeAutoDemoteRepo{insertErr: storage.ErrDuplicate}
+	log := logger.New(logger.DefaultConfig())
+
+	p, err := rule.NewParser(res, rule.WithBlacklistAutoDemote(bl, nil, log))
+	require.NoError(t, err)
+
+	page, err := p.ParsePage(context.Background(),
+		makeRaw("https://news.example.com/breakingnews/politics", indexOnlyHTML))
+	require.NoError(t, err, "Insert ErrDuplicate 는 ParsePage 에러로 전파되면 안 됨")
+	assert.Equal(t, "정치", page.Title)
+}
+
+// TestParser_ParsePage_AutoDemote_InsertFailureNonFatal 는 Insert 가 일반 에러 반환 시
+// ParsePage 가 page 결과를 정상 반환 (강등은 실패하지만 본 요청은 영향 X) 하는지 검증합니다.
+func TestParser_ParsePage_AutoDemote_InsertFailureNonFatal(t *testing.T) {
+	repo := &fakeRepo{rules: []*model.ParserRuleRecord{indexOnlyPageRule()}}
+	res, _ := rule.NewResolver(repo)
+	bl := &fakeAutoDemoteRepo{insertErr: errors.New("db connection lost")}
+	log := logger.New(logger.DefaultConfig())
+
+	p, err := rule.NewParser(res, rule.WithBlacklistAutoDemote(bl, nil, log))
+	require.NoError(t, err)
+
+	page, err := p.ParsePage(context.Background(),
+		makeRaw("https://news.example.com/breakingnews/politics", indexOnlyHTML))
+	require.NoError(t, err, "Insert 일반 에러도 ParsePage 결과에 영향 없어야 함 (non-fatal)")
+	assert.Equal(t, "정치", page.Title)
+}
+
+// TestParser_ParsePage_AutoDemote_NilLoggerOption 은 logger 가 nil 이면 옵션 자체가 noop
+// 인지 검증합니다 (방어 — main wiring 사고 회피).
+func TestParser_ParsePage_AutoDemote_NilLoggerOption(t *testing.T) {
+	repo := &fakeRepo{rules: []*model.ParserRuleRecord{indexOnlyPageRule()}}
+	res, _ := rule.NewResolver(repo)
+	bl := &fakeAutoDemoteRepo{}
+
+	p, err := rule.NewParser(res, rule.WithBlacklistAutoDemote(bl, nil, nil))
+	require.NoError(t, err)
+
+	_, err = p.ParsePage(context.Background(),
+		makeRaw("https://news.example.com/breakingnews/politics", indexOnlyHTML))
+	require.NoError(t, err)
+
+	assert.Empty(t, bl.inserts, "log nil → 옵션 noop → Insert 호출 X")
+}
+
+// TestParser_ParsePage_AutoDemote_NilRepoOption 은 repo 가 nil 이면 옵션 자체가 noop
+// 인지 검증합니다.
+func TestParser_ParsePage_AutoDemote_NilRepoOption(t *testing.T) {
+	repo := &fakeRepo{rules: []*model.ParserRuleRecord{indexOnlyPageRule()}}
+	res, _ := rule.NewResolver(repo)
+	log := logger.New(logger.DefaultConfig())
+
+	p, err := rule.NewParser(res, rule.WithBlacklistAutoDemote(nil, nil, log))
+	require.NoError(t, err)
+
+	_, err = p.ParsePage(context.Background(),
+		makeRaw("https://news.example.com/breakingnews/politics", indexOnlyHTML))
+	require.NoError(t, err, "repo nil → 옵션 noop → ParsePage 정상 동작")
+}

--- a/test/internal/processor/parser/rule/auto_demote_test.go
+++ b/test/internal/processor/parser/rule/auto_demote_test.go
@@ -77,7 +77,8 @@ func indexOnlyPageRule() *model.ParserRuleRecord {
 // blacklist Insert 가 정확히 1회 호출되고 record 가 올바른 mode/source 인지 검증합니다.
 func TestParser_ParsePage_AutoDemote_TriggersInsert(t *testing.T) {
 	repo := &fakeRepo{rules: []*model.ParserRuleRecord{indexOnlyPageRule()}}
-	res, _ := rule.NewResolver(repo)
+	res, errRes := rule.NewResolver(repo)
+	require.NoError(t, errRes)
 	bl := &fakeAutoDemoteRepo{}
 	log := logger.New(logger.DefaultConfig())
 
@@ -89,6 +90,8 @@ func TestParser_ParsePage_AutoDemote_TriggersInsert(t *testing.T) {
 	require.NoError(t, err)
 	// page 자체는 정상 반환 — 호출의 결과는 변경되지 않음
 	assert.Equal(t, "정치", page.Title)
+	// async demote goroutine 완료 대기 (gemini PR #479 피드백으로 비동기 처리)
+	p.WaitAutoDemote()
 
 	require.Len(t, bl.inserts, 1, "expected exactly 1 Insert call")
 	rec := bl.inserts[0]
@@ -104,7 +107,8 @@ func TestParser_ParsePage_AutoDemote_TriggersInsert(t *testing.T) {
 // PublishedAt set) 에서 Insert 가 호출되지 않는지 검증합니다.
 func TestParser_ParsePage_AutoDemote_NotTriggeredOnArticle(t *testing.T) {
 	repo := &fakeRepo{rules: []*model.ParserRuleRecord{pageRule()}}
-	res, _ := rule.NewResolver(repo)
+	res, errRes := rule.NewResolver(repo)
+	require.NoError(t, errRes)
 	bl := &fakeAutoDemoteRepo{}
 	log := logger.New(logger.DefaultConfig())
 
@@ -114,6 +118,7 @@ func TestParser_ParsePage_AutoDemote_NotTriggeredOnArticle(t *testing.T) {
 	_, err = p.ParsePage(context.Background(),
 		makeRaw("https://news.example.com/article/1", articleHTML))
 	require.NoError(t, err)
+	p.WaitAutoDemote() // 비동기 demote 가 spawn 되지 않았어야 함을 확정 — wait 자체 즉시 반환
 
 	assert.Empty(t, bl.inserts, "정상 article 에서 Insert 호출되면 안 됨")
 }
@@ -122,7 +127,8 @@ func TestParser_ParsePage_AutoDemote_NotTriggeredOnArticle(t *testing.T) {
 // 호출되지 않는지 (기존 동작 유지) 검증합니다.
 func TestParser_ParsePage_AutoDemote_DisabledByDefault(t *testing.T) {
 	repo := &fakeRepo{rules: []*model.ParserRuleRecord{indexOnlyPageRule()}}
-	res, _ := rule.NewResolver(repo)
+	res, errRes := rule.NewResolver(repo)
+	require.NoError(t, errRes)
 	bl := &fakeAutoDemoteRepo{}
 
 	p, err := rule.NewParser(res) // 옵션 미주입
@@ -139,7 +145,8 @@ func TestParser_ParsePage_AutoDemote_DisabledByDefault(t *testing.T) {
 // 반환 시 ParsePage 가 정상 동작 + 호출자 모르게 흡수되는지 검증합니다.
 func TestParser_ParsePage_AutoDemote_DuplicateGracefullyAbsorbed(t *testing.T) {
 	repo := &fakeRepo{rules: []*model.ParserRuleRecord{indexOnlyPageRule()}}
-	res, _ := rule.NewResolver(repo)
+	res, errRes := rule.NewResolver(repo)
+	require.NoError(t, errRes)
 	bl := &fakeAutoDemoteRepo{insertErr: storage.ErrDuplicate}
 	log := logger.New(logger.DefaultConfig())
 
@@ -150,13 +157,15 @@ func TestParser_ParsePage_AutoDemote_DuplicateGracefullyAbsorbed(t *testing.T) {
 		makeRaw("https://news.example.com/breakingnews/politics", indexOnlyHTML))
 	require.NoError(t, err, "Insert ErrDuplicate 는 ParsePage 에러로 전파되면 안 됨")
 	assert.Equal(t, "정치", page.Title)
+	p.WaitAutoDemote() // goroutine leak 방지
 }
 
 // TestParser_ParsePage_AutoDemote_InsertFailureNonFatal 는 Insert 가 일반 에러 반환 시
 // ParsePage 가 page 결과를 정상 반환 (강등은 실패하지만 본 요청은 영향 X) 하는지 검증합니다.
 func TestParser_ParsePage_AutoDemote_InsertFailureNonFatal(t *testing.T) {
 	repo := &fakeRepo{rules: []*model.ParserRuleRecord{indexOnlyPageRule()}}
-	res, _ := rule.NewResolver(repo)
+	res, errRes := rule.NewResolver(repo)
+	require.NoError(t, errRes)
 	bl := &fakeAutoDemoteRepo{insertErr: errors.New("db connection lost")}
 	log := logger.New(logger.DefaultConfig())
 
@@ -167,13 +176,15 @@ func TestParser_ParsePage_AutoDemote_InsertFailureNonFatal(t *testing.T) {
 		makeRaw("https://news.example.com/breakingnews/politics", indexOnlyHTML))
 	require.NoError(t, err, "Insert 일반 에러도 ParsePage 결과에 영향 없어야 함 (non-fatal)")
 	assert.Equal(t, "정치", page.Title)
+	p.WaitAutoDemote() // goroutine leak 방지
 }
 
 // TestParser_ParsePage_AutoDemote_NilLoggerOption 은 logger 가 nil 이면 옵션 자체가 noop
 // 인지 검증합니다 (방어 — main wiring 사고 회피).
 func TestParser_ParsePage_AutoDemote_NilLoggerOption(t *testing.T) {
 	repo := &fakeRepo{rules: []*model.ParserRuleRecord{indexOnlyPageRule()}}
-	res, _ := rule.NewResolver(repo)
+	res, errRes := rule.NewResolver(repo)
+	require.NoError(t, errRes)
 	bl := &fakeAutoDemoteRepo{}
 
 	p, err := rule.NewParser(res, rule.WithBlacklistAutoDemote(bl, nil, nil))
@@ -190,7 +201,8 @@ func TestParser_ParsePage_AutoDemote_NilLoggerOption(t *testing.T) {
 // 인지 검증합니다.
 func TestParser_ParsePage_AutoDemote_NilRepoOption(t *testing.T) {
 	repo := &fakeRepo{rules: []*model.ParserRuleRecord{indexOnlyPageRule()}}
-	res, _ := rule.NewResolver(repo)
+	res, errRes := rule.NewResolver(repo)
+	require.NoError(t, errRes)
 	log := logger.New(logger.DefaultConfig())
 
 	p, err := rule.NewParser(res, rule.WithBlacklistAutoDemote(nil, nil, log))
@@ -199,4 +211,50 @@ func TestParser_ParsePage_AutoDemote_NilRepoOption(t *testing.T) {
 	_, err = p.ParsePage(context.Background(),
 		makeRaw("https://news.example.com/breakingnews/politics", indexOnlyHTML))
 	require.NoError(t, err, "repo nil → 옵션 noop → ParsePage 정상 동작")
+}
+
+// TestNewParser_NilOptionGuarded 는 ParserOption 슬라이스에 nil 이 섞여도 panic 없이
+// skip 되는지 검증합니다 (coderabbit PR #479 피드백 — 호출자 wiring 사고 방어).
+func TestNewParser_NilOptionGuarded(t *testing.T) {
+	repo := &fakeRepo{rules: []*model.ParserRuleRecord{pageRule()}}
+	res, errRes := rule.NewResolver(repo)
+	require.NoError(t, errRes)
+
+	// nil 옵션이 섞인 슬라이스 — 호출자가 조건부로 옵션을 append 할 때 잘못된 nil entry 가 들어갈 수 있음
+	p, err := rule.NewParser(res, nil, nil)
+	require.NoError(t, err)
+	require.NotNil(t, p)
+
+	// 정상 동작 확인 — nil 만 있는 옵션이라 autoDemoter 도 미설정
+	_, err = p.ParsePage(context.Background(),
+		makeRaw("https://news.example.com/article/1", articleHTML))
+	require.NoError(t, err)
+}
+
+// TestParser_ParsePage_AutoDemote_LowercasesHost 는 대문자 host URL 의 path pattern
+// 등록 시 host_pattern 이 lower-case 로 정규화되는지 검증합니다 (coderabbit PR #479 피드백).
+//
+// rule 의 HostPattern 은 lowercase 로 저장되어 있고 (DB 컨벤션 + repo 자체가 ToLower),
+// 운영 환경에서는 fetcher 가 URL host 도 normalize 후 라우팅하지만, 본 helper 가 직접
+// URL.Host 를 사용하므로 helper 단에서 lowercase 보장이 필요. 본 테스트는 helper 의
+// pathPatternFromURL 가 host 를 lowercase 처리하는지를 화이트박스 검증.
+func TestParser_ParsePage_AutoDemote_LowercasesHost(t *testing.T) {
+	repo := &fakeRepo{rules: []*model.ParserRuleRecord{indexOnlyPageRule()}}
+	res, errRes := rule.NewResolver(repo)
+	require.NoError(t, errRes)
+	bl := &fakeAutoDemoteRepo{}
+	log := logger.New(logger.DefaultConfig())
+
+	p, err := rule.NewParser(res, rule.WithBlacklistAutoDemote(bl, nil, log))
+	require.NoError(t, err)
+
+	// URL host 에 대문자 — resolver 는 lowercase 라우팅, helper 는 URL.Host (대문자 그대로) 를
+	// 받아서 BlacklistRecord 등록 → pathPatternFromURL 의 ToLower 가 동작해야 lower-case 로 저장.
+	_, err = p.ParsePage(context.Background(),
+		makeRaw("https://News.Example.COM/breakingnews/politics", indexOnlyHTML))
+	require.NoError(t, err)
+	p.WaitAutoDemote()
+
+	require.Len(t, bl.inserts, 1)
+	assert.Equal(t, "news.example.com", bl.inserts[0].HostPattern, "host 는 lower-case 로 정규화돼야 함")
 }


### PR DESCRIPTION
## 연관 이슈
- Closes #477
- Parent: #468 (Depends on: #476 ✅ merged)

<br>

## 구현 내용

이슈 #468 의 sub-issue #477 — #476 머지로 도입된 \`indexonly.IsIndexOnly\` 휴리스틱을 \`rule.Parser.ParsePage\` 결과 처리 단계에 wiring. index-only 로 판정된 페이지는 parser_blacklist 에 \`source='auto'\`, \`mode='extract_links_only'\` 로 자동 등록되어 다음 호출부터 matcher 가 list 모드로 라우팅.

### 1. 신규 helper: \`internal/processor/parser/rule/auto_demote.go\`

- \`autoDemoter\` struct + \`demote(ctx, url, score)\` 메소드
- \`AutoDemoteRegisterer\` 좁은 interface (Insert 만) — \`service.BlacklistService\` / \`repository.BlacklistRepository\` 모두 만족 → service import 회피
- \`pathPatternFromURL\`: \`^/$\` anchor regex 로 정확 일치 pattern 생성. URL parse 실패 시 host-wide catch-all 회피 (\`service.HandleLLMDecision\` 동일 정책)

### 2. 신규 metric: \`internal/processor/parser/rule/auto_demote_metrics.go\`

- \`parser_index_page_auto_demoted_total{host="..."}\` Counter
- nil-safe (registry=nil 또는 \`*AutoDemoteMetrics\`=nil 둘 다 noop)
- \`registerOrReuseCounter\` 패턴으로 동일 registry 재호출 panic 회피
- host 라벨 카디널리티는 등록 site 수로 bounded

### 3. \`parser.go\` wiring

- \`ParserOption\` functional option 도입 + \`WithBlacklistAutoDemote(repo, metrics, log)\`
- \`Parser.autoDemoter\` 필드 (nil 이면 기능 비활성)
- ParsePage 결과 검증 후 index-only 분기 — **본 호출 page 자체는 정상 반환** (호출자 영향 없음), 다음 호출부터 matcher 가 본 URL 을 \`extract_links_only\` 로 라우팅

### 4. \`cmd/issuetracker/main.go\`

- blacklist 구성을 \`ruleParser\` 생성보다 먼저 수행 (참조 의존)
- \`blacklistSvc\` 가 있으면 \`rule.WithBlacklistAutoDemote(blacklistSvc, metrics, log)\` 주입
- \`BLACKLIST_ENABLED=false\` 환경에서는 옵션 자체 noop → 기존 동작 100% 유지

### 5. 단위 테스트 (7 케이스)

| 케이스 | 검증 |
|---|---|
| TriggersInsert | index-only HTML → Insert 1회 + host/path_pattern/source/mode 정확성 |
| NotTriggeredOnArticle | 정상 article (긴 body + PublishedAt) → Insert 호출 0회 |
| DisabledByDefault | 옵션 미주입 시 기존 동작 100% 유지 |
| DuplicateGracefullyAbsorbed | \`ErrDuplicate\` → ParsePage 결과에 영향 없이 흡수 |
| InsertFailureNonFatal | 일반 DB 에러 → ParsePage 결과 정상 반환 (non-fatal) |
| NilLoggerOption / NilRepoOption | 옵션 인자 nil → 옵션 자체 noop |

<br>

## CI / 머지 게이트 점검

### 변경 영향 범위
- 영향 패키지/모듈: \`internal/processor/parser/rule\`, \`cmd/issuetracker\`, \`test/internal/processor/parser/rule\`
- 위험도(택1): **Medium** — ParsePage 의 마지막 단계에 분기 추가. 휴리스틱 false-positive 시 정상 article URL 이 \`extract_links_only\` 로 등록될 수 있음. 단 (a) #476 에서 13 단위 테스트로 false-positive 회피 검증 (b) ParsePage 의 page 반환은 변경 없음 (c) 잘못 등록된 row 는 운영자가 수동 \`enabled=false\` 토글 가능.

### Required Status Checks
- 통과 확인 대상 (PR Checks 탭에서 확인):
  - [ ] \`Commit Lint\`
  - [ ] \`PR Title Lint\`
  - [ ] \`Linked Issue Check\`
  - [ ] \`Format Check\`
  - [ ] \`Build\`
  - [ ] \`Test\`
  - [ ] \`Lint\`

### 로컬 검증
- ✅ \`make fmt\` 통과
- ✅ \`go build ./...\` 통과
- ✅ \`go test -race ./...\` 48 packages OK / 0 FAIL
- ✅ \`go test -v ./test/internal/processor/parser/rule/...\` 신규 7 케이스 + 기존 케이스 모두 PASS

### 롤백 계획
1. 본 PR revert — \`WithBlacklistAutoDemote\` 옵션 미주입 상태로 복귀, ParsePage 기존 동작 그대로
2. 이미 자동 등록된 \`parser_blacklist\` row 는 운영자가 수동으로 \`enabled=false\` 또는 DELETE 처리

<br>

## TODO
- [ ] 본 PR 머지 후 라이브 환경에서 \`daum.net\` 카테고리 페이지 enrich 진입이 자동 차단되는지 5분 spot-check
- [ ] 이슈 #468 main 의 완료 조건 갱신 후 close

<br>

## 논의 사항

### 좁은 interface (\`AutoDemoteRegisterer\`)
\`service.BlacklistService\` 를 직접 의존하면 service 패키지 import 가 발생. 좁은 \`Insert\`-only interface 로 의존 표면 최소화. main.go 가 BlacklistService 를 그대로 전달하면 그 \`Insert\` 메소드가 자동으로 boundary 를 만족 — boilerplate 없음.

### Insert 동기 호출
ParsePage 후반에서 sync 로 Insert. 첫 발견 1회만 실제 DB write 발생하고, 이후는 matcher 가 인터셉트해서 ParsePage 자체가 더 호출되지 않으므로 비용 누적 없음. ErrDuplicate fast-path 도 빠른 반환.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic detection and blacklisting of index-only pages that contain only links or navigation content, preventing unnecessary processing and improving efficiency.

* **Tests**
  * Added comprehensive test coverage for the auto-demote functionality, including edge cases and error handling scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/EinSofINTEREST/IssueTracker/pull/479?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->