### PR TITLE
[REFAC#495] inflight_locker TTL 환경변수화 — REDIS_INFLIGHT_LOCK_TTL

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -45,6 +45,10 @@ REDIS_INGESTION_LOCK_TTL=24h
 # - Category 는 정기 갱신이 본질이므로 cycle 진행 중 overlap 방지용 짧은 TTL
 # - 정상 흐름은 명시적 Release, 본 TTL 은 worker 충돌 시 fallback
 PIPELINE_GUARD_CATEGORY_TTL=60s
+# llmgen (host, targetType) 단위 InflightLocker TTL (이슈 #495)
+# - CLAUDE_CODE_TIMEOUT 변경 시 동기화 필요 — 권장: CLAUDE_CODE_TIMEOUT × 2.5
+# - 기본 5m 은 CLAUDE_CODE_TIMEOUT 기본값 (120s) 의 2.5배 — 프로세스 크래시 후 stuck 슬롯 자동 해제
+REDIS_INFLIGHT_LOCK_TTL=5m
 
 # Redis delayed retry scheduler 의 idle heartbeat 로그 압축 (이슈 #370)
 # - default: 60 — PollInterval=1s 기준 ~1분에 1회 "retry pipeline idle heartbeat" DEBUG

--- a/cmd/issuetracker/main.go
+++ b/cmd/issuetracker/main.go
@@ -502,7 +502,7 @@ func main() {
 		}).Info("LLM prompt loader enabled (file → embed chain)")
 	}
 
-	llmGen, err := llmgenwiring.Build(llmProvider, parserRuleSvc, ruleResolver, promptLoader, redisClientShared, log)
+	llmGen, err := llmgenwiring.Build(llmProvider, parserRuleSvc, ruleResolver, promptLoader, redisClientShared, redisCfg.InflightLockTTL, log)
 	if err != nil {
 		log.WithError(err).Fatal("failed to build llmgen generator")
 	}

