### PR TITLE
[REFAC#502] validation-fail 로그 정리 — .WithError 제거 + url/reject_reason 평탄화

### DIFF
--- a/internal/processor/validate/worker/worker.go
+++ b/internal/processor/validate/worker/worker.go
@@ -235,6 +235,16 @@ func (w *Worker) process(ctx context.Context, msg *queue.Message) error {
 
 	_, err = RunValidation(ctx, v, content)
 	if err != nil {
+		// 본 함수의 모든 validation-fail emit 사이트가 공유하는 공통 필드 빌더.
+		// CanonicalURL 이 URL 과 다를 때만 canonical_url 필드 추가 — redirect / canonical 차이 추적
+		// 가능 (Copilot PR #513 피드백). URL 자체는 contents.url NOT NULL 이라 항상 채워짐.
+		mkFields := func(base map[string]interface{}) map[string]interface{} {
+			base["url"] = content.URL
+			if content.CanonicalURL != "" && content.CanonicalURL != content.URL {
+				base["canonical_url"] = content.CanonicalURL
+			}
+			return base
+		}
 		// validator → parser 재학습 트리거 분기 (이슈 #363/#364) — selector 보강으로 해결
 		// 가능한 에러 (PublishedAt required / Title-Body min_length) 가 trigger 대상.
 		// 본 분기는 cfg.ReparseEnabled + 횟수 < max 일 때만 동작 — 그 외에는 기존 DLQ/requeue 흐름.
@@ -244,16 +254,15 @@ func (w *Worker) process(ctx context.Context, msg *queue.Message) error {
 				// validation 실패는 콘텐츠 필터 결과 (시스템 에러 아님) — .WithError 부착 시
 				// 다운스트림 대시보드/알림이 시스템 에러로 오인. 대신 reject_reason 구조화 필드로
 				// 평탄화하고 url / source / country 를 일관 포함하여 사후 추적·분석 가능하도록.
-				log.WithFields(map[string]interface{}{
+				log.WithFields(mkFields(map[string]interface{}{
 					"job_id":        pm.ID,
 					"ref_id":        ref.ID,
 					"source":        content.SourceID,
 					"country":       content.Country,
-					"url":           content.URL,
 					"reparse_count": reparseCount,
 					"max":           core.MaxValidateReparseCount,
 					"reject_reason": err.Error(),
-				}).Info("content validation failed, triggering parser reparse (LLM rule relearn)")
+				})).Info("content validation failed, triggering parser reparse (LLM rule relearn)")
 
 				// reparse cycle 시작 — 발행 성공 후 contents row 정리 (순서 중요, gemini 반영).
 				// Delete 가 republish 보다 먼저면 Delete 성공 + republish 실패 시 Kafka 재처리에서
@@ -283,16 +292,16 @@ func (w *Worker) process(ctx context.Context, msg *queue.Message) error {
 
 		// 검증 실패: contents에서 삭제 후 DLQ 또는 재큐잉.
 		// 본 emit 들은 validation 필터 결과 (콘텐츠 거부) — 시스템 에러 아니므로 .WithError 미부착.
-		// 모든 사이트에서 동일한 공통 필드 셋 (source / country / url / ref_id / reject_reason) 을 유지.
+		// 모든 사이트에서 동일한 공통 필드 셋 (source / country / url / ref_id / reject_reason +
+		// CanonicalURL 이 url 과 다를 때 canonical_url 추가) 을 유지 (Copilot PR #513 피드백).
 		if pm.RetryCount >= maxRetries(msg) {
-			log.WithFields(map[string]interface{}{
+			log.WithFields(mkFields(map[string]interface{}{
 				"job_id":        pm.ID,
 				"ref_id":        ref.ID,
 				"source":        content.SourceID,
 				"country":       content.Country,
-				"url":           content.URL,
 				"reject_reason": err.Error(),
-			}).Info("content validation failed, deleting content and sending to dlq")
+			})).Info("content validation failed, deleting content and sending to dlq")
 
 			// contents.Delete 직전에 reject 사유를 contents 컬럼에 기록.
 			// 순서가 중요: Delete 후엔 사후 추적 단일 source 가 깨진다.
@@ -309,15 +318,14 @@ func (w *Worker) process(ctx context.Context, msg *queue.Message) error {
 				return fmt.Errorf("send to dlq (max retries): %w", dlqErr)
 			}
 		} else {
-			log.WithFields(map[string]interface{}{
+			log.WithFields(mkFields(map[string]interface{}{
 				"job_id":        pm.ID,
 				"ref_id":        ref.ID,
 				"source":        content.SourceID,
 				"country":       content.Country,
 				"retry_count":   pm.RetryCount,
-				"url":           content.URL,
 				"reject_reason": err.Error(),
-			}).Info("content validation failed, requeueing")
+			})).Info("content validation failed, requeueing")
 			if rqErr := w.requeue(ctx, msg, &pm); rqErr != nil {
 				// requeue 실패 시 commit 하면 재시도 기회 상실 → 에러 반환하여 재소비 보장
 				return fmt.Errorf("requeue: %w", rqErr)

--- a/internal/processor/validate/worker/worker.go
+++ b/internal/processor/validate/worker/worker.go
@@ -241,13 +241,17 @@ func (w *Worker) process(ctx context.Context, msg *queue.Message) error {
 		if w.cfg.ReparseEnabled && IsReparseEligible(err) {
 			reparseCount := readReparseCount(msg)
 			if reparseCount < core.MaxValidateReparseCount {
+				// 이슈 #502: validation 실패는 콘텐츠 필터 결과 (시스템 에러 아님) — .WithError 제거,
+				// reject_reason 구조화 필드로 평탄화 + url 필드 추가 (사후 추적 가능하도록).
 				log.WithFields(map[string]interface{}{
 					"job_id":        pm.ID,
 					"ref_id":        ref.ID,
 					"source":        content.SourceID,
+					"url":           content.URL,
 					"reparse_count": reparseCount,
 					"max":           core.MaxValidateReparseCount,
-				}).WithError(err).Info("content validation failed, triggering parser reparse (LLM rule relearn)")
+					"reject_reason": err.Error(),
+				}).Info("content validation failed, triggering parser reparse (LLM rule relearn)")
 
 				// reparse cycle 시작 — 발행 성공 후 contents row 정리 (순서 중요, gemini 반영).
 				// Delete 가 republish 보다 먼저면 Delete 성공 + republish 실패 시 Kafka 재처리에서
@@ -277,12 +281,15 @@ func (w *Worker) process(ctx context.Context, msg *queue.Message) error {
 
 		// 검증 실패: contents에서 삭제 후 DLQ 또는 재큐잉
 		if pm.RetryCount >= maxRetries(msg) {
+			// 이슈 #502: .WithError 제거 + reject_reason 평탄화 + url 추가.
 			log.WithFields(map[string]interface{}{
-				"job_id":  pm.ID,
-				"ref_id":  ref.ID,
-				"source":  content.SourceID,
-				"country": content.Country,
-			}).WithError(err).Info("content validation failed, deleting content and sending to dlq")
+				"job_id":        pm.ID,
+				"ref_id":        ref.ID,
+				"source":        content.SourceID,
+				"country":       content.Country,
+				"url":           content.URL,
+				"reject_reason": err.Error(),
+			}).Info("content validation failed, deleting content and sending to dlq")
 
 			// contents.Delete 직전에 reject 사유를 contents 컬럼에 기록.
 			// 순서가 중요: Delete 후엔 사후 추적 단일 source 가 깨진다.
@@ -299,10 +306,14 @@ func (w *Worker) process(ctx context.Context, msg *queue.Message) error {
 				return fmt.Errorf("send to dlq (max retries): %w", dlqErr)
 			}
 		} else {
+			// 이슈 #502: .WithError 제거 + reject_reason 평탄화 + url 추가.
 			log.WithFields(map[string]interface{}{
-				"job_id":      pm.ID,
-				"retry_count": pm.RetryCount,
-			}).WithError(err).Info("content validation failed, requeueing")
+				"job_id":        pm.ID,
+				"ref_id":        ref.ID,
+				"retry_count":   pm.RetryCount,
+				"url":           content.URL,
+				"reject_reason": err.Error(),
+			}).Info("content validation failed, requeueing")
 			if rqErr := w.requeue(ctx, msg, &pm); rqErr != nil {
 				// requeue 실패 시 commit 하면 재시도 기회 상실 → 에러 반환하여 재소비 보장
 				return fmt.Errorf("requeue: %w", rqErr)

--- a/internal/processor/validate/worker/worker.go
+++ b/internal/processor/validate/worker/worker.go
@@ -241,12 +241,14 @@ func (w *Worker) process(ctx context.Context, msg *queue.Message) error {
 		if w.cfg.ReparseEnabled && IsReparseEligible(err) {
 			reparseCount := readReparseCount(msg)
 			if reparseCount < core.MaxValidateReparseCount {
-				// 이슈 #502: validation 실패는 콘텐츠 필터 결과 (시스템 에러 아님) — .WithError 제거,
-				// reject_reason 구조화 필드로 평탄화 + url 필드 추가 (사후 추적 가능하도록).
+				// validation 실패는 콘텐츠 필터 결과 (시스템 에러 아님) — .WithError 부착 시
+				// 다운스트림 대시보드/알림이 시스템 에러로 오인. 대신 reject_reason 구조화 필드로
+				// 평탄화하고 url / source / country 를 일관 포함하여 사후 추적·분석 가능하도록.
 				log.WithFields(map[string]interface{}{
 					"job_id":        pm.ID,
 					"ref_id":        ref.ID,
 					"source":        content.SourceID,
+					"country":       content.Country,
 					"url":           content.URL,
 					"reparse_count": reparseCount,
 					"max":           core.MaxValidateReparseCount,
@@ -279,9 +281,10 @@ func (w *Worker) process(ctx context.Context, msg *queue.Message) error {
 			}).Info("reparse count reached max, falling through to existing DLQ/requeue flow")
 		}
 
-		// 검증 실패: contents에서 삭제 후 DLQ 또는 재큐잉
+		// 검증 실패: contents에서 삭제 후 DLQ 또는 재큐잉.
+		// 본 emit 들은 validation 필터 결과 (콘텐츠 거부) — 시스템 에러 아니므로 .WithError 미부착.
+		// 모든 사이트에서 동일한 공통 필드 셋 (source / country / url / ref_id / reject_reason) 을 유지.
 		if pm.RetryCount >= maxRetries(msg) {
-			// 이슈 #502: .WithError 제거 + reject_reason 평탄화 + url 추가.
 			log.WithFields(map[string]interface{}{
 				"job_id":        pm.ID,
 				"ref_id":        ref.ID,
@@ -306,10 +309,11 @@ func (w *Worker) process(ctx context.Context, msg *queue.Message) error {
 				return fmt.Errorf("send to dlq (max retries): %w", dlqErr)
 			}
 		} else {
-			// 이슈 #502: .WithError 제거 + reject_reason 평탄화 + url 추가.
 			log.WithFields(map[string]interface{}{
 				"job_id":        pm.ID,
 				"ref_id":        ref.ID,
+				"source":        content.SourceID,
+				"country":       content.Country,
 				"retry_count":   pm.RetryCount,
 				"url":           content.URL,
 				"reject_reason": err.Error(),

--- a/test/internal/processor/validate/worker/log_fields_test.go
+++ b/test/internal/processor/validate/worker/log_fields_test.go
@@ -2,11 +2,15 @@ package worker_test
 
 // 이슈 #502 — validation-fail 로그 필드 검증.
 //
-// 3개 emit 지점 (deleting-to-dlq / requeueing / triggering parser reparse) 의 로그 출력에서:
+// 검증 대상 emit 2개 — DLQ 분기 (retry >= max) / requeueing 분기 (retry < max):
 //   - `error` 필드가 부착되지 않음 (.WithError 제거)
 //   - `url` 필드 존재 (사후 추적 가능)
 //   - `reject_reason` 필드 존재 (rejected 원인 평탄화)
-// 를 검증합니다.
+//   - CanonicalURL 이 URL 과 다를 때 canonical_url 필드 추가 (Copilot PR #513 피드백)
+//
+// reparse 분기 (triggering parser reparse) 는 ReparseEnabled + IsReparseEligible 양조건 필요 —
+// 동일 mkFields 헬퍼를 공유하므로 본 검증 결과가 그대로 적용됨. 별도 분기 활성 시나리오 테스트는
+// reparse_test.go 가 분기 자체를 커버.
 
 import (
 	"bytes"
@@ -177,4 +181,68 @@ func TestValidateWorker_RequeueLog_NoErrorField_HasURLAndRejectReason(t *testing
 	assert.Contains(t, reason, "VAL_")
 
 	assert.Equal(t, "info", entry["level"])
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 3) canonical_url 필드 (Copilot PR #513 피드백)
+// ─────────────────────────────────────────────────────────────────────────────
+
+// TestValidateWorker_RequeueLog_CanonicalURLDiffers_HasCanonicalField 는
+// content.CanonicalURL 이 URL 과 다를 때 canonical_url 필드가 추가됨을 검증.
+func TestValidateWorker_RequeueLog_CanonicalURLDiffers_HasCanonicalField(t *testing.T) {
+	consumer := new(mockConsumer)
+	producer := new(mockProducer)
+	contentSvc := newMockContentService()
+	log, buf := captureLog()
+	w := newWorkerWithLogger(consumer, producer, contentSvc, log)
+
+	content := newNewsContent()
+	content.Title = "x"
+	content.Body = "short body"
+	content.PublishedAt = time.Time{}
+	content.URL = "https://example.com/article?utm_source=foo"
+	content.CanonicalURL = "https://example.com/article" // URL 과 다름
+	msg := makeProcessingMessage(content, 0)
+
+	contentSvc.On("GetByID", mock.Anything, content.ID).Return(content, nil)
+	producer.On("Publish", mock.Anything, mock.MatchedBy(func(m queue.Message) bool {
+		return m.Topic == queue.TopicNormalized
+	})).Return(nil)
+	consumer.On("CommitMessages", mock.Anything, mock.Anything).Return(nil)
+
+	runWorkerWithLogger(t, consumer, w, msg, log)
+
+	entry := findLogEntry(t, buf, "content validation failed, requeueing")
+	assert.Equal(t, content.URL, entry["url"])
+	canonical, _ := entry["canonical_url"].(string)
+	assert.Equal(t, content.CanonicalURL, canonical, "CanonicalURL != URL 시 canonical_url 필드 추가")
+}
+
+// TestValidateWorker_RequeueLog_CanonicalURLEmpty_NoCanonicalField 는
+// content.CanonicalURL 이 빈 문자열 (default) 일 때 canonical_url 필드가 부재함을 검증.
+func TestValidateWorker_RequeueLog_CanonicalURLEmpty_NoCanonicalField(t *testing.T) {
+	consumer := new(mockConsumer)
+	producer := new(mockProducer)
+	contentSvc := newMockContentService()
+	log, buf := captureLog()
+	w := newWorkerWithLogger(consumer, producer, contentSvc, log)
+
+	content := newNewsContent()
+	content.Title = "x"
+	content.Body = "short body"
+	content.PublishedAt = time.Time{}
+	content.CanonicalURL = "" // default
+	msg := makeProcessingMessage(content, 0)
+
+	contentSvc.On("GetByID", mock.Anything, content.ID).Return(content, nil)
+	producer.On("Publish", mock.Anything, mock.MatchedBy(func(m queue.Message) bool {
+		return m.Topic == queue.TopicNormalized
+	})).Return(nil)
+	consumer.On("CommitMessages", mock.Anything, mock.Anything).Return(nil)
+
+	runWorkerWithLogger(t, consumer, w, msg, log)
+
+	entry := findLogEntry(t, buf, "content validation failed, requeueing")
+	_, hasCanonical := entry["canonical_url"]
+	assert.False(t, hasCanonical, "CanonicalURL 빈 문자열 시 canonical_url 필드 미부착 (노이즈 제거)")
 }

--- a/test/internal/processor/validate/worker/log_fields_test.go
+++ b/test/internal/processor/validate/worker/log_fields_test.go
@@ -1,0 +1,174 @@
+package worker_test
+
+// 이슈 #502 — validation-fail 로그 필드 검증.
+//
+// 3개 emit 지점 (deleting-to-dlq / requeueing / triggering parser reparse) 의 로그 출력에서:
+//   - `error` 필드가 부착되지 않음 (.WithError 제거)
+//   - `url` 필드 존재 (사후 추적 가능)
+//   - `reject_reason` 필드 존재 (rejected 원인 평탄화)
+// 를 검증합니다.
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	"issuetracker/internal/bus"
+	"issuetracker/internal/locks"
+	"issuetracker/internal/processor/validate/worker"
+	"issuetracker/internal/storage/service"
+	processorcfg "issuetracker/pkg/config/processor"
+	"issuetracker/pkg/logger"
+	"issuetracker/pkg/queue"
+)
+
+// captureLog 는 worker 가 emit 한 로그를 buffer 로 캡처하기 위한 logger 와 그 출력 버퍼를 반환합니다.
+func captureLog() (*logger.Logger, *bytes.Buffer) {
+	buf := new(bytes.Buffer)
+	cfg := logger.DefaultConfig()
+	cfg.Output = buf
+	return logger.New(cfg), buf
+}
+
+// runWorkerWithLogger 는 runWorker 와 동일하나 ctx 에 사용자 지정 logger 를 주입합니다.
+// handleMessage 내부의 logger.FromContext(ctx) 가 본 logger 를 반환 — emit 캡처 가능.
+func runWorkerWithLogger(t *testing.T, consumer *mockConsumer, w *worker.Worker, msg *queue.Message, log *logger.Logger) {
+	t.Helper()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	ctx = log.ToContext(ctx)
+
+	consumer.On("FetchMessage", mock.Anything).Return(msg, nil).Once()
+	consumer.On("FetchMessage", mock.Anything).
+		Run(func(_ mock.Arguments) { cancel() }).
+		Return(nil, context.Canceled)
+	consumer.On("Close").Return(nil)
+
+	w.Start(ctx)
+	<-ctx.Done()
+
+	stopCtx, stopCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer stopCancel()
+	_ = w.Stop(stopCtx)
+}
+
+// findLogEntry 는 buf 출력에서 message 가 일치하는 첫 JSON 라인을 반환합니다.
+func findLogEntry(t *testing.T, buf *bytes.Buffer, message string) map[string]interface{} {
+	t.Helper()
+	for _, line := range strings.Split(buf.String(), "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		var entry map[string]interface{}
+		if err := json.Unmarshal([]byte(line), &entry); err != nil {
+			continue
+		}
+		if msg, ok := entry["message"].(string); ok && msg == message {
+			return entry
+		}
+	}
+	t.Fatalf("expected log message %q not found in output:\n%s", message, buf.String())
+	return nil
+}
+
+// newWorkerWithLogger 는 newWorker 와 동일 fixture 이지만 publisher 가 본 테스트의 logger 를 공유하도록
+// 구성합니다 (publisher 도 로그를 찍기에 본 logger 로 통일하면 검증 노이즈가 줄어듦).
+func newWorkerWithLogger(consumer queue.Consumer, producer queue.Producer, contentSvc service.ContentService, log *logger.Logger) *worker.Worker {
+	pub := bus.New(producer, nil, log)
+	return worker.NewWorker(consumer, pub, contentSvc, locks.NewNoopStageGate(), 1, processorcfg.DefaultValidateConfig())
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 1) "content validation failed, deleting content and sending to dlq" 지점
+// ─────────────────────────────────────────────────────────────────────────────
+
+func TestValidateWorker_DLQLog_NoErrorField_HasURLAndRejectReason(t *testing.T) {
+	consumer := new(mockConsumer)
+	producer := new(mockProducer)
+	contentSvc := newMockContentService()
+	log, buf := captureLog()
+	w := newWorkerWithLogger(consumer, producer, contentSvc, log)
+
+	content := newNewsContent()
+	content.Title = "x"         // VAL_003 min_length
+	content.Body = "short body" // VAL_003 min_length
+	content.PublishedAt = time.Time{}
+	msg := makeProcessingMessage(content, 3) // max retries 도달 → DLQ 분기
+
+	contentSvc.On("GetByID", mock.Anything, content.ID).Return(content, nil)
+	contentSvc.On("UpdateValidationStatus", mock.Anything, content.ID, "rejected", mock.Anything, mock.Anything).Return(nil).Maybe()
+	contentSvc.On("Delete", mock.Anything, content.ID).Return(nil)
+	producer.On("Publish", mock.Anything, mock.MatchedBy(func(m queue.Message) bool {
+		return m.Topic == queue.TopicDLQ
+	})).Return(nil)
+	consumer.On("CommitMessages", mock.Anything, mock.Anything).Return(nil)
+
+	runWorkerWithLogger(t, consumer, w, msg, log)
+
+	entry := findLogEntry(t, buf, "content validation failed, deleting content and sending to dlq")
+
+	// 1. .WithError 제거 — error 필드 부재
+	_, hasErr := entry["error"]
+	assert.False(t, hasErr, "error 필드가 부착되지 않아야 함 (.WithError 제거 검증)")
+
+	// 2. url 필드 존재
+	url, _ := entry["url"].(string)
+	assert.Equal(t, content.URL, url, "url 필드는 content.URL 과 일치")
+
+	// 3. reject_reason 평탄화
+	reason, _ := entry["reject_reason"].(string)
+	require.NotEmpty(t, reason, "reject_reason 필드는 validator 의 err.Error() 문자열")
+	assert.Contains(t, reason, "VAL_", "reject_reason 안에 validation 에러 코드 포함")
+
+	// 4. level=info 확인
+	assert.Equal(t, "info", entry["level"], "여전히 INFO level 유지")
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 2) "content validation failed, requeueing" 지점
+// ─────────────────────────────────────────────────────────────────────────────
+
+func TestValidateWorker_RequeueLog_NoErrorField_HasURLAndRejectReason(t *testing.T) {
+	consumer := new(mockConsumer)
+	producer := new(mockProducer)
+	contentSvc := newMockContentService()
+	log, buf := captureLog()
+	w := newWorkerWithLogger(consumer, producer, contentSvc, log)
+
+	content := newNewsContent()
+	content.Title = "x"
+	content.Body = "short body"
+	content.PublishedAt = time.Time{}
+	// retry count=0 → max(3) 미도달 → requeue 분기
+	msg := makeProcessingMessage(content, 0)
+
+	contentSvc.On("GetByID", mock.Anything, content.ID).Return(content, nil)
+	producer.On("Publish", mock.Anything, mock.MatchedBy(func(m queue.Message) bool {
+		return m.Topic == queue.TopicNormalized
+	})).Return(nil)
+	consumer.On("CommitMessages", mock.Anything, mock.Anything).Return(nil)
+
+	runWorkerWithLogger(t, consumer, w, msg, log)
+
+	entry := findLogEntry(t, buf, "content validation failed, requeueing")
+
+	_, hasErr := entry["error"]
+	assert.False(t, hasErr, "requeue 분기도 error 필드 부재 (.WithError 제거 검증)")
+
+	url, _ := entry["url"].(string)
+	assert.Equal(t, content.URL, url, "url 필드는 content.URL 과 일치")
+
+	reason, _ := entry["reject_reason"].(string)
+	require.NotEmpty(t, reason, "reject_reason 필드 존재")
+	assert.Contains(t, reason, "VAL_")
+
+	assert.Equal(t, "info", entry["level"])
+}

--- a/test/internal/processor/validate/worker/log_fields_test.go
+++ b/test/internal/processor/validate/worker/log_fields_test.go
@@ -81,9 +81,15 @@ func findLogEntry(t *testing.T, buf *bytes.Buffer, message string) map[string]in
 
 // newWorkerWithLogger 는 newWorker 와 동일 fixture 이지만 publisher 가 본 테스트의 logger 를 공유하도록
 // 구성합니다 (publisher 도 로그를 찍기에 본 logger 로 통일하면 검증 노이즈가 줄어듦).
+//
+// ReparseEnabled=false 명시 — VAL_003 (Title/Body min_length) 는 IsReparseEligible 이라
+// default 가 향후 true 로 변경되면 본 테스트의 의도된 DLQ/requeue 분기 대신 reparse 분기가 발화 (gemini PR #513 피드백).
+// 본 테스트는 reparse 분기 외의 두 분기 (DLQ / requeue) 의 로그 출력 검증이 목적이므로 명시 잠금.
 func newWorkerWithLogger(consumer queue.Consumer, producer queue.Producer, contentSvc service.ContentService, log *logger.Logger) *worker.Worker {
 	pub := bus.New(producer, nil, log)
-	return worker.NewWorker(consumer, pub, contentSvc, locks.NewNoopStageGate(), 1, processorcfg.DefaultValidateConfig())
+	cfg := processorcfg.DefaultValidateConfig()
+	cfg.ReparseEnabled = false
+	return worker.NewWorker(consumer, pub, contentSvc, locks.NewNoopStageGate(), 1, cfg)
 }
 
 // ─────────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## 연관 이슈
- Closes #502

<br>

## 구현 내용

라이브 51분에서 관측된 VAL_006 spam_flood 52건 / VAL_003 30건의 INFO 로그가 `.WithError(err)` 부착으로 false-positive error 시그널로 오인되던 문제 해소 + URL 부재로 사후 추적 불가능했던 observability 갭 보강.

### 변경 요약

[`internal/processor/validate/worker/worker.go`](internal/processor/validate/worker/worker.go) 의 3개 validation-fail emit 사이트 일괄 정리 (이슈 #502 본문의 후자 권장):

| 위치 | 메시지 | 변경 |
|---|---|---|
| line 244 | `content validation failed, triggering parser reparse (LLM rule relearn)` | `.WithError(err)` 제거 + `url` + `reject_reason` |
| line 280 | `content validation failed, deleting content and sending to dlq` | `.WithError(err)` 제거 + `url` + `reject_reason` |
| line 302 | `content validation failed, requeueing` | `.WithError(err)` 제거 + `url` + `reject_reason` + `ref_id` |

### Before / After

**Before**:
```json
{
  "level": "info",
  "worker_pool": "validate",
  "job_id": "d4d76ebe1fc3e421f3a79b5a62ab7486",
  "retry_count": 0,
  "error": "[validation:VAL_006] content ... failed validation: [{Body spam_flood ...}]",
  "message": "content validation failed, requeueing"
}
```

**After**:
```json
{
  "level": "info",
  "worker_pool": "validate",
  "job_id": "d4d76ebe1fc3e421f3a79b5a62ab7486",
  "ref_id": "...",
  "retry_count": 0,
  "url": "https://example.com/article/123",
  "reject_reason": "[validation:VAL_006] content ... failed validation: [{Body spam_flood ...}]",
  "message": "content validation failed, requeueing"
}
```

- ❌ `error` 필드 제거 → 대시보드/알림 규칙이 더 이상 콘텐츠 필터를 시스템 에러로 카운트 안 함
- ✅ `url` 필드 추가 → spam_flood 의 false-positive 여부 / min_length 의 stale rule 진단 사후 가능
- ✅ `reject_reason` 평탄화 → 동일 정보 유지, 별도 구조화 필드로 검색·필터 친화

### 단위 테스트

[`test/internal/processor/validate/worker/log_fields_test.go`](test/internal/processor/validate/worker/log_fields_test.go) 신규:

- `captureLog()`: `bytes.Buffer` 기반 logger 생성 → ctx 주입
- `runWorkerWithLogger()`: `logger.ToContext` 로 worker 가 본 logger 사용하도록 wiring
- `findLogEntry()`: JSON 라인 파싱 helper

테스트 케이스:
1. **`TestValidateWorker_DLQLog_NoErrorField_HasURLAndRejectReason`** — DLQ 분기 (retry >= max)
2. **`TestValidateWorker_RequeueLog_NoErrorField_HasURLAndRejectReason`** — requeue 분기 (retry < max)

각각 검증:
- `error` 필드 부재
- `url` 필드 == `content.URL`
- `reject_reason` 필드 존재 + `VAL_` 코드 포함
- `level=info` 유지

(reparse 분기는 `ReparseEnabled=true` + `IsReparseEligible(err)` 양조건 필요 — 기존 reparse_test.go 가 분기 자체 검증 + 본 PR 의 변경은 동일 패턴 적용이라 추가 테스트는 reparse 분기 신규 검증보다 비용 대비 가치 낮음. ref_id / url 등 동일 필드 셋이 적용된 것은 코드 리뷰로 검증)

<br>

## CI / 머지 게이트 점검

### 변경 영향 범위
- 영향 패키지/모듈: `internal/processor/validate/worker` 로그 출력만
- 위험도: `Low` — 로그 필드 변경 only, 동작 / 분기 / publish 흐름 무변경. 다운스트림 로그 파서 / 알림 규칙이 기존 `error` 필드에 의존하면 영향 — 그러나 본 PR 의 목적이 그 의존 자체를 깨는 것 (false-positive 해소).

### Required Status Checks
- 통과 확인 대상:
  - [ ] `Commit Lint`
  - [ ] `PR Title Lint`
  - [ ] `Linked Issue Check`
  - [ ] `Format Check`
  - [ ] `Build`
  - [ ] `Test`
  - [ ] `Lint`

### 롤백 계획
- 본 PR revert 만으로 원복 — 로그 필드만 변경이라 데이터/상태 영향 없음.

🤖 Generated with [Claude Code](https://claude.com/claude-code)