### PR TITLE
[DOCS#492] 신규 모듈 문서 — enrich, agent/claude, precheck

### DIFF
--- a/docs/architecture/internal/processor/README.md
+++ b/docs/architecture/internal/processor/README.md
@@ -85,17 +85,18 @@ validate/worker.go → types  (RunValidation 이 types.Validator 인자)
 
 ## 서브패키지
 
-| 디렉토리                                                                       | 문서                                |
-|-------------------------------------------------------------------------------|-------------------------------------|
-| [`internal/processor/fetcher/`](../../../../internal/processor/fetcher/)       | [fetcher/README.md](fetcher/README.md) |
-| [`internal/processor/parser/`](../../../../internal/processor/parser/)         | [parser/README.md](parser/README.md)   |
-| [`internal/processor/validate/`](../../../../internal/processor/validate/)     | [validate.md](validate.md)             |
+| 디렉토리 | 문서 |
+|---|---|
+| [`internal/processor/fetcher/`](../../../../internal/processor/fetcher/) | [fetcher/README.md](fetcher/README.md) |
+| [`internal/processor/parser/`](../../../../internal/processor/parser/) | [parser/README.md](parser/README.md) |
+| [`internal/processor/validate/`](../../../../internal/processor/validate/) | [validate.md](validate.md) |
+| [`internal/processor/enrich/`](../../../../internal/processor/enrich/) | [enrich/README.md](enrich/README.md) — 4-stage enrichment pipeline (이슈 #445 ~ #450, #457) |
+| [`internal/processor/precheck/`](../../../../internal/processor/precheck/) | [precheck.md](precheck.md) — 진입점 URL 처리 가부 게이트 (이슈 #425) |
 
 <br>
 
 ## 향후 확장
 
-- `internal/processor/enrich/` — entity / sentiment / topic
 - `internal/processor/embed/` — vector embedding
 - `internal/processor/classify/` — [internal/classifier](../classifier/README.md) 호출 stage
 

--- a/docs/architecture/internal/processor/enrich/README.md
+++ b/docs/architecture/internal/processor/enrich/README.md
@@ -25,7 +25,7 @@
 ```
 Kafka(issuetracker.validated)
   ↓ Worker.processMessage (claim check 로드)
-  ↓ ProcessingLock.Acquire("enrich", url)
+  ↓ ProcessingLock.Acquire("enricher", url)
   ↓
   ├─ Stage 1: Extractor.Extract(content, html)       — 이슈 #447
   │     → EnrichedFacts (entities[], claims[], facts[], topics[], sentiment)
@@ -36,7 +36,7 @@ Kafka(issuetracker.validated)
   │     → MCP postgres + WebFetch 로 claim 별 cross-verify
   │     → 실패 시 forwarding without verifications
   │
-  ├─ Stage 3: Contextualizer.Contextualize(...)      — 이슈 #449
+  ├─ Stage 3: Contextualizer.Provide(...)            — 이슈 #449
   │     → PageContext (background[], timeline[], implications)
   │     → MCP postgres + WebFetch 로 entity 별 external background 수집
   │     → 실패 시 forwarding without context
@@ -68,7 +68,7 @@ type Verifier interface {
     Verify(ctx, in VerifyInput) ([]Verification, error)
 }
 type Contextualizer interface {
-    Contextualize(ctx, in ContextInput) (*PageContext, error)
+    Provide(ctx context.Context, in ContextInput) (*PageContext, error)
 }
 type Scorer interface {
     Score(ctx, in ScoreInput) (*TrustScoreResult, error)
@@ -158,7 +158,7 @@ type Worker struct {
     rawSvc    service.RawContentService
     contSvc   service.ContentService
     enrichSvc EnrichedContentService
-    lock      *locks.ProcessingLock  // "enrich" stage
+    lock      *locks.ProcessingLock  // "enricher" stage
     log       *logger.Logger
 }
 ```
@@ -182,10 +182,10 @@ type Worker struct {
 ## 의존
 
 - [`pkg/agent/claude`](../../../pkg/agent/claude.md) — claudegen container pool + SessionRunner
-- [`pkg/llm/prompt`](../../../pkg/llm/prompt/) — file → embed prompt loader
+- [`pkg/llm/prompt`](../../../../../pkg/llm/prompt/) — file → embed prompt loader ([`pkg/llm.md`](../../../pkg/llm.md) 안에 포함)
 - [`internal/storage/service`](../../storage/service.md) — RawContentService, ContentService, EnrichedContentService
 - [`internal/storage/repository`](../../storage/README.md) — EnrichedContentRepository (이슈 #450)
-- [`internal/locks`](../../locks/README.md) — ProcessingLock (단계 "enrich")
+- [`internal/locks`](../../locks/README.md) — ProcessingLock (단계 "enricher")
 - [`pkg/queue`](../../../pkg/queue.md), [`pkg/logger`](../../../pkg/logger.md)
 
 <br>

--- a/docs/architecture/internal/processor/enrich/README.md
+++ b/docs/architecture/internal/processor/enrich/README.md
@@ -1,0 +1,222 @@
+# internal/processor/enrich — 4-Stage Enrichment Pipeline
+
+소스: [`internal/processor/enrich/`](../../../../../internal/processor/enrich/)
+
+\`validated\` 토픽의 article 을 입력으로 받아 entity / claim / fact 추출 → cross-verification → external context → trust score 의 4 단계 enrichment 를 수행하고 \`enriched\` 토픽으로 발행 + \`enriched_contents\` 테이블 영속화.
+
+이슈 #445 ~ #450 으로 도입된 enrich subsystem. claudegen ([`pkg/agent/claude`](../../../pkg/agent/claude.md)) 를 LLM 백엔드로, MCP postgres tool (이슈 #472) 을 read-only DB 액세스로 사용.
+
+<br>
+
+## 패키지 구조
+
+| 디렉토리 | 책임 |
+|---|---|
+| [`enrich.go`](../../../../../internal/processor/enrich/enrich.go) | 모듈 entry — Worker 생성 (compose) |
+| [`core/`](../../../../../internal/processor/enrich/core/) | 도메인 모델 + 4단계 interface + claudegen 구현체 (extract / verify / context / score) — 이슈 #460 (stage 별 agent 사용 OOP 분리) |
+| [`worker/`](../../../../../internal/processor/enrich/worker/) | Kafka consumer + 4 단계 직렬 실행 + 영속화 + DLQ |
+
+<br>
+
+## 4-stage Pipeline
+
+\`validated\` 토픽의 단일 article (Content + ContentRef) 가 다음 순서로 처리됩니다:
+
+```
+Kafka(issuetracker.validated)
+  ↓ Worker.processMessage (claim check 로드)
+  ↓ ProcessingLock.Acquire("enrich", url)
+  ↓
+  ├─ Stage 1: Extractor.Extract(content, html)       — 이슈 #447
+  │     → EnrichedFacts (entities[], claims[], facts[], topics[], sentiment)
+  │     → 실패 시 forwarding without facts (graceful fallback)
+  │
+  ├─ Stage 2: Verifier.Verify(content, facts)        — 이슈 #448
+  │     → []Verification {claim_idx, verdict, sources, note}
+  │     → MCP postgres + WebFetch 로 claim 별 cross-verify
+  │     → 실패 시 forwarding without verifications
+  │
+  ├─ Stage 3: Contextualizer.Contextualize(...)      — 이슈 #449
+  │     → PageContext (background[], timeline[], implications)
+  │     → MCP postgres + WebFetch 로 entity 별 external background 수집
+  │     → 실패 시 forwarding without context
+  │
+  └─ Stage 4: Scorer.Score(facts, verifications, context) — 이슈 #450
+        → TrustScoreResult (trust_score, rationale, factors)
+        → factors: claim_support_ratio / source_diversity / context_completeness
+        → 실패 시 forwarding without trust_score (graceful)
+
+  ↓ EnrichedContentRepository.Upsert (이슈 #450, rationale/factors 컬럼: #457)
+  ↓ Producer.Publish(TopicEnriched, ContentRef)
+  ↓ Kafka.CommitMessages
+```
+
+**graceful fallback 정책**: 단계별 실패는 비-fatal — 부분 결과만 누락된 채 다음 단계 + DB upsert 가 진행. 운영 시 `forwarding without {facts|verifications|context|trust_score}` WARN 로그로 가시화.
+
+<br>
+
+## core 패키지의 4 interface + 구현체
+
+[`core/`](../../../../../internal/processor/enrich/core/):
+
+```go
+// 4 단계 각각의 입력/출력 타입과 인터페이스
+type Extractor interface {
+    Extract(ctx, in Input) (*EnrichedFacts, error)
+}
+type Verifier interface {
+    Verify(ctx, in VerifyInput) ([]Verification, error)
+}
+type Contextualizer interface {
+    Contextualize(ctx, in ContextInput) (*PageContext, error)
+}
+type Scorer interface {
+    Score(ctx, in ScoreInput) (*TrustScoreResult, error)
+}
+```
+
+각 인터페이스마다 **두 구현체**:
+
+- **`Noop*`** — stage toggle 비활성 / LLM 비활성 fallback (이슈 #446)
+- **`Claudegen*`** — `pkg/agent/claude` 의 [`SessionRunner = agent.Agent`](../../../pkg/agent/claude.md) 를 통해 claude CLI 호출
+
+예: `NewClaudegenExtractor(runner, loader)` — claudegen worker pool 의 `agent.Agent` 와 prompt loader 를 받아 enrich 프롬프트 ([`pkg/llm/prompt/assets/enrich/claude/extract.user.txt`](../../../../../pkg/llm/prompt/assets/enrich/claude/extract.user.txt)) 로 LLM 호출. 결과 JSON 을 `parseEnrichOutput` 으로 unmarshal.
+
+<br>
+
+## 프롬프트 contract (이슈 #486)
+
+`pkg/llm/prompt/assets/enrich/claude/*.user.txt` 4 개 파일:
+
+| 단계 | 프롬프트 파일 | 핵심 schema |
+|---|---|---|
+| extract | `extract.user.txt` | `{entities, claims, facts, topics, sentiment}` |
+| verify | `cross_verify.user.txt` | `{verifications: [{claim_idx, verdict, sources, note}]}` |
+| context | `context.user.txt` | `{background, timeline, implications}` |
+| score | `score.user.txt` | `{trust_score, rationale, factors}` |
+
+각 프롬프트에 **CRITICAL OUTPUT CONTRACT** 블록이 상단에 명시 (이슈 #486 / PR #487):
+- 응답은 raw JSON object 만 (first char `{`, last char `}`)
+- 금지 시작 단어 명시 (`"I"`, `"The"`, `"Title"`, `"Based on"`, `"Sure"`, `"Okay"`, `"Here"`, `"Let me"`)
+- markdown fence 금지
+- 거부 응답 대신 schema-conformant empty defaults 반환
+- 위반 시 응답 DISCARD 됨을 LLM 에 통지 (helpfulness 본능 억제)
+
+<br>
+
+## EnrichedContents 영속화 (이슈 #450, #457)
+
+`enriched_contents` 테이블 스키마 (migration 029 + 030):
+
+```sql
+id              BIGSERIAL  PRIMARY KEY
+content_id      VARCHAR(255) NOT NULL  -- contents.id 참조 (FK 없음)
+trust_score     NUMERIC(4,3) NOT NULL  -- 0.0 ~ 1.0
+facts           JSONB        NOT NULL  -- entities + claims + facts + topics + sentiment
+verifications   JSONB        NOT NULL  -- [{claim_idx, verdict, sources, note}, ...]
+context         JSONB        NOT NULL  -- background + timeline + implications
+enriched_at     TIMESTAMPTZ  NOT NULL  DEFAULT NOW()
+rationale       TEXT         NOT NULL  DEFAULT ''  -- 이슈 #457 — scorer 진단
+factors         JSONB        NOT NULL  DEFAULT '{}' -- 이슈 #457 — claim_support_ratio 등
+```
+
+Upsert by `content_id` — 동일 article 재enrich 시 갱신. 부분 실패 (facts 만 / verifications 만) 도 partial upsert 로 진행.
+
+<br>
+
+## MCP postgres tool (이슈 #472)
+
+cross-verify / context 단계에서 claudegen 에 read-only DB 접근 권한 부여. `enricher_ro` PostgreSQL role 이 `contents` / `enriched_contents` SELECT 만 허용.
+
+```bash
+# .env
+ENRICHER_DB_RO_HOST=localhost
+ENRICHER_DB_RO_PORT=5432
+ENRICHER_DB_RO_DATABASE=main
+ENRICHER_DB_RO_USER=enricher_ro
+ENRICHER_DB_RO_PASSWORD=enricher_ro_dev_pw
+```
+
+`cmd/issuetracker.go` 의 `buildEnricherROMCPConfig` 가 본 env 를 `mcp.json` 으로 변환 → claudegen container 의 `--mcp-config` 인자로 mount. LLM 은 prompt 내에서 `mcp__issuetracker_ro__query` tool 로 SELECT 가능 (statement_timeout 5s).
+
+미설정 시 MCP tool 없이 WebFetch / WebSearch 만으로 verify / context 진행 — graceful degrade.
+
+<br>
+
+## Worker (Kafka consumer)
+
+[`worker/worker.go`](../../../../../internal/processor/enrich/worker/worker.go):
+
+```go
+type Worker struct {
+    consumer  *kafka.Consumer        // issuetracker.validated
+    producer  *kafka.Producer        // issuetracker.enriched
+    extractor core.Extractor
+    verifier  core.Verifier
+    contextu  core.Contextualizer
+    scorer    core.Scorer
+    rawSvc    service.RawContentService
+    contSvc   service.ContentService
+    enrichSvc EnrichedContentService
+    lock      *locks.ProcessingLock  // "enrich" stage
+    log       *logger.Logger
+}
+```
+
+- input_topic: `issuetracker.validated`
+- output_topic: `issuetracker.enriched`
+- consumer group: `issuetracker-enricher`
+- worker_count: env `ENRICH_WORKER_COUNT` (default 4)
+- Stage Gate Semaphore capacity: env `ENRICH_MAX_CONCURRENT_PER_STAGE` (default 2)
+
+<br>
+
+## graceful shutdown
+
+`Worker.Stop(ctx)` 가 in-flight 4-stage 처리를 ctx 까지 대기. claudegen pool 의 컨테이너 정리는 별도 — [`pkg/agent/claude.md`](../../../pkg/agent/claude.md) 참조.
+
+`CLAUDE_CODE_TIMEOUT` 이 각 stage 의 LLM 세션 timeout (default 120s, .env 180s). 4 단계 직렬이라 단일 article 의 enrich 총 walltime 은 최대 `4 × CLAUDE_CODE_TIMEOUT` 가능.
+
+<br>
+
+## 의존
+
+- [`pkg/agent/claude`](../../../pkg/agent/claude.md) — claudegen container pool + SessionRunner
+- [`pkg/llm/prompt`](../../../pkg/llm/prompt/) — file → embed prompt loader
+- [`internal/storage/service`](../../storage/service.md) — RawContentService, ContentService, EnrichedContentService
+- [`internal/storage/repository`](../../storage/README.md) — EnrichedContentRepository (이슈 #450)
+- [`internal/locks`](../../locks/README.md) — ProcessingLock (단계 "enrich")
+- [`pkg/queue`](../../../pkg/queue.md), [`pkg/logger`](../../../pkg/logger.md)
+
+<br>
+
+## 외부 시스템
+
+- Kafka: `issuetracker.validated` consume, `issuetracker.enriched` produce, `issuetracker.dlq` produce (재시도 한도 초과)
+- PostgreSQL: `enriched_contents` upsert (이슈 #450, #457)
+- claudegen container (Docker): per-session `docker exec` (4 단계 × N article)
+- (optional) MCP postgres tool: `enricher_ro` role 로 read-only DB 액세스 (이슈 #472)
+
+<br>
+
+## Wiring 위치
+
+[`cmd/issuetracker.md`](../../../cmd/issuetracker.md) 의 단계 14 (`EnrichWorker`). `STAGES_ENRICH_ENABLED=true` (default) 일 때만 기동.
+
+<br>
+
+## 관련 이슈
+
+- 이슈 #445 — enrich subsystem 메인 (4 단계 구성)
+- 이슈 #446 — enricher 스켈레톤 (Kafka 토픽 + worker passthrough + stage toggle)
+- 이슈 #447 — Stage 1 Extractor (entity/claim/fact JSON 구조화)
+- 이슈 #448 — Stage 2 Verifier (cross-verify with DB candidates + WebFetch)
+- 이슈 #449 — Stage 3 Contextualizer (external background / timeline / implications)
+- 이슈 #450 — Stage 4 Scorer + enriched_contents 영속화 (trust_score)
+- 이슈 #457 — `rationale` + `factors` 컬럼화 (scorer 진단 정보 영속화)
+- 이슈 #458 — claudegen → `pkg/agent/claude` namespace 분리
+- 이슈 #460 — parser/core + enrich/core — stage 별 agent 사용 OOP 분리
+- 이슈 #470 — claude `--dangerously-skip-permissions` + tool 권한 자동 허가
+- 이슈 #472 — enrich agent MCP postgres read-only DB 직접 접근
+- 이슈 #474 — claudegen 컨테이너 user non-root (node)
+- 이슈 #486 — enrich 프롬프트 JSON-only contract 강화 (CRITICAL OUTPUT CONTRACT 블록)

--- a/docs/architecture/internal/processor/precheck.md
+++ b/docs/architecture/internal/processor/precheck.md
@@ -1,0 +1,128 @@
+# internal/processor/precheck — Common URL Processing Gate
+
+소스: [`internal/processor/precheck/`](../../../../internal/processor/precheck/)
+
+fetcher / parser / 기타 processor stage 가 URL 을 실제로 처리하기 전에 **처리 가부** 를 일괄 판정하는 공용 진입 게이트. 이슈 #425 (PR #436) 으로 도입.
+
+이전에는 blacklist 매칭이 publisher 단계에서만 일어났으나, fetcher 가 publish 한 URL 이 parser 단계에서 다시 한 번 정책 적용을 받아야 하는 케이스가 늘어나면서 cross-cutting 정책을 단일 boundary 로 모음.
+
+<br>
+
+## 설계 목표
+
+- **다중 stage 진입점에서 동일 게이트 호출** — fetch / parse / outgoing chained URL filter 등
+- **cross-cutting 정책의 plug-in** — blacklist / 향후 rate_limit / robots / domain throttle 등
+- **의존성 역전** — Source 는 의존 구현체 (BlacklistMatcher / rate_limit) 를 본 패키지가 모름. 호출자가 wiring 시 주입
+
+<br>
+
+## 핵심 타입
+
+[`precheck.go`](../../../../internal/processor/precheck/precheck.go):
+
+```go
+// 단일 URL 의 처리 결정
+type Verdict int
+
+const (
+    VerdictAllow              Verdict = iota  // 정상 진행
+    VerdictDrop                              // fetch / parse 스킵, commit-only
+    VerdictExtractLinksOnly                   // list 강제 분기 (fetch + ParseLinks 만, ParsePage skip)
+                                              // blacklist 도메인의 'extract_links_only' mode 와 동일
+)
+
+// Source / Decider 의 판정 결과
+type Decision struct {
+    Verdict Verdict
+    Source  string   // 어떤 Source 가 판정했는지 (운영 가시성)
+    Reason  string   // 사후 분류 / 검증
+}
+
+// 단일 정책 plug-in interface
+type Source interface {
+    CheckURL(ctx context.Context, rawURL string) Decision
+}
+
+// 다중 Source 를 합성한 게이트
+type Decider struct { ... }
+func New(sources ...Source) *Decider
+func (d *Decider) CheckURL(ctx context.Context, rawURL string) Decision
+```
+
+`Decider.CheckURL` 은 등록된 Source 들을 순차 호출 — 첫 non-Allow Verdict 가 나오면 즉시 반환. 모두 Allow 면 `VerdictAllow`.
+
+<br>
+
+## Source 구현체
+
+[`blacklist.go`](../../../../internal/processor/precheck/blacklist.go):
+
+```go
+// parser_blacklist 매칭을 precheck Source 로 노출
+// matcher 가 nil 이면 NewBlacklistSource 가 nil 반환 (graceful disable)
+func NewBlacklistSource(matcher *rule.BlacklistMatcher) Source
+```
+
+- BlacklistMatcher 의 mode 별 결과를 Verdict 로 매핑:
+  - `BlacklistModeDrop` → `VerdictDrop`
+  - `BlacklistModeExtractLinksOnly` → `VerdictExtractLinksOnly`
+  - 매칭 없음 → `VerdictAllow`
+
+향후 추가 가능 (계획):
+- `rate_limit.Source` — host 단위 token bucket
+- `robots.Source` — robots.txt 정책
+- `domain_throttle.Source` — 글로벌 도메인 사용 한도
+
+<br>
+
+## 호출 패턴
+
+```go
+// wiring (cmd/issuetracker)
+blacklistSrc := precheck.NewBlacklistSource(blacklistMatcher)  // matcher nil 이면 nil
+preChecker := precheck.New(blacklistSrc)  // nil Source 는 자동 skip
+
+// 호출 (publisher / parser_worker / fetcher 진입점)
+verdict := preChecker.CheckURL(ctx, jobURL)
+switch verdict.Verdict {
+case precheck.VerdictAllow:
+    // 정상 진행
+case precheck.VerdictDrop:
+    // commit-only, 처리 skip + 운영 로그
+case precheck.VerdictExtractLinksOnly:
+    // 파서 단계에서 list 강제 분기 — fetch 는 진행, parse 시 ParseLinks 만
+}
+```
+
+<br>
+
+## 의존
+
+- [`internal/processor/parser/rule`](../parser/rule.md) — `BlacklistMatcher` (BlacklistSource 의 백엔드)
+- [`internal/storage/model`](../../storage/README.md) — `BlacklistMode` 상수
+
+<br>
+
+## 호출 측
+
+| 호출자 | 사용 메소드 | 비고 |
+|---|---|---|
+| [`internal/publisher`](../publisher.md) | `Decider.CheckURL` | publish 직전 마지막 게이트 |
+| [`internal/processor/parser/worker`](parser/README.md) | `Decider.CheckURL` (계획) | parser 진입점 — list / page 라우팅 결정에 활용 |
+| [`internal/processor/fetcher/handler`](fetcher/handler.md) (계획) | `Decider.CheckURL` | fetch 시작 전 (대량 사이트 throttle 등 향후) |
+
+<br>
+
+## Wiring 위치
+
+[`cmd/issuetracker/main.go`](../../../../cmd/issuetracker/main.go) — blacklistMatcher / 기타 Source 구성 후 `precheck.New` 로 합성. `BLACKLIST_ENABLED=false` 환경에서는 `NewBlacklistSource(nil)` 가 nil 반환 → `Decider` 가 빈 Source 리스트라 모든 URL Allow (기능 OFF).
+
+<br>
+
+## 관련 이슈
+
+- **이슈 #425 — precheck 패키지 신설** (다중 stage 진입점 게이트)
+- 이슈 #295 / #297 — parser_blacklist (drop / extract_links_only mode 도메인)
+- 이슈 #431 — BlacklistService (decorator chain + matcher invalidate)
+- 이슈 #477 — auto_demote (parser_blacklist 자동 등록, mode='extract_links_only')
+- 이슈 #480 — LLM auto-blacklist mode 분기 (drop / extract_links_only 등록)

--- a/docs/architecture/internal/processor/precheck.md
+++ b/docs/architecture/internal/processor/precheck.md
@@ -40,13 +40,15 @@ type Decision struct {
 
 // 단일 정책 plug-in interface
 type Source interface {
-    CheckURL(ctx context.Context, rawURL string) Decision
+    Name() string  // 식별자 (예: "blacklist") — Decision.Source 로 들어감
+    Check(ctx context.Context, rawURL string) Decision
 }
 
-// 다중 Source 를 합성한 게이트
-type Decider struct { ... }
-func New(sources ...Source) *Decider
-func (d *Decider) CheckURL(ctx context.Context, rawURL string) Decision
+// 다중 Source 를 합성한 게이트 — interface (struct 아님)
+type Decider interface {
+    CheckURL(ctx context.Context, rawURL string) Decision
+}
+func New(sources ...Source) Decider
 ```
 
 `Decider.CheckURL` 은 등록된 Source 들을 순차 호출 — 첫 non-Allow Verdict 가 나오면 즉시 반환. 모두 Allow 면 `VerdictAllow`.
@@ -98,8 +100,8 @@ case precheck.VerdictExtractLinksOnly:
 
 ## 의존
 
-- [`internal/processor/parser/rule`](../parser/rule.md) — `BlacklistMatcher` (BlacklistSource 의 백엔드)
-- [`internal/storage/model`](../../storage/README.md) — `BlacklistMode` 상수
+- [`internal/processor/parser/rule`](parser/rule.md) — `BlacklistMatcher` (BlacklistSource 의 백엔드)
+- [`internal/storage/model`](../storage/README.md) — `BlacklistMode` 상수
 
 <br>
 
@@ -108,8 +110,8 @@ case precheck.VerdictExtractLinksOnly:
 | 호출자 | 사용 메소드 | 비고 |
 |---|---|---|
 | [`internal/publisher`](../publisher.md) | `Decider.CheckURL` | publish 직전 마지막 게이트 |
-| [`internal/processor/parser/worker`](parser/README.md) | `Decider.CheckURL` (계획) | parser 진입점 — list / page 라우팅 결정에 활용 |
-| [`internal/processor/fetcher/handler`](fetcher/handler.md) (계획) | `Decider.CheckURL` | fetch 시작 전 (대량 사이트 throttle 등 향후) |
+| [`internal/processor/parser/worker`](parser/README.md) | `Decider.CheckURL` | parser 진입점 — list / page 라우팅 결정 (이미 wiring 완료, main.go) |
+| [`internal/processor/fetcher/handler`](fetcher/handler.md) | `Decider.CheckURL` | fetch 시작 전 게이트 (이미 wiring 완료, main.go) |
 
 <br>
 

--- a/docs/architecture/pkg/README.md
+++ b/docs/architecture/pkg/README.md
@@ -11,16 +11,18 @@
 
 ## 패키지 일람
 
-| 디렉토리                                  | 역할                                                            | 문서                                |
-|------------------------------------------|----------------------------------------------------------------|-------------------------------------|
-| [`pkg/config/`](../../../pkg/config/)     | 환경변수 + .env 기반 설정 로더 (DB / Kafka / Redis / LLM / Validate / Scheduler / Refinement / Metrics / Log / Classifier) | [config.md](config.md) |
-| [`pkg/links/`](../../../pkg/links/)       | URL 정규화 (Normalizer) + 링크 추출 (Extractor)                | [links.md](links.md)                |
-| [`pkg/llm/`](../../../pkg/llm/)           | 다중 LLM provider 추상 + Chain 합성 + 정책 라우팅              | [llm.md](llm.md)                    |
-| [`pkg/logger/`](../../../pkg/logger/)     | zerolog 기반 구조화 로거 + ctx 전파                             | [logger.md](logger.md)              |
-| [`pkg/metrics/`](../../../pkg/metrics/)   | Prometheus registry + `/metrics` HTTP endpoint                  | [metrics.md](metrics.md)            |
-| [`pkg/queue/`](../../../pkg/queue/)       | Kafka producer/consumer + 토픽/그룹 상수 + BacklogChecker      | [queue.md](queue.md)                |
-| [`pkg/redis/`](../../../pkg/redis/)       | Redis 클라이언트 wrapper + 분산 락 + ZSET retry queue          | [redis.md](redis.md)                |
-| [`pkg/urlguard/`](../../../pkg/urlguard/) | URL 허용/차단 술어 (Guard) + 적용 dispatcher (Gate)            | [urlguard.md](urlguard.md)          |
+| 디렉토리 | 역할 | 문서 |
+|---|---|---|
+| [`pkg/agent/`](../../../pkg/agent/) | LLM agent adapter namespace (claudegen container + MCP postgres tool) — 이슈 #458 | [agent/README.md](agent/README.md) |
+| [`pkg/config/`](../../../pkg/config/) | 환경변수 + .env 기반 설정 로더 (sub-package 분리, 이슈 #440) | [config.md](config.md) |
+| [`pkg/links/`](../../../pkg/links/) | URL 정규화 (Normalizer) + 링크 추출 (Extractor) | [links.md](links.md) |
+| [`pkg/llm/`](../../../pkg/llm/) | 다중 LLM provider 추상 + Chain 합성 + 정책 라우팅 | [llm.md](llm.md) |
+| [`pkg/llm/prompt/`](../../../pkg/llm/prompt/) | LLM 프롬프트 file → embed loader chain. parser / enrich 단계별 assets (`parser/claude/` + `enrich/claude/`) | (`llm.md` 안에 포함) |
+| [`pkg/logger/`](../../../pkg/logger/) | zerolog 기반 구조화 로거 + ctx 전파 | [logger.md](logger.md) |
+| [`pkg/metrics/`](../../../pkg/metrics/) | Prometheus registry + `/metrics` HTTP endpoint | [metrics.md](metrics.md) |
+| [`pkg/queue/`](../../../pkg/queue/) | Kafka producer/consumer + 토픽/그룹 상수 + BacklogChecker | [queue.md](queue.md) |
+| [`pkg/redis/`](../../../pkg/redis/) | Redis 클라이언트 wrapper + 분산 락 + ZSET retry queue | [redis.md](redis.md) |
+| [`pkg/urlguard/`](../../../pkg/urlguard/) | URL 허용/차단 술어 (Guard) + 적용 dispatcher (Gate) | [urlguard.md](urlguard.md) |
 
 <br>
 

--- a/docs/architecture/pkg/agent/README.md
+++ b/docs/architecture/pkg/agent/README.md
@@ -1,0 +1,38 @@
+# pkg/agent — LLM Agent Adapters
+
+소스: [`pkg/agent/`](../../../../pkg/agent/)
+
+LLM 응답을 도구 호출 권한 + 컨테이너 격리 환경에서 받기 위한 agent adapter 들의 namespace. 이슈 #458 (PR #459) 에서 `internal/claudegen` 을 본 namespace 로 이전.
+
+<br>
+
+## Sub-package
+
+| Sub-package | 문서 | 책임 |
+|---|---|---|
+| [`pkg/agent/claude/`](../../../../pkg/agent/claude/) | [claude.md](claude.md) | claude Code CLI + docker container 기반 agent. parser llmgen + enrich subsystem 의 공용 백엔드 |
+| [`pkg/agent/dependency/db/`](../../../../pkg/agent/dependency/db/) | (별도 문서 없음) | MCP postgres tool 설정 builder — enricher_ro role 의 read-only DB 액세스 (이슈 #472) |
+
+<br>
+
+## Agent interface
+
+각 sub-package 가 만족하는 공용 interface:
+
+```go
+// pkg/agent/Agent (또는 SessionRunner alias)
+type Agent interface {
+    RunSession(ctx context.Context, label string, files map[string]string, promptText string) (stdout string, err error)
+}
+```
+
+호출자 (`enrich/core` 의 4 단계 등) 는 본 interface 만 의존 — 백엔드 교체 가능 (claudegen / future agents). 의존성 역전 (이슈 #460).
+
+<br>
+
+## 관련 이슈
+
+- 이슈 #458 — `internal/claudegen` → `pkg/agent/claude` 이전
+- 이슈 #460 — stage 별 agent 사용 OOP 분리 (Agent interface)
+- 이슈 #472 — MCP postgres tool (`pkg/agent/dependency/db`)
+- 이슈 #474 — claude 컨테이너 user non-root

--- a/docs/architecture/pkg/agent/claude.md
+++ b/docs/architecture/pkg/agent/claude.md
@@ -101,7 +101,7 @@ CMD ["tail", "-f", "/dev/null"]
 
 ### 1. parser llmgen (셀렉터 자동 생성)
 
-[`rule/llmgen.Generator`](../internal/processor/parser/rule.md#4-llm-selector-generator) 가 `ParsePage` 실패 시 host 별로 본 Pool 의 `Worker.ExtractEnriched(host, targetType, html)` 호출. 결과 `ExtractResult` 의 `Selectors` 가 `parser_rules` 에 `enabled=false` 로 INSERT.
+[`rule/llmgen.Generator`](../../internal/processor/parser/rule.md#4-llm-selector-generator) 가 `ParsePage` 실패 시 host 별로 본 Pool 의 `Worker.ExtractEnriched(host, targetType, html)` 호출. 결과 `ExtractResult` 의 `Selectors` 가 `parser_rules` 에 `enabled=false` 로 INSERT.
 
 응답 JSON schema (`worker.go:enrichedOutput`):
 ```json
@@ -118,11 +118,11 @@ CMD ["tail", "-f", "/dev/null"]
 }
 ```
 
-`blacklist_mode` 가 `extract_links_only` 면 [`service.BlacklistService.HandleLLMDecision`](../internal/storage/service.md) 가 `parser_blacklist` 에 mode 그대로 등록 (이슈 #480).
+`blacklist_mode` 가 `extract_links_only` 면 [`service.BlacklistService.HandleLLMDecision`](../../internal/storage/service.md) 가 `parser_blacklist` 에 mode 그대로 등록 (이슈 #480).
 
 ### 2. enrich 4-stage (entity/claim/verify/context/score)
 
-[`enrich/core`](../internal/processor/enrich/README.md) 의 4 단계 각각 `RunSession(ctx, label, files, promptText)` 호출:
+[`enrich/core`](../../internal/processor/enrich/README.md) 의 4 단계 각각 `RunSession(ctx, label, files, promptText)` 호출:
 - label: `enrich-extract` / `enrich-verify` / `enrich-context` / `enrich-score`
 - files: stage 별 page HTML / 직전 단계 결과 JSON
 - 응답: 각 단계 schema 의 JSON
@@ -144,8 +144,8 @@ CMD ["tail", "-f", "/dev/null"]
 
 | 호출자 | 사용 메소드 | 비고 |
 |---|---|---|
-| [`internal/processor/parser/rule/llmgen.Generator`](../internal/processor/parser/rule.md#4-llm-selector-generator) | `Worker.ExtractEnriched(host, targetType, html)` | selector 자동 생성 |
-| [`internal/processor/enrich/core.Claudegen*`](../internal/processor/enrich/README.md) | `agent.Agent.RunSession(label, files, prompt)` (SessionRunner 추상) | 4-stage enrich |
+| [`internal/processor/parser/rule/llmgen.Generator`](../../internal/processor/parser/rule.md#4-llm-selector-generator) | `Worker.ExtractEnriched(host, targetType, html)` | selector 자동 생성 |
+| [`internal/processor/enrich/core.Claudegen*`](../../internal/processor/enrich/README.md) | `agent.Agent.RunSession(label, files, prompt)` (SessionRunner 추상) | 4-stage enrich |
 | [`cmd/issuetracker`](../../cmd/issuetracker.md) | `NewPoolFromEnv` | wiring |
 
 <br>

--- a/docs/architecture/pkg/agent/claude.md
+++ b/docs/architecture/pkg/agent/claude.md
@@ -1,0 +1,173 @@
+# pkg/agent/claude — claudegen Container Pool + LLM Session Runner
+
+소스: [`pkg/agent/claude/`](../../../../pkg/agent/claude/)
+
+claude Code CLI 를 docker container 안에서 호출하여 LLM 응답을 받는 agent. parser llmgen (selector 자동 생성) + enrich pipeline (4 stage) 의 공용 백엔드. 이슈 #458 (PR #459) 으로 기존 `internal/claudegen` 에서 `pkg/agent/claude` namespace 로 이전.
+
+이슈 #474 (PR #475) 머지 후 컨테이너 default user 가 `node` (uid 1000) 로 전환되어 claude CLI 의 `--dangerously-skip-permissions` 가 root/sudo 환경에서 거부되는 회귀 해소.
+
+<br>
+
+## 패키지 구성
+
+| 파일 | 역할 |
+|---|---|
+| [`pool.go`](../../../../pkg/agent/claude/pool.go) | `Pool` — 다중 `Worker` 를 관리, fan-out + graceful shutdown. `NewPoolFromEnv` (운영 wiring) |
+| [`worker.go`](../../../../pkg/agent/claude/worker.go) | `Worker` — 단일 claudegen container 의 lifecycle + `ExtractEnriched` (parser llmgen 경로) |
+| [`container.go`](../../../../pkg/agent/claude/container.go) | `execContainerRunner` — `docker run` / `docker exec` / `docker rm` CLI 래퍼 (`ContainerRunner` interface 구현) |
+| [`enrich.go`](../../../../pkg/agent/claude/enrich.go) | `RunSession` — enrich 4 단계 공용 호출 (각 stage 별 file_count + prompt). 이슈 #460 으로 worker.go 에서 분리 |
+| [`prompt.go`](../../../../pkg/agent/claude/prompt.go) | `buildPrompt` — file → embed loader 로 prompt 텍스트 조립 + placeholder 치환 |
+
+<br>
+
+## 핵심 컨셉
+
+### 1. warm container 패턴
+
+각 `Worker` 는 부팅 시 `docker run -d --rm` 으로 **장기 실행 claudegen container** 를 띄움. 컨테이너는 `tail -f /dev/null` 로 대기. 매 LLM 호출마다 `docker exec <container_id> claude ...` 로 새 세션을 만들지만 컨테이너 자체는 재사용 — `docker run` 오버헤드 회피.
+
+`docker rm -f` 는 graceful shutdown 시 한 번만 (이슈 #458/#460).
+
+### 2. ContainerRunner interface
+
+```go
+type ContainerRunner interface {
+    StartContainer(ctx, image, workDir, authDir, containerAuthPath string) (containerID string, err error)
+    ExecSession(ctx, containerID string, args []string) (stdout, stderr string, err error)
+    StopContainer(ctx, containerID string) error
+}
+```
+
+운영은 `execContainerRunner` (docker CLI). 단위 테스트는 `mockContainerRunner` 가 만족.
+
+### 3. SessionRunner (Agent 추상)
+
+`pkg/agent/Agent` interface — enrich/core 가 본 interface 만 의존 (의존성 역전, 이슈 #460):
+
+```go
+// internal/processor/enrich/core/claude.go
+type SessionRunner = agent.Agent
+```
+
+`Worker` 가 `RunSession(ctx, label, files, promptText) (stdout, err)` 메소드로 본 interface 를 만족. enrich 단계별 (`extract` / `verify` / `context` / `score`) 가 label 로 구분.
+
+<br>
+
+## Container 정책 — non-root user (이슈 #474)
+
+[deployments/docker/claudegen/Dockerfile](../../../../deployments/docker/claudegen/Dockerfile):
+
+```dockerfile
+FROM node:20-slim
+
+# (npm install claude-code + mcp postgres + 디렉토리 준비)
+RUN mkdir -p /home/node/.claude && chown -R node:node /home/node/.claude
+RUN mkdir -p /workspace && chown -R node:node /workspace
+WORKDIR /workspace
+
+# non-root 로 전환 — claude CLI 의 --dangerously-skip-permissions 거부 회피
+USER node
+
+ENTRYPOINT []
+CMD ["tail", "-f", "/dev/null"]
+```
+
+- node:20-slim 의 기존 `node` user (uid=1000, gid=1000) 활용 — 호스트 `juhy0987` (uid 1000) 과 일치
+- 호스트 `~/.claude/` (OAuth 인증) + `~/.claude.json` (CLI 설정) mount RW 가능
+- claude CLI 의 root/sudo 거부 차단
+
+호스트 `~/.claude` 가 root 소유인 환경에서는 mount 권한 mismatch 발생 — 운영자가 `chown -R 1000:1000 ~/.claude` 또는 별도 마운트 디렉토리 생성.
+
+<br>
+
+## 환경 변수
+
+| ENV | Default | 의미 |
+|---|---|---|
+| `CLAUDE_CODE_IMAGE` | `issuetracker-claudegen:local` | 컨테이너 이미지 (`make claudegen-build`) |
+| `CLAUDE_CODE_MODEL` | `claude-sonnet-4-6` | LLM 모델 |
+| `CLAUDE_CODE_TIMEOUT` | `120s` | **세션 단위 timeout** — `docker exec claude ...` 1회당 |
+| `CLAUDE_CODE_WORKER_COUNT` | (default 2) | Pool 내 Worker 수 = 동시 컨테이너 수 |
+| `CLAUDE_CODE_AUTH_DIR` | `$HOME/.claude` | 호스트의 claude OAuth 디렉토리 (RW mount) |
+| `CLAUDE_CODE_CONTAINER_AUTH_PATH` | `/home/node/.claude` | 컨테이너 내 mount 대상 경로 (이슈 #474) |
+| `CLAUDE_CODE_SHUTDOWN_TIMEOUT` | `10s` | `docker rm -f` cleanup timeout (이슈 #458) |
+| `ENRICHER_DB_RO_*` | (없음) | MCP postgres tool — read-only DB 액세스 (이슈 #472) |
+
+`CLAUDE_CODE_TIMEOUT` 의 영향 범위 + raise 시 주의사항 (특히 [`inflight_locker.DefaultInflightLockTTL`](../../../../internal/storage/redis/inflight_locker.go) 동기화) 은 이슈 #495 참조.
+
+<br>
+
+## 사용 경로
+
+### 1. parser llmgen (셀렉터 자동 생성)
+
+[`rule/llmgen.Generator`](../internal/processor/parser/rule.md#4-llm-selector-generator) 가 `ParsePage` 실패 시 host 별로 본 Pool 의 `Worker.ExtractEnriched(host, targetType, html)` 호출. 결과 `ExtractResult` 의 `Selectors` 가 `parser_rules` 에 `enabled=false` 로 INSERT.
+
+응답 JSON schema (`worker.go:enrichedOutput`):
+```json
+{
+  "validity": "ok" | "blacklist",
+  "blacklist_reason": "<korean>",
+  "blacklist_mode": "drop" | "extract_links_only",  // 이슈 #480
+  "page_type": "news" | "community" | ...,
+  "page_type_confidence": <float>,
+  "article": <bool>,
+  "article_confidence": <float>,
+  "selectors": { ... },
+  "self_check": { ... }
+}
+```
+
+`blacklist_mode` 가 `extract_links_only` 면 [`service.BlacklistService.HandleLLMDecision`](../internal/storage/service.md) 가 `parser_blacklist` 에 mode 그대로 등록 (이슈 #480).
+
+### 2. enrich 4-stage (entity/claim/verify/context/score)
+
+[`enrich/core`](../internal/processor/enrich/README.md) 의 4 단계 각각 `RunSession(ctx, label, files, promptText)` 호출:
+- label: `enrich-extract` / `enrich-verify` / `enrich-context` / `enrich-score`
+- files: stage 별 page HTML / 직전 단계 결과 JSON
+- 응답: 각 단계 schema 의 JSON
+
+응답 unmarshal 실패 (LLM 이 prose 응답 emit) 시 enrich worker 가 `forwarding without facts/verifications/context/trust_score` 로 graceful fallback (이슈 #486 / PR #487 의 프롬프트 contract 강화로 빈도 감소).
+
+<br>
+
+## 의존
+
+- [`pkg/agent`](../../../../pkg/agent/) — `Agent` interface (SessionRunner 추상)
+- [`pkg/llm/prompt`](../../../../pkg/llm/prompt/) — prompt loader
+- [`pkg/logger`](../logger.md)
+- 외부: `docker` CLI (PATH 에 있어야 함), `node:20-slim` base image
+
+<br>
+
+## 호출 측
+
+| 호출자 | 사용 메소드 | 비고 |
+|---|---|---|
+| [`internal/processor/parser/rule/llmgen.Generator`](../internal/processor/parser/rule.md#4-llm-selector-generator) | `Worker.ExtractEnriched(host, targetType, html)` | selector 자동 생성 |
+| [`internal/processor/enrich/core.Claudegen*`](../internal/processor/enrich/README.md) | `agent.Agent.RunSession(label, files, prompt)` (SessionRunner 추상) | 4-stage enrich |
+| [`cmd/issuetracker`](../../cmd/issuetracker.md) | `NewPoolFromEnv` | wiring |
+
+<br>
+
+## graceful shutdown
+
+`Pool.Stop(ctx)` 가 모든 in-flight `RunSession` / `ExtractEnriched` 완료 대기 → 각 `Worker` 의 `docker rm -f <containerID>` 호출 (CLAUDE_CODE_SHUTDOWN_TIMEOUT 10s 내). 미정상 종료 시 `--rm` 플래그로 docker 가 잔존 컨테이너 회수 (이슈 #458 의 별도 cleanup 정책 명시).
+
+<br>
+
+## 관련 이슈
+
+- 이슈 #266 — claudegen 도입 (구독 quota 활용)
+- 이슈 #269 — 자체 Docker 이미지 빌드 (`make claudegen-build`)
+- 이슈 #270 — claudegen 버전 고정 + smoke check
+- 이슈 #421 / #423 — parser_rules.article 플래그 wiring (LLM 분류)
+- 이슈 #446 ~ #450 — enrich subsystem
+- **이슈 #458 — claudegen → `pkg/agent/claude` namespace 분리**
+- **이슈 #460 — parser/core + enrich/core — stage 별 agent 사용 OOP 분리** (`SessionRunner = agent.Agent`)
+- **이슈 #470 — `--dangerously-skip-permissions` + tool 권한 자동 허가**
+- **이슈 #472 — MCP postgres read-only DB 직접 접근**
+- **이슈 #474 — 컨테이너 user non-root (node)**
+- 이슈 #480 — `blacklist_mode` 필드 (`extract_links_only` / `drop` 분기)
+- 이슈 #486 — enrich 프롬프트 JSON-only CRITICAL OUTPUT CONTRACT
+- **이슈 #495 — `CLAUDE_CODE_TIMEOUT` 변경 시 `inflight_locker.DefaultInflightLockTTL` 동기화 필요** (백로그)


### PR DESCRIPTION
## 연관 이슈
- Closes #492
- Parent: #488 (마지막 sub-issue)

<br>

## 구현 내용

지난 30 PR 동안 도입되었으나 문서 자체가 부재했던 3개 신규 모듈에 architecture 문서 신규 작성. 메타 이슈 #488 의 sub-issue 4/4 (마지막).

### 신규 파일 4개 (총 +561 LOC)

#### \`docs/architecture/internal/processor/enrich/README.md\` (+222 LOC)

4-stage enrichment pipeline 의 진입 문서:
- 패키지 구조 (\`enrich.go\` / \`core/\` / \`worker/\`) + 책임 분리 (이슈 #460)
- 4 단계 pipeline 다이어그램 (extract → verify → context → score) + graceful fallback
- core 의 4 interface + 각 Noop*/Claudegen* 구현
- 프롬프트 contract (CRITICAL OUTPUT CONTRACT, 이슈 #486)
- enriched_contents 스키마 (이슈 #450) + rationale/factors 컬럼 (이슈 #457)
- MCP postgres tool (이슈 #472)
- Worker (Kafka consumer) + graceful shutdown
- CLAUDE_CODE_TIMEOUT × 4 단계 walltime 영향

#### \`docs/architecture/pkg/agent/claude.md\` (+173 LOC)

claudegen container pool + LLM session runner:
- warm container 패턴 (이슈 #266)
- ContainerRunner interface + SessionRunner = agent.Agent (이슈 #460 의존성 역전)
- non-root user 정책 (이슈 #474, Dockerfile USER node)
- 환경 변수 매트릭스 + 두 사용 경로 (parser llmgen / enrich 4-stage)

#### \`docs/architecture/pkg/agent/README.md\` (+38 LOC)

pkg/agent/ namespace 진입 문서 — sub-package 표 (claude / dependency/db) + Agent interface

#### \`docs/architecture/internal/processor/precheck.md\` (+128 LOC)

URL 처리 가부 공용 게이트 (이슈 #425):
- Verdict / Decision / Source / Decider 타입
- BlacklistSource 구현 + 향후 확장 Source 계획
- 호출 패턴 + 호출 측 표

### 갱신 파일 2개

#### \`docs/architecture/internal/processor/README.md\`

- 서브패키지 표에 \`enrich/README.md\`, \`precheck.md\` 추가
- 향후 확장 섹션에서 enrich 항목 제거 (이미 구현)

#### \`docs/architecture/pkg/README.md\`

- 패키지 일람 표에 \`pkg/agent/\` 추가
- \`pkg/llm/prompt/\` 별도 행 추가
- config sub-package 분리 반영

<br>

## CI / 머지 게이트 점검

### 변경 영향 범위
- 영향: \`docs/architecture/\` 만 — 4 신규 파일 + 2 갱신
- 위험도(택1): **Low** — 문서만 변경, 코드 영향 없음.

### Required Status Checks
- [ ] \`Commit Lint\` / \`PR Title Lint\` / \`Linked Issue Check\`
- [ ] \`Format Check\` / \`Build\` / \`Test\` / \`Lint\`

### 로컬 검증
- ✅ \`go build ./...\` 통과 (문서)

### 롤백 계획
- 본 PR revert — 신규 4 파일 삭제 + 2 파일 원복. 운영 영향 없음.

<br>

## 메타 이슈 #488 종료

본 PR 머지 후 메타 이슈 #488 의 4 sub 모두 close 됨:
- ✅ #489 (PR #493 merged) — parser docs
- ✅ #490 (PR #494 merged) — cmd / pkg docs
- ✅ #491 (PR #496) — storage docs
- **이 PR** — 신규 모듈 docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)