--- a/internal/processor/parser/rule/llmgen/wiring/wiring.go
+++ b/internal/processor/parser/rule/llmgen/wiring/wiring.go
@@ -7,6 +7,7 @@ package wiring
 
 import (
 	"fmt"
+	"time"
 
 	"issuetracker/internal/processor/parser/rule"
 	"issuetracker/internal/processor/parser/rule/llmgen"
@@ -24,7 +25,8 @@ import (
 // provider 가 nil (LLM 비활성) 이면 (nil, nil) 반환 — parser worker 는 ErrNoRule 시 raw 만 잔존.
 // llmgen.New 자체 실패는 wiring 버그 — 호출자 (main) 에서 Fatal 결정.
 // redisClient 가 nil 이면 in-process memInflightLocker 로 graceful degrade.
-func Build(provider llm.Provider, repo repository.ParserRuleRepository, resolver *rule.Resolver, promptLoader prompt.Loader, redisClient *redis.Client, log *logger.Logger) (*llmgen.Generator, error) {
+// inflightLockTTL ≤ 0 이면 NewInflightLocker 내부에서 DefaultInflightLockTTL (5m) 로 보정 (이슈 #495).
+func Build(provider llm.Provider, repo repository.ParserRuleRepository, resolver *rule.Resolver, promptLoader prompt.Loader, redisClient *redis.Client, inflightLockTTL time.Duration, log *logger.Logger) (*llmgen.Generator, error) {
 	if provider == nil {
 		return nil, nil
 	}
@@ -33,12 +35,12 @@ func Build(provider llm.Provider, repo repository.ParserRuleRepository, resolver
 		return nil, fmt.Errorf("construct llmgen generator: %w", err)
 	}
 	if redisClient != nil {
-		locker, lockerErr := redisstore.NewInflightLocker(redisClient.Raw(), redisstore.DefaultInflightLockTTL)
+		locker, lockerErr := redisstore.NewInflightLocker(redisClient.Raw(), inflightLockTTL)
 		if lockerErr != nil {
 			return nil, fmt.Errorf("construct redis inflight locker: %w", lockerErr)
 		}
 		gen.SetLocker(locker)
-		log.Info("llmgen: Redis 분산 inflight lock 활성화")
+		log.WithField("ttl", inflightLockTTL.String()).Info("llmgen: Redis 분산 inflight lock 활성화")
 	}
 
 	// Host breaker (#215) — 동일 host 의 LLM 호출이 N회 연속 rate_limit hit 시 cooldown.

--- a/internal/processor/parser/rule/llmgen/wiring/wiring.go
+++ b/internal/processor/parser/rule/llmgen/wiring/wiring.go
@@ -35,12 +35,18 @@ func Build(provider llm.Provider, repo repository.ParserRuleRepository, resolver
 		return nil, fmt.Errorf("construct llmgen generator: %w", err)
 	}
 	if redisClient != nil {
-		locker, lockerErr := redisstore.NewInflightLocker(redisClient.Raw(), inflightLockTTL)
+		// inflightLockTTL ≤ 0 은 NewInflightLocker 내부에서 DefaultInflightLockTTL 로 보정 —
+		// 로그에 실제 적용된 값이 찍히도록 호출 전에 동일 fallback 을 미리 적용.
+		appliedTTL := inflightLockTTL
+		if appliedTTL <= 0 {
+			appliedTTL = redisstore.DefaultInflightLockTTL
+		}
+		locker, lockerErr := redisstore.NewInflightLocker(redisClient.Raw(), appliedTTL)
 		if lockerErr != nil {
 			return nil, fmt.Errorf("construct redis inflight locker: %w", lockerErr)
 		}
 		gen.SetLocker(locker)
-		log.WithField("ttl", inflightLockTTL.String()).Info("llmgen: Redis 분산 inflight lock 활성화")
+		log.WithField("ttl", appliedTTL.String()).Info("llmgen: Redis 분산 inflight lock 활성화")
 	}
 
 	// Host breaker (#215) — 동일 host 의 LLM 호출이 N회 연속 rate_limit hit 시 cooldown.

--- a/internal/storage/redis/inflight_locker.go
+++ b/internal/storage/redis/inflight_locker.go
@@ -16,6 +16,10 @@ import (
 
 // DefaultInflightLockTTL 은 Redis 분산 Lock 의 기본 TTL 입니다.
 // CLAUDE_CODE_TIMEOUT 기본값(120s) 의 2.5배 — 프로세스 크래시 후 stuck 슬롯 자동 해제 보장.
+//
+// 런타임 환경에서는 REDIS_INFLIGHT_LOCK_TTL 환경변수로 덮어쓸 수 있습니다 (이슈 #495).
+// CLAUDE_CODE_TIMEOUT 을 늘렸을 때 본 TTL 도 함께 늘려야 (CLAUDE_CODE_TIMEOUT × 2.5 권장)
+// 정상 LLM 호출이 lock TTL 초과로 stuck 표시되는 false positive 를 회피.
 const DefaultInflightLockTTL = 5 * time.Minute
 
 const inflightKeyPrefix = "llmgen:inflight:"

--- a/pkg/config/storage/redis.go
+++ b/pkg/config/storage/redis.go
@@ -31,6 +31,12 @@ type RedisConfig struct {
 	// 본 TTL 은 fallback (worker 가 release 호출 못 하고 죽은 경우 자동 회수).
 	// 환경변수: PIPELINE_GUARD_CATEGORY_TTL (default 60s).
 	PipelineGuardCategoryTTL time.Duration
+
+	// InflightLockTTL: llmgen 의 (host, targetType) 단위 분산 InflightLocker TTL (이슈 #495).
+	// CLAUDE_CODE_TIMEOUT 변경 시 동기화 가능하도록 환경변수로 노출.
+	// 기본 5m 은 CLAUDE_CODE_TIMEOUT 기본값 (120s) 의 2.5배 — 프로세스 크래시 후 stuck 슬롯 자동 해제.
+	// 환경변수: REDIS_INFLIGHT_LOCK_TTL (default 5m).
+	InflightLockTTL time.Duration
 }
 
 // DefaultRedisConfig는 로컬 개발 환경용 기본 RedisConfig를 반환합니다.
@@ -46,6 +52,7 @@ func DefaultRedisConfig() RedisConfig {
 		PoolSize:                 10,
 		IngestionLockTTL:         24 * time.Hour,
 		PipelineGuardCategoryTTL: 60 * time.Second,
+		InflightLockTTL:          5 * time.Minute,
 	}
 }
 
@@ -146,6 +153,16 @@ func LoadRedis(envFiles ...string) (RedisConfig, error) {
 			return RedisConfig{}, fmt.Errorf("invalid PIPELINE_GUARD_CATEGORY_TTL %q: must be positive", v)
 		}
 		cfg.PipelineGuardCategoryTTL = d
+	}
+	if v := os.Getenv("REDIS_INFLIGHT_LOCK_TTL"); v != "" {
+		d, err := time.ParseDuration(v)
+		if err != nil {
+			return RedisConfig{}, fmt.Errorf("parse REDIS_INFLIGHT_LOCK_TTL %q: %w", v, err)
+		}
+		if d <= 0 {
+			return RedisConfig{}, fmt.Errorf("invalid REDIS_INFLIGHT_LOCK_TTL %q: must be positive", v)
+		}
+		cfg.InflightLockTTL = d
 	}
 
 	return cfg, nil

--- a/test/pkg/config/config_test.go
+++ b/test/pkg/config/config_test.go
@@ -239,6 +239,8 @@ func unsetRedisEnvVars(t *testing.T) {
 		"REDIS_HOST", "REDIS_PORT", "REDIS_PASSWORD",
 		"REDIS_DB", "REDIS_DIAL_TIMEOUT", "REDIS_READ_TIMEOUT",
 		"REDIS_WRITE_TIMEOUT", "REDIS_POOL_SIZE",
+		"REDIS_INGESTION_LOCK_TTL", "PIPELINE_GUARD_CATEGORY_TTL",
+		"REDIS_INFLIGHT_LOCK_TTL",
 	}
 	for _, v := range vars {
 		t.Setenv(v, "")
@@ -268,6 +270,47 @@ func TestLoadRedis_DefaultValues(t *testing.T) {
 	}
 	if cfg.DialTimeout != def.DialTimeout {
 		t.Errorf("DialTimeout: got %v, want %v", cfg.DialTimeout, def.DialTimeout)
+	}
+	if cfg.InflightLockTTL != def.InflightLockTTL {
+		t.Errorf("InflightLockTTL: got %v, want %v", cfg.InflightLockTTL, def.InflightLockTTL)
+	}
+	if cfg.InflightLockTTL != 5*time.Minute {
+		t.Errorf("InflightLockTTL default: got %v, want 5m", cfg.InflightLockTTL)
+	}
+}
+
+func TestLoadRedis_InflightLockTTLOverride(t *testing.T) {
+	unsetRedisEnvVars(t)
+	t.Setenv("REDIS_INFLIGHT_LOCK_TTL", "10m")
+
+	cfg, err := storagecfg.LoadRedis("/tmp/nonexistent-env-file.env")
+	if err != nil {
+		t.Fatalf("REDIS_INFLIGHT_LOCK_TTL 로드 실패: %v", err)
+	}
+	if cfg.InflightLockTTL != 10*time.Minute {
+		t.Errorf("InflightLockTTL: got %v, want 10m", cfg.InflightLockTTL)
+	}
+}
+
+func TestLoadRedis_InvalidInflightLockTTL(t *testing.T) {
+	tests := []struct {
+		name  string
+		value string
+	}{
+		{"not a duration", "not-a-duration"},
+		{"zero", "0s"},
+		{"negative", "-1m"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			unsetRedisEnvVars(t)
+			t.Setenv("REDIS_INFLIGHT_LOCK_TTL", tt.value)
+
+			_, err := storagecfg.LoadRedis("/tmp/nonexistent-env-file.env")
+			if err == nil {
+				t.Fatalf("REDIS_INFLIGHT_LOCK_TTL=%q: 에러가 반환되어야 합니다", tt.value)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## 연관 이슈
- Closes #495

<br>

## 구현 내용

`internal/storage/redis/inflight_locker.go` 의 `DefaultInflightLockTTL = 5 * time.Minute` 가 하드코딩되어, `CLAUDE_CODE_TIMEOUT` 을 늘려도 동기화되지 않는 문제를 해결. Option A (env 직접 노출) 적용.

### 변경 사항

- **`pkg/config/storage/redis.go`** — `RedisConfig` 에 `InflightLockTTL time.Duration` 필드 추가
  - `DefaultRedisConfig`: 5m 기본값 (기존 동작 보존)
  - `LoadRedis`: `REDIS_INFLIGHT_LOCK_TTL` 파싱 + 양수 validation (기존 `*_TTL` 패턴 일관)
- **`internal/processor/parser/rule/llmgen/wiring/wiring.go`** — `Build` 에 `inflightLockTTL time.Duration` 파라미터 추가, `DefaultInflightLockTTL` 하드코딩 제거
  - ttl ≤ 0 fallback 은 `NewInflightLocker` 내부 기존 로직 유지 (방어적)
  - 활성화 로그에 `ttl` 필드 추가 — 운영 환경에서 적용 TTL 확인 가능
- **`internal/storage/redis/inflight_locker.go`** — `DefaultInflightLockTTL` 주석 보강: env 명시 + `CLAUDE_CODE_TIMEOUT × 2.5` 가이드
- **`cmd/issuetracker/main.go:505`** — `llmgenwiring.Build` 호출에 `redisCfg.InflightLockTTL` 전달
- **`.env.example`** — `REDIS_INFLIGHT_LOCK_TTL=5m` + 운영 가이드 주석 추가
- **`test/pkg/config/config_test.go`** — 단위 테스트 추가
  - 기본값 5m 확인
  - `REDIS_INFLIGHT_LOCK_TTL=10m` override
  - invalid: not-a-duration / zero / negative
  - `unsetRedisEnvVars` 헬퍼에 *_TTL 변수 3개 추가 (테스트 격리)

### 운영 가이드

`CLAUDE_CODE_TIMEOUT` 변경 시 `REDIS_INFLIGHT_LOCK_TTL` 도 함께 갱신 권장:
- `CLAUDE_CODE_TIMEOUT=120s` → `REDIS_INFLIGHT_LOCK_TTL=5m` (× 2.5)
- `CLAUDE_CODE_TIMEOUT=180s` → `REDIS_INFLIGHT_LOCK_TTL=7m30s` 또는 `8m`
- `CLAUDE_CODE_TIMEOUT=300s` → `REDIS_INFLIGHT_LOCK_TTL=12m30s` 또는 `15m`

미설정 시 default 5m — 기존 동작과 동일.

<br>

## CI / 머지 게이트 점검

### 변경 영향 범위
- 영향 패키지/모듈:
  - `pkg/config/storage` (env 추가, 신규 필드)
  - `internal/processor/parser/rule/llmgen/wiring` (Build signature 확장)
  - `internal/storage/redis/inflight_locker` (주석만)
  - `cmd/issuetracker` (Build 호출 인자 1개 추가)
- 위험도: `Low` — 기본값 5m 으로 기존 동작 보존, signature 변경은 단일 caller 경로 (main) 만 영향

### Required Status Checks
- 통과 확인 대상:
  - [ ] `Commit Lint`
  - [ ] `PR Title Lint`
  - [ ] `Linked Issue Check`
  - [ ] `Format Check`
  - [ ] `Build`
  - [ ] `Test`
  - [ ] `Lint`

### 롤백 계획
- 본 PR revert 만으로 원복 가능 — 신규 env 키 `REDIS_INFLIGHT_LOCK_TTL` 무시되고 기본 5m 으로 복귀.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added configurable Redis inflight lock timeout setting via `REDIS_INFLIGHT_LOCK_TTL` environment variable (default: 5 minutes). This timeout can be adjusted to align with system timeouts and prevent false-positive lock scenarios.

* **Tests**
  * Added test coverage for the new Redis inflight lock TTL configuration, including validation of default values and invalid inputs.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/EinSofINTEREST/IssueTracker/pull/500?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->