### PR TITLE
[FIX#486] enrich 프롬프트 JSON-only 강화 — CRITICAL OUTPUT CONTRACT 블록 추가

### DIFF
--- a/pkg/llm/prompt/assets/enrich/claude/context.user.txt
+++ b/pkg/llm/prompt/assets/enrich/claude/context.user.txt
@@ -1,5 +1,17 @@
 You are gathering external context for a news/community article. Go beyond the page itself — find background, timeline, and broader implications for the entities, events, and topics it covers.
 
+═══════════════════════════════════════════════════════════════
+CRITICAL OUTPUT CONTRACT — read first, applies to your ENTIRE response:
+═══════════════════════════════════════════════════════════════
+- Your response MUST be ONE raw JSON object — nothing else.
+- FIRST character MUST be `{`. LAST character MUST be `}`.
+- DO NOT start with: "I", "The", "Title", "Based on", "Sure", "Okay", "Here", "Let me", or any natural-language sentence.
+- DO NOT wrap in markdown fences (no ```json blocks, no ``` of any kind).
+- DO NOT append trailing prose after the closing brace.
+- If you cannot fulfill the task (no external sources, tools unavailable, entities ungrounded), STILL emit a valid JSON object with empty-field defaults per the schema (background=[], timeline=[], implications with all-empty strings). DO NOT apologize or explain in prose.
+- Violating responses are DISCARDED upstream — the article is logged as failed and re-attempted, wasting LLM quota and operational signal.
+═══════════════════════════════════════════════════════════════
+
 Source article:
 - URL: {{URL}}
 - Host: {{HOST}}
@@ -84,4 +96,4 @@ Example output (illustrative — your values will differ; starts immediately wit
   }
 }
 
-Return ONLY the JSON object — no preamble, no markdown fences, no trailing prose. Begin your response with `{` and end with `}`.
+Return ONLY the JSON object. First character `{`, last character `}`. No preamble, no markdown fences, no trailing prose. (See CRITICAL OUTPUT CONTRACT at the top.)

--- a/pkg/llm/prompt/assets/enrich/claude/context.user.txt
+++ b/pkg/llm/prompt/assets/enrich/claude/context.user.txt
@@ -8,7 +8,7 @@ CRITICAL OUTPUT CONTRACT — read first, applies to your ENTIRE response:
 - DO NOT start with: "I", "The", "Title", "Based on", "Sure", "Okay", "Here", "Let me", or any natural-language sentence.
 - DO NOT wrap in markdown fences (no ```json blocks, no ``` of any kind).
 - DO NOT append trailing prose after the closing brace.
-- If you cannot fulfill the task (no external sources, tools unavailable, entities ungrounded), STILL emit a valid JSON object with empty-field defaults per the schema (background=[], timeline=[], implications with all-empty strings). DO NOT apologize or explain in prose.
+- If you cannot fulfill the task (no external sources, tools unavailable, entities ungrounded), STILL emit a valid JSON object with empty-field defaults per the schema (background=[], timeline=[], implications object with each of `political`/`social`/`technical` set to ""). DO NOT apologize or explain in prose. The `implications` field MUST remain an object — do NOT replace it with a string.
 - Violating responses are DISCARDED upstream — the article is logged as failed and re-attempted, wasting LLM quota and operational signal.
 ═══════════════════════════════════════════════════════════════
 

--- a/pkg/llm/prompt/assets/enrich/claude/cross_verify.user.txt
+++ b/pkg/llm/prompt/assets/enrich/claude/cross_verify.user.txt
@@ -1,5 +1,17 @@
 You are verifying claims extracted from a news/community article. Your goal is to assess each claim against external sources.
 
