### PR TITLE
[FIX#480] llmgen auto-blacklist mode 분기 — 카테고리 페이지를 extract_links_only 로 등록

### DIFF
--- a/internal/processor/parser/rule/llmgen/extractor.go
+++ b/internal/processor/parser/rule/llmgen/extractor.go
@@ -32,6 +32,12 @@ type BlacklistDecision struct {
 	// Reason 은 운영자가 사후 분류 / 검증할 수 있도록 한국어로 작성된 사유.
 	// parser_blacklist.reason 컬럼에 그대로 저장.
 	Reason string
+
+	// Mode 는 parser_blacklist 등록 시 적용할 차단 정책입니다 (이슈 #480).
+	//   - "drop"               : URL 자체 drop — 광고 / interstitial / empty / captcha 등 본문/링크 모두 무가치한 케이스
+	//   - "extract_links_only" : list 모드로 강등 — 카테고리 / 섹션 인덱스 등 본문은 없지만 article-like link 가 있는 케이스
+	// 빈 문자열이면 호출자 (service.HandleLLMDecision) 가 default "drop" 으로 보정 — backward compat.
+	Mode model.BlacklistMode
 }
 
 // ExtractResult 는 EnrichedExtractor 의 다단계 추출 결과입니다.

--- a/internal/processor/parser/rule/llmgen/generator.go
+++ b/internal/processor/parser/rule/llmgen/generator.go
@@ -187,8 +187,10 @@ func (g *Generator) SetExtractor(e SelectorExtractor) {
 //
 // storage/service.BlacklistService 가 본 인터페이스를 만족 — Generator 는 service 패키지를
 // 직접 import 하지 않고 인터페이스만 의존 (의존성 역전).
+//
+// 이슈 #480 — mode 인자 추가. 빈 문자열이면 service 가 default "drop" 으로 보정.
 type BlacklistAutoRegister interface {
-	HandleLLMDecision(ctx context.Context, host, sampleURL string, targetType model.TargetType, reason string) (inserted bool, err error)
+	HandleLLMDecision(ctx context.Context, host, sampleURL string, targetType model.TargetType, reason string, mode model.BlacklistMode) (inserted bool, err error)
 }
 
 // SetBlacklistService 는 EnrichedExtractor 가 페이지를 blacklist 로 판정했을 때 등록할
@@ -783,7 +785,8 @@ func (g *Generator) handleBlacklistDecision(ctx context.Context, host, sampleURL
 		return
 	}
 	// service 가 INSERT / ErrDuplicate / 로그 모두 처리 — Generator 는 결과 무시 (모든 실패 non-fatal).
-	_, _ = g.blacklistSvc.HandleLLMDecision(ctx, host, sampleURL, targetType, decision.Reason)
+	// decision.Mode 가 빈 문자열이면 service 가 default "drop" 으로 보정 (이슈 #480).
+	_, _ = g.blacklistSvc.HandleLLMDecision(ctx, host, sampleURL, targetType, decision.Reason, decision.Mode)
 }
 
 // pathPatternFromURL 은 service/blacklist.go 로 이전 (이슈 #431).

--- a/internal/storage/service/blacklist.go
+++ b/internal/storage/service/blacklist.go
@@ -25,14 +25,15 @@ import (
 
 // BlacklistService 는 parser_blacklist 도메인의 비즈니스 boundary 입니다.
 type BlacklistService interface {
-	// HandleLLMDecision 은 LLM blacklist 판정 결과를 parser_blacklist 에 자동 등록합니다 (이슈 #326).
+	// HandleLLMDecision 은 LLM blacklist 판정 결과를 parser_blacklist 에 자동 등록합니다 (이슈 #326, #480).
 	//
 	//   - sample URL 의 path 를 escape + ^/$ anchor 한 정확 일치 regex 로 path_pattern 생성
 	//   - URL parse 실패 → insert skip (host-wide catch-all over-reach 회피)
+	//   - mode 인자가 빈 문자열이면 default "drop" — backward compat (이슈 #480)
 	//   - INSERT 성공 → (true, nil)
 	//   - ErrDuplicate (이미 등록) → (false, nil) — 정상 (graceful 흡수)
 	//   - 그 외 INSERT 에러 → (false, err) — 호출자 정책 (현재 모두 warn 로그 후 흐름 계속)
-	HandleLLMDecision(ctx context.Context, host, sampleURL string, targetType model.TargetType, reason string) (inserted bool, err error)
+	HandleLLMDecision(ctx context.Context, host, sampleURL string, targetType model.TargetType, reason string, mode model.BlacklistMode) (inserted bool, err error)
 
 	// Insert 는 row 를 직접 INSERT (운영자 manual 또는 다른 source 경로용).
 	Insert(ctx context.Context, rec *model.BlacklistRecord) error
@@ -91,12 +92,31 @@ func NewBlacklistService(repo repository.BlacklistRepository, log *logger.Logger
 }
 
 // HandleLLMDecision 흡수 — 기존 llmgen.Generator.handleBlacklistDecision 의 로직.
-func (s *blacklistService) HandleLLMDecision(ctx context.Context, host, sampleURL string, targetType model.TargetType, reason string) (bool, error) {
+//
+// mode 가 빈 문자열이거나 인식되지 않는 값이면 default "drop" 으로 보정 — backward compat
+// + 안전 (이슈 #480). 운영 가시성을 위해 fallback 시 WARN 로그 출력.
+func (s *blacklistService) HandleLLMDecision(ctx context.Context, host, sampleURL string, targetType model.TargetType, reason string, mode model.BlacklistMode) (bool, error) {
+	switch mode {
+	case model.BlacklistModeDrop, model.BlacklistModeExtractLinksOnly:
+		// 인식된 값 — 그대로 사용.
+	default:
+		// 빈 문자열 또는 unknown — drop 으로 보정.
+		if mode != "" {
+			s.log.WithFields(map[string]interface{}{
+				"host":           host,
+				"sample_url":     sampleURL,
+				"requested_mode": string(mode),
+			}).Warn("blacklist HandleLLMDecision: unknown mode, falling back to drop")
+		}
+		mode = model.BlacklistModeDrop
+	}
+
 	logFields := map[string]interface{}{
 		"host":             host,
 		"sample_url":       sampleURL,
 		"target_type":      string(targetType),
 		"blacklist_reason": reason,
+		"blacklist_mode":   string(mode),
 	}
 
 	pathPattern := pathPatternFromURL(sampleURL)
@@ -110,7 +130,7 @@ func (s *blacklistService) HandleLLMDecision(ctx context.Context, host, sampleUR
 		PathPattern: pathPattern,
 		Reason:      reason,
 		Source:      model.BlacklistSourceAuto,
-		Mode:        model.BlacklistModeDrop,
+		Mode:        mode,
 		Enabled:     true,
 	}
 	if err := s.repo.Insert(ctx, rec); err != nil {

--- a/pkg/agent/claude/worker.go
+++ b/pkg/agent/claude/worker.go
@@ -458,6 +458,7 @@ func (w *Worker) ExtractEnriched(ctx context.Context, host string, targetType mo
 type enrichedOutput struct {
 	Validity           string            `json:"validity"`
 	BlacklistReason    string            `json:"blacklist_reason"`
+	BlacklistMode      string            `json:"blacklist_mode"` // 이슈 #480 — "drop" | "extract_links_only" (legacy: 빈 문자열 → drop fallback)
 	PageType           string            `json:"page_type"`
 	PageTypeConfidence float64           `json:"page_type_confidence"`
 	Article            bool              `json:"article"`
@@ -490,8 +491,11 @@ func parseEnrichedOutput(output string) (*llmgen.ExtractResult, error) {
 		if reason == "" {
 			reason = "(no reason provided)"
 		}
+		// 이슈 #480 — mode 가 명시된 경우 ExtractLinksOnly / Drop 분기. 빈 값 또는 unknown 은
+		// 서비스 단에서 default drop 으로 보정되므로 본 단계는 단순 통과.
+		mode := model.BlacklistMode(strings.TrimSpace(eo.BlacklistMode))
 		return &llmgen.ExtractResult{
-			Blacklist: &llmgen.BlacklistDecision{Reason: reason},
+			Blacklist: &llmgen.BlacklistDecision{Reason: reason, Mode: mode},
 		}, nil
 	case "ok":
 		return &llmgen.ExtractResult{

--- a/pkg/agent/claude/worker.go
+++ b/pkg/agent/claude/worker.go
@@ -493,7 +493,9 @@ func parseEnrichedOutput(output string) (*llmgen.ExtractResult, error) {
 		}
 		// 이슈 #480 — mode 가 명시된 경우 ExtractLinksOnly / Drop 분기. 빈 값 또는 unknown 은
 		// 서비스 단에서 default drop 으로 보정되므로 본 단계는 단순 통과.
-		mode := model.BlacklistMode(strings.TrimSpace(eo.BlacklistMode))
+		// ToLower 정규화 — LLM 응답 case 변종 (DROP / Drop) 이 unknown 으로 downgrade 되어
+		// link harvest fallback 이 의도치 않게 막히는 케이스 회피 (coderabbit PR #481 피드백).
+		mode := model.BlacklistMode(strings.ToLower(strings.TrimSpace(eo.BlacklistMode)))
 		return &llmgen.ExtractResult{
 			Blacklist: &llmgen.BlacklistDecision{Reason: reason, Mode: mode},
 		}, nil

--- a/pkg/llm/prompt/assets/parser/claude/list.user.txt
+++ b/pkg/llm/prompt/assets/parser/claude/list.user.txt
@@ -9,6 +9,7 @@ Output schema:
 {
   "validity": "ok" or "blacklist",
   "blacklist_reason": "<korean reason if validity=blacklist, else null>",
+  "blacklist_mode": "drop" or "extract_links_only" (required if validity=blacklist, else null),
   "page_type": "news" | "community" | "info" | "commercial" | "paper" | "other",
   "page_type_confidence": <float 0.0 to 1.0>,
   "selectors": {
@@ -33,6 +34,11 @@ Validity decision rules:
   * Page with no parseable list of articles (just a single large component, embed widget, etc.)
 - "ok" otherwise. If "ok", you MUST fill `selectors` and `self_check` based on the actual HTML.
 - If "blacklist", `selectors` and `self_check` may be empty objects (`{}`), and `blacklist_reason` MUST be a short Korean explanation (e.g., "광고 페이지", "리스트 없음").
+
+Blacklist mode rules (required when validity="blacklist"):
+- "drop" — page is ads / paywall / empty / captcha / redirect landing and has no useful internal links to harvest. List target sees these as terminal — block the URL entirely.
+- "extract_links_only" — rare on a list target (list rule already extracts links); use only when the page is a non-standard hub layout that wraps article links but does not match the configured item_container selector well. The downstream router will retry as list.
+- When unsure, prefer "drop" — list-target pages that already lack a usable item_container are typically dead ends.
 
 Page type classification:
 - "news"       — news aggregator / category page with editorial article links

--- a/pkg/llm/prompt/assets/parser/claude/page.user.txt
+++ b/pkg/llm/prompt/assets/parser/claude/page.user.txt
@@ -9,6 +9,7 @@ Output schema:
 {
   "validity": "ok" or "blacklist",
   "blacklist_reason": "<korean reason if validity=blacklist, else null>",
+  "blacklist_mode": "drop" or "extract_links_only" (required if validity=blacklist, else null),
   "page_type": "news" | "community" | "info" | "commercial" | "paper" | "other",
   "page_type_confidence": <float 0.0 to 1.0>,
   "article": <boolean>,
@@ -37,8 +38,14 @@ Validity decision rules:
   * Pure navigation page with no article-like content
   * Captcha / bot-detection page
   * URL shortener / redirect landing
+  * Category / section index page (e.g., "/news/society", "/tech") that has no single article body but contains many article-like links
 - "ok" otherwise. If "ok", you MUST fill `selectors` and `self_check` based on the actual HTML.
-- If "blacklist", `selectors` and `self_check` may be empty objects (`{}`), and `blacklist_reason` MUST be a short Korean explanation (e.g., "광고 페이지", "로그인 요구", "빈 페이지").
+- If "blacklist", `selectors` and `self_check` may be empty objects (`{}`), and `blacklist_reason` MUST be a short Korean explanation (e.g., "광고 페이지", "로그인 요구", "빈 페이지", "카테고리 인덱스").
+
+Blacklist mode rules (required when validity="blacklist"):
+- "extract_links_only" — page has no single article body BUT contains many same-site article-like links (e.g., category / section landing / news index / hub). Downstream will refetch this URL as a list page to discover articles.
+- "drop" — page has neither body nor useful links (ads, paywalls, captcha, empty / 404 / login walls, URL shorteners, etc.). Fetch / parse / link extraction all blocked for this URL.
+- When unsure, prefer "drop" (conservative — no false-positive link harvesting from ad-laden pages).
 
 Page type classification:
 - "news"       — journalistic article (newspaper, broadcaster, news aggregator with editorial content)

--- a/test/internal/processor/parser/rule/llmgen/enriched_extractor_test.go
+++ b/test/internal/processor/parser/rule/llmgen/enriched_extractor_test.go
@@ -64,7 +64,7 @@ type recordingBlacklistRepo struct {
 // HandleLLMDecision 은 BlacklistAutoRegister 인터페이스를 만족합니다 (llmgen.Generator 가 의존).
 // 본 stub 은 실제 service 와 같은 path_pattern 변환 로직을 직접 수행 — 기존 테스트의 검증 부분
 // (rec.PathPattern Contains "/promo/123") 이 그대로 통과되도록.
-func (r *recordingBlacklistRepo) HandleLLMDecision(_ context.Context, host, sampleURL string, _ model.TargetType, reason string) (bool, error) {
+func (r *recordingBlacklistRepo) HandleLLMDecision(_ context.Context, host, sampleURL string, _ model.TargetType, reason string, mode model.BlacklistMode) (bool, error) {
 	u, err := url.Parse(sampleURL)
 	if err != nil {
 		return false, nil
@@ -73,12 +73,16 @@ func (r *recordingBlacklistRepo) HandleLLMDecision(_ context.Context, host, samp
 	if path == "" {
 		path = "/"
 	}
+	// 이슈 #480 — mode 인자 보정 (빈 문자열은 drop 으로 fallback, 실제 service 와 동일 정책).
+	if mode != model.BlacklistModeDrop && mode != model.BlacklistModeExtractLinksOnly {
+		mode = model.BlacklistModeDrop
+	}
 	rec := &model.BlacklistRecord{
 		HostPattern: host,
 		PathPattern: "^" + regexp.QuoteMeta(path) + "$",
 		Reason:      reason,
 		Source:      model.BlacklistSourceAuto,
-		Mode:        model.BlacklistModeDrop,
+		Mode:        mode,
 		Enabled:     true,
 	}
 	r.mu.Lock()

--- a/test/internal/storage/blacklist_handle_llm_decision_test.go
+++ b/test/internal/storage/blacklist_handle_llm_decision_test.go
@@ -1,0 +1,109 @@
+// blacklist_handle_llm_decision_test.go 는 service.BlacklistService.HandleLLMDecision 의
+// mode 분기 동작을 검증합니다 (이슈 #480).
+//
+// 검증 매트릭스:
+//   - mode='drop'                → drop 으로 그대로 등록
+//   - mode='extract_links_only'  → extract_links_only 로 등록
+//   - mode='' (빈 문자열)         → drop fallback
+//   - mode='unknown'             → drop fallback + WARN 로그
+
+package storage_test
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"issuetracker/internal/storage/model"
+	"issuetracker/internal/storage/service"
+)
+
+// fakeBlacklistInsertRepo 는 BlacklistRepository 의 Insert 동작만 캡처합니다.
+// 다른 메소드는 본 테스트 범위 밖이므로 noop / nil-safe 로 구현.
+type fakeBlacklistInsertRepo struct {
+	mu      sync.Mutex
+	inserts []*model.BlacklistRecord
+}
+
+func (r *fakeBlacklistInsertRepo) Insert(_ context.Context, rec *model.BlacklistRecord) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.inserts = append(r.inserts, rec)
+	return nil
+}
+func (r *fakeBlacklistInsertRepo) Update(_ context.Context, _ *model.BlacklistRecord) error {
+	return nil
+}
+func (r *fakeBlacklistInsertRepo) Delete(_ context.Context, _ int64) error { return nil }
+func (r *fakeBlacklistInsertRepo) GetByID(_ context.Context, _ int64) (*model.BlacklistRecord, error) {
+	return nil, nil
+}
+func (r *fakeBlacklistInsertRepo) FindEnabledByHost(_ context.Context, _ string) ([]*model.BlacklistRecord, error) {
+	return nil, nil
+}
+func (r *fakeBlacklistInsertRepo) List(_ context.Context, _ model.BlacklistFilter) ([]*model.BlacklistRecord, error) {
+	return nil, nil
+}
+
+// TestHandleLLMDecision_ModeMatrix 는 mode 인자의 4 가지 입력 (drop / extract_links_only / 빈 / unknown)
+// 이 모두 올바른 BlacklistRecord.Mode 로 INSERT 되는지 검증합니다.
+func TestHandleLLMDecision_ModeMatrix(t *testing.T) {
+	cases := []struct {
+		name      string
+		inputMode model.BlacklistMode
+		wantMode  model.BlacklistMode
+	}{
+		{"drop 그대로", model.BlacklistModeDrop, model.BlacklistModeDrop},
+		{"extract_links_only 그대로", model.BlacklistModeExtractLinksOnly, model.BlacklistModeExtractLinksOnly},
+		{"빈 문자열 → drop fallback", "", model.BlacklistModeDrop},
+		{"unknown 값 → drop fallback", model.BlacklistMode("garbage"), model.BlacklistModeDrop},
+	}
+
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			repo := &fakeBlacklistInsertRepo{}
+			svc := service.NewBlacklistService(repo, newTestLogger())
+
+			inserted, err := svc.HandleLLMDecision(
+				context.Background(),
+				"news.example.com",
+				"https://news.example.com/category/news",
+				model.TargetTypePage,
+				"카테고리 인덱스",
+				tt.inputMode,
+			)
+			require.NoError(t, err)
+			require.True(t, inserted)
+
+			require.Len(t, repo.inserts, 1)
+			assert.Equal(t, tt.wantMode, repo.inserts[0].Mode)
+			assert.Equal(t, model.BlacklistSourceAuto, repo.inserts[0].Source)
+			assert.Equal(t, "news.example.com", repo.inserts[0].HostPattern)
+			assert.Equal(t, "^/category/news$", repo.inserts[0].PathPattern)
+			assert.True(t, repo.inserts[0].Enabled)
+		})
+	}
+}
+
+// TestHandleLLMDecision_URLParseFailure_SkipsInsert 는 sample URL parse 실패 시 host-wide
+// catch-all 회피를 위해 Insert 가 스킵되는지 검증합니다 (mode 분기와 독립적인 정책).
+func TestHandleLLMDecision_URLParseFailure_SkipsInsert(t *testing.T) {
+	repo := &fakeBlacklistInsertRepo{}
+	svc := service.NewBlacklistService(repo, newTestLogger())
+
+	// 잘못된 URL (scheme + host 부재) → pathPattern="" → skip
+	inserted, err := svc.HandleLLMDecision(
+		context.Background(),
+		"news.example.com",
+		":::invalid:::",
+		model.TargetTypePage,
+		"reason",
+		model.BlacklistModeExtractLinksOnly,
+	)
+	require.NoError(t, err)
+	assert.False(t, inserted)
+	assert.Empty(t, repo.inserts, "URL parse 실패 시 Insert 호출되면 안 됨")
+}

--- a/test/pkg/agent/claude/parse_enriched_output_test.go
+++ b/test/pkg/agent/claude/parse_enriched_output_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"issuetracker/internal/processor/parser/rule/llmgen"
+	"issuetracker/internal/storage/model"
 )
 
 // TestExtractResult_BlacklistDecision_JSONShape 은 BlacklistDecision 이 운영자 manual review
@@ -29,11 +30,36 @@ func TestExtractResult_BlacklistDecision_JSONShape(t *testing.T) {
 	var unmarshalled struct {
 		Blacklist *struct {
 			Reason string `json:"Reason"`
+			Mode   string `json:"Mode"`
 		} `json:"Blacklist"`
 	}
 	require.NoError(t, json.Unmarshal(data, &unmarshalled))
 	require.NotNil(t, unmarshalled.Blacklist)
 	assert.Equal(t, "광고 페이지", unmarshalled.Blacklist.Reason)
+	assert.Equal(t, "", unmarshalled.Blacklist.Mode, "Mode 미설정 시 빈 문자열 직렬화 — service 가 default drop 으로 fallback")
+}
+
+// TestExtractResult_BlacklistDecision_ModeField 는 Mode 필드가 두 mode 값에 대해 round-trip
+// 직렬화/역직렬화 되는지 검증합니다 (이슈 #480).
+func TestExtractResult_BlacklistDecision_ModeField(t *testing.T) {
+	cases := []model.BlacklistMode{model.BlacklistModeDrop, model.BlacklistModeExtractLinksOnly}
+	for _, want := range cases {
+		t.Run(string(want), func(t *testing.T) {
+			res := llmgen.ExtractResult{
+				Blacklist: &llmgen.BlacklistDecision{
+					Reason: "카테고리 인덱스",
+					Mode:   want,
+				},
+			}
+			data, err := json.Marshal(res)
+			require.NoError(t, err)
+
+			var roundtrip llmgen.ExtractResult
+			require.NoError(t, json.Unmarshal(data, &roundtrip))
+			require.NotNil(t, roundtrip.Blacklist)
+			assert.Equal(t, want, roundtrip.Blacklist.Mode)
+		})
+	}
 }
 
 // TestPageType_Constants 는 claudegen prompt 와 storage layer 사이의 분류 string 계약이


### PR DESCRIPTION
## 연관 이슈
- Closes #480

<br>

## 구현 내용

이슈 #480 의 Option A 적용 — LLM 의 blacklist 판정 결과에 \`mode\` 신호를 명시적으로 추가하여, 카테고리/섹션 인덱스 페이지는 \`extract_links_only\` 모드로 등록되도록 분기.

### 1. \`llmgen.BlacklistDecision\` 에 \`Mode\` 필드 추가

\`internal/processor/parser/rule/llmgen/extractor.go\`:
\`\`\`go
type BlacklistDecision struct {
    Reason string
    Mode   model.BlacklistMode  // \"drop\" | \"extract_links_only\" — 빈 문자열은 service 가 drop fallback
}
\`\`\`

### 2. \`BlacklistService.HandleLLMDecision\` 시그니처 확장

\`internal/storage/service/blacklist.go\`:
\`\`\`go
HandleLLMDecision(ctx, host, sampleURL, targetType, reason string, mode model.BlacklistMode) (inserted bool, err error)
\`\`\`

- 인식된 두 mode 는 그대로 INSERT
- 빈 문자열 또는 unknown 값은 default \`drop\` 으로 보정 + WARN 로그 (backward compat + 안전)
- \`llmgen.Generator.handleBlacklistDecision\` 가 \`decision.Mode\` 를 forward

### 3. LLM 프롬프트 갱신

\`pkg/llm/prompt/assets/parser/claude/{page,list}.user.txt\`:

**Output schema** 에 \`blacklist_mode\` 필드 추가:
\`\`\`json
\"blacklist_mode\": \"drop\" or \"extract_links_only\" (required if validity=blacklist, else null)
\`\`\`

**Validity decision rules** 에 카테고리 케이스 추가 (page rule 기준):
- *Category / section index page (e.g., \`/news/society\`, \`/tech\`) that has no single article body but contains many article-like links*

**Blacklist mode rules** 신규 섹션:
- \`extract_links_only\` — 본문 없지만 same-site article-like links 다수
- \`drop\` — 본문도 링크도 무가치 (ads / paywall / captcha / empty / login)
- 불확실 시 \`drop\` 보수 분류

### 4. claudegen worker 파싱

\`pkg/agent/claude/worker.go\`:
- \`enrichedOutput\` 에 \`BlacklistMode string \`json:\"blacklist_mode\"\`\` 추가
- \`parseEnrichedOutput\` 가 \`validity=\"blacklist\"\` 분기에서 \`BlacklistDecision.Mode\` 에 전파

### 5. 단위 테스트

| 파일 | 신규 케이스 |
|---|---|
| \`test/internal/storage/blacklist_handle_llm_decision_test.go\` (신규) | mode 매트릭스 4 케이스 + URL parse 실패 |
| \`test/pkg/agent/claude/parse_enriched_output_test.go\` | Mode 필드 round-trip (drop / extract_links_only) |
| \`test/internal/processor/parser/rule/llmgen/enriched_extractor_test.go\` | stub 시그니처 + service 동일 fallback 정책 |

<br>

## CI / 머지 게이트 점검

### 변경 영향 범위
- 영향 패키지/모듈: \`internal/processor/parser/rule/llmgen\`, \`internal/storage/service\`, \`pkg/agent/claude\`, \`pkg/llm/prompt/assets/parser/claude\`, 테스트 다수
- 위험도(택1): **Medium** — \`BlacklistService.HandleLLMDecision\` interface 시그니처 변경. 호출처는 \`llmgen.Generator\` 단일. backward compat 은 \`mode=\"\"\` 입력의 drop fallback 으로 보장.

### Required Status Checks
- 통과 확인 대상 (PR Checks 탭에서 확인):
  - [ ] \`Commit Lint\`
  - [ ] \`PR Title Lint\`
  - [ ] \`Linked Issue Check\`
  - [ ] \`Format Check\`
  - [ ] \`Build\`
  - [ ] \`Test\`
  - [ ] \`Lint\`

### 로컬 검증
- ✅ \`make fmt\` 통과
- ✅ \`go build ./...\` 통과
- ✅ \`go test -race ./...\` 48 packages OK / 0 FAIL
- ✅ 신규 테스트 케이스 모두 PASS (mode 매트릭스 4 + URL parse 1 + JSON round-trip 2)

### 롤백 계획
1. 본 PR revert — interface 시그니처 변경이 있으나 LLM 측은 \`blacklist_mode\` 필드를 누락해도 정상 동작 (parser 가 빈 문자열로 받아 drop fallback). revert 후 즉시 머지 전 상태와 동등.
2. 이미 등록된 \`mode='extract_links_only'\` row 는 그대로 두면 (a) revert 후에도 의미 동일 (mode 컬럼은 #297 머지 후 존재), 또는 (b) 운영자가 수동으로 \`mode='drop'\` 으로 변경 가능.

<br>

## TODO
- [ ] 본 PR 머지 후 라이브 spot-check — daum.net 카테고리 URL 이 \`mode='extract_links_only'\` 로 등록되는지 확인
- [ ] (별건) #468 #477 의 휴리스틱-기반 auto-demote 와 본 LLM-기반 결정의 wiring 일관성 review

<br>

## 논의 사항

### Backward compat 정책
LLM 이 기존 프롬프트로 응답할 경우 (\`blacklist_mode\` 필드 부재) → \`Mode=\"\"\` → service 에서 drop 으로 fallback. 운영 환경에서는 새 프롬프트로 점진 전환되면서 자연스럽게 적용. 강제 마이그레이션 불필요.

### 휴리스틱 (#477) 과의 관계
- #477 의 \`indexonly.IsIndexOnly\` 휴리스틱은 **ParsePage 가 성공한 후** index-only 분기
- 본 PR (#480) 의 LLM 판정은 **ParsePage 가 실패한 후** llmgen 경로 분기
- 두 경로 모두 동일 mode (\`extract_links_only\`) 로 등록되어 운영 일관성 확보

### \`drop\` vs \`extract_links_only\` 의 conservative bias
프롬프트에 \"불확실 시 drop 선호\" 명시 — 광고-laden 페이지를 카테고리로 잘못 분류해 link harvesting 으로 광고 link 가 article job 으로 published 되는 false-positive 회피.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for two blacklist handling modes: drop URLs entirely or extract links only, enabling more granular control over content processing from blacklisted sources.

* **Tests**
  * Added comprehensive test coverage for blacklist mode selection and handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/EinSofINTEREST/IssueTracker/pull/481?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->