### PR TITLE
[REFAC#503] rate_limit 로그에 label 필드 추가 — throttled 호스트/IP 사후 추적 가능

### DIFF
--- a/internal/processor/fetcher/rate_limiter/ip_registry.go
+++ b/internal/processor/fetcher/rate_limiter/ip_registry.go
@@ -127,7 +127,9 @@ func (r *IPRateLimiterRegistry) getOrCreate(ip string, rph int) core.RateLimiter
 		return entry.limiter
 	}
 
-	limiter := NewRateLimiter(rph, r.burst)
+	// label 은 throttle 로그 추적 식별자 — IP registry 는 IP 그대로 전달 (이슈 #503).
+	// 같은 IP 의 모든 host 가 limiter 를 공유하므로 host 보다 IP 가 정확한 식별자.
+	limiter := NewRateLimiter(rph, r.burst, ip)
 	r.limiters[ip] = limiterEntry{limiter: limiter, lastUsed: now}
 
 	// 주기적 eviction: 새 limiter 생성 시점에 만료 항목 정리

--- a/internal/processor/fetcher/rate_limiter/token_bucket.go
+++ b/internal/processor/fetcher/rate_limiter/token_bucket.go
@@ -16,7 +16,11 @@ import (
 
 // TokenBucketRateLimiter는 token bucket 알고리즘을 사용한 rate limiter입니다.
 // 시간당 요청 수를 제한하며, burst를 허용합니다.
+//
+// label 은 throttle 로그의 추적 식별자 — IP 단위 registry 에서는 IP 문자열, 그 외 호출자가
+// 의미 있는 식별자를 자유롭게 전달 (이슈 #503). 빈 문자열도 허용 — 로그에 label="" 만 찍힘.
 type TokenBucketRateLimiter struct {
+	label      string
 	rate       float64 // tokens per second
 	burst      int     // maximum tokens
 	tokens     float64 // current tokens
@@ -27,7 +31,11 @@ type TokenBucketRateLimiter struct {
 // NewRateLimiter는 새로운 rate limiter를 생성합니다.
 // requestsPerHour: 시간당 허용 요청 수 (0 이하면 제한 없음)
 // burst: 한번에 허용되는 최대 요청 수 (최소 1)
-func NewRateLimiter(requestsPerHour, burst int) core.RateLimiter {
+// label: 본 limiter 의 추적 식별자 (이슈 #503) — Wait 로그의 `label` 필드에 emit.
+//
+//	IP registry 호출 시 IP, 그 외 호출자가 host 또는 의미 있는 식별자를 전달.
+//	0 이하 RPH 시 noopRateLimiter 가 반환되므로 label 은 무시되지만, signature 일관성을 위해 유지.
+func NewRateLimiter(requestsPerHour, burst int, label string) core.RateLimiter {
 	// 0 이하 값 방어: divide by zero 및 무한 대기 방지
 	if requestsPerHour <= 0 {
 		return &noopRateLimiter{}
@@ -39,6 +47,7 @@ func NewRateLimiter(requestsPerHour, burst int) core.RateLimiter {
 	rate := float64(requestsPerHour) / 3600.0 // convert to per second
 
 	return &TokenBucketRateLimiter{
+		label:      label,
 		rate:       rate,
 		burst:      burst,
 		tokens:     float64(burst),
@@ -62,7 +71,10 @@ func (r *TokenBucketRateLimiter) Wait(ctx context.Context) error {
 	for {
 		if r.Allow() {
 			if waitCount > 0 {
-				log.WithField("wait_count", waitCount).Debug("rate limit wait completed")
+				log.WithFields(map[string]interface{}{
+					"label":      r.label,
+					"wait_count": waitCount,
+				}).Debug("rate limit wait completed")
 			}
 			return nil
 		}
@@ -72,6 +84,7 @@ func (r *TokenBucketRateLimiter) Wait(ctx context.Context) error {
 
 		if waitCount == 1 {
 			log.WithFields(map[string]interface{}{
+				"label":   r.label,
 				"wait_ms": sleepDuration.Milliseconds(),
 				"rate":    r.rate,
 				"burst":   r.burst,
@@ -82,6 +95,7 @@ func (r *TokenBucketRateLimiter) Wait(ctx context.Context) error {
 		case <-ctx.Done():
 			ctxErr := ctx.Err()
 			log.WithFields(map[string]interface{}{
+				"label":      r.label,
 				"wait_count": waitCount,
 				"rate":       r.rate,
 				"burst":      r.burst,

--- a/test/internal/processor/fetcher/rate_limiter/ip_registry_test.go
+++ b/test/internal/processor/fetcher/rate_limiter/ip_registry_test.go
@@ -135,7 +135,7 @@ func TestIPRateLimiterRegistry_Wait_DNSFailure_ContextCanceled_ReturnsCtxErr(t *
 }
 
 func TestNewRateLimiter_ZeroRequestsPerHour_ReturnsNoopLimiter(t *testing.T) {
-	limiter := ratelimiter.NewRateLimiter(0, 10)
+	limiter := ratelimiter.NewRateLimiter(0, 10, "test")
 
 	// 0 이하 RequestsPerHour는 noop limiter를 반환 (모든 요청 허용)
 	for i := 0; i < 100; i++ {

--- a/test/internal/processor/fetcher/rate_limiter/token_bucket_test.go
+++ b/test/internal/processor/fetcher/rate_limiter/token_bucket_test.go
@@ -47,12 +47,12 @@ func findLog(buf *bytes.Buffer, message string) map[string]interface{} {
 }
 
 func TestNewRateLimiter(t *testing.T) {
-	limiter := ratelimiter.NewRateLimiter(3600, 10)
+	limiter := ratelimiter.NewRateLimiter(3600, 10, "test")
 	assert.NotNil(t, limiter)
 }
 
 func TestRateLimiter_Allow_InitialBurst(t *testing.T) {
-	limiter := ratelimiter.NewRateLimiter(3600, 5)
+	limiter := ratelimiter.NewRateLimiter(3600, 5, "test")
 
 	// 초기 burst만큼 허용되어야 함
 	for i := 0; i < 5; i++ {
@@ -65,7 +65,7 @@ func TestRateLimiter_Allow_InitialBurst(t *testing.T) {
 
 func TestRateLimiter_Allow_Refill(t *testing.T) {
 	// 시간당 3600 요청 = 초당 1 요청
-	limiter := ratelimiter.NewRateLimiter(3600, 1)
+	limiter := ratelimiter.NewRateLimiter(3600, 1, "test")
 
 	assert.True(t, limiter.Allow())
 
@@ -79,7 +79,7 @@ func TestRateLimiter_Allow_Refill(t *testing.T) {
 }
 
 func TestRateLimiter_Wait_Success(t *testing.T) {
-	limiter := ratelimiter.NewRateLimiter(3600, 2)
+	limiter := ratelimiter.NewRateLimiter(3600, 2, "test")
 	ctx := context.Background()
 
 	// 처음 2개는 즉시 허용
@@ -96,8 +96,8 @@ func TestRateLimiter_Wait_Success(t *testing.T) {
 }
 
 func TestRateLimiter_Wait_ContextCanceled(t *testing.T) {
-	limiter := ratelimiter.NewRateLimiter(10, 1) // 낮은 rate로 설정
-	limiter.Allow()                              // 토큰 소진
+	limiter := ratelimiter.NewRateLimiter(10, 1, "test") // 낮은 rate로 설정
+	limiter.Allow()                                      // 토큰 소진
 
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
@@ -107,8 +107,8 @@ func TestRateLimiter_Wait_ContextCanceled(t *testing.T) {
 }
 
 func TestRateLimiter_Wait_ContextTimeout(t *testing.T) {
-	limiter := ratelimiter.NewRateLimiter(10, 1) // 낮은 rate로 설정
-	limiter.Allow()                              // 토큰 소진
+	limiter := ratelimiter.NewRateLimiter(10, 1, "test") // 낮은 rate로 설정
+	limiter.Allow()                                      // 토큰 소진
 
 	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
 	defer cancel()
@@ -118,7 +118,7 @@ func TestRateLimiter_Wait_ContextTimeout(t *testing.T) {
 }
 
 func TestRateLimiter_ConcurrentRequests(t *testing.T) {
-	limiter := ratelimiter.NewRateLimiter(100, 10)
+	limiter := ratelimiter.NewRateLimiter(100, 10, "test")
 
 	// 동시에 20개 요청
 	var allowed atomic.Int32
@@ -146,7 +146,7 @@ func TestRateLimiter_ConcurrentRequests(t *testing.T) {
 }
 
 func TestTokenBucketRateLimiter_String(t *testing.T) {
-	limiter := ratelimiter.NewRateLimiter(3600, 10)
+	limiter := ratelimiter.NewRateLimiter(3600, 10, "test")
 	str := limiter.(*ratelimiter.TokenBucketRateLimiter).String()
 
 	assert.Contains(t, str, "RateLimiter")
@@ -158,7 +158,7 @@ func TestRateLimiter_Wait_LogsWaitStart(t *testing.T) {
 	var buf bytes.Buffer
 	ctx := debugContext(&buf)
 
-	limiter := ratelimiter.NewRateLimiter(3600, 1)
+	limiter := ratelimiter.NewRateLimiter(3600, 1, "test")
 	require.NoError(t, limiter.Wait(ctx)) // 첫 번째 — 즉시 통과
 	buf.Reset()
 
@@ -175,7 +175,7 @@ func TestRateLimiter_Wait_LogsWaitCompleted(t *testing.T) {
 	var buf bytes.Buffer
 	ctx := debugContext(&buf)
 
-	limiter := ratelimiter.NewRateLimiter(3600, 1)
+	limiter := ratelimiter.NewRateLimiter(3600, 1, "test")
 	require.NoError(t, limiter.Wait(ctx)) // 첫 번째 — 즉시 통과
 	buf.Reset()
 
@@ -189,7 +189,7 @@ func TestRateLimiter_Wait_LogsWaitCompleted(t *testing.T) {
 func TestRateLimiter_Wait_LogsContextCancelled(t *testing.T) {
 	var buf bytes.Buffer
 
-	limiter := ratelimiter.NewRateLimiter(10, 1)
+	limiter := ratelimiter.NewRateLimiter(10, 1, "test")
 	limiter.Allow() // 토큰 소진
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -208,4 +208,79 @@ func TestRateLimiter_Wait_LogsContextCancelled(t *testing.T) {
 	assert.Contains(t, entry, "wait_count")
 	assert.Contains(t, entry, "rate")
 	assert.Contains(t, entry, "burst")
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// label 필드 (이슈 #503)
+//
+// 모든 throttle 로그 (rate limit reached / wait completed / wait context done) 가 생성자에
+// 주입된 label 을 그대로 emit 하는지 검증. 운영자가 어떤 호스트/IP 가 throttled 인지 사후 추적
+// 가능하도록.
+// ─────────────────────────────────────────────────────────────────────────────
+
+func TestRateLimiter_Wait_LogsLabelOnReached(t *testing.T) {
+	var buf bytes.Buffer
+	ctx := debugContext(&buf)
+
+	limiter := ratelimiter.NewRateLimiter(3600, 1, "192.0.2.10")
+	require.NoError(t, limiter.Wait(ctx)) // 첫 번째 — 즉시 통과
+	buf.Reset()
+
+	require.NoError(t, limiter.Wait(ctx)) // 두 번째 — 대기 발생
+
+	entry := findLog(&buf, "rate limit reached, waiting for token")
+	require.NotNil(t, entry)
+	assert.Equal(t, "192.0.2.10", entry["label"], "label 필드가 생성자 인자 그대로 emit")
+}
+
+func TestRateLimiter_Wait_LogsLabelOnCompleted(t *testing.T) {
+	var buf bytes.Buffer
+	ctx := debugContext(&buf)
+
+	limiter := ratelimiter.NewRateLimiter(3600, 1, "example.com")
+	require.NoError(t, limiter.Wait(ctx)) // 첫 번째 — 즉시 통과
+	buf.Reset()
+
+	require.NoError(t, limiter.Wait(ctx)) // 두 번째 — 대기 후 완료
+
+	entry := findLog(&buf, "rate limit wait completed")
+	require.NotNil(t, entry)
+	assert.Equal(t, "example.com", entry["label"])
+}
+
+func TestRateLimiter_Wait_LogsLabelOnContextCancelled(t *testing.T) {
+	var buf bytes.Buffer
+
+	limiter := ratelimiter.NewRateLimiter(10, 1, "slow.example.com")
+	limiter.Allow() // 토큰 소진
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	logCfg := logger.DefaultConfig()
+	logCfg.Level = logger.LevelDebug
+	logCfg.Output = &buf
+	ctx = logger.New(logCfg).ToContext(ctx)
+
+	err := limiter.Wait(ctx)
+	require.ErrorIs(t, err, context.Canceled)
+
+	entry := lastLog(t, &buf)
+	assert.Equal(t, "slow.example.com", entry["label"])
+}
+
+func TestRateLimiter_EmptyLabel_StillEmits(t *testing.T) {
+	var buf bytes.Buffer
+	ctx := debugContext(&buf)
+
+	limiter := ratelimiter.NewRateLimiter(3600, 1, "") // 빈 label 도 허용
+	require.NoError(t, limiter.Wait(ctx))
+	buf.Reset()
+	require.NoError(t, limiter.Wait(ctx))
+
+	entry := findLog(&buf, "rate limit reached, waiting for token")
+	require.NotNil(t, entry)
+	// 빈 문자열이라도 필드는 존재 — JSON 에 "label":"" 로 emit
+	label, ok := entry["label"].(string)
+	require.True(t, ok)
+	assert.Equal(t, "", label)
 }


### PR DESCRIPTION
## 연관 이슈
- Closes #503

<br>

## 구현 내용

라이브 회차에서 관측된 `rate limit reached, waiting for token` 로그 137회 발화에 `host`/`ip` 정보 부재 — 어느 호스트가 throttled 인지 디버깅 출발점 없던 observability 갭 보강.

### 변경 사항

#### 1) `pkg/`/`internal/` 시그니처 확장

`internal/processor/fetcher/rate_limiter/token_bucket.go`:
- `TokenBucketRateLimiter` 에 `label string` 필드 추가
- `NewRateLimiter(rph, burst int, label string)` — 신규 인자 추가 (issue 본문 옵션 A)
- label 은 throttle 로그의 추적 식별자 — 빈 문자열 허용

#### 2) 3개 Debug 로그 모두에 `label` 필드 emit

| 메시지 | 의미 |
|---|---|
| `rate limit reached, waiting for token` | wait 시작 (waitCount==1 시) |
| `rate limit wait completed` | wait 종료 |
| `rate limit wait context done` | ctx cancel/timeout |

#### 3) Production 호출처 갱신

`internal/processor/fetcher/rate_limiter/ip_registry.go:130`:
```go
limiter := NewRateLimiter(rph, r.burst, ip)  // IP 그대로 label
```

같은 IP 의 모든 host 가 limiter 를 공유하므로 host 보다 IP 가 정확한 식별자.

#### 4) 테스트 호출처 12곳 일괄 갱신

`token_bucket_test.go` 11곳 + `ip_registry_test.go` 1곳 모두 `"test"` label 로 갱신.

### 단위 테스트 4건 신규

- `TestRateLimiter_Wait_LogsLabelOnReached` — wait 시작 로그에 IP label emit
- `TestRateLimiter_Wait_LogsLabelOnCompleted` — wait 완료 로그에 host label emit
- `TestRateLimiter_Wait_LogsLabelOnContextCancelled` — ctx cancel 로그에 label emit
- `TestRateLimiter_EmptyLabel_StillEmits` — 빈 label 도 JSON 필드 부착 (`"label":""`)

### 운영 회복

라이브에서 `rate=0.028` (≈ 1req/36s) 의 극단 throttle 이 발화하더라도 다음과 같이 즉시 식별 가능:

```json
{
  "level": "debug",
  "label": "203.0.113.42",
  "rate": 0.028,
  "burst": 10,
  "wait_ms": 34935,
  "message": "rate limit reached, waiting for token"
}
```

<br>

## CI / 머지 게이트 점검

### 변경 영향 범위
- 영향 패키지/모듈:
  - `internal/processor/fetcher/rate_limiter` (시그니처 변경)
  - test 호출처 12곳
- 위험도: `Low` — 시그니처 변경이지만 production 호출처는 1곳 (ip_registry), 그 외는 모두 test. 로그 추가만 (분기/동작 무변경).

### Required Status Checks
- 통과 확인 대상:
  - [ ] `Commit Lint`
  - [ ] `PR Title Lint`
  - [ ] `Linked Issue Check`
  - [ ] `Format Check`
  - [ ] `Build`
  - [ ] `Test`
  - [ ] `Lint`

### 롤백 계획
- 본 PR revert 만으로 원복 — 로그 필드 추가만이라 데이터/상태 영향 없음.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Enhanced rate limiting system with improved logging that includes identifiers for throttled requests, enabling better monitoring and debugging of rate limit behavior.

* **Tests**
  * Added comprehensive test coverage for rate limit logging functionality.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/EinSofINTEREST/IssueTracker/pull/514?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->