### PR TITLE
[DOCS#489] parser/rule.md + parser/README.md — 최근 변경 반영

### DIFF
--- a/docs/architecture/internal/processor/parser/README.md
+++ b/docs/architecture/internal/processor/parser/README.md
@@ -99,7 +99,7 @@ Worker 가 이상 종료 / rule.Error 잔존 / LLM 재처리 윈도우 만료된
   - `raw_contents` (load+delete)
   - `contents` (store)
   - `parser_rule_sample_urls` (insert)
-  - `parser_blacklist` (auto_demote INSERT — async, mode='extract_links_only')
+  - `parser_blacklist` (auto_demote / llmgen INSERT — async, mode='extract_links_only' | 'drop')
 - Redis: ProcessingLock (단계="parser")
 
 <br>

--- a/docs/architecture/internal/processor/parser/README.md
+++ b/docs/architecture/internal/processor/parser/README.md
@@ -4,7 +4,7 @@
 
 본 패키지는 두 layer 로 구성됩니다 (이슈 #196 통합):
 
-1. **Rule engine** ([rule.md](rule.md)) — `parser.go` (도메인 중립 인터페이스) + `rule/` (DB-driven engine, llmgen, pathinfer, refiner)
+1. **Rule engine** ([rule.md](rule.md)) — `types/types.go` (도메인 중립 인터페이스) + `rule/` (DB-driven engine, indexonly heuristic, auto_demote, llmgen, pathinfer, refiner, blacklist matcher)
 2. **Kafka worker** ([worker/](../../../../../internal/processor/parser/worker/)) — Claim Check 패턴으로 raw 로드 + rule engine 호출 + content 저장
 
 이슈 #134 에서 fetcher 와 parser 를 분리하면서 도입된 별도 consumer group `issuetracker-parsers`.
@@ -15,10 +15,10 @@ Kafka 메시지에 raw HTML 을 싣지 않고 DB 에서 로드합니다.
 
 ## 구성
 
-| 파일                                                                    | 역할                                                |
-|------------------------------------------------------------------------|-----------------------------------------------------|
-| [parser_worker.go](../../../../../internal/processor/parser/worker/parser_worker.go) | `ParserWorker` — TopicFetched consume + parse + content store |
-| [cleanup.go](../../../../../internal/processor/parser/worker/cleanup.go)             | `RawContentCleaner` — cron 으로 오래된 raw_contents 정리 |
+| 파일 | 역할 |
+|------|------|
+| [worker.go](../../../../../internal/processor/parser/worker/worker.go) | `Worker` — TopicFetched consume + parse + content store (이슈 #419 으로 `parser_worker.go` → `worker.go`, `ParserWorker` → `Worker` rename) |
+| [cleanup.go](../../../../../internal/processor/parser/worker/cleanup.go) | `RawContentCleaner` — cron 으로 오래된 raw_contents 정리 |
 
 <br>
 
@@ -30,14 +30,18 @@ Kafka 메시지에 raw HTML 을 싣지 않고 DB 에서 로드합니다.
 2. RawContentService.GetByID(ref.ID) → core.RawContent (HTML)
 3. ProcessingLock.Acquire("parser", raw.URL)
 4. target_type 분기:
-   ┌─ TargetTypeCategory (list)
+   ┌─ TargetTypeList (category / index)
    │  ├ rule.Parser.ParseLinks(ctx, raw) → []LinkItem
    │  └ Publisher.PublishBatch(...) — chained article CrawlJob 발행
    └─ TargetTypePage (article)
       ├ rule.Parser.ParsePage(ctx, raw) → Page
       │     ├ ErrNoRule → llmGen.Enqueue (이슈 #149) + commit (raw 잔존)
-      │     └ ErrParseFailure / ErrEmptySelector → commit (raw 잔존)
-      ├ general.ConvertPageToContent(page) → core.Content
+      │     ├ ErrParseFailure / ErrEmptySelector → commit (raw 잔존, LLM 재처리 대기)
+      │     └ 성공 + index-only 휴리스틱 통과 시 (이슈 #477):
+      │           autoDemoter.demoteAsync (비동기) →
+      │           parser_blacklist 에 mode='extract_links_only' 자동 등록 →
+      │           다음 호출부터 BlacklistMatcher 가 list 모드로 라우팅
+      ├ general.ConvertPageToContent(page) → core.Content (Article 플래그 전파, 이슈 #423)
       ├ ContentService.Store → ContentRef
       ├ Producer.Publish(TopicNormalized, ContentRef)
       └ Resolver 매칭 결과 + sample URL 누적 (SampleURLRepository.Insert) — 이슈 #173 단계 4-1
@@ -49,11 +53,13 @@ Kafka 메시지에 raw HTML 을 싣지 않고 DB 에서 로드합니다.
 - `rule.Error` 계열: raw 잔존 + commit (재시도 X) — LLM 재처리 대기
 - 기타 transient 에러: commit 안 함 → Kafka 재배달
 
+**graceful shutdown**: `Worker.Stop()` 가 `Parser.WaitAutoDemote()` 도 함께 호출 — in-flight async demote goroutine 완료까지 대기.
+
 <br>
 
 ## RawContentCleaner
 
-ParserWorker 가 이상 종료 / rule.Error 잔존 / LLM 재처리 윈도우 만료된 row 가 누적되는 것을 방지하는
+Worker 가 이상 종료 / rule.Error 잔존 / LLM 재처리 윈도우 만료된 row 가 누적되는 것을 방지하는
 간단한 cron. [`cleanup.go`](../../../../../internal/processor/parser/worker/cleanup.go) 가 일정 주기마다
 `RawContentService.PurgeOlderThan(...)` 호출.
 
@@ -61,28 +67,39 @@ ParserWorker 가 이상 종료 / rule.Error 잔존 / LLM 재처리 윈도우 만
 
 ## 의존
 
-- [`internal/processor/parser/rule`](rule.md) — `Parser`, `Resolver`
-- [`internal/processor/parser/rule/llmgen`](rule.md) — `Generator.Enqueue` (선택)
+- [`internal/processor/parser/rule`](rule.md) — `Parser`, `Resolver`, `BlacklistMatcher`
+- [`internal/processor/parser/rule/llmgen`](rule.md#4-llm-selector-generator) — `Generator.Enqueue` (선택)
+- [`internal/processor/parser/rule/indexonly`](rule.md#3-index-only-heuristic) — `IsIndexOnly` (auto-demote 흐름 내부)
 - [`internal/processor/fetcher/domain/general`](../fetcher/domain.md) — `ConvertPageToContent`
 - [`internal/locks`](../../locks/README.md) — `ProcessingLock`
-- [`internal/storage/service`](../../storage/service.md) — `RawContentService`, `ContentService`
+- [`internal/storage/service`](../../storage/service.md) — `RawContentService`, `ContentService`, `BlacklistService` (auto-demote 의존성 역전)
 - [`internal/storage`](../../storage/README.md) — `SampleURLRepository`
-- [`internal/publisher`](../../publisher.md) — chained job 발행
-- [`pkg/queue`](../../pkg/queue.md), [`pkg/logger`](../../pkg/logger.md)
+- [`internal/publisher`](../../publisher.md) — chained job 발행 (BlacklistMatcher.Classify 사후 분류)
+- [`internal/processor/precheck`](../precheck.md) — 발행 직전 URL 처리 가부 게이트 (이슈 #425)
+- [`pkg/agent/claude`](../../../pkg/agent/claude.md) — EnrichedExtractor (llmgen 의 LLM 호출 백엔드)
+- [`pkg/queue`](../../../pkg/queue.md), [`pkg/logger`](../../../pkg/logger.md)
 
 <br>
 
 ## Wiring 위치
 
-[`cmd/issuetracker/main.go`](../../../../../cmd/issuetracker/main.go) — 단계 10 (parser worker), 단계 12
-(cleanup cron). 자세한 wiring 은 [cmd/issuetracker.md](../../../cmd/issuetracker.md) 참조.
+[`cmd/issuetracker/main.go`](../../../../../cmd/issuetracker/main.go) — parser worker 단계, cleanup cron 단계.
+
+`rule.Parser` 생성 시 `WithBlacklistAutoDemote(blacklistSvc, metrics, log)` 옵션 주입 (이슈 #477) —
+`BLACKLIST_ENABLED=false` 환경에서는 옵션이 noop 으로 기존 동작 유지.
+
+자세한 wiring 은 [cmd/issuetracker.md](../../../cmd/issuetracker.md) 참조.
 
 <br>
 
 ## 외부 시스템
 
 - Kafka: `issuetracker.fetched` consume / `issuetracker.normalized` + `issuetracker.crawl.{high,normal,low}` (chained jobs) produce
-- PostgreSQL: `raw_contents` (load+delete), `contents` (store), `parsing_rule_sample_urls` (insert)
+- PostgreSQL:
+  - `raw_contents` (load+delete)
+  - `contents` (store)
+  - `parser_rule_sample_urls` (insert)
+  - `parser_blacklist` (auto_demote INSERT — async, mode='extract_links_only')
 - Redis: ProcessingLock (단계="parser")
 
 <br>
@@ -93,3 +110,11 @@ ParserWorker 가 이상 종료 / rule.Error 잔존 / LLM 재처리 윈도우 만
 - 이슈 #149 — LLM 기반 selector 자동 생성
 - 이슈 #173 단계 4-1 — sample URL 누적
 - 이슈 #178 — ProcessingLock 단계 prefix
+- 이슈 #196 — Rule engine + Worker 통합 패키지화
+- 이슈 #419 — `parser_worker.go` → `worker.go` + `ParserWorker` → `Worker` rename
+- 이슈 #423 — `parser_rules.article` 다운스트림 전파
+- 이슈 #425 — precheck 패키지 신설 + 진입점 게이트
+- 이슈 #463 — RuleLookup interface + extract.go 분리
+- 이슈 #477 — ParsePage 결과 index-only 자동 강등 wiring
+- 이슈 #480 — LLM auto-blacklist mode 분기
+- 이슈 #482 — 부팅 시 `VerifySeeded` 폐기 (DB-driven readiness 신뢰)

--- a/docs/architecture/internal/processor/parser/rule.md
+++ b/docs/architecture/internal/processor/parser/rule.md
@@ -112,7 +112,7 @@ ParsePage(ctx, raw)
 
 ## 4. LLM Selector Generator ([rule/llmgen/](../../../../../internal/processor/parser/rule/llmgen/))
 
-이슈 #149. `ErrNoRule` / `ErrParseFailure` 등 발생 시 **비동기**로 LLM 에게 selector 를 생성시키고 `enabled=false` 로 DB 에 INSERT (운영자 검토 후 활성). 또한 LLM 이 페이지를 "파싱 부적합" 으로 판정하면 `parser_blacklist` 에 `source='auto'` 로 자동 등록 (이슈 #326, #480).
+이슈 #149. `ErrNoRule` / `ErrParseFailure` 등 발생 시 **비동기**로 LLM 에게 selector 를 생성시키고 `enabled=true` 로 DB 에 INSERT (CSS 검증을 품질 게이트로 사용해 통과 시 즉시 활성 — pending 큐의 URL 재처리가 유효하도록). 또한 LLM 이 페이지를 "파싱 부적합" 으로 판정하면 `parser_blacklist` 에 `source='auto'` 로 자동 등록 (이슈 #326, #480).
 
 | 파일 | 역할 |
 |------|------|
@@ -135,7 +135,7 @@ LLM 프롬프트 ([`pkg/llm/prompt/assets/parser/claude/{page,list}.user.txt`](.
 
 **article 플래그** (이슈 #421/#423): `ExtractResult.Article` + `ArticleConfidence` 가 LLM 자체 분류. parser_rules.article 컬럼에 영속화 → 다운스트림 validator 가 `Article=true` 에만 PublishedAt 필수 강제.
 
-**동작**: ParserWorker 가 `ErrNoRule` / `ErrParseFailure` 받으면 `llmGen.Enqueue(ctx, host, targetType, raw)` 호출 — `targetType` (`page`/`list`) 별로 별도 in-flight set 으로 dedup. Generator 는 별도 goroutine 에서 EnrichedExtractor (claudegen) 호출 → 결과 검증 → INSERT (enabled=false) → [`Resolver.Invalidate(host, targetType)`](../../../../../internal/processor/parser/rule/resolver.go).
+**동작**: ParserWorker 가 `ErrNoRule` / `ErrParseFailure` 받으면 `llmGen.Enqueue(ctx, host, targetType, raw)` 호출 — `targetType` (`page`/`list`) 별로 별도 in-flight set 으로 dedup. Generator 는 별도 goroutine 에서 EnrichedExtractor (claudegen) 호출 → 결과 검증 (CSS selector 가 실제 매칭되는지 확인) → INSERT (`enabled=true`, CSS 검증 통과 시) → [`Resolver.Invalidate(host, targetType)`](../../../../../internal/processor/parser/rule/resolver.go).
 
 <br>
 
@@ -164,7 +164,7 @@ LLM 프롬프트 ([`pkg/llm/prompt/assets/parser/claude/{page,list}.user.txt`](.
 ```
 1. polling goroutine 가 interval 마다 RunOnce 호출
 2. parser_rules 에서 source_name='llm-auto' AND path_pattern='' (catch-all) 조회
-3. 각 rule 에 대해 sample_urls 에서 누적 URL 로드 (MinSamples 미만이면 skip)
+3. 각 rule 에 대해 parser_rule_sample_urls 에서 누적 URL 로드 (MinSamples 미만이면 skip)
 4. pathinfer.InferHeuristic → 실패 + LLM 있으면 InferLLM
 5. 결과 path_pattern 으로 parser_rules.UpdatePathPattern (optimistic guard)
 6. Resolver.Invalidate(host) + SampleURLRepository.Purge(rule_id)
@@ -190,7 +190,7 @@ rule/parser.go ──→ rule/resolver.go (RuleLookup) ──→ internal/storag
 rule/llmgen/ ──→ pkg/agent/claude (EnrichedExtractor) + storage (parser_rules INSERT)
                   │
                   └──→ service.BlacklistService.HandleLLMDecision (mode 인자, #480)
-rule/refiner/ ──→ pathinfer + pkg/llm + storage (parser_rules UPDATE / sample_urls)
+rule/refiner/ ──→ pathinfer + pkg/llm + storage (parser_rules UPDATE / parser_rule_sample_urls)
 rule/discovery/ ──→ pkg/links (link extract)
 rule/blacklist_matcher.go ──→ storage.BlacklistRepository (host 단위 lookup)
 ```

--- a/docs/architecture/internal/processor/parser/rule.md
+++ b/docs/architecture/internal/processor/parser/rule.md
@@ -2,13 +2,13 @@
 
 상위 [README.md](README.md) 의 layer 1 (rule engine) 상세 문서. Kafka worker 부분은 README 참조.
 
-소스: [`internal/processor/parser/parser.go`](../../../../../internal/processor/parser/parser.go) (도메인 중립 인터페이스) + [`internal/processor/parser/rule/`](../../../../../internal/processor/parser/rule/) (`parsing_rules` 테이블 기반 단일 engine, 이슈 #100)
+소스: [`internal/processor/parser/types/types.go`](../../../../../internal/processor/parser/types/types.go) (도메인 중립 인터페이스 + `Page` / `LinkItem`) + [`internal/processor/parser/rule/`](../../../../../internal/processor/parser/rule/) (`parser_rules` 테이블 기반 단일 engine, 이슈 #100)
 
 사이트별 hardcode 파서 (NaverParser/CNNParser/…) 를 폐기하고 DB 기반 rule 한 개의 parser engine 으로 모든 사이트를 처리.
 
 <br>
 
-## 1. 도메인 중립 인터페이스 ([parser.go](../../../../../internal/processor/parser/parser.go))
+## 1. 도메인 중립 인터페이스 ([types/types.go](../../../../../internal/processor/parser/types/types.go))
 
 ```go
 type ContentParser interface {
@@ -25,6 +25,10 @@ type Page struct {
     Tags        []string
     Images      []string
     Metadata    map[string]string
+
+    // 이슈 #423 — 적용된 parser_rule 의 article 플래그. 다운스트림 validator 가
+    // PublishedAt 강제 여부를 결정 (article=true 일 때만 필수).
+    Article bool
 }
 ```
 
@@ -35,73 +39,134 @@ type Page struct {
 
 ## 2. Rule Engine ([rule/](../../../../../internal/processor/parser/rule/))
 
-| 파일                                                                                     | 역할                                                            |
-|----------------------------------------------------------------------------------------|-----------------------------------------------------------------|
-| [parser.go](../../../../../internal/processor/parser/rule/parser.go)                         | `Parser` 구조체 — `ParsePage` / `ParseLinks` 를 SelectorMap 으로 실행 |
-| [resolver.go](../../../../../internal/processor/parser/rule/resolver.go)                     | `Resolver` — host → `[]*ParsingRuleRecord` 캐시 (TTL 5min/30s, regex compile cache) |
-| [discovery.go](../../../../../internal/processor/parser/rule/discovery.go)                   | `PageLinkDiscovery` — 전체 페이지 `<a>` 스캔 모드 (이슈 #139)    |
-| [errors.go](../../../../../internal/processor/parser/rule/errors.go)                         | `Error` + `ErrCode` (`ErrNoRule`, `ErrEmptySelector`, `ErrParseFailure`) |
+| 파일 | 역할 |
+|------|------|
+| [parser.go](../../../../../internal/processor/parser/rule/parser.go) | `Parser` 구조체 — `ParsePage` / `ParseLinks` 를 SelectorMap 으로 실행. `ParserOption` functional option + `WithBlacklistAutoDemote` (이슈 #477) |
+| [resolver.go](../../../../../internal/processor/parser/rule/resolver.go) | `Resolver` — host → `[]*ParserRuleRecord` 캐시 (TTL 5min/30s, regex compile cache). `RuleLookup` interface 구현체 (이슈 #463) |
+| [extract.go](../../../../../internal/processor/parser/rule/extract.go) | `validateRaw` / `extractField` / `extractFieldMulti` / `extractDate` 등 helper 모음 (이슈 #463 분리) |
+| [discovery.go](../../../../../internal/processor/parser/rule/discovery.go) | `PageLinkDiscovery` — 전체 페이지 `<a>` 스캔 모드 (이슈 #139) |
+| [errors.go](../../../../../internal/processor/parser/rule/errors.go) | `Error` + `ErrCode` (`ErrNoRule`, `ErrEmptySelector`, `ErrParseFailure`) |
+| [blacklist_matcher.go](../../../../../internal/processor/parser/rule/blacklist_matcher.go) | `BlacklistMatcher` — host 단위 lookup + path regex 매칭. `Classify(urls) → Drop / ExtractLinksOnly / Pass` 분기 (이슈 #295, #297) |
+| [auto_demote.go](../../../../../internal/processor/parser/rule/auto_demote.go) | `autoDemoter` — index-only 판정 페이지를 `parser_blacklist` 에 `mode='extract_links_only'` 로 비동기 자동 등록 (이슈 #477). `AutoDemoteRegisterer` narrow interface — `service.BlacklistService` 가 만족 |
+| [auto_demote_metrics.go](../../../../../internal/processor/parser/rule/auto_demote_metrics.go) | `AutoDemoteMetrics` — `parser_index_page_auto_demoted_total{host}` Counter (nil-safe, idempotent register) |
+
+**RuleLookup interface** (이슈 #463) — `*Resolver` 가 본 interface 를 만족. `Parser` 는 concrete 대신 interface 의존으로 단위 테스트 mock 주입 가능:
+
+```go
+type RuleLookup interface {
+    ResolveByURL(ctx context.Context, rawURL string, targetType model.TargetType) (*model.ParserRuleRecord, error)
+}
+```
+
+**ParserOption 패턴** (이슈 #477):
+
+```go
+type ParserOption func(*Parser)
+
+// repo / log 가 nil 이면 옵션 noop (기존 동작 100% 유지)
+func WithBlacklistAutoDemote(repo AutoDemoteRegisterer, metrics *AutoDemoteMetrics, log *logger.Logger) ParserOption
+```
 
 **처리 흐름**:
 ```
 ParsePage(ctx, raw)
-   ├ Resolver.ResolveByURL(raw.URL) → 매칭 ParsingRuleRecord
+   ├ validateRaw → raw.HTML 비어있으면 ErrParseFailure
+   ├ Resolver.ResolveByURL(raw.URL, page) → 매칭 ParserRuleRecord
    │   ├ host_pattern = exact / wildcard
    │   └ path_pattern = regex (애플리케이션 레벨 매칭, 다중 rule 지원)
-   ├ 없음 → ErrNoRule (호출자가 llmgen 으로 fallback)
-   └ 있음 → SelectorMap 으로 goquery 추출 → Page 반환
+   ├ rule 없음 → ErrNoRule (호출자가 llmgen 으로 fallback)
+   ├ Title/MainContent selector 부재 → ErrEmptySelector
+   ├ Selectors 로 goquery 추출 → Page
+   ├ Title/MainContent 매칭 0건 → ErrParseFailure (stale rule 진단)
+   └ 이슈 #477 분기: autoDemoter != nil 이면
+       indexonly.IsIndexOnly(page, raw.HTML) 평가 →
+       true 시 demoteAsync (별도 goroutine + context.WithoutCancel) →
+       page 자체는 정상 반환 (다음 호출부터 matcher 가 extract_links_only 로 라우팅)
 ```
 
-<br>
-
-## 3. LLM Selector Generator ([rule/llmgen/](../../../../../internal/processor/parser/rule/llmgen/))
-
-이슈 #149. `ErrNoRule` 발생 시 **비동기**로 LLM 에게 selector 를 생성시키고 `enabled=false` 로
-DB 에 INSERT (운영자 검토 후 활성).
-
-| 파일                                                                                              | 역할                                                  |
-|--------------------------------------------------------------------------------------------------|-------------------------------------------------------|
-| [generator.go](../../../../../internal/processor/parser/rule/llmgen/generator.go)                      | `Generator` — Enqueue / 처리 goroutine / Stop          |
-| [prompt.go](../../../../../internal/processor/parser/rule/llmgen/prompt.go)                            | LLM 프롬프트 템플릿 (HTML 샘플 + 출력 스키마)          |
-| [dedup.go](../../../../../internal/processor/parser/rule/llmgen/dedup.go)                              | in-flight set — 동일 host 중복 enqueue 방지            |
-
-**동작**: ParserWorker 가 `ErrNoRule` 받으면 `llmGen.Enqueue(ctx, host, targetType, raw)` 호출 —
-`targetType` (`page`/`list`) 별로 별도 in-flight set 으로 dedup 됩니다. Generator 는 별도 goroutine 에서
-LLM 호출 → 결과 검증 (selector 가 실제 매칭되는지 확인) → INSERT (enabled=false) →
-[`Resolver.Invalidate(host, targetType)`](../../../../../internal/processor/parser/rule/resolver.go) 로
-해당 (host, targetType) 캐시 항목 무효화 (전체 invalidation 은 `Resolver.InvalidateAll()`).
+`Parser.WaitAutoDemote()` 는 in-flight async demote goroutine 완료 대기 — graceful shutdown / 테스트 race 회피용.
 
 <br>
 
-## 4. Path Pattern Inference ([rule/pathinfer/](../../../../../internal/processor/parser/rule/pathinfer/))
+## 3. Index-only Heuristic ([rule/indexonly/](../../../../../internal/processor/parser/rule/indexonly/))
 
-| 파일                                                                                              | 역할                                                  |
-|--------------------------------------------------------------------------------------------------|-------------------------------------------------------|
-| [pathinfer.go](../../../../../internal/processor/parser/rule/pathinfer/pathinfer.go)                   | `InferHeuristic` — 알고리즘 only (공통 prefix / 숫자 ID 패턴) |
-| [llm.go](../../../../../internal/processor/parser/rule/pathinfer/llm.go)                               | `InferLLM` — heuristic 실패 시 LLM 에 위임            |
+이슈 #476. ParsePage 결과가 카테고리/링크 hub 페이지로 보이는지 판정하는 pure-logic 모듈.
+
+| 파일 | 역할 |
+|------|------|
+| [indexonly.go](../../../../../internal/processor/parser/rule/indexonly/indexonly.go) | `IsIndexOnly(page, rawHTML, cfg) (bool, Score)` + `Config` + `Score` |
+
+**판정 기준** (AND, false-positive 회피):
+
+- 본문이 짧음 — `Page.MainContent` rune 길이 < `MinBodyRunes` (default 200)
+- `PublishedAt` zero-value (카테고리/목록 페이지)
+- 링크 hub 신호 (둘 중 하나):
+  - same-host anchor 텍스트 비율 ≥ `MinLinkRatio` (default 0.8)
+  - article-like link ≥ `MinArticleLinks` (default 5)
+
+**Same-host 필터**: LinkRatio / ArticleLinks 모두 same-host anchor 만 카운트 — 외부 광고 / 관련 사이트 영역의 false-positive 차단.
+
+호출 측 ([rule/parser.go](../../../../../internal/processor/parser/rule/parser.go) ParsePage 후반부) 이 결과를 받아 `autoDemoter.demoteAsync` 로 위임.
+
+<br>
+
+## 4. LLM Selector Generator ([rule/llmgen/](../../../../../internal/processor/parser/rule/llmgen/))
+
+이슈 #149. `ErrNoRule` / `ErrParseFailure` 등 발생 시 **비동기**로 LLM 에게 selector 를 생성시키고 `enabled=false` 로 DB 에 INSERT (운영자 검토 후 활성). 또한 LLM 이 페이지를 "파싱 부적합" 으로 판정하면 `parser_blacklist` 에 `source='auto'` 로 자동 등록 (이슈 #326, #480).
+
+| 파일 | 역할 |
+|------|------|
+| [generator.go](../../../../../internal/processor/parser/rule/llmgen/generator.go) | `Generator` — Enqueue / 처리 goroutine / Stop / `BlacklistAutoRegister` interface |
+| [extractor.go](../../../../../internal/processor/parser/rule/llmgen/extractor.go) | `BlacklistDecision` (Reason + **Mode**, 이슈 #480) / `ExtractResult` / `EnrichedExtractor` interface |
+| [confidence.go](../../../../../internal/processor/parser/rule/llmgen/confidence.go) | LLM 신뢰도 → INSERT 결정 |
+| [breaker.go](../../../../../internal/processor/parser/rule/llmgen/breaker.go) | host 단위 circuit breaker (3-strike / 10min cooldown) |
+| [pending.go](../../../../../internal/processor/parser/rule/llmgen/pending.go) | Redis 기반 pending URL 큐 |
+
+**BlacklistDecision.Mode** (이슈 #480):
+
+```go
+type BlacklistDecision struct {
+    Reason string
+    Mode   model.BlacklistMode  // "drop" | "extract_links_only" (빈 문자열은 service 가 drop fallback)
+}
+```
+
+LLM 프롬프트 ([`pkg/llm/prompt/assets/parser/claude/{page,list}.user.txt`](../../../../../pkg/llm/prompt/assets/parser/claude/)) 가 `blacklist_mode` 필드를 emit. claudegen worker ([`pkg/agent/claude/worker.go`](../../../../../pkg/agent/claude/worker.go)) 가 `enrichedOutput.BlacklistMode` 파싱 → `BlacklistDecision.Mode` 에 전파. `service.BlacklistService.HandleLLMDecision(ctx, host, sampleURL, targetType, reason, mode)` 호출.
+
+**article 플래그** (이슈 #421/#423): `ExtractResult.Article` + `ArticleConfidence` 가 LLM 자체 분류. parser_rules.article 컬럼에 영속화 → 다운스트림 validator 가 `Article=true` 에만 PublishedAt 필수 강제.
+
+**동작**: ParserWorker 가 `ErrNoRule` / `ErrParseFailure` 받으면 `llmGen.Enqueue(ctx, host, targetType, raw)` 호출 — `targetType` (`page`/`list`) 별로 별도 in-flight set 으로 dedup. Generator 는 별도 goroutine 에서 EnrichedExtractor (claudegen) 호출 → 결과 검증 → INSERT (enabled=false) → [`Resolver.Invalidate(host, targetType)`](../../../../../internal/processor/parser/rule/resolver.go).
+
+<br>
+
+## 5. Path Pattern Inference ([rule/pathinfer/](../../../../../internal/processor/parser/rule/pathinfer/))
+
+| 파일 | 역할 |
+|------|------|
+| [pathinfer.go](../../../../../internal/processor/parser/rule/pathinfer/pathinfer.go) | `InferHeuristic` — 알고리즘 only (공통 prefix / 숫자 ID 패턴) |
+| [llm.go](../../../../../internal/processor/parser/rule/pathinfer/llm.go) | `InferLLM` — heuristic 실패 시 LLM 에 위임 |
 
 [refiner](../../../../../internal/processor/parser/rule/refiner/) 가 본 함수들을 호출.
 
 <br>
 
-## 5. Refiner ([rule/refiner/](../../../../../internal/processor/parser/rule/refiner/))
+## 6. Refiner ([rule/refiner/](../../../../../internal/processor/parser/rule/refiner/))
 
-이슈 #173 단계 4-2. `llm-auto` source 의 **catch-all** rule 의 `path_pattern` 을 `sample_urls`
-누적 데이터로 정밀화.
+이슈 #173 단계 4-2. `llm-auto` source 의 **catch-all** rule 의 `path_pattern` 을 `sample_urls` 누적 데이터로 정밀화.
 
-| 파일                                                                                                 | 역할                                                 |
-|-----------------------------------------------------------------------------------------------------|------------------------------------------------------|
-| [refiner.go](../../../../../internal/processor/parser/rule/refiner/refiner.go)                            | `Refiner` — Start / Stop / RunOnce — interval polling goroutine |
-| [llm_adapter.go](../../../../../internal/processor/parser/rule/refiner/llm_adapter.go)                    | `pkg/llm.Provider` → `LLMClient` 인터페이스 어댑터    |
-| [metrics.go](../../../../../internal/processor/parser/rule/refiner/metrics.go)                            | `refiner_attempts` Prometheus counter (PR #191)      |
+| 파일 | 역할 |
+|------|------|
+| [refiner.go](../../../../../internal/processor/parser/rule/refiner/refiner.go) | `Refiner` — Start / Stop / RunOnce — interval polling goroutine |
+| [llm_adapter.go](../../../../../internal/processor/parser/rule/refiner/llm_adapter.go) | `pkg/llm.Provider` → `LLMClient` 인터페이스 어댑터 |
+| [metrics.go](../../../../../internal/processor/parser/rule/refiner/metrics.go) | `refinement_attempts` Prometheus counter (PR #191) |
 
 **동작**:
 ```
 1. polling goroutine 가 interval 마다 RunOnce 호출
-2. parsing_rules 에서 source_name='llm-auto' AND path_pattern='' (catch-all) 조회
+2. parser_rules 에서 source_name='llm-auto' AND path_pattern='' (catch-all) 조회
 3. 각 rule 에 대해 sample_urls 에서 누적 URL 로드 (MinSamples 미만이면 skip)
 4. pathinfer.InferHeuristic → 실패 + LLM 있으면 InferLLM
-5. 결과 path_pattern 으로 parsing_rules.UpdatePathPattern (optimistic guard)
+5. 결과 path_pattern 으로 parser_rules.UpdatePathPattern (optimistic guard)
 6. Resolver.Invalidate(host) + SampleURLRepository.Purge(rule_id)
 ```
 
@@ -110,34 +175,51 @@ LLM 호출 → 결과 검증 (selector 가 실제 매칭되는지 확인) → IN
 ## 의존 그래프
 
 ```
-parser.go (interface)
+types/types.go (interface)
     │
     ▼
-rule/parser.go ──→ rule/resolver.go ──→ internal/storage (ParsingRuleRepository)
-                          │
-                          └──→ regex cache + TTL cache
+rule/parser.go ──→ rule/resolver.go (RuleLookup) ──→ internal/storage (ParserRuleRepository)
+       │                  │
+       │                  └──→ regex cache + TTL cache
+       │
+       ├──→ rule/indexonly.IsIndexOnly (#476)
+       └──→ rule/auto_demote.autoDemoter ──→ service.BlacklistService (#477)
+                                                 │
+                                                 └──→ AutoDemoteMetrics → prometheus
 
-rule/llmgen/ ──→ pkg/llm + storage (parsing_rules INSERT)
-rule/refiner/ ──→ pathinfer + pkg/llm + storage (parsing_rules UPDATE / sample_urls)
+rule/llmgen/ ──→ pkg/agent/claude (EnrichedExtractor) + storage (parser_rules INSERT)
+                  │
+                  └──→ service.BlacklistService.HandleLLMDecision (mode 인자, #480)
+rule/refiner/ ──→ pathinfer + pkg/llm + storage (parser_rules UPDATE / sample_urls)
 rule/discovery/ ──→ pkg/links (link extract)
+rule/blacklist_matcher.go ──→ storage.BlacklistRepository (host 단위 lookup)
 ```
 
 <br>
 
 ## 호출 측
 
-- [`internal/processor/parser/worker.ParserWorker`](README.md) — `rule.Parser` 와 `Resolver` 를 인스턴스로 보유, 각 메시지마다 `ParsePage` / `ParseLinks` 호출
-- [`internal/processor/parser/worker.ParserWorker`](README.md) — `ErrNoRule` 발생 시 `llmGen.Enqueue` 호출
-- [`cmd/issuetracker.buildRefiner`](../../../cmd/issuetracker.md) — Refiner 인스턴스 wire
+- [`internal/processor/parser/worker.Worker`](README.md) — `rule.Parser` 와 `Resolver` 를 인스턴스로 보유, 각 메시지마다 `ParsePage` / `ParseLinks` 호출
+- [`internal/processor/parser/worker.Worker`](README.md) — `ErrNoRule` / `ErrParseFailure` 발생 시 `llmGen.Enqueue` 호출
+- [`internal/processor/precheck.Precheck`](../precheck.md) — 발행 직전 `BlacklistMatcher.Classify` 호출 (이슈 #425)
+- [`cmd/issuetracker`](../../../cmd/issuetracker.md) — `rule.NewParser(resolver, rule.WithBlacklistAutoDemote(blacklistSvc, metrics, log))` wiring + Refiner 인스턴스 wire
 
 <br>
 
 ## 관련 이슈
 
-- 이슈 #100 — DB-driven parsing rules
+- 이슈 #100 — DB-driven parser rules
 - 이슈 #139 — full-page link discovery (LinkDiscoveryConfig)
 - 이슈 #149 — LLM selector 자동 생성
 - 이슈 #173 — path_pattern 정밀화 (refiner)
 - 이슈 #190 — refinement trigger refinement
-- 이슈 #192 — refiner LLM 추론 검증 강화 (백로그)
 - PR #191 — refiner Prometheus metric (refinement_attempts)
+- 이슈 #295 — page-parse 블랙리스트 인프라 (drop)
+- 이슈 #297 — `extract_links_only` mode 도입
+- 이슈 #326 — LLM 자동 blacklist 등록
+- 이슈 #421/#423 — `parser_rules.article` 플래그 + 다운스트림 wiring
+- 이슈 #463 — RuleLookup interface + extract.go 분리
+- 이슈 #476 — index-only 휴리스틱 모듈 (`indexonly/`)
+- 이슈 #477 — ParsePage 자동 강등 wiring + `parser_index_page_auto_demoted_total` metric
+- 이슈 #480 — LLM auto-blacklist mode 분기 (BlacklistDecision.Mode)
+- 이슈 #482 — `seededHostTargets` / `VerifySeeded` 폐기 (DB-driven readiness 신뢰)


### PR DESCRIPTION
## 연관 이슈
- Closes #489
- Parent: #488

<br>

## 구현 내용

지난 30 PR (#419 ~ #487) 동안 \`internal/processor/parser/\` 패키지에 추가된 모듈 / 인터페이스 / 흐름 변경을 두 architecture 문서에 일괄 반영. 메타 이슈 #488 의 첫 sub-issue.

### parser/rule.md (+184 −68 LOC)

- 도메인 중립 인터페이스 소스 위치 정정 (\`parser.go\` → \`types/types.go\`) + \`Page.Article\` 플래그 명시
- Rule Engine 파일 표에 신규 4개 행 (extract.go / blacklist_matcher.go / auto_demote.go / auto_demote_metrics.go) + parser.go 의 ParserOption 설명
- \`RuleLookup\` interface (이슈 #463) 시그니처
- \`ParserOption\` / \`WithBlacklistAutoDemote\` 시그니처 (이슈 #477)
- ParsePage 처리 흐름 다이어그램에 index-only 자동 강등 분기 + \`WaitAutoDemote\` 추가
- **신규 섹션 3**: Index-only Heuristic (이슈 #476)
- 4 LLM Selector Generator 의 \`BlacklistDecision.Mode\` (이슈 #480) + article 플래그 (이슈 #421/#423)
- 의존 그래프 갱신 (신규 의존: indexonly, auto_demoter, BlacklistService, AutoDemoteMetrics, BlacklistRepository) + \`claudegen\` → \`pkg/agent/claude\` (이슈 #458)
- 호출 측에 \`precheck.Precheck\` 추가 (이슈 #425)
- 관련 이슈 추가: #295 #297 #326 #421 #423 #463 #476 #477 #480 #482

### parser/README.md (+59 −22 LOC)

- 파일 표: \`parser_worker.go\` → \`worker.go\`, \`ParserWorker\` → \`Worker\` rename (이슈 #419)
- 동작 흐름: \`TargetTypeCategory\` → \`TargetTypeList\` 정정 + index-only 자동 강등 분기 추가
- graceful shutdown: \`Parser.WaitAutoDemote\` 도 호출 명시
- 의존 섹션에 \`BlacklistService\`, \`precheck\`, \`pkg/agent/claude\`, \`parser_blacklist\` 외부 시스템 추가
- 관련 이슈 추가: #196 #419 #423 #425 #463 #477 #480 #482

<br>

## CI / 머지 게이트 점검

### 변경 영향 범위
- 영향 패키지/모듈: \`docs/architecture/internal/processor/parser/\` (2 파일)
- 위험도(택1): **Low** — 문서만 변경, 코드 영향 없음. 모든 코드 라인 링크는 latest main 기준.

### Required Status Checks
- [ ] \`Commit Lint\` / \`PR Title Lint\` / \`Linked Issue Check\`
- [ ] \`Format Check\` / \`Build\` / \`Test\` / \`Lint\`

### 로컬 검증
- ✅ \`go build ./...\` 통과 (문서 변경이라 코드 영향 없음)

### 롤백 계획
- 본 PR revert — 문서만 원복. 운영 영향 없음.

<br>

## 논의 사항

- 본 PR 은 메타 이슈 #488 의 sub-issue 1/4. 나머지 sub:
  - #490 — cmd/issuetracker + pkg/metrics + pkg/config
  - #491 — storage/README + storage/service
  - #492 — 신규 모듈 문서 (enrich, agent/claude, precheck)

🤖 Generated with [Claude Code](https://claude.com/claude-code)