+═══════════════════════════════════════════════════════════════
+CRITICAL OUTPUT CONTRACT — read first, applies to your ENTIRE response:
+═══════════════════════════════════════════════════════════════
+- Your response MUST be ONE raw JSON object — nothing else.
+- FIRST character MUST be `{`. LAST character MUST be `}`.
+- DO NOT start with: "I", "The", "Title", "Based on", "Sure", "Okay", "Here", "Let me", or any natural-language sentence.
+- DO NOT wrap in markdown fences (no ```json blocks, no ``` of any kind).
+- DO NOT append trailing prose after the closing brace.
+- If you cannot fulfill the task (tools unavailable, search returns nothing, ambiguous claims), STILL emit a valid JSON object with empty-field defaults per the schema (every claim_idx gets verdict="unverified", sources=[], short note). DO NOT apologize or explain in prose.
+- Violating responses are DISCARDED upstream — the article is logged as failed and re-attempted, wasting LLM quota and operational signal.
+═══════════════════════════════════════════════════════════════
+
 Source article:
 - URL: {{URL}}
 - Host: {{HOST}}
@@ -70,4 +82,4 @@ Example output (illustrative — your values will differ):
   ]
 }
 
-Return ONLY the JSON object — no preamble, no markdown fences, no trailing prose.
+Return ONLY the JSON object. First character `{`, last character `}`. No preamble, no markdown fences, no trailing prose. (See CRITICAL OUTPUT CONTRACT at the top.)

--- a/pkg/llm/prompt/assets/enrich/claude/cross_verify.user.txt
+++ b/pkg/llm/prompt/assets/enrich/claude/cross_verify.user.txt
@@ -8,7 +8,7 @@ CRITICAL OUTPUT CONTRACT — read first, applies to your ENTIRE response:
 - DO NOT start with: "I", "The", "Title", "Based on", "Sure", "Okay", "Here", "Let me", or any natural-language sentence.
 - DO NOT wrap in markdown fences (no ```json blocks, no ``` of any kind).
 - DO NOT append trailing prose after the closing brace.
-- If you cannot fulfill the task (tools unavailable, search returns nothing, ambiguous claims), STILL emit a valid JSON object with empty-field defaults per the schema (every claim_idx gets verdict="unverified", sources=[], short note). DO NOT apologize or explain in prose.
+- If you cannot fulfill the task (tools unavailable, search returns nothing, ambiguous claims), STILL emit a valid JSON object with empty-field defaults per the schema (every claim_idx gets verdict="unverified", sources=[], note="<short reason e.g. tools unavailable>"). The key MUST be `note` exactly — not `short_note`, `comment`, or any variant. DO NOT apologize or explain in prose.
 - Violating responses are DISCARDED upstream — the article is logged as failed and re-attempted, wasting LLM quota and operational signal.
 ═══════════════════════════════════════════════════════════════
 

--- a/pkg/llm/prompt/assets/enrich/claude/extract.user.txt
+++ b/pkg/llm/prompt/assets/enrich/claude/extract.user.txt
@@ -1,6 +1,18 @@
 Read the HTML file at {{SESSION_PATH}}/page.html from the {{HOST}} website.
 
-Your task: extract structured facts from this page. Return a single JSON object — no explanation, no markdown, no code blocks.
+Your task: extract structured facts from this page.
+
+═══════════════════════════════════════════════════════════════
+CRITICAL OUTPUT CONTRACT — read first, applies to your ENTIRE response:
+═══════════════════════════════════════════════════════════════
+- Your response MUST be ONE raw JSON object — nothing else.
+- FIRST character MUST be `{`. LAST character MUST be `}`.
+- DO NOT start with: "I", "The", "Title", "Based on", "Sure", "Okay", "Here", "Let me", or any natural-language sentence.
+- DO NOT wrap in markdown fences (no ```json blocks, no ``` of any kind).
+- DO NOT append trailing prose after the closing brace.
+- If you cannot fulfill the task (HTML insufficient, ambiguous content, refusal-worthy material), STILL emit a valid JSON object with empty-field defaults per the schema (empty arrays for entities/claims/facts/topics, "neutral" sentiment). DO NOT apologize or explain in prose.
+- Violating responses are DISCARDED upstream — the article is logged as failed and re-attempted, wasting LLM quota and operational signal.
+═══════════════════════════════════════════════════════════════
 
 Page URL: {{URL}}
 Page title: {{TITLE}}
@@ -47,4 +59,4 @@ Example output (illustrative — your values will differ):
   "sentiment": "negative"
 }
 
