### PR TITLE
[FIX#508] parser rule.Error 의 Host 필드 누락 보정 — stale_relearn / host failure counter 정상화

### DIFF
--- a/internal/processor/parser/rule/discovery.go
+++ b/internal/processor/parser/rule/discovery.go
@@ -3,7 +3,6 @@ package rule
 import (
 	"fmt"
 	"math/rand/v2"
-	"net/url"
 	"regexp"
 
 	"issuetracker/internal/processor/fetcher/core"
@@ -55,7 +54,7 @@ func (d *PageLinkDiscovery) Discover(raw *core.RawContent, cfg *model.LinkDiscov
 		return nil, &Error{
 			Code:       ErrEmptySelector,
 			Message:    "link discovery requires non-nil LinkDiscoveryConfig",
-			Host:       errorHost(raw.URL),
+			Host:       NormalizeHost(raw.URL),
 			URL:        raw.URL,
 			TargetType: string(model.TargetTypeList),
 		}
@@ -69,7 +68,7 @@ func (d *PageLinkDiscovery) Discover(raw *core.RawContent, cfg *model.LinkDiscov
 			return nil, &Error{
 				Code:       ErrEmptySelector,
 				Message:    fmt.Sprintf("invalid ArticleURLPattern regex: %q", cfg.ArticleURLPattern),
-				Host:       errorHost(raw.URL),
+				Host:       NormalizeHost(raw.URL),
 				URL:        raw.URL,
 				TargetType: string(model.TargetTypeList),
 				Err:        err,
@@ -98,7 +97,7 @@ func (d *PageLinkDiscovery) Discover(raw *core.RawContent, cfg *model.LinkDiscov
 		return nil, &Error{
 			Code:       ErrParseFailure,
 			Message:    "link extractor failed",
-			Host:       errorHost(raw.URL),
+			Host:       NormalizeHost(raw.URL),
 			URL:        raw.URL,
 			TargetType: string(model.TargetTypeList),
 			Err:        err,
@@ -114,7 +113,7 @@ func (d *PageLinkDiscovery) Discover(raw *core.RawContent, cfg *model.LinkDiscov
 	// 외부 링크 (cross-origin) 는 광고/제휴 노이즈 비율 높으므로 cap 으로 통제하되,
 	// 무작위 sample 로 특정 영역 (예: 페이지 상단의 광고 슬롯) 에 편향되지 않도록.
 	maxOut := cfg.MaxLinksPerPage
-	pageHost := hostOf(raw.URL)
+	pageHost := NormalizeHost(raw.URL)
 
 	sameOrigin := make([]types.LinkItem, 0, len(candidates))
 	crossOrigin := make([]types.LinkItem, 0)
@@ -123,7 +122,7 @@ func (d *PageLinkDiscovery) Discover(raw *core.RawContent, cfg *model.LinkDiscov
 			continue
 		}
 		item := types.LinkItem{URL: l.URL, Title: l.Text}
-		if pageHost != "" && hostOf(l.URL) == pageHost {
+		if pageHost != "" && NormalizeHost(l.URL) == pageHost {
 			sameOrigin = append(sameOrigin, item)
 		} else {
 			crossOrigin = append(crossOrigin, item)
@@ -164,20 +163,10 @@ func (d *PageLinkDiscovery) Discover(raw *core.RawContent, cfg *model.LinkDiscov
 		return nil, &Error{
 			Code:       ErrParseFailure,
 			Message:    msg,
-			Host:       errorHost(raw.URL),
+			Host:       NormalizeHost(raw.URL),
 			URL:        raw.URL,
 			TargetType: string(model.TargetTypeList),
 		}
 	}
 	return out, nil
-}
-
-// hostOf 는 URL 문자열에서 host 를 추출합니다 (parse 실패 시 빈 문자열).
-// 본 함수는 same-origin 분류 비교용 — 빈 문자열 비교는 항상 cross-origin 으로 취급되도록.
-func hostOf(rawURL string) string {
-	u, err := url.Parse(rawURL)
-	if err != nil || u == nil {
-		return ""
-	}
-	return u.Host
 }

--- a/internal/processor/parser/rule/discovery.go
+++ b/internal/processor/parser/rule/discovery.go
@@ -55,6 +55,7 @@ func (d *PageLinkDiscovery) Discover(raw *core.RawContent, cfg *model.LinkDiscov
 		return nil, &Error{
 			Code:       ErrEmptySelector,
 			Message:    "link discovery requires non-nil LinkDiscoveryConfig",
+			Host:       errorHost(raw.URL),
 			URL:        raw.URL,
 			TargetType: string(model.TargetTypeList),
 		}
@@ -68,6 +69,7 @@ func (d *PageLinkDiscovery) Discover(raw *core.RawContent, cfg *model.LinkDiscov
 			return nil, &Error{
 				Code:       ErrEmptySelector,
 				Message:    fmt.Sprintf("invalid ArticleURLPattern regex: %q", cfg.ArticleURLPattern),
+				Host:       errorHost(raw.URL),
 				URL:        raw.URL,
 				TargetType: string(model.TargetTypeList),
 				Err:        err,
@@ -96,6 +98,7 @@ func (d *PageLinkDiscovery) Discover(raw *core.RawContent, cfg *model.LinkDiscov
 		return nil, &Error{
 			Code:       ErrParseFailure,
 			Message:    "link extractor failed",
+			Host:       errorHost(raw.URL),
 			URL:        raw.URL,
 			TargetType: string(model.TargetTypeList),
 			Err:        err,
@@ -161,6 +164,7 @@ func (d *PageLinkDiscovery) Discover(raw *core.RawContent, cfg *model.LinkDiscov
 		return nil, &Error{
 			Code:       ErrParseFailure,
 			Message:    msg,
+			Host:       errorHost(raw.URL),
 			URL:        raw.URL,
 			TargetType: string(model.TargetTypeList),
 		}

--- a/internal/processor/parser/rule/extract.go
+++ b/internal/processor/parser/rule/extract.go
@@ -34,7 +34,7 @@ func validateRaw(raw *core.RawContent) error {
 	if raw != nil {
 		u = raw.URL
 	}
-	return &Error{Code: ErrParseFailure, Message: "raw content empty", URL: u}
+	return &Error{Code: ErrParseFailure, Message: "raw content empty", Host: errorHost(u), URL: u}
 }
 
 // extractField 는 단일 필드를 추출합니다 (selector 가 nil 이면 빈 문자열).

--- a/internal/processor/parser/rule/extract.go
+++ b/internal/processor/parser/rule/extract.go
@@ -34,7 +34,7 @@ func validateRaw(raw *core.RawContent) error {
 	if raw != nil {
 		u = raw.URL
 	}
-	return &Error{Code: ErrParseFailure, Message: "raw content empty", Host: errorHost(u), URL: u}
+	return &Error{Code: ErrParseFailure, Message: "raw content empty", Host: NormalizeHost(u), URL: u}
 }
 
 // extractField 는 단일 필드를 추출합니다 (selector 가 nil 이면 빈 문자열).

--- a/internal/processor/parser/rule/parser.go
+++ b/internal/processor/parser/rule/parser.go
@@ -22,6 +22,19 @@ import (
 // ctx 에 이미 더 짧은 deadline 이 있으면 그것이 우선 (context.WithTimeout 이 합성).
 const resolveTimeout = 5 * time.Second
 
+// errorHost 는 rule.Error 의 Host 필드용 canonical host 를 추출합니다 (이슈 #508).
+//
+// resolver 의 extractHostPath 와 동일 정규화 (u.Hostname() + lowercase) — port 제거 + 대소문자 일관.
+// 이 정규화로 worker 의 staleCounter / failureCounter 가 같은 host 를 같은 키로 누적.
+// parse 실패 / 빈 host → 빈 문자열 (호출 측은 빈 host 를 noop 으로 흡수, host="" 가드 유지).
+func errorHost(rawURL string) string {
+	u, err := url.Parse(rawURL)
+	if err != nil || u == nil {
+		return ""
+	}
+	return strings.ToLower(u.Hostname())
+}
+
 // Parser 는 DB 기반 파싱 규칙으로 동작하는 단일 page parser engine 입니다.
 //
 // Parser implements both types.ContentParser and types.LinkListParser, driven by
@@ -135,6 +148,7 @@ func (p *Parser) ParsePage(ctx context.Context, raw *core.RawContent) (*types.Pa
 		return nil, &Error{
 			Code:       ErrNoRule,
 			Message:    "rule lookup returned nil rule",
+			Host:       errorHost(raw.URL),
 			URL:        raw.URL,
 			TargetType: string(model.TargetTypePage),
 		}
@@ -146,6 +160,7 @@ func (p *Parser) ParsePage(ctx context.Context, raw *core.RawContent) (*types.Pa
 		return nil, &Error{
 			Code:       ErrEmptySelector,
 			Message:    "page rule missing required Title or MainContent selector",
+			Host:       errorHost(raw.URL),
 			URL:        raw.URL,
 			TargetType: string(model.TargetTypePage),
 		}
@@ -153,7 +168,7 @@ func (p *Parser) ParsePage(ctx context.Context, raw *core.RawContent) (*types.Pa
 
 	doc, err := goquery.NewDocumentFromReader(strings.NewReader(raw.HTML))
 	if err != nil {
-		return nil, &Error{Code: ErrParseFailure, Message: "goquery parse failed", URL: raw.URL, Err: err}
+		return nil, &Error{Code: ErrParseFailure, Message: "goquery parse failed", Host: errorHost(raw.URL), URL: raw.URL, Err: err}
 	}
 
 	page := &types.Page{
@@ -174,6 +189,7 @@ func (p *Parser) ParsePage(ctx context.Context, raw *core.RawContent) (*types.Pa
 		return nil, &Error{
 			Code:       ErrParseFailure,
 			Message:    "Title or MainContent selector matched 0 elements (rule may be stale)",
+			Host:       errorHost(raw.URL),
 			URL:        raw.URL,
 			TargetType: string(model.TargetTypePage),
 		}
@@ -225,6 +241,7 @@ func (p *Parser) ParseLinks(ctx context.Context, raw *core.RawContent) ([]types.
 		return nil, &Error{
 			Code:       ErrNoRule,
 			Message:    "rule lookup returned nil rule",
+			Host:       errorHost(raw.URL),
 			URL:        raw.URL,
 			TargetType: string(model.TargetTypeList),
 		}
@@ -242,6 +259,7 @@ func (p *Parser) ParseLinks(ctx context.Context, raw *core.RawContent) ([]types.
 		return nil, &Error{
 			Code:       ErrEmptySelector,
 			Message:    "list rule missing required ItemContainer or ItemLink selector (or set LinkDiscovery.ArticleURLPattern)",
+			Host:       errorHost(raw.URL),
 			URL:        raw.URL,
 			TargetType: string(model.TargetTypeList),
 		}
@@ -249,7 +267,7 @@ func (p *Parser) ParseLinks(ctx context.Context, raw *core.RawContent) ([]types.
 
 	doc, err := goquery.NewDocumentFromReader(strings.NewReader(raw.HTML))
 	if err != nil {
-		return nil, &Error{Code: ErrParseFailure, Message: "goquery parse failed", URL: raw.URL, Err: err}
+		return nil, &Error{Code: ErrParseFailure, Message: "goquery parse failed", Host: errorHost(raw.URL), URL: raw.URL, Err: err}
 	}
 
 	base, baseErr := url.Parse(raw.URL)
@@ -265,6 +283,7 @@ func (p *Parser) ParseLinks(ctx context.Context, raw *core.RawContent) ([]types.
 		return nil, &Error{
 			Code:       ErrParseFailure,
 			Message:    "ItemContainer selector matched 0 elements (rule may be stale)",
+			Host:       errorHost(raw.URL),
 			URL:        raw.URL,
 			TargetType: string(model.TargetTypeList),
 		}
@@ -294,6 +313,7 @@ func (p *Parser) ParseLinks(ctx context.Context, raw *core.RawContent) ([]types.
 		return nil, &Error{
 			Code:       ErrParseFailure,
 			Message:    "ItemContainer matched but no valid ItemLink found (ItemLink selector may be stale)",
+			Host:       errorHost(raw.URL),
 			URL:        raw.URL,
 			TargetType: string(model.TargetTypeList),
 		}

--- a/internal/processor/parser/rule/parser.go
+++ b/internal/processor/parser/rule/parser.go
@@ -22,14 +22,20 @@ import (
 // ctx 에 이미 더 짧은 deadline 이 있으면 그것이 우선 (context.WithTimeout 이 합성).
 const resolveTimeout = 5 * time.Second
 
-// errorHost 는 rule.Error 의 Host 필드용 canonical host 를 추출합니다 (이슈 #508).
+// NormalizeHost 는 rawURL 에서 canonical host 를 추출합니다 (이슈 #508).
 //
 // resolver 의 extractHostPath 와 동일 정규화 (u.Hostname() + lowercase) — port 제거 + 대소문자 일관.
-// 이 정규화로 worker 의 staleCounter / failureCounter 가 같은 host 를 같은 키로 누적.
-// parse 실패 / 빈 host → 빈 문자열 (호출 측은 빈 host 를 noop 으로 흡수, host="" 가드 유지).
-func errorHost(rawURL string) string {
+// 이 정규화로 staleCounter / failureCounter 가 같은 host 를 같은 키로 누적.
+//
+// 본 패키지 전체 single source of truth:
+//   - rule.Error 의 Host 필드 (parser.go / discovery.go / extract.go 발산)
+//   - PageLinkDiscovery 의 same-origin 비교 (discovery.go)
+//   - worker 패키지의 handleRuleError fallback (rule.NormalizeHost 호출)
+//
+// parse 실패 / 빈 host → 빈 문자열 — 호출 측은 빈 host 를 noop 으로 흡수.
+func NormalizeHost(rawURL string) string {
 	u, err := url.Parse(rawURL)
-	if err != nil || u == nil {
+	if err != nil {
 		return ""
 	}
 	return strings.ToLower(u.Hostname())
@@ -148,7 +154,7 @@ func (p *Parser) ParsePage(ctx context.Context, raw *core.RawContent) (*types.Pa
 		return nil, &Error{
 			Code:       ErrNoRule,
 			Message:    "rule lookup returned nil rule",
-			Host:       errorHost(raw.URL),
+			Host:       NormalizeHost(raw.URL),
 			URL:        raw.URL,
 			TargetType: string(model.TargetTypePage),
 		}
@@ -160,7 +166,7 @@ func (p *Parser) ParsePage(ctx context.Context, raw *core.RawContent) (*types.Pa
 		return nil, &Error{
 			Code:       ErrEmptySelector,
 			Message:    "page rule missing required Title or MainContent selector",
-			Host:       errorHost(raw.URL),
+			Host:       NormalizeHost(raw.URL),
 			URL:        raw.URL,
 			TargetType: string(model.TargetTypePage),
 		}
@@ -168,7 +174,7 @@ func (p *Parser) ParsePage(ctx context.Context, raw *core.RawContent) (*types.Pa
 
 	doc, err := goquery.NewDocumentFromReader(strings.NewReader(raw.HTML))
 	if err != nil {
-		return nil, &Error{Code: ErrParseFailure, Message: "goquery parse failed", Host: errorHost(raw.URL), URL: raw.URL, Err: err}
+		return nil, &Error{Code: ErrParseFailure, Message: "goquery parse failed", Host: NormalizeHost(raw.URL), URL: raw.URL, Err: err}
 	}
 
 	page := &types.Page{
@@ -189,7 +195,7 @@ func (p *Parser) ParsePage(ctx context.Context, raw *core.RawContent) (*types.Pa
 		return nil, &Error{
 			Code:       ErrParseFailure,
 			Message:    "Title or MainContent selector matched 0 elements (rule may be stale)",
-			Host:       errorHost(raw.URL),
+			Host:       NormalizeHost(raw.URL),
 			URL:        raw.URL,
 			TargetType: string(model.TargetTypePage),
 		}
@@ -241,7 +247,7 @@ func (p *Parser) ParseLinks(ctx context.Context, raw *core.RawContent) ([]types.
 		return nil, &Error{
 			Code:       ErrNoRule,
 			Message:    "rule lookup returned nil rule",
-			Host:       errorHost(raw.URL),
+			Host:       NormalizeHost(raw.URL),
 			URL:        raw.URL,
 			TargetType: string(model.TargetTypeList),
 		}
@@ -259,7 +265,7 @@ func (p *Parser) ParseLinks(ctx context.Context, raw *core.RawContent) ([]types.
 		return nil, &Error{
 			Code:       ErrEmptySelector,
 			Message:    "list rule missing required ItemContainer or ItemLink selector (or set LinkDiscovery.ArticleURLPattern)",
-			Host:       errorHost(raw.URL),
+			Host:       NormalizeHost(raw.URL),
 			URL:        raw.URL,
 			TargetType: string(model.TargetTypeList),
 		}
@@ -267,7 +273,7 @@ func (p *Parser) ParseLinks(ctx context.Context, raw *core.RawContent) ([]types.
 
 	doc, err := goquery.NewDocumentFromReader(strings.NewReader(raw.HTML))
 	if err != nil {
-		return nil, &Error{Code: ErrParseFailure, Message: "goquery parse failed", Host: errorHost(raw.URL), URL: raw.URL, Err: err}
+		return nil, &Error{Code: ErrParseFailure, Message: "goquery parse failed", Host: NormalizeHost(raw.URL), URL: raw.URL, Err: err}
 	}
 
 	base, baseErr := url.Parse(raw.URL)
@@ -283,7 +289,7 @@ func (p *Parser) ParseLinks(ctx context.Context, raw *core.RawContent) ([]types.
 		return nil, &Error{
 			Code:       ErrParseFailure,
 			Message:    "ItemContainer selector matched 0 elements (rule may be stale)",
-			Host:       errorHost(raw.URL),
+			Host:       NormalizeHost(raw.URL),
 			URL:        raw.URL,
 			TargetType: string(model.TargetTypeList),
 		}
@@ -313,7 +319,7 @@ func (p *Parser) ParseLinks(ctx context.Context, raw *core.RawContent) ([]types.
 		return nil, &Error{
 			Code:       ErrParseFailure,
 			Message:    "ItemContainer matched but no valid ItemLink found (ItemLink selector may be stale)",
-			Host:       errorHost(raw.URL),
+			Host:       NormalizeHost(raw.URL),
 			URL:        raw.URL,
 			TargetType: string(model.TargetTypeList),
 		}

--- a/internal/processor/parser/worker/worker.go
+++ b/internal/processor/parser/worker/worker.go
@@ -21,9 +21,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"net/url"
 	"strconv"
-	"strings"
 	"time"
 	"unicode/utf8"
 
@@ -783,18 +781,13 @@ func (w *Worker) recordStaleAndMaybeRelearn(ctx context.Context, host string, ta
 	w.llmGen.EnqueueStale(ctx, host, targetType, raw, llmRetryCount, crawlerName, jobTimeout)
 }
 
-// hostOf 는 raw.URL 에서 canonical host 를 추출합니다.
+// hostOf 는 rule.NormalizeHost 의 thin wrapper 로 worker 패키지의 in-file 호출처 가독성 보조.
 //
-// 정규화: u.Hostname() (port 제거) + lowercase — resolver 의 extractHostPath 와 동일.
-// 이슈 #508 — 본 함수가 handleRuleError 의 rerr.Host fallback 으로도 사용되어 parser.go 의
-// errorHost 와 같은 canonical form 을 반환해야 staleCounter / failureCounter 키 일관성 보장.
-// 파싱 실패 시 빈 문자열 — 호출자가 빈 host 를 noop 으로 흡수.
+// 정규화 로직 (u.Hostname() + lowercase, port 제거) 의 single source of truth 는 rule.NormalizeHost
+// (gemini PR #509 피드백, 이슈 #508). resolver / parser.go / discovery.go / extract.go / worker
+// 모두 동일 canonical form 사용 — staleCounter / failureCounter 키 일관성 보장.
 func hostOf(rawURL string) string {
-	u, err := url.Parse(rawURL)
-	if err != nil || u.Host == "" {
-		return ""
-	}
-	return strings.ToLower(u.Hostname())
+	return rule.NormalizeHost(rawURL)
 }
 
 // recordEmptyBodyIfApplicable 는 page 의 Title / MainContent 길이가 임계값 미달이면

--- a/internal/processor/parser/worker/worker.go
+++ b/internal/processor/parser/worker/worker.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"net/url"
 	"strconv"
+	"strings"
 	"time"
 	"unicode/utf8"
 
@@ -598,6 +599,13 @@ func (w *Worker) processArticlePage(ctx context.Context, raw *core.RawContent, r
 func (w *Worker) handleRuleError(ctx context.Context, raw *core.RawContent, rawID, stage string, targetType model.TargetType, err error, llmRetryCount int, crawlerName string, jobTimeout time.Duration, mlog *logger.Logger) error {
 	var rerr *rule.Error
 	if errors.As(err, &rerr) {
+		// 방어책 (이슈 #508): rule.Error 생성 측에서 Host 누락 시 raw.URL 에서 derive.
+		// parser.go 의 14개 Error 발산이 모두 errorHost 로 Host 를 채우지만, 향후 신규 발산
+		// 지점에서 누락하더라도 staleCounter / failureCounter 가 무력화되지 않도록 fail-safe.
+		if rerr.Host == "" && raw != nil {
+			rerr.Host = hostOf(raw.URL)
+		}
+
 		mlog.WithFields(map[string]interface{}{
 			"stage":       stage,
 			"error_code":  string(rerr.Code),
@@ -775,14 +783,18 @@ func (w *Worker) recordStaleAndMaybeRelearn(ctx context.Context, host string, ta
 	w.llmGen.EnqueueStale(ctx, host, targetType, raw, llmRetryCount, crawlerName, jobTimeout)
 }
 
-// hostOf 는 raw.URL 에서 host 만 추출합니다 (port 제거).
+// hostOf 는 raw.URL 에서 canonical host 를 추출합니다.
+//
+// 정규화: u.Hostname() (port 제거) + lowercase — resolver 의 extractHostPath 와 동일.
+// 이슈 #508 — 본 함수가 handleRuleError 의 rerr.Host fallback 으로도 사용되어 parser.go 의
+// errorHost 와 같은 canonical form 을 반환해야 staleCounter / failureCounter 키 일관성 보장.
 // 파싱 실패 시 빈 문자열 — 호출자가 빈 host 를 noop 으로 흡수.
 func hostOf(rawURL string) string {
 	u, err := url.Parse(rawURL)
 	if err != nil || u.Host == "" {
 		return ""
 	}
-	return u.Hostname()
+	return strings.ToLower(u.Hostname())
 }
 
 // recordEmptyBodyIfApplicable 는 page 의 Title / MainContent 길이가 임계값 미달이면

--- a/test/internal/processor/parser/rule/parser_test.go
+++ b/test/internal/processor/parser/rule/parser_test.go
@@ -352,10 +352,12 @@ func TestParser_ParsePage_ErrorHost_LowercasesHost(t *testing.T) {
 	res, _ := rule.NewResolver(repo)
 	p, _ := rule.NewParser(res)
 
-	// 대문자 host — errorHost 가 lowercase 로 정규화해야 staleCounter 키가 resolver 와 일치.
+	// 대문자 host — NormalizeHost 가 lowercase 로 정규화해야 staleCounter 키가 resolver 와 일치.
 	_, err := p.ParsePage(context.Background(), makeRaw("https://NEWS.EXAMPLE.COM/x", articleHTML))
 	var rerr *rule.Error
 	require.ErrorAs(t, err, &rerr)
+	// rerr.Code 도 pin — 다른 에러 경로 (예: ErrNoRule) 로 통과해도 Host 단정만으로 PASS 회피 (coderabbit PR #509).
+	assert.Equal(t, rule.ErrEmptySelector, rerr.Code)
 	assert.Equal(t, "news.example.com", rerr.Host, "Host 는 소문자로 정규화되어야 함")
 }
 
@@ -370,6 +372,8 @@ func TestParser_ParsePage_ErrorHost_StripsPort(t *testing.T) {
 	_, err := p.ParsePage(context.Background(), makeRaw("https://news.example.com:8080/x", articleHTML))
 	var rerr *rule.Error
 	require.ErrorAs(t, err, &rerr)
+	// rerr.Code 도 pin — 시나리오 잠금 (coderabbit PR #509).
+	assert.Equal(t, rule.ErrEmptySelector, rerr.Code)
 	assert.Equal(t, "news.example.com", rerr.Host, "Host 는 port 제거된 hostname")
 }
 

--- a/test/internal/processor/parser/rule/parser_test.go
+++ b/test/internal/processor/parser/rule/parser_test.go
@@ -297,3 +297,122 @@ func TestParser_RuleLookupMock_NilRuleSuccess_NoPanic(t *testing.T) {
 	require.ErrorAs(t, err, &rerr)
 	assert.Equal(t, rule.ErrNoRule, rerr.Code)
 }
+
+// ─────────────────────────────────────────────────────────────────────────────
+// rule.Error 의 Host 필드 — 이슈 #508
+//
+// parser.go 의 모든 Error 발산이 raw.URL 에서 canonical host (lowercase hostname, port 제거) 를
+// 채워야 worker 의 staleCounter / failureCounter 가 올바른 host 키로 누적됨.
+// ─────────────────────────────────────────────────────────────────────────────
+
+func TestParser_ParsePage_ErrorHost_EmptySelector(t *testing.T) {
+	r := pageRule()
+	r.Selectors.Title = nil
+	repo := &fakeRepo{rules: []*model.ParserRuleRecord{r}}
+	res, _ := rule.NewResolver(repo)
+	p, _ := rule.NewParser(res)
+
+	_, err := p.ParsePage(context.Background(), makeRaw("https://news.example.com/x", articleHTML))
+	var rerr *rule.Error
+	require.ErrorAs(t, err, &rerr)
+	assert.Equal(t, rule.ErrEmptySelector, rerr.Code)
+	assert.Equal(t, "news.example.com", rerr.Host, "Host 필드는 raw.URL 의 canonical host 와 일치해야 함")
+}
+
+func TestParser_ParsePage_ErrorHost_ParseFailure(t *testing.T) {
+	r := pageRule()
+	r.Selectors.MainContent = &model.FieldSelector{CSS: "div.no-such-class", Multi: true}
+	repo := &fakeRepo{rules: []*model.ParserRuleRecord{r}}
+	res, _ := rule.NewResolver(repo)
+	p, _ := rule.NewParser(res)
+
+	_, err := p.ParsePage(context.Background(), makeRaw("https://news.example.com/x", articleHTML))
+	var rerr *rule.Error
+	require.ErrorAs(t, err, &rerr)
+	assert.Equal(t, rule.ErrParseFailure, rerr.Code)
+	assert.Equal(t, "news.example.com", rerr.Host)
+}
+
+func TestParser_ParsePage_ErrorHost_EmptyRaw_ParseFailure(t *testing.T) {
+	repo := &fakeRepo{rules: []*model.ParserRuleRecord{pageRule()}}
+	res, _ := rule.NewResolver(repo)
+	p, _ := rule.NewParser(res)
+
+	_, err := p.ParsePage(context.Background(), &core.RawContent{URL: "https://news.example.com/x", HTML: ""})
+	var rerr *rule.Error
+	require.ErrorAs(t, err, &rerr)
+	assert.Equal(t, rule.ErrParseFailure, rerr.Code)
+	assert.Equal(t, "news.example.com", rerr.Host, "validateRaw 가 발산한 Error 도 Host 필드를 채워야 함")
+}
+
+func TestParser_ParsePage_ErrorHost_LowercasesHost(t *testing.T) {
+	r := pageRule()
+	r.Selectors.Title = nil
+	repo := &fakeRepo{rules: []*model.ParserRuleRecord{r}}
+	res, _ := rule.NewResolver(repo)
+	p, _ := rule.NewParser(res)
+
+	// 대문자 host — errorHost 가 lowercase 로 정규화해야 staleCounter 키가 resolver 와 일치.
+	_, err := p.ParsePage(context.Background(), makeRaw("https://NEWS.EXAMPLE.COM/x", articleHTML))
+	var rerr *rule.Error
+	require.ErrorAs(t, err, &rerr)
+	assert.Equal(t, "news.example.com", rerr.Host, "Host 는 소문자로 정규화되어야 함")
+}
+
+func TestParser_ParsePage_ErrorHost_StripsPort(t *testing.T) {
+	r := pageRule()
+	r.Selectors.Title = nil
+	r.HostPattern = "news.example.com"
+	repo := &fakeRepo{rules: []*model.ParserRuleRecord{r}}
+	res, _ := rule.NewResolver(repo)
+	p, _ := rule.NewParser(res)
+
+	_, err := p.ParsePage(context.Background(), makeRaw("https://news.example.com:8080/x", articleHTML))
+	var rerr *rule.Error
+	require.ErrorAs(t, err, &rerr)
+	assert.Equal(t, "news.example.com", rerr.Host, "Host 는 port 제거된 hostname")
+}
+
+func TestParser_ParseLinks_ErrorHost_EmptySelector(t *testing.T) {
+	r := listRule()
+	r.Selectors.ItemContainer = nil
+	repo := &fakeRepo{rules: []*model.ParserRuleRecord{r}}
+	res, _ := rule.NewResolver(repo)
+	p, _ := rule.NewParser(res)
+
+	_, err := p.ParseLinks(context.Background(), makeRaw("https://news.example.com/category/politics", listHTML))
+	var rerr *rule.Error
+	require.ErrorAs(t, err, &rerr)
+	assert.Equal(t, rule.ErrEmptySelector, rerr.Code)
+	assert.Equal(t, "news.example.com", rerr.Host)
+}
+
+func TestParser_ParseLinks_ErrorHost_ParseFailure(t *testing.T) {
+	r := listRule()
+	r.Selectors.ItemContainer = &model.FieldSelector{CSS: "ul.no-such-class li"}
+	repo := &fakeRepo{rules: []*model.ParserRuleRecord{r}}
+	res, _ := rule.NewResolver(repo)
+	p, _ := rule.NewParser(res)
+
+	_, err := p.ParseLinks(context.Background(), makeRaw("https://news.example.com/category/politics", listHTML))
+	var rerr *rule.Error
+	require.ErrorAs(t, err, &rerr)
+	assert.Equal(t, rule.ErrParseFailure, rerr.Code)
+	assert.Equal(t, "news.example.com", rerr.Host)
+}
+
+func TestParser_NilRuleSuccess_ErrorHost(t *testing.T) {
+	mockLookup := &stubRuleLookup{rule: nil, err: nil}
+	p, _ := rule.NewParser(mockLookup)
+
+	// ParsePage nil-rule
+	_, err := p.ParsePage(context.Background(), makeRaw("https://example.com/a", articleHTML))
+	var rerr *rule.Error
+	require.ErrorAs(t, err, &rerr)
+	assert.Equal(t, "example.com", rerr.Host, "nil-rule ErrNoRule 도 Host 채워야 함")
+
+	// ParseLinks nil-rule
+	_, err = p.ParseLinks(context.Background(), makeRaw("https://example.com/list", listHTML))
+	require.ErrorAs(t, err, &rerr)
+	assert.Equal(t, "example.com", rerr.Host)
+}


### PR DESCRIPTION
## 연관 이슈
- Closes #508

<br>

## 구현 내용

라이브 회차 분석에서 v.daum.net 81건 + news.daum.net 34건 등 ~221건 page parse 실패가 누적됐음에도 stale_relearn 메커니즘이 **단 한 번도 발화하지 않은** 회귀 수정.

### 근본 원인

[`internal/processor/parser/rule/parser.go`](internal/processor/parser/rule/parser.go) / [`discovery.go`](internal/processor/parser/rule/discovery.go) / [`extract.go`](internal/processor/parser/rule/extract.go) 의 **14개 `&Error{}` 발산** 모두 `URL: raw.URL` 만 채우고 `Host` 필드 누락. → `handleRuleError` → `recordStaleAndMaybeRelearn` 의 `host == ""` 가드에 막혀 `staleCounter.Record` 가 호출되지 않음.

비교: [`resolver.go`](internal/processor/parser/rule/resolver.go) 의 ErrNoRule 두 지점만 정상 설정 (그래서 resolver 발산 ErrNoRule 흐름은 정상 동작).

### 변경 요약

**1) 정공법 — parser.go / discovery.go / extract.go 의 모든 Error 발산에 Host 명시 설정 (commit f03a203)**

- 신규 헬퍼 `errorHost(rawURL string) string` — resolver 의 `extractHostPath` 와 동일한 canonical 정규화 (`u.Hostname()` + `strings.ToLower`)
- 14개 발산 지점에 `Host: errorHost(raw.URL)` 추가:
  - `parser.go` 9개 (ParsePage 4개 + ParseLinks 5개)
  - `discovery.go` 4개 (PageLinkDiscovery)
  - `extract.go` 1개 (validateRaw)

**2) 방어책 — worker.go fallback (commit 0d804b0)**

- `handleRuleError` 진입 직후 `rerr.Host == "" && raw != nil` 이면 `hostOf(raw.URL)` 로 backfill
- 향후 새 Error 발산 지점에서 Host 를 까먹어도 stale_relearn / chromedp 자동 전환이 무력화되지 않도록 fail-safe
- worker 의 `hostOf` 도 `strings.ToLower` 추가 — resolver / parser.errorHost 와 canonical form 일치 (counter 키 일관성)

**3) 단위 테스트 (commit 3407a34)**

- ParsePage / ParseLinks 의 각 에러 경로 (ErrEmptySelector / ErrParseFailure / nil-rule ErrNoRule / validateRaw 빈 raw) 에서 `rerr.Host` 가 정상 설정되는지 검증
- 정규화 검증: 대문자 host → lowercase, port 포함 → port 제거
- 8개 신규 테스트 케이스 추가

### 라이브 검증 가능 지표

다음 라이브 회차에서 확인 (LLM quota 정상 상태 전제):
- [ ] `"stale rule failure recorded"` (DEBUG) 또는 `"stale rule threshold reached — LLM relearn trigger eligible"` (INFO) 로그 실제 발생
- [ ] v.daum.net 의 룰이 LLM relearn 으로 자동 회복

<br>

## CI / 머지 게이트 점검

### 변경 영향 범위
- 영향 패키지/모듈:
  - `internal/processor/parser/rule` (parser.go / discovery.go / extract.go — Error 발산 14개)
  - `internal/processor/parser/worker` (handleRuleError fallback + hostOf 정규화)
  - 테스트 (test/internal/processor/parser/rule/parser_test.go — 8 신규 케이스)
- 위험도: `Low` — 기존 호출 시그니처 / 메시지 / 에러 코드 동일, Host 필드만 추가. 정규화 변경 (worker hostOf 의 lowercase) 은 resolver/parser.errorHost 와 일관성 통일이라 회귀 위험 낮음.

### Required Status Checks
- 통과 확인 대상:
  - [ ] `Commit Lint`
  - [ ] `PR Title Lint`
  - [ ] `Linked Issue Check`
  - [ ] `Format Check`
  - [ ] `Build`
  - [ ] `Test`
  - [ ] `Lint`

### 롤백 계획
- 본 PR revert 만으로 원복 가능. 단, 원복 시 stale_relearn / host failure counter 가 다시 무력화 상태로 회귀 — 가급적 forward-fix 권장.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Error messages now include canonical host context information across parser operations.
  * Enhanced error handling to populate host context consistently, even when unavailable from primary sources.

* **Tests**
  * Added comprehensive test coverage for error host context scenarios, including uppercase normalization and port stripping.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/EinSofINTEREST/IssueTracker/pull/509?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->