### PR TITLE
[DOCS#490] cmd/issuetracker + pkg/metrics + pkg/config — 최근 변경 반영

### DIFF
--- a/docs/architecture/cmd/issuetracker.md
+++ b/docs/architecture/cmd/issuetracker.md
@@ -3,7 +3,7 @@
 소스: [`cmd/issuetracker/main.go`](../../../cmd/issuetracker/main.go)
 산출물: `bin/issuetracker` (`make build`)
 
-전체 파이프라인 (Crawler + Parser + Validator + Scheduler + Refiner) 을 **단일 프로세스에서 wire** 하는
+전체 파이프라인 (Fetcher + Parser + Validator + Enricher + Scheduler + Refiner) 을 **단일 프로세스에서 wire** 하는
 오케스트레이터. 운영 시 권장 entry point.
 
 <br>
@@ -13,79 +13,123 @@
 - `main()` 은 오직 **wiring 다이어그램** — 비즈니스 로직 0
 - 각 단계는 동일 `context.Context` 를 공유 → SIGTERM 시 일괄 cancel
 - Redis / LLM 은 fail-soft — 부재 시 noop fallback 으로 graceful degrade
+- Stage toggle (이슈 #443) 로 한 바이너리에서 일부 단계만 기동 가능
 
 <br>
 
 ## Wiring 흐름 (코드 순서)
 
 ```
-1. logger / metrics endpoint    (pkg/logger, pkg/metrics)
-2. Kafka producer + 3-tier consumers (high/normal/low)
-3. PostgreSQL pool              (internal/storage/postgres)
-4. rule.Parser + rule.Resolver  (parsing_rules 시드 검증 → 부재 시 fail-fast)
-5. raw_contents Service / Content Service (Claim Check)
-6. Source 등록                  (kr.Register / us.Register → handler.Registry)
-7. Redis: ProcessingLock / IngestionLock / DelayedRetryScheduler (이슈 #178, #82)
-8. PoolManager (3-tier crawler workers)
-9. LLM provider (chain policy, 이슈 #149)
-10. ParserWorker (consumer group: parsers)
-11. Refiner (path_pattern 정밀화, 이슈 #173 단계 4-2)
-12. RawContentCleaner cron       (Claim Check 잔존물 정리)
-13. Scheduler + BacklogThrottler (이슈 #124)
-14. Validate Worker
-15. SIGTERM 대기 → 역순 graceful shutdown
+1. logger / shutdown / metrics endpoint   (pkg/logger, pkg/config/app, pkg/metrics)
+2. stage toggle 로드                       (runtimecfg.LoadStages — fetcher/parser/validate/enrich/scheduler, 이슈 #443)
+3. Kafka producer + 3-tier consumers       (high/normal/low)
+4. PostgreSQL pool                         (TimedPool 데코레이터, 이슈 #427)
+5. parser_rules + Resolver                 (RuleLookup interface, 이슈 #463)
+6. parser_blacklist Service / Matcher      (BlacklistService + BlacklistMatcher, 이슈 #295/#297/#431)
+7. rule.Parser + WithBlacklistAutoDemote   (#477 — blacklistSvc 있을 때만 옵션 wiring)
+8. raw_contents Service / Content Service  (Claim Check)
+9. Source 등록                              (kr.Register / us.Register → handler.Registry)
+10. Redis: ProcessingLock / IngestionLock / DelayedRetryScheduler (이슈 #178, #82)
+11. PoolManager (3-tier crawler workers)
+12. LLM provider (chain policy, 이슈 #149)
+13. ParserWorker (consumer group: parsers)
+14. EnrichWorker (consumer group: enrichers, 이슈 #446 ~ #450)
+15. ValidateWorker (consumer group: validators)
+16. Refiner (path_pattern 정밀화, 이슈 #173 단계 4-2)
+17. RawContentCleaner cron                 (Claim Check 잔존물 정리)
+18. Scheduler + BacklogThrottler           (이슈 #124)
+19. SIGTERM 대기 → 역순 graceful shutdown
 ```
+
+각 단계는 `runtimecfg.StagesConfig` 의 `*Enabled` 가 false 면 skip — 같은 바이너리를 fetcher-only / parser-only / 등으로 분리 배포 가능 (이슈 #443).
 
 각 단계의 자세한 책임은 해당 패키지 문서 참조:
 
 - [internal/processor/fetcher/worker.md](../internal/processor/fetcher/worker.md) — PoolManager, RetryScheduler
 - [internal/locks/README.md](../internal/locks/README.md) — ProcessingLock, IngestionLock
-- [internal/processor/parser/rule.md](../internal/processor/parser/rule.md) — rule.Parser, llmgen, refiner
+- [internal/processor/parser/rule.md](../internal/processor/parser/rule.md) — rule.Parser, indexonly, auto_demote, llmgen, refiner, blacklist matcher
 - [internal/processor/parser/README.md](../internal/processor/parser/README.md) — ParserWorker (Claim Check)
 - [internal/processor/validate.md](../internal/processor/validate.md) — Validator
+- [internal/processor/enrich/README.md](../internal/processor/enrich/README.md) — EnrichWorker (4-stage pipeline, 이슈 #446 ~ #450)
+- [internal/processor/precheck.md](../internal/processor/precheck.md) — URL 처리 가부 게이트 (이슈 #425)
 - [internal/scheduler.md](../internal/scheduler.md) — seed job 발행
+- [pkg/agent/claude.md](../pkg/agent/claude.md) — claudegen 컨테이너 (parser_llmgen + enrich LLM 백엔드)
 
 <br>
 
 ## Build helpers (main.go 내부)
 
-| 함수                      | 책임                                                        | 실패 동작        |
-|--------------------------|------------------------------------------------------------|------------------|
-| `buildLLMProvider()`      | `LLM_ENABLED` + API key 검증 → [`pkg/llm`](../../../pkg/llm/) chain provider 구성 | nil 반환 (LLM 비활성) |
-| `buildLLMGenerator()`     | provider nil 이면 nil — 아니면 [`llmgen.New`](../../../internal/processor/parser/rule/llmgen/) | nil 허용         |
-| `buildRefiner()`          | `REFINEMENT_ENABLED` + provider 옵션 결합 → [`refiner.New`](../../../internal/processor/parser/rule/refiner/) | nil 반환 (정밀화 비활성) |
-| `verifyParsingRulesSeeded()` | 기본 파싱 규칙(seed data) 이 DB 에 정상 로드됐는지 검증 | **fail-fast (Fatal)** |
+| 함수 | 책임 | 실패 동작 |
+|---|---|---|
+| `buildLLMProvider()` | `LLM_ENABLED` + API key 검증 → [`pkg/llm`](../../../pkg/llm/) chain provider 구성 | nil 반환 (LLM 비활성) |
+| `buildLLMGenerator()` | provider nil 이면 nil — 아니면 [`llmgen.New`](../../../internal/processor/parser/rule/llmgen/) | nil 허용 |
+| `buildRefiner()` | `REFINEMENT_ENABLED` + provider 옵션 결합 → [`refiner.New`](../../../internal/processor/parser/rule/refiner/) | nil 반환 (정밀화 비활성) |
+| `buildClaudegenPool()` | claudegen worker pool (parser llmgen + enrich 공용 백엔드, 이슈 #458/#460) | nil 반환 (LLM 비활성 시) |
+| `buildEnricherROMCPConfig()` | `ENRICHER_DB_RO_*` env → MCP postgres tool 구성 (이슈 #472) | nil 허용 (env 미설정 시 MCP 비활성) |
+
+이슈 #482 (PR #483) 머지 후 부팅 시 `parser_rules` 시드 검증 (`verifyParsingRulesSeeded` / `rule.VerifySeeded`) 은 **제거됨** — DB-driven 메타데이터 관리 신뢰. parser_rules row 부재는 호출별 `ErrNoRule` 진단으로 위임.
 
 <br>
 
 ## 환경 변수 의존
 
-config 로딩은 [`pkg/config`](../../../pkg/config/) 가 단일 소스. 주요 키:
+config 로딩은 [`pkg/config`](../pkg/config.md) sub-package 분리 (이슈 #440). 주요 키:
 
-| Loader                  | 결정 항목                                              | 비활성 시                               |
-|-------------------------|-------------------------------------------------------|----------------------------------------|
-| `LoadLog()`             | 로그 레벨 / Pretty 출력                                | 기본값                                  |
-| `LoadMetrics()`         | `METRICS_ADDR` (default `:9090`)                      | 빈 값이면 endpoint 미기동              |
-| `Load()` (DB)           | PostgreSQL 접속                                        | **fail-fast**                          |
-| `LoadRedis()`           | Redis 접속                                             | warn 후 NoopProcessingLock fallback    |
-| `LoadLLM()`             | provider, model, API key, timeout                     | nil provider                            |
-| `LoadRefinement()`      | refiner interval / min samples                        | nil refiner                             |
-| `LoadScheduler()`       | seed entry interval / backlog 임계값                  | **fail-fast**                          |
-| `LoadValidate()`        | 검증 임계값                                            | **fail-fast**                          |
+| Loader | 패키지 | 결정 항목 | 비활성 시 |
+|---|---|---|---|
+| `app.LoadLog` | `pkg/config/app` | 로그 레벨 / Pretty 출력 | 기본값 |
+| `app.LoadMetrics` | `pkg/config/app` | `METRICS_ADDR` (default `:9090`) | 빈 값이면 endpoint 미기동 |
+| `app.LoadShutdown` | `pkg/config/app` | overall + claudegen shutdown timeout | 기본값 |
+| `storage.Load` | `pkg/config/storage` | PostgreSQL 접속 | **fail-fast** |
+| `storage.LoadRedis` | `pkg/config/storage` | Redis 접속 | warn 후 NoopProcessingLock fallback |
+| `llm.LoadLLM` | `pkg/config/llm` | provider, model, API key, timeout | nil provider |
+| `llm.LoadPathInfer` | `pkg/config/llm` | refiner interval / min samples | nil refiner |
+| `processor.LoadScheduler` | `pkg/config/processor` | seed entry interval / backlog 임계값 | **fail-fast** |
+| `processor.LoadValidate` | `pkg/config/processor` | 검증 임계값 | **fail-fast** |
+| `processor.LoadBlacklist` | `pkg/config/processor` | parser_blacklist matcher 활성 | warn — Matcher 미주입 (기능 OFF) |
+| `processor.LoadStaleRelearn` | `pkg/config/processor` | stale rule 자동 재학습 | warn — 기능 OFF |
+| `fetcher.LoadChromedpPool` | `pkg/config/fetcher` | chromedp pool / remote URLs / worker count | **fail-fast** (pool 활성 시 remote URL 부재) |
+| `fetcher.LoadAutoUpgrade` | `pkg/config/fetcher` | goquery → chromedp 자동 승격 | warn — auto-upgrade 비활성 |
+| `runtime.LoadStages` | `pkg/config/runtime` | **fetcher/parser/validate/enrich/scheduler 단계 toggle** (이슈 #443) | **모두 false 시 fail-fast** |
+| `runtime.LoadWorkerCounts` | `pkg/config/runtime` | 단계별 worker pool 크기 | 기본값 |
+| `runtime.LoadStageGate` | `pkg/config/runtime` | ProcessingLock + Semaphore 임계값 | 기본값 |
+
+자세한 env 키 매트릭스는 [`pkg/config.md`](../pkg/config.md) 참조. 전체 키 목록은 [`.env.example`](../../../.env.example) 가 단일 소스.
 
 <br>
 
-## Worker 카운트 상수
+## Worker 카운트 (runtime.WorkerCountsConfig)
 
-```go
-const (
-    validateWorkerCount = 8
-    parserWorkerCount   = 6
-)
+`STAGES_*_WORKER_COUNT` env 로 단계별 조정 (이슈 #443/runtime):
+
+```
+FETCHER_HIGH_WORKER_COUNT=3     # high-priority 작업
+FETCHER_NORMAL_WORKER_COUNT=6   # 일반 article fetch
+FETCHER_LOW_WORKER_COUNT=2      # background backfill
+PARSER_WORKER_COUNT=10
+VALIDATE_WORKER_COUNT=6
+ENRICH_WORKER_COUNT=4
 ```
 
-- `validateWorkerCount` ≤ `issuetracker.normalized` 파티션 수 (기본 32)
-- `parserWorkerCount` 는 fetcher 와 독립 — chromedp/LLM 부담이 클수록 증설
+- `*_WORKER_COUNT` ≤ 해당 Kafka 토픽 파티션 수 (validate=32, enrich=16 등)
+- chromedp pool 은 별도 `FETCHER_CHROMEDP_WORKER_COUNT` (chrome 컨테이너 수와 동기)
+
+<br>
+
+## Stage Toggle (이슈 #443)
+
+같은 바이너리를 stage 별로 분리 배포할 때 사용:
+
+```bash
+# fetcher-only 노드
+STAGES_FETCHER_ENABLED=true
+STAGES_PARSER_ENABLED=false
+STAGES_VALIDATE_ENABLED=false
+STAGES_ENRICH_ENABLED=false
+STAGES_SCHEDULER_ENABLED=false
+```
+
+Kafka consumer group 이 stage 간 결합을 담당 (각 stage 가 자기 topic 만 consume). 모든 stage false 는 `LoadStages` 가 에러로 거부.
 
 <br>
 
@@ -95,12 +139,37 @@ SIGINT/SIGTERM 수신 시:
 
 1. logger 에 `shutting_down=true` 부착 (이슈 #72)
 2. root `cancel()` — 모든 goroutine 의 ctx 무효화
-3. shutdownCtx (30s timeout) 로 역순 Stop:
+3. shutdownCtx (`SHUTDOWN_TIMEOUT`, default 30s 또는 2m) 로 역순 Stop:
    - `sched.Stop()`
    - `manager.Stop(shutdownCtx)` — drain crawler workers
-   - `pw.Stop(shutdownCtx)` — parser worker
+   - `parserWorker.Stop(shutdownCtx)` — Parser.WaitAutoDemote 도 함께 호출 (이슈 #477)
+   - `validateWorker.Stop(shutdownCtx)`
+   - `enrichWorker.Stop(shutdownCtx)` — claudegen pool drain
    - `llmGen.Stop(shutdownCtx)` — in-flight LLM call drain (이슈 #149)
    - `pathRefiner.Stop(shutdownCtx)` — refiner cycle drain (PR #191)
    - `cleaner.Stop()` — cleanup cron
-   - `validateWorker.Stop(shutdownCtx)`
+   - `claudegenPool.Stop(shutdownCtx)` — claudegen 컨테이너 정리 (이슈 #458, CLAUDE_CODE_SHUTDOWN_TIMEOUT)
 4. `defer` 체인이 Kafka producer/consumer, redis, pgpool 닫음
+
+<br>
+
+## 관련 이슈
+
+- 이슈 #82 — IngestionLock (Publisher 직전)
+- 이슈 #124 — Scheduler + BacklogThrottler
+- 이슈 #149 — LLM Generator
+- 이슈 #178 — ProcessingLock 단계 prefix
+- 이슈 #295/#297 — parser_blacklist matcher
+- 이슈 #427 — TimedPool decorator
+- 이슈 #431 — BlacklistService / ParserRuleService 분리
+- 이슈 #439/#440 — pkg/config 검증 helper + sub-package 분리
+- 이슈 #443 — stage toggle env flags
+- 이슈 #446 ~ #450 — Enrich worker (extract / cross_verify / context / score)
+- 이슈 #457 — enriched_contents.rationale + factors 컬럼화
+- 이슈 #458 — claudegen → pkg/agent/claude namespace
+- 이슈 #463 — RuleLookup interface
+- 이슈 #472 — enrich MCP postgres
+- 이슈 #474 — claudegen 컨테이너 user non-root
+- 이슈 #477 — ParsePage 결과 index-only 자동 강등 wiring
+- 이슈 #480 — LLM auto-blacklist mode 분기
+- 이슈 #482 — `verifyParsingRulesSeeded` 폐기 (부팅 시 DB seed 검증 제거)

--- a/docs/architecture/cmd/issuetracker.md
+++ b/docs/architecture/cmd/issuetracker.md
@@ -33,11 +33,11 @@
 11. PoolManager (3-tier crawler workers)
 12. LLM provider (chain policy, 이슈 #149)
 13. ParserWorker (consumer group: parsers)
-14. EnrichWorker (consumer group: enrichers, 이슈 #446 ~ #450)
-15. ValidateWorker (consumer group: validators)
-16. Refiner (path_pattern 정밀화, 이슈 #173 단계 4-2)
-17. RawContentCleaner cron                 (Claim Check 잔존물 정리)
-18. Scheduler + BacklogThrottler           (이슈 #124)
+14. Refiner (path_pattern 정밀화, 이슈 #173 단계 4-2)
+15. RawContentCleaner cron                 (Claim Check 잔존물 정리)
+16. Scheduler + BacklogThrottler           (이슈 #124)
+17. ValidateWorker (consumer group: validators)
+18. EnrichWorker (consumer group: enrichers, 이슈 #446 ~ #450)
 19. SIGTERM 대기 → 역순 graceful shutdown
 ```
 
@@ -139,7 +139,7 @@ SIGINT/SIGTERM 수신 시:
 
 1. logger 에 `shutting_down=true` 부착 (이슈 #72)
 2. root `cancel()` — 모든 goroutine 의 ctx 무효화
-3. shutdownCtx (`SHUTDOWN_TIMEOUT`, default 30s 또는 2m) 로 역순 Stop:
+3. shutdownCtx (`SHUTDOWN_TIMEOUT`, default 30s) 로 stages 역순 Stop:
    - `sched.Stop()`
    - `manager.Stop(shutdownCtx)` — drain crawler workers
    - `parserWorker.Stop(shutdownCtx)` — Parser.WaitAutoDemote 도 함께 호출 (이슈 #477)
@@ -148,8 +148,9 @@ SIGINT/SIGTERM 수신 시:
    - `llmGen.Stop(shutdownCtx)` — in-flight LLM call drain (이슈 #149)
    - `pathRefiner.Stop(shutdownCtx)` — refiner cycle drain (PR #191)
    - `cleaner.Stop()` — cleanup cron
-   - `claudegenPool.Stop(shutdownCtx)` — claudegen 컨테이너 정리 (이슈 #458, CLAUDE_CODE_SHUTDOWN_TIMEOUT)
-4. `defer` 체인이 Kafka producer/consumer, redis, pgpool 닫음
+4. cleanupCtx (`CLAUDE_CODE_SHUTDOWN_TIMEOUT`, default 10s) 로 claudegen 정리 — shutdownCtx 와 분리하여 stages.Stop 이 timeout 으로 cancel 되더라도 `docker rm -f` 가 반드시 시도되도록 보장:
+   - `claudegenPool.Stop(cleanupCtx)` — claudegen 컨테이너 정리 (이슈 #458)
+5. `defer` 체인이 Kafka producer/consumer, redis, pgpool 닫음
 
 <br>
 

--- a/docs/architecture/pkg/config.md
+++ b/docs/architecture/pkg/config.md
@@ -1,27 +1,90 @@
 # pkg/config — Environment-Driven Configuration
 
-소스: [`pkg/config/config.go`](../../../pkg/config/config.go)
+소스: [`pkg/config/`](../../../pkg/config/)
 
 `.env` + 환경변수 기반 설정 로더. 모든 컴포넌트가 본 패키지의 Load* 함수를 호출해 자기 config struct
 를 받습니다.
 
+이슈 #440 (PR #441) 에서 21 file 단일 패키지를 도메인별 6 sub-package 로 분리. 이슈 #439 (PR #442) 에서 env 값 검증을 위한 공통 `parse` helper 도입.
+
 <br>
 
-## Loader 함수
+## Sub-package 구조
 
-| 함수                  | 반환 타입             | 결정 항목                                          |
-|----------------------|---------------------|---------------------------------------------------|
-| `Load()`              | `DBConfig`           | PostgreSQL host/port/user/password/database/MaxConns/MinConns |
-| `LoadLog()`           | `LogConfig`          | log level, pretty                                  |
-| `LoadMetrics()`       | `MetricsConfig`      | `METRICS_ADDR` (default `:9090`)                  |
-| `LoadValidate()`      | `ValidateConfig`     | 본문 길이 임계값 / reliability 임계값             |
-| `LoadScheduler()`     | `SchedulerConfig`    | entry interval / MaxBacklog / MaxRetries          |
-| `LoadRefinement()`    | `RefinementConfig`   | refiner enabled / interval / minSamples (이슈 #173) |
-| `LoadLLM()`           | `LLMConfig`          | provider / API key / model / timeout / enabled (이슈 #149) |
-| `LoadRedis()`         | `RedisConfig`        | host/port/password/DB/IngestionLockTTL/poolSize   |
-| `LoadClassifier()`    | `ClassifierConfig`   | gRPC/HTTP endpoint / timeout                       |
+| Sub-package | 책임 | 주요 Loader |
+|---|---|---|
+| [`pkg/config/app/`](../../../pkg/config/app/) | 애플리케이션 부트스트랩 | `LoadLog`, `LoadMetrics`, `LoadShutdown` |
+| [`pkg/config/storage/`](../../../pkg/config/storage/) | PostgreSQL / Redis 접속 | `Load` (DB), `LoadRedis` |
+| [`pkg/config/fetcher/`](../../../pkg/config/fetcher/) | crawler / chromedp pool / 자동 transition | `LoadChromedpPool`, `LoadAutoUpgrade`, `LoadAutoDowngrade` |
+| [`pkg/config/processor/`](../../../pkg/config/processor/) | parser/validate/scheduler/blacklist | `LoadBlacklist`, `LoadScheduler`, `LoadStaleRelearn`, `LoadValidate` |
+| [`pkg/config/llm/`](../../../pkg/config/llm/) | LLM provider / prompt / classifier | `LoadLLM`, `LoadPrompt`, `LoadPathInfer`, `LoadClassifier`, `LoadGoogleCSE` |
+| [`pkg/config/runtime/`](../../../pkg/config/runtime/) | worker count / stage toggle / retry scheduler / stage gate | `LoadStages`, `LoadWorkerCounts`, `LoadStageGate`, `LoadRetryScheduler` |
+| [`pkg/config/internal/parse/`](../../../pkg/config/internal/parse/) | env 값 파싱 helper (port / duration / int / bool / float / ratio 등) — sub-package 들이 의존 |
+
+<br>
+
+## Loader 함수 (대표)
+
+| 함수 | 패키지 | 반환 타입 | 결정 항목 |
+|---|---|---|---|
+| `app.LoadLog` | app | `LogConfig` | log level, pretty |
+| `app.LoadMetrics` | app | `MetricsConfig` | `METRICS_ADDR` (default `:9090`) |
+| `app.LoadShutdown` | app | `ShutdownConfig` | overall + claudegen shutdown timeout |
+| `storage.Load` | storage | `DBConfig` | PostgreSQL host/port/user/password/database/MaxConns/MinConns/QueryTimeout |
+| `storage.LoadRedis` | storage | `RedisConfig` | host/port/password/DB/IngestionLockTTL/poolSize |
+| `fetcher.LoadChromedpPool` | fetcher | `ChromedpPoolConfig` | worker_count, semaphore, remote URLs |
+| `fetcher.LoadAutoUpgrade` | fetcher | `AutoUpgradeConfig` | goquery → chromedp 자동 승격 임계값 |
+| `processor.LoadBlacklist` | processor | `BlacklistConfig` | parser_blacklist 활성/캐시 TTL (이슈 #295/#297) |
+| `processor.LoadScheduler` | processor | `SchedulerConfig` | entry interval / MaxBacklog / MaxRetries (이슈 #124) |
+| `processor.LoadValidate` | processor | `ValidateConfig` | 본문 길이 임계값 / reliability 임계값 |
+| `processor.LoadStaleRelearn` | processor | `StaleRelearnConfig` | stale rule 자동 재학습 (PR #294) |
+| `llm.LoadLLM` | llm | `LLMConfig` | provider / API key / model / timeout / enabled (이슈 #149) |
+| `llm.LoadPathInfer` | llm | `PathInferConfig` | refiner enabled / interval / minSamples (이슈 #173) |
+| `llm.LoadPrompt` | llm | `PromptConfig` | prompt loader (file → embed chain) |
+| `llm.LoadClassifier` | llm | `ClassifierConfig` | classifier gRPC/HTTP endpoint / timeout |
+| `runtime.LoadStages` | runtime | `StagesConfig` | **stage toggle** — fetcher/parser/validate/enrich/scheduler 별 enable (이슈 #443) |
+| `runtime.LoadWorkerCounts` | runtime | `WorkerCountsConfig` | fetcher/parser/validate/enrich worker pool 크기 |
+| `runtime.LoadStageGate` | runtime | `StageGateConfig` | 단계별 ProcessingLock + Semaphore 임계값 |
 
 각 Config struct 는 보통 `DSN()` 등 헬퍼 메소드를 포함합니다.
+
+<br>
+
+## Stage Toggle (이슈 #443)
+
+`runtime.StagesConfig` 가 한 바이너리로 fetcher-only / parser-only / validate-only / enrich-only / scheduler-only 노드 운영을 가능하게 함. Kafka consumer group 이 partition 분배를 처리하므로 stage 간 결합은 토픽 경유로 유지.
+
+```bash
+STAGES_FETCHER_ENABLED=true    # default true
+STAGES_PARSER_ENABLED=true     # default true
+STAGES_VALIDATE_ENABLED=true   # default true
+STAGES_ENRICH_ENABLED=true     # default true (이슈 #446)
+STAGES_SCHEDULER_ENABLED=true  # default true
+```
+
+모든 stage 가 false 인 구성은 의미 없음 — `LoadStages` 가 에러로 거부.
+
+<br>
+
+## `parse` helper (이슈 #439)
+
+`pkg/config/internal/parse/` 가 env 값 파싱/검증의 공통 정책을 제공:
+
+- env 변수가 비어있으면 noop (default 보존)
+- 비어있지 않으면 파싱 시도, 실패 시 명확한 wrap 에러
+- 의미적 경계 검증 (port 범위 / 양수 / 비음수 / ratio 등) 실패 시 명확한 에러
+
+**호출 패턴**:
+```go
+if err := parse.Port("POSTGRES_PORT", &cfg.Port); err != nil {
+    return DBConfig{}, err
+}
+if err := parse.Duration("POSTGRES_QUERY_TIMEOUT", &cfg.QueryTimeout); err != nil {
+    return DBConfig{}, err
+}
+```
+
+잘못된 env 값에 의한 silent degraded 동작 (무한 대기 / port 0 / 음수 timeout 등) 방지가 목적.
 
 <br>
 
@@ -29,8 +92,9 @@
 
 - 환경변수는 모두 `os.Getenv` 또는 `joho/godotenv` 로 읽음
 - 누락 시 default 적용 또는 명시적 에러 (Loader 마다 정책)
-- 한 곳 (`config.go`) 에 집중 — ENV 키 추가는 본 파일에 새 Load* 함수 추가 또는 기존 함수 확장
+- 도메인별 sub-package 로 분리 — 추가 ENV 키는 해당 sub-package 에 새 Load* 함수 추가 또는 기존 함수 확장
 - struct 필드는 export — 호출자가 직접 읽음 (getter 없음)
+- 파싱은 항상 `parse` helper 경유 — silent degraded 회피
 
 <br>
 
@@ -51,17 +115,33 @@
 
 ## ENV 키 (요약)
 
-| Prefix             | 사용처                                        |
-|--------------------|----------------------------------------------|
-| `DB_*`             | [Load](../internal/storage/postgres.md)       |
-| `KAFKA_*`          | [pkg/queue](queue.md)                         |
-| `REDIS_*`          | [pkg/redis](redis.md)                         |
+| Prefix | 사용처 |
+|---|---|
+| `POSTGRES_*` | [storage](../internal/storage/postgres.md) |
+| `KAFKA_*` | [pkg/queue](queue.md) |
+| `REDIS_*` | [pkg/redis](redis.md) |
 | `LLM_*`, `GEMINI_API_KEY`, `OPENAI_API_KEY`, `ANTHROPIC_API_KEY` | [pkg/llm](llm.md) |
-| `VALIDATE_*`       | [validate.md](../internal/processor/validate.md) |
-| `SCHEDULER_*`      | [scheduler.md](../internal/scheduler.md)      |
-| `REFINEMENT_*`     | [refiner](../internal/processor/parser/rule.md)      |
-| `METRICS_ADDR`     | [pkg/metrics](metrics.md)                     |
-| `LOG_*`            | [pkg/logger](logger.md)                        |
-| `CLASSIFIER_*`     | [classifier](../internal/classifier/README.md) |
+| `CLAUDE_CODE_*` | [pkg/agent/claude](agent/claude.md) — claudegen 컨테이너 |
+| `STAGES_*_ENABLED` | [runtime](#stage-toggle-이슈-443) — stage toggle (이슈 #443) |
+| `FETCHER_*` | [fetcher](../internal/processor/fetcher/README.md) — chromedp pool / auto upgrade |
+| `BLACKLIST_*` | parser_blacklist matcher (이슈 #295/#297) |
+| `VALIDATE_*` | [validate.md](../internal/processor/validate.md) |
+| `SCHEDULER_*` | [scheduler.md](../internal/scheduler.md) |
+| `PATH_INFER_*`, `REFINEMENT_*` | [refiner](../internal/processor/parser/rule.md) |
+| `METRICS_ADDR` | [pkg/metrics](metrics.md) |
+| `LOG_*` | [pkg/logger](logger.md) |
+| `CLASSIFIER_*` | [classifier](../internal/classifier/README.md) |
+| `SHUTDOWN_TIMEOUT` | overall graceful shutdown |
+| `ENRICHER_DB_RO_*` | enrich MCP postgres (이슈 #472) |
 
 전체 키 목록은 [`.env.example`](../../../.env.example) 가 단일 소스.
+
+<br>
+
+## 관련 이슈
+
+- 이슈 #439 — env 값 파싱/검증 공통 helper (`parse` package)
+- 이슈 #440 — 21 file → 6 sub-package 도메인 그룹화
+- 이슈 #443 — stage toggle env flags
+- 이슈 #446 — enrich stage 도입
+- 이슈 #472 — enrich MCP postgres ENV

--- a/docs/architecture/pkg/metrics.md
+++ b/docs/architecture/pkg/metrics.md
@@ -24,15 +24,54 @@ defer stop()
 
 ## 등록되는 메트릭
 
-| 메트릭                              | 종류       | 위치                                                                | 의미                                |
-|------------------------------------|-----------|---------------------------------------------------------------------|-------------------------------------|
-| Go runtime / process               | Collector | NewRegistry 자동                                                     | GC, goroutine, mem, fd 등           |
-| `refiner_attempts`                 | Counter   | [refiner/metrics.go](../../../internal/processor/parser/rule/refiner/metrics.go) | path_pattern 정밀화 시도 횟수 (PR #191) |
-| (그 외) Circuit Breaker 상태 등    | (개별 패키지가 자체 등록) | -                                                  |                                     |
+각 모듈이 자체적으로 `NewCounterVec` 등을 만들고 본 registry 에 `MustRegister` 또는 idempotent register helper 로 등록.
 
-신규 메트릭 추가 시 해당 패키지 (예: `internal/processor/parser/rule/refiner`) 가
-`prometheus.NewCounterVec` 등으로 만들고 `metricsRegistry.MustRegister` 로 등록 — registry 인스턴스를
+| 메트릭 | 종류 | 위치 | 의미 | Label |
+|---|---|---|---|---|
+| Go runtime / process | Collector | `NewRegistry` 자동 | GC, goroutine, mem, fd 등 | — |
+| `refinement_attempts` | Counter | [`rule/refiner/metrics.go`](../../../internal/processor/parser/rule/refiner/metrics.go) | path_pattern 정밀화 시도 (PR #191) | `result` (success/skipped/error), `method` (algorithm/llm/none) |
+| `refinement_llm_calls_total` | Counter | [`rule/refiner/metrics.go`](../../../internal/processor/parser/rule/refiner/metrics.go) | refiner 의 LLM 호출 결과 | `status` (success/error) |
+| `parser_index_page_auto_demoted_total` | Counter | [`rule/auto_demote_metrics.go`](../../../internal/processor/parser/rule/auto_demote_metrics.go) | index-only 페이지 자동 강등 (이슈 #477) | `host` |
+| `llm_*` (pkg/llm 자체) | Histogram / Counter | [`pkg/llm/measured.go`](../../../pkg/llm/measured.go) | provider 별 latency / 호출 결과 | provider, status 등 |
+| (그 외) Circuit Breaker / Worker Pool 등 | 개별 패키지 자체 등록 | — | — | — |
+
+신규 메트릭 추가 시 해당 패키지 (예: `internal/processor/parser/rule/auto_demote_metrics.go`) 가
+`prometheus.NewCounterVec` 등으로 만들고 호출자가 registry 인스턴스를 전달해서 등록. registry 인스턴스를
 [`cmd/issuetracker`](../cmd/issuetracker.md) 가 wiring 시점에 주입.
+
+<br>
+
+## 등록 패턴 — idempotent register
+
+여러 위치에서 동일 collector 가 등록 시도되더라도 panic 없이 기존 collector 재사용. [`rule/auto_demote_metrics.go`](../../../internal/processor/parser/rule/auto_demote_metrics.go) 의 `registerOrReuseAutoDemoteCounter` / [`rule/refiner/metrics.go`](../../../internal/processor/parser/rule/refiner/metrics.go) 의 `registerOrReuseCounter` / [`pkg/llm/measured.go`](../../../pkg/llm/measured.go) 의 `MeasuredFactory` 가 동일 패턴 적용:
+
+```go
+counter := prometheus.NewCounterVec(opts, labels)
+if err := registry.Register(counter); err != nil {
+    var are prometheus.AlreadyRegisteredError
+    if errors.As(err, &are) {
+        if existing, ok := are.ExistingCollector.(*prometheus.CounterVec); ok {
+            return existing  // 재사용
+        }
+    }
+    panic(err)  // incompatible collector 충돌
+}
+```
+
+<br>
+
+## nil-safe Metrics 패턴
+
+`*Metrics` 가 nil 이거나 내부 collector 가 nil 이면 `Record*` 메소드가 noop — 호출자는 nil 검사 없이 항상 호출 가능. `NewAutoDemoteMetrics(nil)` 또는 `NewAutoDemoteMetrics(registry)` 둘 다 허용 — METRICS 비활성 환경 cover:
+
+```go
+func (m *AutoDemoteMetrics) RecordAutoDemote(host string) {
+    if m == nil || m.autoDemoted == nil {
+        return
+    }
+    m.autoDemoted.WithLabelValues(host).Inc()
+}
+```
 
 <br>
 
@@ -45,12 +84,22 @@ defer stop()
 
 ## Wiring 위치
 
-- [`cmd/issuetracker`](../cmd/issuetracker.md) 단계 1
+- [`cmd/issuetracker`](../cmd/issuetracker.md) 단계 1 — registry 생성 + endpoint serve
 - [`cmd/processor`](../cmd/processor.md) 동일
+
+각 모듈은 registry 를 wiring 시점에 받아 자기 collector 를 등록:
+
+```go
+// cmd/issuetracker/main.go
+autoDemoteMetrics := rule.NewAutoDemoteMetrics(metricsRegistry)
+parserOpts = append(parserOpts, rule.WithBlacklistAutoDemote(blacklistSvc, autoDemoteMetrics, log))
+```
 
 <br>
 
 ## 관련 이슈
 
 - 이슈 #165 — metrics endpoint 도입
-- PR #191 — refiner_attempts counter 추가
+- PR #191 — `refinement_attempts` counter 추가
+- 이슈 #477 — `parser_index_page_auto_demoted_total` counter 추가
+- 이슈 #472 — enrich MCP postgres tool (별도 metric 없음, 추후 enrich 단계별 metric 추가 백로그)


### PR DESCRIPTION
## 연관 이슈
- Closes #490
- Parent: #488

<br>

## 구현 내용

지난 30 PR (#419 ~ #487) 동안 cmd/issuetracker, pkg/metrics, pkg/config 에 추가된 구조 / wiring / metric 변경을 architecture 문서에 일괄 반영. 메타 이슈 #488 의 sub-issue 2/4.

### cmd/issuetracker.md (+159 −66 LOC)

- Wiring 흐름 (코드 순서) 갱신 — 19 단계 명시 (이슈 #443/#477/#446-450/#482/#427/#458/#460/#472)
- Build helpers 표: \`verifyParsingRulesSeeded\` 제거, \`buildClaudegenPool\` / \`buildEnricherROMCPConfig\` 추가
- 환경 변수 의존 표: sub-package 분리 (이슈 #440) + Stage Toggle env (이슈 #443) 별도 섹션
- Worker 카운트 env (\`STAGES_*_WORKER_COUNT\`) 추가
- Graceful Shutdown: \`enrichWorker.Stop\` + \`claudegenPool.Stop\` + \`Parser.WaitAutoDemote\` 추가

### pkg/metrics.md (+69 −20 LOC)

- 등록되는 메트릭 표 갱신:
  - \`parser_index_page_auto_demoted_total\` 추가 (이슈 #477, host label)
  - \`refinement_attempts\` label 명시 (result, method)
  - \`refinement_llm_calls_total\` 추가
  - \`llm_*\` (pkg/llm/measured.go) 추가
- 등록 패턴 (idempotent register) + nil-safe Metrics 패턴 명문화
- Wiring 예제: \`AutoDemoteMetrics\` registry 주입

### pkg/config.md (+130 −59 LOC)

- Sub-package 구조 표 신설 (이슈 #440 — 21 file → 6 sub-package)
- Loader 함수 표 sub-package 별 재분류 + 신규 Loader 추가
- Stage Toggle 섹션 신설 (이슈 #443) — \`STAGES_*_ENABLED\` 5개 env
- \`parse\` helper 섹션 신설 (이슈 #439) — silent degraded 회피
- ENV 키 표 갱신 (POSTGRES_*, STAGES_*, CLAUDE_CODE_*, ENRICHER_DB_RO_*, BLACKLIST_*)

<br>

## CI / 머지 게이트 점검

### 변경 영향 범위
- 영향 파일: \`docs/architecture/cmd/issuetracker.md\`, \`docs/architecture/pkg/metrics.md\`, \`docs/architecture/pkg/config.md\`
- 위험도(택1): **Low** — 문서만 변경.

### Required Status Checks
- [ ] \`Commit Lint\` / \`PR Title Lint\` / \`Linked Issue Check\`
- [ ] \`Format Check\` / \`Build\` / \`Test\` / \`Lint\`

### 로컬 검증
- ✅ \`go build ./...\` 통과 (문서 변경)

### 롤백 계획
- 본 PR revert — 문서만 원복.

<br>

## 논의 사항

- 메타 이슈 #488 의 sub 2/4. 나머지:
  - ✅ #489 (PR #493) — parser docs
  - #491 — storage docs
  - #492 — 신규 모듈 문서 (enrich, agent/claude, precheck)

🤖 Generated with [Claude Code](https://claude.com/claude-code)