-Return ONLY the JSON object — no preamble, no markdown fences, no trailing prose.
+Return ONLY the JSON object. First character `{`, last character `}`. No preamble, no markdown fences, no trailing prose. (See CRITICAL OUTPUT CONTRACT at the top.)

--- a/pkg/llm/prompt/assets/enrich/claude/score.user.txt
+++ b/pkg/llm/prompt/assets/enrich/claude/score.user.txt
@@ -8,7 +8,7 @@ CRITICAL OUTPUT CONTRACT — read first, applies to your ENTIRE response:
 - DO NOT start with: "I", "The", "Title", "Based on", "Sure", "Okay", "Here", "Let me", or any natural-language sentence.
 - DO NOT wrap in markdown fences (no ```json blocks, no ``` of any kind).
 - DO NOT append trailing prose after the closing brace.
-- If inputs are sparse (no claims / no verifications / no context), STILL emit a valid JSON object: trust_score=0.0, factors all 0.0, rationale=<short reason mentioning sparse evidence>. DO NOT apologize or explain in prose outside the rationale field.
+- If inputs are sparse (no claims / no verifications / no context), STILL emit a valid JSON object: trust_score=0.0, factors object with each of `claim_support_ratio`/`source_diversity`/`context_completeness` set to 0.0, rationale="<short reason mentioning sparse evidence>". The `factors` field MUST remain an object — do NOT replace it with a scalar number. DO NOT apologize or explain in prose outside the rationale field.
 - Violating responses are DISCARDED upstream — the article is logged as failed and re-attempted, wasting LLM quota and operational signal.
 ═══════════════════════════════════════════════════════════════
 

--- a/pkg/llm/prompt/assets/enrich/claude/score.user.txt
+++ b/pkg/llm/prompt/assets/enrich/claude/score.user.txt
@@ -1,5 +1,17 @@
 You are computing a single page-level trust score (0.0 ~ 1.0) for an enriched article.
 
+═══════════════════════════════════════════════════════════════
+CRITICAL OUTPUT CONTRACT — read first, applies to your ENTIRE response:
+═══════════════════════════════════════════════════════════════
+- Your response MUST be ONE raw JSON object — nothing else.
+- FIRST character MUST be `{`. LAST character MUST be `}`.
+- DO NOT start with: "I", "The", "Title", "Based on", "Sure", "Okay", "Here", "Let me", or any natural-language sentence.
+- DO NOT wrap in markdown fences (no ```json blocks, no ``` of any kind).
+- DO NOT append trailing prose after the closing brace.
+- If inputs are sparse (no claims / no verifications / no context), STILL emit a valid JSON object: trust_score=0.0, factors all 0.0, rationale=<short reason mentioning sparse evidence>. DO NOT apologize or explain in prose outside the rationale field.
+- Violating responses are DISCARDED upstream — the article is logged as failed and re-attempted, wasting LLM quota and operational signal.
+═══════════════════════════════════════════════════════════════
+
 Source article:
 - URL: {{URL}}
 - Host: {{HOST}}
@@ -53,4 +65,4 @@ Example output (illustrative — your values will differ):
   }
 }
 
-Return ONLY the JSON object — no preamble, no markdown fences, no trailing prose.
+Return ONLY the JSON object. First character `{`, last character `}`. No preamble, no markdown fences, no trailing prose. (See CRITICAL OUTPUT CONTRACT at the top.)


### PR DESCRIPTION
## 연관 이슈
- Closes #486

<br>

## 구현 내용

