### PR TITLE
[DOCS#498] root README.md + docs/ko/README.md — v0.6.0 이후 변경 일괄 반영

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,595 +5,315 @@
 > Global Issue Collection and Analysis System
 
 [![Go Version](https://img.shields.io/badge/Go-1.22+-00ADD8?style=flat&logo=go)](https://go.dev/)
-[![Test Coverage](https://img.shields.io/badge/coverage-92.1%25-brightgreen)](./coverage.out)
 [![License](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
 
 ## Overview
 
-IssueTracker is a scalable, extensible system designed to crawl news, social media, and community sources worldwide, process and normalize multilingual content, and identify major issues through embedding and clustering.
+IssueTracker crawls news / community / social sources worldwide, normalizes and validates the content, **enriches** it with extracted entities/claims/facts and cross-source verification, then scores trust and clusters issues. The pipeline is fully Kafka-driven and operates as **one binary, multiple stages** (`make start`).
 
-**Initial Target Markets**: United States and South Korea
+**Initial Target Markets**: United States and South Korea.
 
 ## Features
 
-- 🌐 **Multi-source Crawling**: Support for news sites, RSS feeds, APIs, and community platforms
-- 🔄 **Kafka-based Pipeline**: Distributed, asynchronous processing with fault tolerance
-- 🧠 **ML-powered Analysis**: Embedding generation and clustering for issue detection
-- 🌍 **Multilingual Support**: Process content in multiple languages (English, Korean)
-- 📊 **Real-time Monitoring**: Prometheus metrics and health checks
-- ✅ **Production-ready**: Comprehensive error handling, retry logic, and rate limiting
-- 🏗️ **Standard Go Layout**: Following golang-standards/project-layout
+- 🌐 **Multi-source crawling** — news / community / RSS / SPA (chromedp) handler chain
+- 🔄 **Kafka-driven 5-stage pipeline** — fetcher / parser / validate / enrich / scheduler
+- 🧠 **LLM-backed selector auto-learning** — parser rules + path-pattern refinement (claudegen container pool)
+- 🔍 **4-stage enrichment** — entity extraction → cross-verification → external context → trust score
+- 🗂️ **DB-driven rules** — `parser_rules` / `parser_blacklist` / `scheduler_entries` — no hardcoded selectors
+- 🛡️ **Auto-demote & blacklist** — index-only heuristic + LLM-based mode-aware blacklist (`drop` / `extract_links_only`)
+- ⚙️ **Stage toggle** — run the same binary as fetcher-only / parser-only / enrich-only nodes (`STAGES_*_ENABLED`)
+- 📊 **Prometheus metrics** — `/metrics` endpoint + per-module counters
+- ✅ **Graceful shutdown** — staged drain with claudegen container cleanup
 
-## Architecture
+## High-level Architecture
 
 ```
-┌─────────────────────────────────────────┐
-│     API / Job Scheduler Layer           │
-├─────────────────────────────────────────┤
-│     Crawler Orchestration Layer         │
-├─────────────────────────────────────────┤
-│     Source-Specific Crawlers            │
-│  (News, Community, Social Media)        │
-├─────────────────────────────────────────┤
-│     Data Processing Pipeline            │
-│  (Normalize, Validate, Enrich)          │
-├─────────────────────────────────────────┤
-│     Embedding & ML Layer                │
-│  (Vectorize, Cluster, Classify)         │
-├─────────────────────────────────────────┤
-│     Storage Layer                       │
-│  (Raw, Processed, Embeddings)           │
-└─────────────────────────────────────────┘
+                          ┌────────────────────────┐
+   Scheduler (DB-driven)  │  scheduler_entries     │
+        │                 └────────────────────────┘
+        ▼                                ▲
+  Kafka: crawl.{high,normal,low,chromedp}
+        │
+        ▼
+  Fetcher (PoolManager + handler chain: goquery / chromedp / browser / RSS)
+        │
+        ├─→ raw_contents (Claim Check)
+        ▼
+  Kafka: fetched
+        │
+        ▼
+  Parser Worker  ── ParsePage / ParseLinks (rule engine, indexonly heuristic, auto-demote)
+        │            ├─ llmgen.Generator (selector auto-learning + blacklist mode)
+        │            └─ refiner (path_pattern refinement)
+        ▼
+  Kafka: normalized
+        │
+        ▼
+  Validate Worker (news / community)
+        │
+        ▼
+  Kafka: validated
+        │
+        ▼
+  Enrich Worker (4-stage: extract → verify → context → score)
+        │  └─ claudegen container pool (pkg/agent/claude)
+        │  └─ MCP postgres tool (enricher_ro read-only)
+        ▼
+  Kafka: enriched + enriched_contents persistence (trust_score, rationale, factors)
 ```
+
+Detailed component docs live under [`docs/architecture/`](docs/architecture/). Suggested reading order:
+
+1. [`cmd/issuetracker.md`](docs/architecture/cmd/issuetracker.md) — wiring & shutdown
+2. [`internal/processor/README.md`](docs/architecture/internal/processor/README.md) — stage layer
+3. [`internal/processor/parser/rule.md`](docs/architecture/internal/processor/parser/rule.md) — rule engine, indexonly, auto_demote, llmgen, refiner
+4. [`internal/processor/enrich/README.md`](docs/architecture/internal/processor/enrich/README.md) — 4-stage enrichment
+5. [`internal/processor/precheck.md`](docs/architecture/internal/processor/precheck.md) — URL processing gate
+6. [`internal/storage/README.md`](docs/architecture/internal/storage/README.md) — repository / service / decorator layering
+7. [`pkg/agent/claude.md`](docs/architecture/pkg/agent/claude.md) — claudegen container pool
 
 ## Quick Start
 
 ### Prerequisites
 
-- Go 1.21+
+- Go 1.22+
 - PostgreSQL 15+
-- Apache Kafka 3.5+
+- Apache Kafka 4.x (KRaft mode, no Zookeeper)
 - Redis 7+
+- Docker (for chromedp pool + claudegen container)
 
 ### Installation
 
 ```bash
-git clone https://github.com/yourusername/issuetracker
-cd issuetracker
-go mod tidy
+git clone https://github.com/EinSofINTEREST/IssueTracker
+cd IssueTracker
+cp .env.example .env  # then fill in DB / API keys / stage toggles
+make build            # builds all binaries to bin/
+make claudegen-build  # builds the claudegen container image (issuetracker-claudegen:local)
 ```
 
-### Building
+### Binaries
+
+| Binary | Entry Point | Description |
+|---|---|---|
+| `bin/issuetracker` | `cmd/issuetracker/` | **Integrated pipeline** — fetcher + parser + validate + enrich + scheduler (운영 entry) |
+| `bin/processor` | `cmd/processor/` | Validate processor standalone |
+| `bin/migrate` | `cmd/migrate/` | Run DB migrations (up) |
+| `bin/migrate-down` | `cmd/migrate-down/` | Rollback DB migrations |
+| `bin/rule-validator` | `cmd/rule-validator/` | Parser rule selector validator (dry-run tool) |
+
+### Bringing the pipeline up
 
 ```bash
-# Build all binaries
-make build
+# 1. Bring up infra (idempotent — safe to re-run)
+make pg-start          # PostgreSQL container
+make pg-migrate        # apply migrations (currently 031)
+make kafka-start       # Kafka broker + UI (http://localhost:8080) + topic init
+make chrome-start      # chromedp containers (worker_count replicas)
 
-# Or build individual binaries
-go build -o bin/crawler ./cmd/crawler
-go build -o bin/processor ./cmd/processor
-go build -o bin/issuetracker ./cmd/issuetracker
-go build -o bin/migrate ./cmd/migrate
-go build -o bin/migrate-down ./cmd/migrate-down
+# 2. Run the integrated pipeline
+make start             # = chrome-ensure → kafka-ensure → run-issuetracker
+                       # auto-discovers chromedp remote URLs and injects them
 ```
 
-### Kafka Setup
+Stop the pipeline with `SIGINT`/`SIGTERM` — graceful shutdown drains all stages then cleans up the claudegen container pool.
+
+### Stage Toggle
+
+Run the same binary as a partial-pipeline node:
 
 ```bash
-# Start Kafka broker + UI (localhost:9092, UI: http://localhost:8080)
-make kafka-start
-
-# Stop (data preserved)
-make kafka-stop
-
-# Stop + delete all data
-make kafka-clean
+# fetcher-only node
+STAGES_FETCHER_ENABLED=true
+STAGES_PARSER_ENABLED=false
+STAGES_VALIDATE_ENABLED=false
+STAGES_ENRICH_ENABLED=false
+STAGES_SCHEDULER_ENABLED=false
 ```
 
-**Partition configuration** — adjust the unified `.env` (root) before starting:
+Kafka consumer groups handle the inter-stage routing; each stage just consumes its own topic.
+
+## Project Structure
+
+Standard Go project layout:
+
+```
+issuetracker/
+├── cmd/                            # Application entry points → bin/
+│   ├── issuetracker/               # integrated pipeline (main entry)
+│   ├── processor/                  # validate-only
+│   ├── migrate/  ├── migrate-down/ # DB schema migrations
+│   └── rule-validator/             # parser rule dry-run tool
+│
+├── internal/
+│   ├── processor/
+│   │   ├── processor.go            # Stage lifecycle interface
+│   │   ├── fetcher/                # crawler pool + handler chain (goquery / chromedp / browser / RSS)
+│   │   │   ├── core/   handler/   worker/   domain/   implementation/
+│   │   │   └── rate_limiter/
+│   │   ├── parser/
+│   │   │   ├── types/              # Page / LinkItem / ContentParser interfaces
+│   │   │   ├── rule/               # DB-driven rule engine
+│   │   │   │   ├── indexonly/      # index-only heuristic
+│   │   │   │   ├── llmgen/         # LLM selector auto-learning
+│   │   │   │   ├── pathinfer/      # path_pattern inference
+│   │   │   │   └── refiner/        # path_pattern refinement
+│   │   │   └── worker/             # Kafka consumer + Claim Check
+│   │   ├── validate/               # news / community validators + worker
+│   │   ├── enrich/                 # 4-stage: extract / verify / context / score
+│   │   │   ├── core/               # interfaces + Noop*/Claudegen* implementations
+│   │   │   └── worker/             # Kafka consumer
+│   │   └── precheck/               # URL processing gate (BlacklistSource etc.)
+│   ├── storage/                    # 7-layer separation (Phase 1/2)
+│   │   ├── model/                  # domain types
+│   │   ├── repository/             # CRUD interfaces
+│   │   ├── primitive/              # InflightLocker etc.
+│   │   ├── decorator/              # timeout / cache invalidator
+│   │   ├── service/                # business logic (ContentService, BlacklistService, ParserRuleService, ...)
+│   │   ├── postgres/               # PostgreSQL implementations
+│   │   └── redis/                  # Redis implementations (locks, sliding window)
+│   ├── locks/                      # ProcessingLock / IngestionLock (Redis)
+│   ├── bus/                        # Kafka producer/consumer with retry scheduler
+│   ├── publisher/                  # Crawl job publisher (precheck gate consumer)
+│   ├── scheduler/                  # DB-driven seed job emitter
+│   ├── workerpool/                 # generic worker pool primitives
+│   └── classifier/                 # external classifier gRPC/HTTP client
+│
+├── pkg/                            # Public, domain-neutral utilities
+│   ├── agent/                      # LLM agent adapters
+│   │   └── claude/                 # claudegen container pool (parser llmgen + enrich backend)
+│   ├── config/                     # 6 sub-packages (app / storage / fetcher / processor / llm / runtime)
+│   ├── llm/                        # multi-provider LLM abstraction + prompt loader
+│   ├── logger/                     # zerolog-based structured logger
+│   ├── metrics/                    # Prometheus registry + /metrics endpoint
+│   ├── queue/                      # Kafka abstraction (producer / consumer / topics)
+│   ├── redis/                      # Redis client wrapper
+│   ├── links/                      # URL normalization + extraction
+│   └── urlguard/                   # URL allow/deny predicates
+│
+├── deployments/
+│   └── docker/
+│       ├── docker-compose.yml      # Kafka (KRaft) + chrome pool
+│       └── claudegen/Dockerfile    # node:20-slim + claude-code + mcp-postgres (non-root)
+│
+├── migrations/                     # 031 SQL migrations (up + down)
+├── test/                           # mirrors source tree
+└── docs/
+    ├── architecture/               # canonical architecture docs
+    ├── en/  └── ko/                # README translations
+```
+
+### Key Design Choices
+
+- **DB-driven rules** — Parser selectors / blacklist / scheduler entries all live in PostgreSQL (`parser_rules`, `parser_blacklist`, `scheduler_entries`). Site additions are SQL changes, not code (이슈 #100, #482).
+- **Claim Check pattern** — Raw HTML is stored in `raw_contents` and **only the row ID** travels through Kafka. Parser worker loads it once, deletes after success (이슈 #134).
+- **Storage layering (Phase 1/2)** — `model/` (types) → `repository/` (CRUD interfaces) → `decorator/` (timeout / cache invalidator) → `service/` (business logic). Decorator chain is auto-composed by `service.New*` (이슈 #430, #431).
+- **Stage Gate Semaphore** — Per-stage `ProcessingLock` + `Semaphore` capacity prevents same-URL concurrent work and bounds concurrency below worker count.
+- **Auto-blacklist** — Two paths register to `parser_blacklist`:
+  - **Heuristic auto-demote** ([`rule/indexonly/`](internal/processor/parser/rule/indexonly/)) — when ParsePage succeeds but content is index-only → `mode='extract_links_only'`
+  - **LLM-based** ([`llmgen.BlacklistDecision`](internal/processor/parser/rule/llmgen/)) — when LLM classifies the page → `mode='drop'` or `'extract_links_only'`
+
+## Operations Reference
+
+### Build & Test
 
 ```bash
-cp .env.example .env
-# Edit: KAFKA_PARTITIONS_HIGH, KAFKA_PARTITIONS_NORMAL, KAFKA_PARTITIONS_LOW, KAFKA_PARTITIONS_CHROMEDP
-make kafka-start
+make build               # all 5 binaries
+make claudegen-build     # claudegen container image
+
+make test                # all unit tests
+make coverage            # coverage report
+make lint                # golangci-lint
+make fmt                 # gofmt
+
+make clean               # remove build artifacts
+```
+
+### Infrastructure
+
+```bash
+# PostgreSQL
+make pg-start | pg-stop | pg-clean | pg-status | pg-psql
+make pg-migrate          # idempotent up
+make pg-migrate-down     # rollback (use carefully)
+
+# Kafka (KRaft)
+make kafka-start         # broker + UI (http://localhost:8080) + topic init
+make kafka-stop | kafka-clean
+make kafka-status | kafka-topics | kafka-describe
+make kafka-scale-partitions TOPIC=<t> PARTITIONS=<n>
+
+# chromedp pool
+make chrome-start | chrome-stop | chrome-status
+make chrome-remote-urls  # discover dynamic ws:// URLs
 ```
 
 ### Running
 
 ```bash
-# Start Kafka first
-make kafka-start
+make start               # integrated pipeline (운영 entry — preferred)
+make run-issuetracker    # same, no chrome/kafka pre-check
+make run-processor       # validate worker only
 
-# Run crawler only (connects to localhost:9092, subscribes to crawl.high/normal/low)
-make run-crawler
-
-# Run validate processor only (subscribes to issuetracker.normalized)
-make run-processor
-
-# Run crawler + processor together (single process)
-make run-issuetracker
-
-# Run Kafka pipeline example (in-memory mock, no Kafka required)
-make run-kafka-pipeline
-
-# Run basic example
+# examples
 make run-example
-
-# Run binaries directly
-./bin/crawler
-./bin/processor
-./bin/issuetracker
+make run-kafka-pipeline  # in-memory mock, no Kafka required
 ```
 
-**Binary summary:**
+### Configuration
 
-| Binary | Entry Point | Description |
-|--------|-------------|-------------|
-| `bin/crawler` | `cmd/crawler/` | Crawler pool manager only |
-| `bin/processor` | `cmd/processor/` | Validate worker only |
-| `bin/issuetracker` | `cmd/issuetracker/` | Crawler + Processor combined |
-| `bin/migrate` | `cmd/migrate/` | Run database migrations (up) |
-| `bin/migrate-down` | `cmd/migrate-down/` | Rollback database migrations |
+All env vars live in `.env` (single source). Loaded via [`pkg/config`](docs/architecture/pkg/config.md) sub-packages:
 
-### Database Setup
+| Prefix | Sub-package |
+|---|---|
+| `POSTGRES_*`, `REDIS_*` | `storage` |
+| `KAFKA_*` | (via `pkg/queue`) |
+| `LLM_*`, `GEMINI_API_KEY`, `ANTHROPIC_API_KEY` | `llm` |
+| `CLAUDE_CODE_*` | `pkg/agent/claude` |
+| `FETCHER_*`, `STAGES_*_ENABLED`, `STAGES_*_WORKER_COUNT` | `fetcher` / `runtime` |
+| `BLACKLIST_*`, `VALIDATE_*`, `SCHEDULER_*` | `processor` |
+| `ENRICHER_DB_RO_*` | enrich MCP postgres (이슈 #472) |
+| `METRICS_ADDR`, `LOG_*`, `SHUTDOWN_TIMEOUT` | `app` |
 
-The project uses PostgreSQL with pgx/v5 driver for data persistence.
-
-```bash
-# Start PostgreSQL container
-make pg-start
-
-# Check PostgreSQL status
-make pg-status
-
-# Run migrations (idempotent, safe to run multiple times)
-make pg-migrate
-
-# Rollback migrations (use with caution in production)
-make pg-migrate-down
-
-# Connect to PostgreSQL shell
-make pg-psql
-```
-
-**Migrations**:
-- `001_create_raw_contents.up.sql` — Store RawContent (original HTML)
-- `002_create_contents.up.sql` — Store normalized Content
-- `003_create_news_articles.up.sql` — Store NewsArticle (title, body, author, category, tags, image_urls, published_at)
-
-### Testing
-
-```bash
-# Run all tests
-make test
-
-# Run with verbose output
-make test-verbose
-
-# Check coverage
-make coverage
-
-# Generate HTML coverage report
-make coverage-html
-```
-
-### Development
-
-```bash
-# Format code
-make fmt
-
-# Run linter
-make lint
-
-# Clean build artifacts
-make clean
-
-# Update dependencies
-make deps
-```
-
-## Current Status
-
-✅ **Core Crawler Infrastructure** (v0.2.0)
-- [x] Core interfaces and data models
-- [x] HTTP client with connection pooling
-- [x] Token bucket rate limiter
-- [x] Retry logic with exponential backoff
-- [x] Comprehensive error handling
-- [x] Structured logging with zerolog
-- [x] Context-aware logging
-- [x] 92.1% test coverage
-- [x] Standard Go project layout
-- [x] Makefile for build automation
-- [x] cmd/ entry points
-
-✅ **Kafka Integration** (v0.3.0)
-- [x] Producer / Consumer interface abstraction (`pkg/queue`)
-- [x] KafkaConsumerPool — priority-based multi-worker goroutine pool
-- [x] Handler Registry — crawler name → handler dispatch
-- [x] DLQ (Dead Letter Queue) with retry-count-based routing
-- [x] Docker Compose Kafka stack (KRaft mode, no Zookeeper)
-- [x] Kafka topic initialization with configurable partitions via `.env`
-- [x] Kafka UI at `http://localhost:8080`
-- [x] Priority-based multi-pool manager (`PoolManager`)
-
-✅ **News Domain Crawlers** (v0.4.0)
-- [x] News domain DIP interfaces (`internal/processor/fetcher/domain/news/news.go`)
-- [x] Chain of Responsibility handler (`handler.go`) — RSS → GoQuery → Browser fallback chain
-- [x] RSS/GoQuery/Browser adapters (`fetcher/`)
-- [x] **Korean Sources**:
-  - [x] Naver crawler (GoQuery → Browser fallback) + Parser
-  - [x] Yonhap crawler (GoQuery) + Parser
-  - [x] Daum crawler (GoQuery) + Parser
-  - [x] KR registry assembly entry point (`kr/registry.go`)
-- [x] **US Sources**:
-  - [x] CNN crawler (GoQuery) + Parser
-  - [x] US registry assembly entry point (`us/registry.go`)
-- [x] PostgreSQL storage layer (`internal/storage/news_article.go`, `postgres/news_article.go`)
-- [x] Migration — `news_articles` table creation (`003_create_news_articles.up.sql`)
-- [x] Tests — 780+ cases for KR parser/crawler, 519+ cases for US parser/crawler
-
-✅ **Kafka Blob Offloading** (v0.5.0)
-- [x] `RawContentRef` — lightweight Kafka message struct (ID + metadata, no HTML body)
-- [x] `RawContentService` injected into `KafkaConsumerPool` for Postgres-first storage
-- [x] Worker saves full `RawContent` (including HTML) to Postgres, then publishes only `RawContentRef` to Kafka
-- [x] Duplicate URL handling — returns existing record ID without error
-- [x] `PoolManager` (`manager.go`) — priority-based multi-pool orchestration (High / Normal / Low)
-- [x] Unit tests for pool processing logic (`test/internal/worker/`)
-
-✅ **Content Validation Pipeline** (v0.6.0)
-- [x] `ContentProcessor` interface — common pipeline stage interface (`internal/processor/processor.go`)
-- [x] `Validator` interface + `ValidationResult` / `ValidationError` types — shared validation contract
-- [x] `NewValidator` factory — `SourceType` 기반 디스패치 (news / community)
-- [x] News validator (`validate/news/`) — Title 10~500자, Body 100~50,000자, PublishedAt 필수, 품질 점수 산출, 스팸(대문자·구두점 과용) 탐지
-- [x] Community validator (`validate/community/`) — Body 50자 이상, PublishedAt 선택, 반복 문자·도배 패턴 탐지
-- [x] `NewContentProcessor` adapter — Validator → ContentProcessor 어댑팅, Reliability 필드 업데이트
-- [x] Validate `Worker` — Kafka Consumer/Producer 기반 워커 (수동 커밋, retry count 기반 DLQ 라우팅)
-- [x] Unit tests — 89.1% coverage (`test/internal/processor/validate/`)
-- [x] `Content` struct에 JSON 직렬화 태그 추가 (Kafka `ProcessingMessage.Data` 호환)
-
-📋 **Planned**
-- [ ] Normalize processing stage
-- [ ] Enrich processing stage (entity extraction, sentiment analysis)
-- [ ] Embedding generation
-- [ ] Clustering algorithms
-- [ ] API endpoints
-- [ ] Web dashboard
-
-## Project Structure
-
-Following the [Standard Go Project Layout](https://github.com/golang-standards/project-layout):
-
-```
-issuetracker/
-├── cmd/                           # Application entry points (all build to bin/)
-│   ├── crawler/               # Crawler-only entry point → bin/crawler
-│   │   └── main.go
-│   ├── processor/             # Validate processor entry point → bin/processor
-│   │   └── main.go
-│   ├── issuetracker/          # Crawler + Processor combined entry point → bin/issuetracker
-│   │   └── main.go
-│   ├── migrate/               # DB migration (up) → bin/migrate
-│   │   └── main.go
-│   └── migrate-down/          # DB migration (down) → bin/migrate-down
-│       └── main.go
-│
-├── internal/
-│   ├── crawler/
-│   │   ├── core/              # Crawler interfaces, models, errors, retry
-│   │   ├── handler/           # Handler interface + Registry (crawler name dispatch)
-│   │   │   ├── handler.go     # Handler interface, Registry
-│   │   │   └── noop.go        # Fallback noop handler
-│   │   ├── worker/            # Kafka consumer pool
-│   │   │   ├── pool.go        # KafkaConsumerPool (goroutine worker pool + DLQ + Postgres offload)
-│   │   │   └── manager.go     # PoolManager (High/Normal/Low priority pool orchestration)
-│   │   └── domain/
-│   │       └── news/          # News domain crawlers (DIP + Chain of Responsibility)
-│   │           ├── news.go    # Domain interfaces (NewsFetcher, NewsRSSFetcher, ...)
-│   │           ├── handler.go # Chain: RSS → GoQuery → Browser
-│   │           ├── fetcher/   # Adapters (rss, goquery, browser)
-│   │           ├── kr/        # Korean sources
-│   │           │   ├── naver/ # Naver (config, crawler, parser)
-│   │           │   ├── yonhap/ # Yonhap (config, crawler, parser)
-│   │           │   ├── daum/  # Daum (config, crawler, parser)
-│   │           │   └── registry.go # Assembly & registration entry point
-│   │           └── us/        # US sources
-│   │               ├── cnn/   # CNN (config, crawler, parser)
-│   │               └── registry.go # Assembly & registration entry point
-│   ├── processor/
-│   │   ├── processor.go       # ContentProcessor, Validator, ValidationResult interfaces
-│   │   └── validate/          # Content validation stage
-│   │       ├── validator.go   # NewValidator factory + NewContentProcessor adapter
-│   │       ├── worker.go      # Kafka Worker (normalized → validated, DLQ routing)
-│   │       ├── news/          # News-specific validator
-│   │       │   └── validator.go # Title/Body length, PublishedAt, spam detection
-│   │       └── community/     # Community-specific validator
-│   │           └── validator.go # Min body, flood pattern detection
-│   └── storage/               # Data access layer
-│       ├── news_article.go    # NewsArticle repository interface
-│       └── postgres/          # PostgreSQL implementation
-│           └── news_article.go # pgx/v5 based NewsArticle CRUD
-│
-├── pkg/
-│   ├── logger/                # Structured logger (zerolog)
-│   └── queue/                 # Kafka producer/consumer abstraction
-│       ├── queue.go           # Producer, Consumer interfaces
-│       ├── config.go          # Topic/group constants, Config
-│       ├── producer.go        # KafkaProducer (kafka-go)
-│       └── consumer.go        # KafkaConsumer (kafka-go, manual commit)
-│
-├── deployments/
-│   └── docker/
-│       ├── docker-compose.yml # Kafka broker (KRaft) + kafka-ui
-│       └── .env.example       # Partition configuration template
-│
-├── examples/
-│   ├── basic_usage.go
-│   └── kafka_pipeline/        # In-memory mock pipeline example
-│
-├── migrations/                # Database migrations (PostgreSQL)
-│   ├── 001_create_raw_contents.up.sql     # raw_contents table
-│   ├── 002_create_contents.up.sql         # contents table
-│   ├── 003_create_news_articles.up.sql    # news_articles table + indexes
-│   └── *.down.sql             # Rollback migrations
-│
-├── test/                      # Package-level tests
-├── docs/
-│   ├── en/
-│   └── ko/
-├── Makefile
-├── go.mod
-└── go.sum
-```
-
-### Design Rationale
-
-**Standard Go Project Layout:**
-- **`cmd/`**: Application entry points (main packages)
-- **`internal/`**: Private code (cannot be imported by external projects)
-- **`pkg/`**: Public library code (can be imported by external projects)
-- Benefits:
-  - Industry-standard structure
-  - Clear separation of concerns
-  - Easy to navigate for Go developers
-  - Better dependency management
-
-## Core Components
-
-### Crawler Interface
-
-```go
-type Crawler interface {
-  Name() string
-  Source() SourceInfo
-  Initialize(ctx context.Context, config Config) error
-  Start(ctx context.Context) error
-  Stop(ctx context.Context) error
-  Fetch(ctx context.Context, target Target) (*RawContent, error)
-  HealthCheck(ctx context.Context) error
-}
-```
-
-### HTTP Client
-
-- Connection pooling (max 100 idle connections)
-- Configurable timeouts
-- Response size limiting (10MB)
-- Automatic retry on network errors
-- Integrated logging
-
-### Rate Limiter
-
-- Token bucket algorithm
-- Configurable requests per hour
-- Burst support
-- Context-aware waiting
-- Performance optimized
-
-### Error Handling
-
-- Typed errors with categories
-- Retryable vs non-retryable errors
-- Error codes for tracking
-- Full error context preservation
-
-### Structured Logger
-
-- Built on `zerolog` for high performance
-- Context-aware logging
-- Multiple log levels (Debug, Info, Warn, Error, Fatal)
-- JSON and pretty-print formats
-- Request ID tracking
-- Crawler-specific fields
-
-## Crawler Implementations
-
-IssueTracker provides two crawlers for static and dynamic pages:
-
-### Goquery - Static Crawling (`implementation/goquery`)
-
-Lightweight crawler for static HTML pages.
-
-```go
-crawler := goquery.NewGoqueryCrawler("my-crawler", sourceInfo, config)
-raw, err := crawler.Fetch(ctx, target)
-article, err := crawler.FetchAndParse(ctx, target, selectors)
-```
-
-### Chromedp - Dynamic Crawling (`implementation/chromedp`)
-
-Headless browser crawler for dynamic pages requiring JavaScript rendering.
-
-```go
-crawler := chromedp.NewChromedpCrawler("my-crawler", sourceInfo, config)
-crawler.Initialize(ctx, config)
-defer crawler.Stop(ctx)
-
-raw, err := crawler.Fetch(ctx, target)                       // Rendered HTML
-article, err := crawler.FetchAndParse(ctx, target, selectors) // Render + Parse
-result, err := crawler.EvaluateJS(ctx, url, "document.title") // Execute JS
-```
-
-### Comparison
-
-| | Goquery | Chromedp |
-|---|---|---|
-| **Purpose** | Static HTML | JavaScript SPA |
-| **Speed** | Fast (~1s) | Slow (~3-5s) |
-| **Memory** | Low (~10MB) | High (~100MB) |
-| **JS Support** | ✗ | ✓ |
-| **Use Cases** | News, RSS | Community, SPA |
-
-### Run Example
-
-```bash
-make run-comparison
-```
-
-## News Domain Crawlers
-
-### Korean Sources
-
-#### Naver
-- **Fetcher**: GoQuery → Browser fallback
-- **Features**: Category extraction, image URL collection, KST → UTC conversion
-- **Date Format**: `"2026-03-02 14:54:16"` (KST)
-
-#### Yonhap
-- **Fetcher**: GoQuery
-- **Features**: Multiple author extraction, tags/keywords collection, photo gallery support
-- **Date Format**: `"2024-01-15 14:30"` (KST)
-
-#### Daum
-- **Fetcher**: GoQuery
-- **Features**: Category, images, metadata extraction
-- **Date Format**: ISO 8601
-
-### US Sources
-
-#### CNN
-- **Fetcher**: GoQuery
-- **Features**: Section/subsection extraction, byline parsing, metadata support
-- **Date Format**: ISO 8601
-
-**All parsers**:
-- Extract: Title, Body, Author, Category, Tags, ImageURLs, PublishedAt
-- Handle missing fields gracefully (fallback to defaults)
-- Convert all timestamps to UTC
-- 780+ test cases (KR), 519+ test cases (US)
+See [`.env.example`](.env.example) for the canonical list.
 
 ## Development
 
+### Workflow
+
+Development conventions are codified in [`.claude/rules/`](.claude/rules/):
+
+1. [01-architecture.md](.claude/rules/01-architecture.md) — system architecture
+2. [02-crawler-implementation.md](.claude/rules/02-crawler-implementation.md) — fetcher standards
+3. [03-data-processing.md](.claude/rules/03-data-processing.md) — processing pipeline
+4. [04-error-handling.md](.claude/rules/04-error-handling.md) — error handling & monitoring
+5. [05-testing.md](.claude/rules/05-testing.md) — testing strategy
+6. [06-code-style.md](.claude/rules/06-code-style.md) — code conventions
+7. [07-workflow.md](.claude/rules/07-workflow.md) — issue-first / commit-per-TODO / autonomous progression
+
 ### Code Style
 
-- **Indentation**: 2 spaces (NOT tabs)
-- **Comments**: Korean + English mix
-- **Testing**: Minimum 70% coverage (currently 92.1%)
-- **Naming**: Clear, self-documenting names
+- Go formatting: `gofmt -w .` (tabs)
+- Korean / English mix in comments (Korean primary)
+- Korean commit messages with category prefix: `[FEAT]`, `[FIX]`, `[REFAC]`, `[DOCS]`, `[CHORE]`
+- PR titles: `[CATEGORY#ISSUE] description` (CI-enforced)
 
-### Running Linters
+### CI / Merge Gates
 
-```bash
-# Using Makefile
-make lint
+Required status checks (see [`docs/ci/`](docs/ci/)):
+- Commit Lint / PR Title Lint / Linked Issue Check
+- Format Check / Build / Test / Lint
 
-# Or directly
-golangci-lint run
-```
+## Documentation
 
-### Documentation
-
-Development rules are located in [`.claude/rules/`](.claude/rules/):
-
-1. **[01-architecture.md](.claude/rules/01-architecture.md)** - System architecture
-2. **[02-crawler-implementation.md](.claude/rules/02-crawler-implementation.md)** - Crawler standards
-3. **[03-data-processing.md](.claude/rules/03-data-processing.md)** - Processing pipeline
-4. **[04-error-handling.md](.claude/rules/04-error-handling.md)** - Error handling & monitoring
-5. **[05-testing.md](.claude/rules/05-testing.md)** - Testing strategy
-6. **[06-code-style.md](.claude/rules/06-code-style.md)** - Code conventions
-
-## Example Usage
-
-See [examples/basic_usage.go](examples/basic_usage.go) for a complete example:
-
-```go
-import (
-  "issuetracker/pkg/logger"
-  "issuetracker/internal/processor/fetcher/core"
-)
-
-// Setup logger (development mode with pretty printing)
-logConfig := logger.DefaultConfig()
-logConfig.Level = logger.LevelDebug
-logConfig.Pretty = true
-log := logger.New(logConfig)
-
-// Create HTTP client with rate limiting
-config := core.DefaultConfig()
-config.RequestsPerHour = 60
-httpClient := core.NewHTTPClient(config)
-rateLimiter := core.NewRateLimiter(config.RequestsPerHour, config.BurstSize)
-
-// Add logger to context
-ctx := context.Background()
-ctx = log.ToContext(ctx)
-
-// Add request ID for tracing
-requestLog := log.WithRequestID("req-123")
-requestCtx := requestLog.ToContext(ctx)
-
-// Fetch with retry (logging happens automatically)
-var resp *core.HTTPResponse
-err := core.WithRetry(requestCtx, core.DefaultRetryPolicy, func() error {
-  var fetchErr error
-  resp, fetchErr = httpClient.Get(requestCtx, url)
-  return fetchErr
-})
-```
-
-## Makefile Commands
-
-```bash
-# Build & Run
-make build              # Build all binaries → bin/crawler, bin/processor, bin/issuetracker, bin/migrate, bin/migrate-down
-make run-crawler        # Build and run crawler only
-make run-processor      # Build and run validate processor only
-make run-issuetracker   # Build and run crawler + processor combined
-make run-example        # Run basic usage example
-make run-kafka-pipeline # Run in-memory Kafka pipeline example
-
-# Test & Quality
-make test               # Run all tests
-make coverage           # Run tests with coverage report
-make lint               # Run linters
-make fmt                # Format code
-make clean              # Remove build artifacts
-
-# Kafka
-make kafka-start        # Start Kafka broker + UI (creates topics)
-make kafka-stop         # Stop (data preserved at KAFKA_DATA_DIR)
-make kafka-clean        # Stop + delete all data
-make kafka-status       # Show container status
-make kafka-topics       # List all topics
-make kafka-describe     # Show partition/leader details per topic
-make kafka-scale-partitions TOPIC=<topic> PARTITIONS=<n>  # Increase partitions
-
-# PostgreSQL
-make pg-start           # Start PostgreSQL container
-make pg-stop            # Stop PostgreSQL (data preserved)
-make pg-clean           # Stop + delete all data
-make pg-status          # Show PostgreSQL container status
-make pg-migrate         # Run database migrations (idempotent)
-make pg-migrate-down    # Rollback migrations (use with caution)
-make pg-psql            # Connect to PostgreSQL shell
-
-make help               # Show all commands with descriptions
-```
+- **Canonical** : [`docs/architecture/`](docs/architecture/) — per-package design docs
+- **Operations** : [`docs/ci/`](docs/ci/) — CI conventions + required status checks
+- **Workflow** : [`.claude/rules/07-workflow.md`](.claude/rules/07-workflow.md) — AI / human collaboration conventions
+- **Translations** : [`docs/ko/`](docs/ko/) — Korean (synced with English)
 
 ## Contributing
 
-Please read the development rules in `.claude/rules/` before contributing.
+Please read [`.claude/rules/07-workflow.md`](.claude/rules/07-workflow.md) for the issue-first workflow and labeling policy before contributing.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 > Global Issue Collection and Analysis System
 
-[![Go Version](https://img.shields.io/badge/Go-1.22+-00ADD8?style=flat&logo=go)](https://go.dev/)
+[![Go Version](https://img.shields.io/badge/Go-1.24+-00ADD8?style=flat&logo=go)](https://go.dev/)
 [![License](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
 
 ## Overview
@@ -76,7 +76,7 @@ Detailed component docs live under [`docs/architecture/`](docs/architecture/). S
 
 ### Prerequisites
 
-- Go 1.22+
+- Go 1.24+
 - PostgreSQL 15+
 - Apache Kafka 4.x (KRaft mode, no Zookeeper)
 - Redis 7+
@@ -96,7 +96,7 @@ make claudegen-build  # builds the claudegen container image (issuetracker-claud
 
 | Binary | Entry Point | Description |
 |---|---|---|
-| `bin/issuetracker` | `cmd/issuetracker/` | **Integrated pipeline** — fetcher + parser + validate + enrich + scheduler (운영 entry) |
+| `bin/issuetracker` | `cmd/issuetracker/` | **Integrated pipeline** — fetcher + parser + validate + enrich + scheduler (production entry) |
 | `bin/processor` | `cmd/processor/` | Validate processor standalone |
 | `bin/migrate` | `cmd/migrate/` | Run DB migrations (up) |
 | `bin/migrate-down` | `cmd/migrate-down/` | Rollback DB migrations |
@@ -142,14 +142,19 @@ issuetracker/
 ├── cmd/                            # Application entry points → bin/
 │   ├── issuetracker/               # integrated pipeline (main entry)
 │   ├── processor/                  # validate-only
-│   ├── migrate/  ├── migrate-down/ # DB schema migrations
+│   ├── migrate/                    # DB schema migrations (up)
+│   ├── migrate-down/               # DB schema migrations (down)
 │   └── rule-validator/             # parser rule dry-run tool
 │
 ├── internal/
 │   ├── processor/
 │   │   ├── processor.go            # Stage lifecycle interface
 │   │   ├── fetcher/                # crawler pool + handler chain (goquery / chromedp / browser / RSS)
-│   │   │   ├── core/   handler/   worker/   domain/   implementation/
+│   │   │   ├── core/
+│   │   │   ├── handler/
+│   │   │   ├── worker/
+│   │   │   ├── domain/
+│   │   │   ├── implementation/
 │   │   │   └── rate_limiter/
 │   │   ├── parser/
 │   │   │   ├── types/              # Page / LinkItem / ContentParser interfaces
@@ -174,7 +179,6 @@ issuetracker/
 │   │   └── redis/                  # Redis implementations (locks, sliding window)
 │   ├── locks/                      # ProcessingLock / IngestionLock (Redis)
 │   ├── bus/                        # Kafka producer/consumer with retry scheduler
-│   ├── publisher/                  # Crawl job publisher (precheck gate consumer)
 │   ├── scheduler/                  # DB-driven seed job emitter
 │   ├── workerpool/                 # generic worker pool primitives
 │   └── classifier/                 # external classifier gRPC/HTTP client
@@ -205,9 +209,9 @@ issuetracker/
 
 ### Key Design Choices
 
-- **DB-driven rules** — Parser selectors / blacklist / scheduler entries all live in PostgreSQL (`parser_rules`, `parser_blacklist`, `scheduler_entries`). Site additions are SQL changes, not code (이슈 #100, #482).
-- **Claim Check pattern** — Raw HTML is stored in `raw_contents` and **only the row ID** travels through Kafka. Parser worker loads it once, deletes after success (이슈 #134).
-- **Storage layering (Phase 1/2)** — `model/` (types) → `repository/` (CRUD interfaces) → `decorator/` (timeout / cache invalidator) → `service/` (business logic). Decorator chain is auto-composed by `service.New*` (이슈 #430, #431).
+- **DB-driven rules** — Parser selectors / blacklist / scheduler entries all live in PostgreSQL (`parser_rules`, `parser_blacklist`, `scheduler_entries`). Site additions are SQL changes, not code (Issue #100, #482).
+- **Claim Check pattern** — Raw HTML is stored in `raw_contents` and **only the row ID** travels through Kafka. Parser worker loads it once, deletes after success (Issue #134).
+- **Storage layering (Phase 1/2)** — `model/` (types) → `repository/` (CRUD interfaces) → `decorator/` (timeout / cache invalidator) → `service/` (business logic). Decorator chain is auto-composed by `service.New*` (Issue #430, #431).
 - **Stage Gate Semaphore** — Per-stage `ProcessingLock` + `Semaphore` capacity prevents same-URL concurrent work and bounds concurrency below worker count.
 - **Auto-blacklist** — Two paths register to `parser_blacklist`:
   - **Heuristic auto-demote** ([`rule/indexonly/`](internal/processor/parser/rule/indexonly/)) — when ParsePage succeeds but content is index-only → `mode='extract_links_only'`
@@ -251,7 +255,7 @@ make chrome-remote-urls  # discover dynamic ws:// URLs
 ### Running
 
 ```bash
-make start               # integrated pipeline (운영 entry — preferred)
+make start               # integrated pipeline (production entry — preferred)
 make run-issuetracker    # same, no chrome/kafka pre-check
 make run-processor       # validate worker only
 
@@ -272,7 +276,7 @@ All env vars live in `.env` (single source). Loaded via [`pkg/config`](docs/arch
 | `CLAUDE_CODE_*` | `pkg/agent/claude` |
 | `FETCHER_*`, `STAGES_*_ENABLED`, `STAGES_*_WORKER_COUNT` | `fetcher` / `runtime` |
 | `BLACKLIST_*`, `VALIDATE_*`, `SCHEDULER_*` | `processor` |
-| `ENRICHER_DB_RO_*` | enrich MCP postgres (이슈 #472) |
+| `ENRICHER_DB_RO_*` | enrich MCP postgres (Issue #472) |
 | `METRICS_ADDR`, `LOG_*`, `SHUTDOWN_TIMEOUT` | `app` |
 
 See [`.env.example`](.env.example) for the canonical list.

--- a/docs/ko/README.md
+++ b/docs/ko/README.md
@@ -5,547 +5,320 @@
 > 글로벌 이슈 수집 및 분석 시스템
 
 [![Go Version](https://img.shields.io/badge/Go-1.22+-00ADD8?style=flat&logo=go)](https://go.dev/)
-[![Test Coverage](https://img.shields.io/badge/coverage-92.1%25-brightgreen)](./coverage.out)
 [![License](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
 
 ## 개요
 
-IssueTracker는 전 세계의 뉴스, 소셜 미디어, 커뮤니티 소스를 크롤링하고, 다국어 콘텐츠를 처리 및 정규화하며, 임베딩과 클러스터링을 통해 주요 이슈를 식별하도록 설계된 확장 가능하고 유연한 시스템입니다.
+IssueTracker 는 전 세계의 뉴스 / 커뮤니티 / 소셜 소스를 크롤링하고, 콘텐츠를 정규화/검증한 뒤, entity/claim/fact 추출과 cross-source verification 으로 **enrich** 하고, trust score 계산 및 이슈 클러스터링을 수행합니다. 파이프라인은 Kafka 기반이며, **하나의 binary 가 여러 stage** 로 동작합니다 (`make start`).
 
-**초기 타겟 시장**: 미국과 대한민국
+**초기 타겟 시장**: 미국과 대한민국.
 
 ## 주요 기능
 
-- 🌐 **다중 소스 크롤링**: 뉴스 사이트, RSS 피드, API, 커뮤니티 플랫폼 지원
-- 🔄 **Kafka 기반 파이프라인**: 장애 허용성을 갖춘 분산 비동기 처리
-- 🧠 **ML 기반 분석**: 이슈 탐지를 위한 임베딩 생성 및 클러스터링
-- 🌍 **다국어 지원**: 여러 언어(영어, 한국어)의 콘텐츠 처리
-- 📊 **실시간 모니터링**: Prometheus 메트릭 및 헬스 체크
-- ✅ **프로덕션 준비 완료**: 포괄적인 에러 핸들링, 재시도 로직, 속도 제한
-- 🏗️ **표준 Go 레이아웃**: golang-standards/project-layout 준수
+- 🌐 **다중 소스 크롤링** — 뉴스 / 커뮤니티 / RSS / SPA (chromedp) handler chain
+- 🔄 **Kafka 기반 5-stage 파이프라인** — fetcher / parser / validate / enrich / scheduler
+- 🧠 **LLM 기반 셀렉터 자동 학습** — parser rule + path-pattern 정밀화 (claudegen 컨테이너 pool)
+- 🔍 **4-stage enrichment** — entity 추출 → cross-verification → 외부 context → trust score
+- 🗂️ **DB-driven rule** — `parser_rules` / `parser_blacklist` / `scheduler_entries` — 하드코딩 selector 없음
+- 🛡️ **Auto-demote + blacklist** — index-only 휴리스틱 + LLM 기반 mode 분기 (`drop` / `extract_links_only`)
+- ⚙️ **Stage toggle** — 같은 binary 를 fetcher-only / parser-only / enrich-only 노드로 분리 배포 (`STAGES_*_ENABLED`)
+- 📊 **Prometheus 메트릭** — `/metrics` endpoint + 모듈별 counter
+- ✅ **Graceful shutdown** — stage 단계 drain + claudegen 컨테이너 정리
 
-## 아키텍처
+## 상위 아키텍처
 
 ```
-┌─────────────────────────────────────────┐
-│     API / Job Scheduler Layer           │
-├─────────────────────────────────────────┤
-│     Crawler Orchestration Layer         │
-├─────────────────────────────────────────┤
-│     Source-Specific Crawlers            │
-│  (News, Community, Social Media)        │
-├─────────────────────────────────────────┤
-│     Data Processing Pipeline            │
-│  (Normalize, Validate, Enrich)          │
-├─────────────────────────────────────────┤
-│     Embedding & ML Layer                │
-│  (Vectorize, Cluster, Classify)         │
-├─────────────────────────────────────────┤
-│     Storage Layer                       │
-│  (Raw, Processed, Embeddings)           │
-└─────────────────────────────────────────┘
+                          ┌────────────────────────┐
+   Scheduler (DB-driven)  │  scheduler_entries     │
+        │                 └────────────────────────┘
+        ▼                                ▲
+  Kafka: crawl.{high,normal,low,chromedp}
+        │
+        ▼
+  Fetcher (PoolManager + handler chain: goquery / chromedp / browser / RSS)
+        │
+        ├─→ raw_contents (Claim Check)
+        ▼
+  Kafka: fetched
+        │
+        ▼
+  Parser Worker  ── ParsePage / ParseLinks (rule engine, indexonly heuristic, auto-demote)
+        │            ├─ llmgen.Generator (selector 자동 학습 + blacklist mode 분기)
+        │            └─ refiner (path_pattern 정밀화)
+        ▼
+  Kafka: normalized
+        │
+        ▼
+  Validate Worker (news / community)
+        │
+        ▼
+  Kafka: validated
+        │
+        ▼
+  Enrich Worker (4-stage: extract → verify → context → score)
+        │  └─ claudegen 컨테이너 pool (pkg/agent/claude)
+        │  └─ MCP postgres tool (enricher_ro read-only)
+        ▼
+  Kafka: enriched + enriched_contents 영속화 (trust_score, rationale, factors)
 ```
+
+세부 컴포넌트 문서는 [`docs/architecture/`](../architecture/) 에 위치. 권장 읽기 순서:
+
+1. [`cmd/issuetracker.md`](../architecture/cmd/issuetracker.md) — wiring & shutdown
+2. [`internal/processor/README.md`](../architecture/internal/processor/README.md) — stage layer
+3. [`internal/processor/parser/rule.md`](../architecture/internal/processor/parser/rule.md) — rule engine, indexonly, auto_demote, llmgen, refiner
+4. [`internal/processor/enrich/README.md`](../architecture/internal/processor/enrich/README.md) — 4-stage enrichment
+5. [`internal/processor/precheck.md`](../architecture/internal/processor/precheck.md) — URL 처리 가부 게이트
+6. [`internal/storage/README.md`](../architecture/internal/storage/README.md) — repository / service / decorator layering
+7. [`pkg/agent/claude.md`](../architecture/pkg/agent/claude.md) — claudegen 컨테이너 pool
 
 ## 빠른 시작
 
-### 사전 요구사항
+### 요구사항
 
-- Go 1.21+
+- Go 1.22+
 - PostgreSQL 15+
-- Apache Kafka 3.5+
+- Apache Kafka 4.x (KRaft 모드, Zookeeper 불필요)
 - Redis 7+
+- Docker (chromedp pool + claudegen 컨테이너용)
 
 ### 설치
 
 ```bash
-git clone https://github.com/yourusername/issuetracker
-cd issuetracker
-go mod tidy
+git clone https://github.com/EinSofINTEREST/IssueTracker
+cd IssueTracker
+cp .env.example .env  # DB / API 키 / stage toggle 입력
+make build            # 모든 binary 를 bin/ 에 빌드
+make claudegen-build  # claudegen 컨테이너 이미지 (issuetracker-claudegen:local)
 ```
 
-### 빌드
+### 바이너리
+
+| 바이너리 | Entry Point | 설명 |
+|---|---|---|
+| `bin/issuetracker` | `cmd/issuetracker/` | **통합 파이프라인** — fetcher + parser + validate + enrich + scheduler (운영 entry) |
+| `bin/processor` | `cmd/processor/` | Validate processor 단독 |
+| `bin/migrate` | `cmd/migrate/` | DB 마이그레이션 실행 (up) |
+| `bin/migrate-down` | `cmd/migrate-down/` | DB 마이그레이션 롤백 |
+| `bin/rule-validator` | `cmd/rule-validator/` | Parser rule selector 검증 도구 (dry-run) |
+
+### 파이프라인 기동
 
 ```bash
-# 모든 바이너리 빌드
-make build
+# 1. 인프라 기동 (멱등 — 재실행 안전)
+make pg-start          # PostgreSQL 컨테이너
+make pg-migrate        # 마이그레이션 적용 (현재 031)
+make kafka-start       # Kafka broker + UI (http://localhost:8080) + 토픽 초기화
+make chrome-start      # chromedp 컨테이너 (worker_count 만큼)
 
-# 특정 바이너리 빌드
-go build -o bin/crawler ./cmd/crawler
+# 2. 통합 파이프라인 실행
+make start             # = chrome-ensure → kafka-ensure → run-issuetracker
+                       # chromedp 동적 포트를 자동 발견하여 env 주입
 ```
 
-### Kafka 설정
+`SIGINT`/`SIGTERM` 으로 종료 — graceful shutdown 이 모든 stage 를 drain 한 뒤 claudegen 컨테이너 pool 정리.
+
+### Stage Toggle
+
+같은 binary 를 부분 파이프라인 노드로 분리 실행:
 
 ```bash
-# Kafka 브로커 + UI 시작 (localhost:9092, UI: http://localhost:8080)
-make kafka-start
-
-# 중지 (데이터 보존)
-make kafka-stop
-
-# 중지 + 모든 데이터 삭제
-make kafka-clean
+# fetcher-only 노드
+STAGES_FETCHER_ENABLED=true
+STAGES_PARSER_ENABLED=false
+STAGES_VALIDATE_ENABLED=false
+STAGES_ENRICH_ENABLED=false
+STAGES_SCHEDULER_ENABLED=false
 ```
 
-**파티션 설정** — 시작하기 전에 통합된 루트 `.env` 를 조정:
+Kafka consumer group 이 stage 간 라우팅을 담당 — 각 stage 는 자기 topic 만 consume.
+
+## 프로젝트 구조
+
+표준 Go 프로젝트 레이아웃:
+
+```
+issuetracker/
+├── cmd/                            # 애플리케이션 entry → bin/
+│   ├── issuetracker/               # 통합 파이프라인 (메인 entry)
+│   ├── processor/                  # validate 전용
+│   ├── migrate/  ├── migrate-down/ # DB 스키마 마이그레이션
+│   └── rule-validator/             # parser rule dry-run 도구
+│
+├── internal/
+│   ├── processor/
+│   │   ├── processor.go            # Stage lifecycle interface
+│   │   ├── fetcher/                # crawler pool + handler chain (goquery / chromedp / browser / RSS)
+│   │   │   ├── core/   handler/   worker/   domain/   implementation/
+│   │   │   └── rate_limiter/
+│   │   ├── parser/
+│   │   │   ├── types/              # Page / LinkItem / ContentParser interface
+│   │   │   ├── rule/               # DB-driven rule engine
+│   │   │   │   ├── indexonly/      # index-only 휴리스틱
+│   │   │   │   ├── llmgen/         # LLM selector 자동 학습
+│   │   │   │   ├── pathinfer/      # path_pattern 추론
+│   │   │   │   └── refiner/        # path_pattern 정밀화
+│   │   │   └── worker/             # Kafka consumer + Claim Check
+│   │   ├── validate/               # news / community validator + worker
+│   │   ├── enrich/                 # 4-stage: extract / verify / context / score
+│   │   │   ├── core/               # interface + Noop*/Claudegen* 구현
+│   │   │   └── worker/             # Kafka consumer
+│   │   └── precheck/               # URL 처리 가부 게이트 (BlacklistSource 등)
+│   ├── storage/                    # 7-layer 분리 (Phase 1/2)
+│   │   ├── model/                  # 도메인 타입
+│   │   ├── repository/             # CRUD interface
+│   │   ├── primitive/              # InflightLocker 등
+│   │   ├── decorator/              # timeout / cache invalidator
+│   │   ├── service/                # 비즈니스 로직 (ContentService, BlacklistService, ParserRuleService, …)
+│   │   ├── postgres/               # PostgreSQL 구현
+│   │   └── redis/                  # Redis 구현 (lock, sliding window)
+│   ├── locks/                      # ProcessingLock / IngestionLock (Redis)
+│   ├── bus/                        # Kafka producer/consumer + retry scheduler
+│   ├── publisher/                  # Crawl job publisher (precheck 게이트 consumer)
+│   ├── scheduler/                  # DB-driven seed job emitter
+│   ├── workerpool/                 # generic worker pool primitives
+│   └── classifier/                 # external classifier gRPC/HTTP client
+│
+├── pkg/                            # 도메인 중립 공개 utility
+│   ├── agent/                      # LLM agent adapter
+│   │   └── claude/                 # claudegen 컨테이너 pool (parser llmgen + enrich 백엔드)
+│   ├── config/                     # 6 sub-package (app / storage / fetcher / processor / llm / runtime)
+│   ├── llm/                        # 다중 provider LLM 추상 + prompt loader
+│   ├── logger/                     # zerolog 기반 구조화 logger
+│   ├── metrics/                    # Prometheus registry + /metrics endpoint
+│   ├── queue/                      # Kafka 추상 (producer / consumer / topic)
+│   ├── redis/                      # Redis 클라이언트 wrapper
+│   ├── links/                      # URL 정규화 + 추출
+│   └── urlguard/                   # URL 허용/차단 술어
+│
+├── deployments/
+│   └── docker/
+│       ├── docker-compose.yml      # Kafka (KRaft) + chrome pool
+│       └── claudegen/Dockerfile    # node:20-slim + claude-code + mcp-postgres (non-root)
+│
+├── migrations/                     # 031 SQL 마이그레이션 (up + down)
+├── test/                           # 소스 트리 미러링
+└── docs/
+    ├── architecture/               # canonical architecture 문서
+    ├── en/  └── ko/                # README 번역
+```
+
+### 주요 설계 결정
+
+- **DB-driven rule** — Parser selector / blacklist / scheduler entry 모두 PostgreSQL (`parser_rules`, `parser_blacklist`, `scheduler_entries`) 에 영속. 사이트 추가는 SQL 변경, 코드 변경 X (이슈 #100, #482).
+- **Claim Check 패턴** — Raw HTML 은 `raw_contents` 에 저장하고 Kafka 메시지에는 **row ID 만**. Parser worker 가 1 회 로드 후 즉시 Delete (이슈 #134).
+- **Storage layering (Phase 1/2)** — `model/` (타입) → `repository/` (CRUD interface) → `decorator/` (timeout / cache invalidator) → `service/` (비즈니스 로직). Decorator chain 은 `service.New*` 가 자동 합성 (이슈 #430, #431).
+- **Stage Gate Semaphore** — stage 별 `ProcessingLock` + `Semaphore` capacity 가 동일 URL 동시 처리 방지 + worker count 미만 동시성 보장.
+- **Auto-blacklist** — `parser_blacklist` 자동 등록 경로 2종:
+  - **휴리스틱 auto-demote** ([`rule/indexonly/`](../../internal/processor/parser/rule/indexonly/)) — ParsePage 성공했으나 index-only 일 때 → `mode='extract_links_only'`
+  - **LLM 기반** ([`llmgen.BlacklistDecision`](../../internal/processor/parser/rule/llmgen/)) — LLM 이 페이지를 분류하면 → `mode='drop'` 또는 `'extract_links_only'`
+
+## 운영 레퍼런스
+
+### 빌드 & 테스트
 
 ```bash
-cp .env.example .env
-# 편집: KAFKA_PARTITIONS_HIGH, KAFKA_PARTITIONS_NORMAL, KAFKA_PARTITIONS_LOW, KAFKA_PARTITIONS_CHROMEDP
-make kafka-start
+make build               # 5 binary 전체
+make claudegen-build     # claudegen 컨테이너 이미지
+
+make test                # 모든 단위 테스트
+make coverage            # 커버리지 리포트
+make lint                # golangci-lint
+make fmt                 # gofmt
+
+make clean               # 빌드 산출물 제거
+```
+
+### 인프라
+
+```bash
+# PostgreSQL
+make pg-start | pg-stop | pg-clean | pg-status | pg-psql
+make pg-migrate          # 멱등 up
+make pg-migrate-down     # 롤백 (주의)
+
+# Kafka (KRaft)
+make kafka-start         # broker + UI (http://localhost:8080) + topic init
+make kafka-stop | kafka-clean
+make kafka-status | kafka-topics | kafka-describe
+make kafka-scale-partitions TOPIC=<t> PARTITIONS=<n>
+
+# chromedp pool
+make chrome-start | chrome-stop | chrome-status
+make chrome-remote-urls  # 동적 ws:// URL 발견
 ```
 
 ### 실행
 
 ```bash
-# 먼저 Kafka 시작
-make kafka-start
+make start               # 통합 파이프라인 (운영 entry — 권장)
+make run-issuetracker    # 동일, chrome/kafka 사전 체크 없음
+make run-processor       # validate worker 단독
 
-# 크롤러 실행 (localhost:9092에 연결, crawl.normal 구독)
-make run-crawler
-
-# Kafka 파이프라인 예제 실행 (인메모리 모의 구현, Kafka 불필요)
-make run-kafka-pipeline
-
-# 기본 예제 실행
+# 예제
 make run-example
-
-# 바이너리 직접 실행
-./bin/crawler
+make run-kafka-pipeline  # in-memory mock, Kafka 불필요
 ```
 
-### 데이터베이스 설정
+### 설정
 
-이 프로젝트는 데이터 지속성을 위해 pgx/v5 드라이버와 함께 PostgreSQL을 사용합니다.
+모든 env 변수는 `.env` 단일 소스. [`pkg/config`](../architecture/pkg/config.md) sub-package 별 로드:
 
-```bash
-# PostgreSQL 컨테이너 시작
-make pg-start
+| Prefix | Sub-package |
+|---|---|
+| `POSTGRES_*`, `REDIS_*` | `storage` |
+| `KAFKA_*` | (via `pkg/queue`) |
+| `LLM_*`, `GEMINI_API_KEY`, `ANTHROPIC_API_KEY` | `llm` |
+| `CLAUDE_CODE_*` | `pkg/agent/claude` |
+| `FETCHER_*`, `STAGES_*_ENABLED`, `STAGES_*_WORKER_COUNT` | `fetcher` / `runtime` |
+| `BLACKLIST_*`, `VALIDATE_*`, `SCHEDULER_*` | `processor` |
+| `ENRICHER_DB_RO_*` | enrich MCP postgres (이슈 #472) |
+| `METRICS_ADDR`, `LOG_*`, `SHUTDOWN_TIMEOUT` | `app` |
 
-# PostgreSQL 상태 확인
-make pg-status
-
-# 마이그레이션 실행 (멱등성, 여러 번 실행해도 안전)
-make pg-migrate
-
-# 마이그레이션 롤백 (프로덕션에서는 주의해서 사용)
-make pg-migrate-down
-
-# PostgreSQL 셸 연결
-make pg-psql
-```
-
-**마이그레이션**:
-- `001_create_raw_contents.up.sql` — RawContent 저장 (원본 HTML)
-- `002_create_contents.up.sql` — 정규화된 Content 저장
-- `003_create_news_articles.up.sql` — NewsArticle 저장 (title, body, author, category, tags, image_urls, published_at)
-
-### 테스트
-
-```bash
-# 모든 테스트 실행
-make test
-
-# 상세 출력과 함께 실행
-make test-verbose
-
-# 커버리지 확인
-make coverage
-
-# HTML 커버리지 보고서 생성
-make coverage-html
-```
-
-### 개발
-
-```bash
-# 코드 포맷
-make fmt
-
-# 린터 실행
-make lint
-
-# 빌드 아티팩트 정리
-make clean
-
-# 의존성 업데이트
-make deps
-```
-
-## 현재 상태
-
-✅ **핵심 크롤러 인프라** (v0.2.0)
-- [x] 핵심 인터페이스 및 데이터 모델
-- [x] 커넥션 풀링을 갖춘 HTTP 클라이언트
-- [x] 토큰 버킷 속도 제한기
-- [x] 지수 백오프를 사용한 재시도 로직
-- [x] 포괄적인 에러 핸들링
-- [x] zerolog를 사용한 구조화된 로깅
-- [x] 컨텍스트 인식 로깅
-- [x] 92.1% 테스트 커버리지
-- [x] 표준 Go 프로젝트 레이아웃
-- [x] 빌드 자동화를 위한 Makefile
-- [x] cmd/ 진입점
-
-✅ **Kafka 통합** (v0.3.0)
-- [x] Producer / Consumer 인터페이스 추상화 (`pkg/queue`)
-- [x] KafkaConsumerPool — 우선순위 기반 다중 워커 고루틴 풀
-- [x] Handler Registry — 크롤러 이름 → 핸들러 디스패치
-- [x] 재시도 횟수 기반 라우팅을 갖춘 DLQ (Dead Letter Queue)
-- [x] Docker Compose Kafka 스택 (KRaft 모드, Zookeeper 불필요)
-- [x] `.env`를 통한 설정 가능한 파티션으로 Kafka 토픽 초기화
-- [x] Kafka UI (`http://localhost:8080`)
-- [x] 우선순위 기반 다중 풀 매니저 (`PoolManager`)
-
-✅ **뉴스 도메인 크롤러** (v0.4.0)
-- [x] 뉴스 도메인 DIP 인터페이스 (`internal/processor/fetcher/domain/news/news.go`)
-- [x] Chain of Responsibility 핸들러 (`handler.go`) — RSS → GoQuery → Browser 폴백 체인
-- [x] RSS/GoQuery/Browser 어댑터 (`fetcher/`)
-- [x] **한국 소스**:
-  - [x] Naver 크롤러 (GoQuery → Browser 폴백) + Parser
-  - [x] Yonhap 크롤러 (RSS → GoQuery 폴백) + Parser
-  - [x] Daum 크롤러 (GoQuery) + Parser
-  - [x] KR 레지스트리 조립 진입점 (`kr/registry.go`)
-- [x] **미국 소스**:
-  - [x] CNN 크롤러 (GoQuery) + Parser
-  - [x] US 레지스트리 조립 진입점 (`us/registry.go`)
-- [x] PostgreSQL 스토리지 레이어 (`internal/storage/news_article.go`, `postgres/news_article.go`)
-- [x] 마이그레이션 — `news_articles` 테이블 생성 (`003_create_news_articles.up.sql`)
-- [x] 테스트 — KR 파서/크롤러 780+ 케이스, US 파서/크롤러 519+ 케이스
-
-✅ **Kafka Blob 오프로딩** (v0.5.0)
-- [x] `RawContentRef` — 경량 Kafka 메시지 구조체 (ID + 메타데이터, HTML 본문 제외)
-- [x] `RawContentService`를 `KafkaConsumerPool`에 주입하여 Postgres 우선 저장
-- [x] 워커가 전체 `RawContent`(HTML 포함)를 Postgres에 저장 후 `RawContentRef`만 Kafka에 발행
-- [x] 중복 URL 처리 — 에러 없이 기존 레코드 ID 반환
-- [x] `PoolManager` (`manager.go`) — 우선순위 기반 다중 풀 오케스트레이션 (High / Normal / Low)
-- [x] 풀 처리 로직 단위 테스트 (`test/internal/worker/`)
-
-📋 **계획됨**
-- [ ] 처리 파이프라인 (normalize → validate → enrich)
-- [ ] 임베딩 생성
-- [ ] 클러스터링 알고리즘
-- [ ] API 엔드포인트
-- [ ] 웹 대시보드
-
-## 프로젝트 구조
-
-[Standard Go Project Layout](https://github.com/golang-standards/project-layout)을 따릅니다:
-
-```
-issuetracker/
-├── cmd/
-│   └── crawler/               # 크롤러 진입점
-│       └── main.go
-│
-├── internal/
-│   ├── crawler/
-│   │   ├── core/              # 크롤러 인터페이스, 모델, 에러, 재시도
-│   │   ├── handler/           # Handler 인터페이스 + Registry (크롤러 이름 디스패치)
-│   │   │   ├── handler.go     # Handler 인터페이스, Registry
-│   │   │   └── noop.go        # 폴백 noop 핸들러
-│   │   ├── worker/            # Kafka consumer 풀
-│   │   │   ├── pool.go        # KafkaConsumerPool (고루틴 워커 풀 + DLQ + Postgres 오프로딩)
-│   │   │   └── manager.go     # PoolManager (High/Normal/Low 우선순위 풀 오케스트레이션)
-│   └── storage/               # 데이터 액세스 레이어
-│       ├── news_article.go    # NewsArticle 리포지토리 인터페이스
-│       └── postgres/          # PostgreSQL 구현
-│           └── news_article.go # pgx/v5 기반 NewsArticle CRUD
-│       └── domain/
-│           └── news/          # 뉴스 도메인 크롤러 (DIP + Chain of Responsibility)
-│               ├── news.go    # 도메인 인터페이스 (NewsFetcher, NewsRSSFetcher, ...)
-│               ├── handler.go # Chain: RSS → GoQuery → Browser
-│               ├── fetcher/   # 어댑터 (rss, goquery, browser)
-│               ├── kr/        # 한국 소스
-│               │   ├── naver/ # 네이버 (config, crawler, parser)
-│               │   ├── yonhap/ # 연합뉴스 (config, crawler, parser)
-│               │   ├── daum/  # 다음 (config, crawler, parser)
-│               │   └── registry.go # 조립 & 등록 진입점
-│               └── us/        # 미국 소스
-│                   ├── cnn/   # CNN (config, crawler, parser)
-│                   └── registry.go # 조립 & 등록 진입점
-│
-├── pkg/
-│   ├── logger/                # 구조화된 로거 (zerolog)
-│   └── queue/                 # Kafka producer/consumer 추상화
-│       ├── queue.go           # Producer, Consumer 인터페이스
-│       ├── config.go          # 토픽/그룹 상수, Config
-│       ├── producer.go        # KafkaProducer (kafka-go)
-│       └── consumer.go        # KafkaConsumer (kafka-go, 수동 커밋)
-│
-├── deployments/
-│   └── docker/
-│       ├── docker-compose.yml # Kafka 브로커 (KRaft) + kafka-ui
-│       └── .env.example       # 파티션 설정 템플릿
-│
-├── examples/
-│   ├── basic_usage.go
-│   └── kafka_pipeline/        # 인메모리 모의 파이프라인 예제
-│
-├── migrations/                # 데이터베이스 마이그레이션 (PostgreSQL)
-│   ├── 001_create_raw_contents.up.sql     # raw_contents 테이블
-│   ├── 002_create_contents.up.sql         # contents 테이블
-│   ├── 003_create_news_articles.up.sql    # news_articles 테이블 + 인덱스
-│   └── *.down.sql             # 롤백 마이그레이션
-│
-├── test/                      # 패키지 레벨 테스트
-├── docs/
-│   ├── en/
-│   └── ko/
-├── Makefile
-├── go.mod
-└── go.sum
-```
-
-### 설계 근거
-
-**표준 Go 프로젝트 레이아웃:**
-- **`cmd/`**: 애플리케이션 진입점 (main 패키지)
-- **`internal/`**: 비공개 코드 (외부 프로젝트에서 임포트 불가)
-- **`pkg/`**: 공개 라이브러리 코드 (외부 프로젝트에서 임포트 가능)
-- 장점:
-  - 업계 표준 구조
-  - 명확한 관심사 분리
-  - Go 개발자에게 친숙한 탐색
-  - 향상된 의존성 관리
-
-## 핵심 컴포넌트
-
-### Crawler 인터페이스
-
-```go
-type Crawler interface {
-  Name() string
-  Source() SourceInfo
-  Initialize(ctx context.Context, config Config) error
-  Start(ctx context.Context) error
-  Stop(ctx context.Context) error
-  Fetch(ctx context.Context, target Target) (*RawContent, error)
-  HealthCheck(ctx context.Context) error
-}
-```
-
-### HTTP Client
-
-- 커넥션 풀링 (최대 100개의 유휴 연결)
-- 설정 가능한 타임아웃
-- 응답 크기 제한 (10MB)
-- 네트워크 에러 시 자동 재시도
-- 통합 로깅
-
-### Rate Limiter
-
-- 토큰 버킷 알고리즘
-- 시간당 요청 수 설정 가능
-- 버스트 지원
-- 컨텍스트 인식 대기
-- 성능 최적화
-
-### 에러 핸들링
-
-- 카테고리가 있는 타입 에러
-- 재시도 가능 vs 불가능 에러
-- 추적을 위한 에러 코드
-- 완전한 에러 컨텍스트 보존
-
-### 구조화된 Logger
-
-- 고성능을 위해 `zerolog` 기반
-- 컨텍스트 인식 로깅
-- 다양한 로그 레벨 (Debug, Info, Warn, Error, Fatal)
-- JSON 및 pretty-print 형식
-- 요청 ID 추적
-- 크롤러별 필드
-
-## 크롤러 구현
-
-IssueTracker는 정적 및 동적 페이지를 위한 두 가지 크롤러를 제공합니다:
-
-### Goquery - 정적 크롤링 (`implementation/goquery`)
-
-정적 HTML 페이지를 위한 경량 크롤러입니다.
-
-```go
-crawler := goquery.NewGoqueryCrawler("my-crawler", sourceInfo, config)
-raw, err := crawler.Fetch(ctx, target)
-article, err := crawler.FetchAndParse(ctx, target, selectors)
-```
-
-### Chromedp - 동적 크롤링 (`implementation/chromedp`)
-
-JavaScript 렌더링이 필요한 동적 페이지를 위한 헤드리스 브라우저 크롤러입니다.
-
-```go
-crawler := chromedp.NewChromedpCrawler("my-crawler", sourceInfo, config)
-crawler.Initialize(ctx, config)
-defer crawler.Stop(ctx)
-
-raw, err := crawler.Fetch(ctx, target)                       // 렌더링된 HTML
-article, err := crawler.FetchAndParse(ctx, target, selectors) // 렌더링 + 파싱
-result, err := crawler.EvaluateJS(ctx, url, "document.title") // JS 실행
-```
-
-### 비교
-
-| | Goquery | Chromedp |
-|---|---|---|
-| **용도** | 정적 HTML | JavaScript SPA |
-| **속도** | 빠름 (~1초) | 느림 (~3-5초) |
-| **메모리** | 낮음 (~10MB) | 높음 (~100MB) |
-| **JS 지원** | ✗ | ✓ |
-| **사용 사례** | 뉴스, RSS | 커뮤니티, SPA |
-
-### 예제 실행
-
-```bash
-make run-comparison
-```
-
-## 뉴스 도메인 크롤러
-
-### 한국 소스
-
-#### Naver (네이버)
-- **Fetcher**: GoQuery → Browser 폴백
-- **기능**: 카테고리 추출, 이미지 URL 수집, KST → UTC 변환
-- **날짜 형식**: `"2026-03-02 14:54:16"` (KST)
-
-#### Yonhap (연합뉴스)
-- **Fetcher**: RSS → GoQuery 폴백
-- **기능**: 복수 기자 추출, 태그/키워드 수집, 사진 갤러리 지원
-- **날짜 형식**: `"2024-01-15 14:30"` (KST)
-
-#### Daum (다음)
-- **Fetcher**: GoQuery
-- **기능**: 카테고리, 이미지, 메타데이터 추출
-- **날짜 형식**: ISO 8601
-
-### 미국 소스
-
-#### CNN
-- **Fetcher**: GoQuery
-- **기능**: Section/subsection 추출, byline 파싱, 메타데이터 지원
-- **날짜 형식**: ISO 8601
-
-**모든 파서**:
-- 추출: Title, Body, Author, Category, Tags, ImageURLs, PublishedAt
-- 누락된 필드를 gracefully 처리 (기본값으로 폴백)
-- 모든 타임스탬프를 UTC로 변환
-- 780+ 테스트 케이스 (한국), 519+ 테스트 케이스 (미국)
+전체 키 목록은 [`.env.example`](../../.env.example) 참조.
 
 ## 개발
 
+### Workflow
+
+개발 규약은 [`.claude/rules/`](../../.claude/rules/) 에 정리:
+
+1. [01-architecture.md](../../.claude/rules/01-architecture.md) — 시스템 아키텍처
+2. [02-crawler-implementation.md](../../.claude/rules/02-crawler-implementation.md) — fetcher 표준
+3. [03-data-processing.md](../../.claude/rules/03-data-processing.md) — 처리 파이프라인
+4. [04-error-handling.md](../../.claude/rules/04-error-handling.md) — 에러 처리 & 모니터링
+5. [05-testing.md](../../.claude/rules/05-testing.md) — 테스트 전략
+6. [06-code-style.md](../../.claude/rules/06-code-style.md) — 코드 컨벤션
+7. [07-workflow.md](../../.claude/rules/07-workflow.md) — issue-first / commit-per-TODO / 자율 진행
+
 ### 코드 스타일
 
-- **인덴트**: 2 스페이스 (탭 아님)
-- **주석**: 한국어 + 영어 혼용
-- **테스트**: 최소 70% 커버리지 (현재 92.1%)
-- **네이밍**: 명확하고 자체 문서화된 이름
+- Go formatting: `gofmt -w .` (tab)
+- 주석은 한국어 / 영어 혼용 (한국어 우선)
+- 한국어 커밋 메시지 + 카테고리 prefix: `[FEAT]`, `[FIX]`, `[REFAC]`, `[DOCS]`, `[CHORE]`
+- PR 제목: `[카테고리#이슈번호] 설명` (CI 강제)
 
-### 린터 실행
+### CI / 머지 게이트
 
-```bash
-# Makefile 사용
-make lint
+Required status checks ([`docs/ci/`](../ci/) 참조):
+- Commit Lint / PR Title Lint / Linked Issue Check
+- Format Check / Build / Test / Lint
 
-# 직접 실행
-golangci-lint run
-```
+## 문서
 
-### 문서
+- **Canonical**: [`docs/architecture/`](../architecture/) — 패키지별 설계 문서
+- **운영**: [`docs/ci/`](../ci/) — CI 컨벤션 + required status check
+- **Workflow**: [`.claude/rules/07-workflow.md`](../../.claude/rules/07-workflow.md) — AI / 사람 협업 규약
+- **번역**: [`docs/ko/`](.) — 한국어 (영어판과 동기화)
 
-개발 규칙은 [`.claude/rules/`](../../.claude/rules/)에 있습니다:
+## 기여
 
-1. **[01-architecture.md](../../.claude/rules/01-architecture.md)** - 시스템 아키텍처
-2. **[02-crawler-implementation.md](../../.claude/rules/02-crawler-implementation.md)** - 크롤러 표준
-3. **[03-data-processing.md](../../.claude/rules/03-data-processing.md)** - 처리 파이프라인
-4. **[04-error-handling.md](../../.claude/rules/04-error-handling.md)** - 에러 핸들링 & 모니터링
-5. **[05-testing.md](../../.claude/rules/05-testing.md)** - 테스트 전략
-6. **[06-code-style.md](../../.claude/rules/06-code-style.md)** - 코드 규칙
-
-## 사용 예제
-
-전체 예제는 [examples/basic_usage.go](../../examples/basic_usage.go)를 참조하세요:
-
-```go
-import (
-  "issuetracker/pkg/logger"
-  "issuetracker/internal/processor/fetcher/core"
-)
-
-// 로거 설정 (개발 모드, pretty printing)
-logConfig := logger.DefaultConfig()
-logConfig.Level = logger.LevelDebug
-logConfig.Pretty = true
-log := logger.New(logConfig)
-
-// 속도 제한이 있는 HTTP 클라이언트 생성
-config := core.DefaultConfig()
-config.RequestsPerHour = 60
-httpClient := core.NewHTTPClient(config)
-rateLimiter := core.NewRateLimiter(config.RequestsPerHour, config.BurstSize)
-
-// 컨텍스트에 로거 추가
-ctx := context.Background()
-ctx = log.ToContext(ctx)
-
-// 추적을 위한 요청 ID 추가
-requestLog := log.WithRequestID("req-123")
-requestCtx := requestLog.ToContext(ctx)
-
-// 재시도와 함께 가져오기 (로깅은 자동으로 발생)
-var resp *core.HTTPResponse
-err := core.WithRetry(requestCtx, core.DefaultRetryPolicy, func() error {
-  var fetchErr error
-  resp, fetchErr = httpClient.Get(requestCtx, url)
-  return fetchErr
-})
-```
-
-## Makefile 명령어
-
-```bash
-# 빌드 & 실행
-make build              # 크롤러 바이너리 빌드 → bin/crawler
-make run-crawler        # 빌드 후 크롤러 실행
-make run-example        # 기본 사용 예제 실행
-make run-kafka-pipeline # 인메모리 Kafka 파이프라인 예제 실행
-
-# 테스트 & 품질
-make test               # 모든 테스트 실행
-make coverage           # 커버리지 보고서와 함께 테스트 실행
-make lint               # 린터 실행
-make fmt                # 코드 포맷
-make clean              # 빌드 아티팩트 제거
-
-# Kafka
-make kafka-start        # Kafka 브로커 + UI 시작 (토픽 생성)
-make kafka-stop         # 중지 (KAFKA_DATA_DIR에 데이터 보존)
-make kafka-clean        # 중지 + 모든 데이터 삭제
-make kafka-status       # 컨테이너 상태 표시
-make kafka-topics       # 모든 토픽 나열
-make kafka-describe     # 토픽별 파티션/리더 세부 정보 표시
-make kafka-scale-partitions TOPIC=<topic> PARTITIONS=<n>  # 파티션 증가
-
-# PostgreSQL
-make pg-start           # PostgreSQL 컨테이너 시작
-make pg-stop            # PostgreSQL 중지 (데이터 보존)
-make pg-clean           # 중지 + 모든 데이터 삭제
-make pg-status          # PostgreSQL 컨테이너 상태 표시
-make pg-migrate         # 데이터베이스 마이그레이션 실행 (멱등성)
-make pg-migrate-down    # 마이그레이션 롤백 (주의해서 사용)
-make pg-psql            # PostgreSQL 셸 연결
-
-make help               # 설명과 함께 모든 명령어 표시
-```
-
-## 기여하기
-
-기여하기 전에 `.claude/rules/`의 개발 규칙을 읽어주세요.
+[`.claude/rules/07-workflow.md`](../../.claude/rules/07-workflow.md) 의 issue-first workflow 및 labeling 정책을 먼저 읽어주세요.
 
 ## 라이선스
 
 MIT
 
-## 문의
+## 연락처
 
-질문이나 피드백이 있으시면 GitHub에서 이슈를 열어주세요.
+문의 / 피드백은 GitHub issue 로 부탁드립니다.

--- a/docs/ko/README.md
+++ b/docs/ko/README.md
@@ -4,7 +4,7 @@
 
 > 글로벌 이슈 수집 및 분석 시스템
 
-[![Go Version](https://img.shields.io/badge/Go-1.22+-00ADD8?style=flat&logo=go)](https://go.dev/)
+[![Go Version](https://img.shields.io/badge/Go-1.24+-00ADD8?style=flat&logo=go)](https://go.dev/)
 [![License](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
 
 ## 개요
@@ -76,7 +76,7 @@ IssueTracker 는 전 세계의 뉴스 / 커뮤니티 / 소셜 소스를 크롤�
 
 ### 요구사항
 
-- Go 1.22+
+- Go 1.24+
 - PostgreSQL 15+
 - Apache Kafka 4.x (KRaft 모드, Zookeeper 불필요)
 - Redis 7+
@@ -142,14 +142,19 @@ issuetracker/
 ├── cmd/                            # 애플리케이션 entry → bin/
 │   ├── issuetracker/               # 통합 파이프라인 (메인 entry)
 │   ├── processor/                  # validate 전용
-│   ├── migrate/  ├── migrate-down/ # DB 스키마 마이그레이션
+│   ├── migrate/                    # DB 스키마 마이그레이션 (up)
+│   ├── migrate-down/               # DB 스키마 마이그레이션 (down)
 │   └── rule-validator/             # parser rule dry-run 도구
 │
 ├── internal/
 │   ├── processor/
 │   │   ├── processor.go            # Stage lifecycle interface
 │   │   ├── fetcher/                # crawler pool + handler chain (goquery / chromedp / browser / RSS)
-│   │   │   ├── core/   handler/   worker/   domain/   implementation/
+│   │   │   ├── core/
+│   │   │   ├── handler/
+│   │   │   ├── worker/
+│   │   │   ├── domain/
+│   │   │   ├── implementation/
 │   │   │   └── rate_limiter/
 │   │   ├── parser/
 │   │   │   ├── types/              # Page / LinkItem / ContentParser interface
@@ -174,7 +179,6 @@ issuetracker/
 │   │   └── redis/                  # Redis 구현 (lock, sliding window)
 │   ├── locks/                      # ProcessingLock / IngestionLock (Redis)
 │   ├── bus/                        # Kafka producer/consumer + retry scheduler
-│   ├── publisher/                  # Crawl job publisher (precheck 게이트 consumer)
 │   ├── scheduler/                  # DB-driven seed job emitter
 │   ├── workerpool/                 # generic worker pool primitives
 │   └── classifier/                 # external classifier gRPC/HTTP client


### PR DESCRIPTION
## 연관 이슈
- Closes #498
- Parent: #488

<br>

## 구현 내용

루트 \`README.md\` 와 한국어 번역본 \`docs/ko/README.md\` 가 모두 v0.6.0 (Content Validation Pipeline, 2026-05-12) 시점에 멈춰있어 그 이후 머지된 핵심 변경 (enrich subsystem, claudegen, DB-driven rule, storage Phase 1/2, stage toggle 등) 이 전혀 반영되지 않은 상태였음. 30+ PR 누적 변경을 일괄 반영하면서 versioning 추적 패턴을 폐기하고 현재 아키텍처 중심 서술로 전환.

### 주요 변경

- **Versioning 패턴 폐기** — v0.2.0 ~ v0.6.0 "Current Status" 섹션 제거. milestone 추적이 더 이상 의미 없는 시점.
- **High-level Architecture 다이어그램 신설** — 5-stage Kafka pipeline + scheduler/raw_contents/enriched_contents 의존 관계
- **Features 갱신** — 4-stage enrichment, LLM selector 자동 학습, DB-driven rule, auto-demote, stage toggle 명시
- **Binaries 표 정정** — 5 binary (issuetracker / processor / migrate / migrate-down / rule-validator). \`bin/crawler\` 단독 entry 제거됨.
- **Project Structure 재작성** — \`internal/crawler/\` → \`internal/processor/fetcher/\`. \`enrich/\`, \`precheck/\`, \`parser/rule/{indexonly,llmgen,pathinfer,refiner}\`, \`storage\` 7-layer, \`pkg/agent/claude\`, \`pkg/config\` sub-package 모두 반영.
- **Key Design Choices 신설** — DB-driven rule (#100,#482) / Claim Check (#134) / Storage layering (#430,#431) / Stage Gate Semaphore / Auto-blacklist 두 경로
- **Quick Start 정정** — \`make start\` 가 chrome-ensure + kafka-ensure + run-issuetracker 자동 실행. \`claudegen-build\` 단계 명시.
- **Stage Toggle 섹션 신설** (이슈 #443) — fetcher-only / parser-only 분리 배포 패턴
- **Operations Reference 4 sub-section** — Build/Test, Infrastructure, Running, Configuration
- **Documentation / ENV 매트릭스 갱신** — \`docs/architecture/\` canonical + ENV 매트릭스 (\`POSTGRES_*\` / \`STAGES_*\` / \`CLAUDE_CODE_*\` / \`ENRICHER_DB_RO_*\` 등)

### Diff 통계

\`2 files changed, 452 insertions(+), 959 deletions(-)\` — 순 -507 LOC (요약 + 현재 코드 반영으로 압축).

<br>

## CI / 머지 게이트 점검

### 변경 영향 범위
- 영향 파일: \`README.md\`, \`docs/ko/README.md\`
- 위험도(택1): **Low** — 문서만 변경.

### Required Status Checks
- [ ] \`Commit Lint\` / \`PR Title Lint\` / \`Linked Issue Check\`
- [ ] \`Format Check\` / \`Build\` / \`Test\` / \`Lint\`

### 로컬 검증
- ✅ \`go build ./...\` 통과 (문서 변경)

### 롤백 계획
- 본 PR revert — 두 파일 원복.

<br>

## 메타 이슈 #488 진행 상황

- ✅ #489 (PR #493) — parser docs
- ✅ #490 (PR #494) — cmd / pkg docs
- ✅ #491 (PR #496) — storage docs (피드백 반영 commit 추가)
- ✅ #492 (PR #497) — 신규 모듈 docs (피드백 반영 commit 추가)
- **이 PR** — root README

본 PR 머지 시 메타 이슈 #488 의 5 sub 모두 close 됨.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Completely refreshed README with current architecture overview, pipeline configuration, and operational guidance
  * Updated installation prerequisites, build commands, and setup procedures
  * Expanded infrastructure configuration documentation and environment variable mappings
  * Updated Korean README documentation to align with current system design

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/EinSofINTEREST/IssueTracker/pull/499?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->