라이브 spot-check 에서 enrich extract 단계 LLM 응답이 JSON 대신 prose 로 emit 되는 케이스가 \`n.news.naver.com\` host 중심으로 36% (4/11) 발생. 현재 4개 enrich 프롬프트의 JSON-only 지시가 **마지막 줄에만** 존재해 LLM 이 응답 시작 시 본 지시를 \"가까이서\" 보지 않는 구조적 약점.

### 변경 대상

\`pkg/llm/prompt/assets/enrich/claude/{extract,cross_verify,context,score}.user.txt\` 4개 파일 모두에 **상단 (task 소개 직후)** CRITICAL OUTPUT CONTRACT 블록 삽입.

### 블록 내용 (4개 파일 공통)

| 규칙 | 의도 |
|---|---|
| FIRST character MUST be \`{\`. LAST character MUST be \`}\` | 명확한 boundary 명시 |
| DO NOT start with: "I", "The", "Title", "Based on", "Sure", "Okay", "Here", "Let me" | LLM 의 자연스러운 preamble 본능 억제 (라이브에서 관측된 'I'/'T' 시작 케이스 직접 대응) |
| DO NOT wrap in markdown fences | \`\`\`json 블록 회피 |
| DO NOT append trailing prose | 닫는 \`}\` 이후 부언 금지 |
| If you cannot fulfill the task, STILL emit schema-conformant empty defaults | 거부 응답 대신 graceful empty payload — fallback 처리에 적합 |
| Violating responses are DISCARDED upstream | LLM 의 helpfulness 본능 억제 (응답이 무용해진다는 신호) |

각 파일별 empty defaults 가이드는 schema 에 맞춰 다르게:
- **extract**: \`entities=[], claims=[], facts=[], topics=[], sentiment=\"neutral\"\`
- **cross_verify**: 모든 claim_idx 는 \`verdict=\"unverified\", sources=[]\`
- **context**: \`background=[], timeline=[], implications\` 전부 empty string
- **score**: \`trust_score=0.0, factors\` 전부 0.0, rationale 에 sparse evidence 사유 기재

마지막 \`Return ONLY the JSON object\` 줄도 \"first char \`{\`, last char \`}\`. (See CRITICAL OUTPUT CONTRACT at the top.)\" 로 강화해 contract 재인지.

<br>

## CI / 머지 게이트 점검

### 변경 영향 범위
- 영향 패키지/모듈: \`pkg/llm/prompt/assets/enrich/claude\` (4 prompt files only)
- 위험도(택1): **Low** — 텍스트 변경 only, 코드 변경 없음. LLM 응답 schema 자체는 동일. embed loader 통해 binary 재빌드 시 자동 반영.

### Required Status Checks
- [ ] \`Commit Lint\` / \`PR Title Lint\` / \`Linked Issue Check\`
- [ ] \`Format Check\` / \`Build\` / \`Test\` / \`Lint\`

### 로컬 검증
- ✅ \`make fmt\` 통과
- ✅ \`go build ./...\` 통과
- ✅ \`go test -race ./...\` 48 packages OK / 0 FAIL

### 롤백 계획
- 본 PR revert — 4 파일 텍스트만 원복. 운영 동작 즉시 복귀.

<br>

## TODO
- [ ] 본 PR 머지 후 라이브 spot-check 으로 unmarshal 에러 비율 감소 확인 (이전 36% → 목표 < 5%)
- [ ] (관찰 후) 동일 패턴이 비-naver host 에서도 사라지는지 확인

<br>

## 논의 사항

### 본 PR 은 prompt-only — 코드 측 retry 보완은 별건
\`parseEnrichedOutput\` 가 unmarshal 실패 시 graceful fallback (\`forwarding without facts\`) 으로 처리. 본 PR 은 입력단 강화만 다룸. 만약 prompt 강화 후에도 일정 비율의 prose 응답이 잔존하면, **JSON 추출 robustness** (예: 응답 중 첫 \`{\` ~ 마지막 \`}\` 추출 — \`extractJSON\` 의 logic 확장) 가 후속 옵션이지만 본 이슈 범위 외.

### 왜 이 시점에 발견됐는가
- \`n.news.naver.com\` host 의 article body 구조가 특정 LLM trigger 를 유도하는 host-specific 가능성. 4건 모두 동일 host 라 일반화 단정은 어려움. 본 PR 의 contract 강화로 host 무관하게 prose-emit 자체를 차단.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced output validation for data enrichment and extraction operations, enforcing stricter formatting requirements to ensure more consistent and reliable results from language model integrations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/EinSofINTEREST/IssueTracker/pull/487?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->