### PR TITLE
[FIX#517] chromedp graceful capture 'context canceled' 해소 — cdproto 직접 호출 + 진단 강화

### DIFF
--- a/internal/processor/fetcher/implementation/chromedp/fetch.go
+++ b/internal/processor/fetcher/implementation/chromedp/fetch.go
@@ -136,10 +136,19 @@ func (c *ChromedpCrawler) Fetch(ctx context.Context, target core.Target) (*core.
 		// (statusCode == 0 이면서 capturedHTML 도 빈 상태) 만 진짜 실패로 분류한다.
 		partialHTML, captureErr := captureOuterHTML(browserCtx, c.opts.GracefulCaptureTimeout)
 		if captureErr != nil {
-			log.WithFields(map[string]interface{}{
+			// 이슈 #517 — capture 실패 시 cancel 출처 진단을 위해 ctx 상태 emit.
+			// "context canceled" 가 browserCtx / allocCtx 어디에서 왔는지 명확화.
+			fields := map[string]interface{}{
 				"url":        target.URL,
 				"timeout_ms": c.config.Timeout.Milliseconds(),
-			}).WithError(captureErr).Warn("graceful capture failed, proceeding with empty partial body")
+			}
+			if browserErr := browserCtx.Err(); browserErr != nil {
+				fields["browser_ctx_err"] = browserErr.Error()
+			}
+			if allocErr := c.allocCtx.Err(); allocErr != nil {
+				fields["alloc_ctx_err"] = allocErr.Error()
+			}
+			log.WithFields(fields).WithError(captureErr).Warn("graceful capture failed, proceeding with empty partial body")
 			partialHTML = ""
 		} else if !IsValidPartialDOM(partialHTML) {
 			log.WithFields(map[string]interface{}{

--- a/internal/processor/fetcher/implementation/chromedp/graceful_timeout.go
+++ b/internal/processor/fetcher/implementation/chromedp/graceful_timeout.go
@@ -79,6 +79,11 @@ func captureOuterHTML(browserCtx context.Context, captureTimeout time.Duration) 
 		if derr != nil {
 			return derr
 		}
+		// nil node 방어 (gemini PR #518 피드백) — cdproto 가 success 반환해도 node nil 가능성 대비.
+		// nil 시 NodeID 접근 panic 회피 + 명시적 error.
+		if node == nil {
+			return errors.New("dom.GetDocument returned nil node")
+		}
 		result, herr := dom.GetOuterHTML().WithNodeID(node.NodeID).Do(ctx)
 		if herr != nil {
 			return herr

--- a/internal/processor/fetcher/implementation/chromedp/graceful_timeout.go
+++ b/internal/processor/fetcher/implementation/chromedp/graceful_timeout.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/chromedp/cdproto/dom"
 	"github.com/chromedp/cdproto/page"
 	"github.com/chromedp/chromedp"
 )
@@ -50,10 +51,16 @@ func IsValidPartialDOM(html string) bool {
 // browserCtx는 timeout으로 cancel되지 않은 tab context여야 하며,
 // chromedp가 동일 탭에 새 명령을 발행할 수 있어야 한다.
 //
-// page.StopLoading() 을 OuterHTML 직전에 발행하여 navigation polling 을 즉시 중단,
-// CDP 가 응답할 여유를 확보. analytics / SSE / long-poll 페이지처럼 navigation 이
-// 끝나지 않는 케이스에서 OuterHTML 만 호출하면 응답이 안 와서 context canceled 로
-// 끝나는 현상을 회피한다.
+// 이슈 #517: 기존 구현은 `chromedp.Run` 을 두 번 호출하는 패턴 (StopLoading 따로 + OuterHTML 따로)
+// 이었으나, 외부 chromedp.Run timeout 이후 chromedp 내부 task system 이 cancel 전파되어 후속 Run
+// 이 `context canceled` 로 실패 (라이브 8/8 케이스). 단일 `chromedp.Run` 안에서 cdproto 액션
+// (page.StopLoading / dom.GetDocument / dom.GetOuterHTML) 을 ActionFunc 로 묶어 실행 — chromedp
+// task lifecycle 영향 격리.
+//
+// 동작:
+//  1. page.StopLoading — navigation polling 즉시 중단. 실패해도 무시 (이미 stopped 일 수 있음).
+//  2. dom.GetDocument — 루트 노드 ID 획득.
+//  3. dom.GetOuterHTML(NodeID) — 현재 DOM 의 outer HTML 반환.
 //
 // captureTimeout 가 0 이하이면 DefaultGracefulCaptureTimeout 을 사용한다.
 func captureOuterHTML(browserCtx context.Context, captureTimeout time.Duration) (string, error) {
@@ -64,10 +71,22 @@ func captureOuterHTML(browserCtx context.Context, captureTimeout time.Duration) 
 	defer cancel()
 
 	var html string
-	if err := chromedp.Run(rescueCtx,
-		page.StopLoading(),
-		chromedp.OuterHTML("html", &html),
-	); err != nil {
+	err := chromedp.Run(rescueCtx, chromedp.ActionFunc(func(ctx context.Context) error {
+		// StopLoading 실패는 무시 — 이미 멈춘 상태일 수 있고, 본 함수의 목적은 HTML 캡처.
+		_ = page.StopLoading().Do(ctx)
+
+		node, derr := dom.GetDocument().Do(ctx)
+		if derr != nil {
+			return derr
+		}
+		result, herr := dom.GetOuterHTML().WithNodeID(node.NodeID).Do(ctx)
+		if herr != nil {
+			return herr
+		}
+		html = result
+		return nil
+	}))
+	if err != nil {
 		return "", err
 	}
 	return html, nil


### PR DESCRIPTION
## 연관 이슈
- Closes #517

<br>

## 구현 내용

라이브 회차 분석에서 발견된 **graceful capture 100% 실패** 현상 (debug.log 51분 7/7, /tmp/issuetracker.log 15분 1/1) 해소.

### 변경 사항

#### 1) `captureOuterHTML` 을 단일 `chromedp.Run` + `ActionFunc` 패턴으로 리팩터

**Before** (graceful_timeout.go):
```go
chromedp.Run(rescueCtx,
    page.StopLoading(),
    chromedp.OuterHTML("html", &html),
)
```

**After**:
```go
chromedp.Run(rescueCtx, chromedp.ActionFunc(func(ctx context.Context) error {
    _ = page.StopLoading().Do(ctx)  // 실패 무시 — 이미 멈췄을 수 있음

    node, _ := dom.GetDocument().Do(ctx)
    result, _ := dom.GetOuterHTML().WithNodeID(node.NodeID).Do(ctx)
    html = result
    return nil
}))
```

**효과**: cdproto 액션을 직접 호출하여 chromedp 의 task system 영향 격리. 외부 `chromedp.Run` 의 timeout 후 cancel 전파로 인한 후속 Run 실패 회피.

#### 2) graceful capture 실패 시 진단 로깅 강화

`fetch.go:137+` 의 capture 실패 분기에 추가 필드:
- `browser_ctx_err` — `browserCtx.Err()` 값
- `alloc_ctx_err` — `c.allocCtx.Err()` 값

→ `context canceled` 의 정확한 출처 (chromedp 내부 / allocCtx / browserCtx) 다음 라이브에서 확정 가능.

### Backward compatibility

- API 시그니처 변경 없음
- 기존 단위 테스트 통과 (`TestIsTimeoutError_*`, `TestIsValidPartialDOM_*`, `TestDefaultGracefulCaptureTimeout_Value`)
- partial DOM 반환 흐름 동일 — 다운스트림 영향 없음

### 라이브 검증 계획

본 수정은 chromedp 의 내부 동작에 의존하므로 단위 테스트로는 검증 한계 (chrome session 의존). 라이브 검증 핵심 지표:

1. **`graceful capture failed` 발화 비율**:
   - 이전 라이브: 8/8 (100%) `context canceled`
   - 목표: 0% 또는 50% 이하
2. **`partial DOM did not meet validation threshold, retaining anyway`** 로그 발생:
   - capture 는 성공했으나 길이 < 512 인 케이스 발생 → 본 수정이 효과 있다는 증거
3. **yna 같은 lazy-load 사이트의 본문 추출 성공률**:
   - timeout 후 partial HTML 이 다운스트림 (parser) 에서 정상 파싱되는지 확인
4. **실패 시 추가 진단**:
   - 본 PR 의 진단 로그 (`browser_ctx_err` / `alloc_ctx_err`) 가 emit 되면 cancel 출처 확정 후 후속 이슈 분기

<br>

## CI / 머지 게이트 점검

### 변경 영향 범위
- 영향 패키지/모듈:
  - `internal/processor/fetcher/implementation/chromedp/` (`graceful_timeout.go` capture 로직 + `fetch.go` 진단 로깅)
- 위험도: `Low` — API 시그니처 동일, 기존 단위 테스트 통과. cdproto 액션 (dom.GetDocument / dom.GetOuterHTML) 은 chromedp.OuterHTML 의 internal 구현과 동등 — semantic 변경 없음. 다만 chromedp 라이브러리 동작 의존 부분이라 실제 효과는 라이브 검증 필요.

### Required Status Checks
- 통과 확인 대상:
  - [ ] `Commit Lint`
  - [ ] `PR Title Lint`
  - [ ] `Linked Issue Check`
  - [ ] `Format Check`
  - [ ] `Build`
  - [ ] `Test`
  - [ ] `Lint`

### 롤백 계획
- 본 PR revert 만으로 원복 — 기존 chromedp.Run 두 번 호출 패턴으로 복귀. 진단 로깅 차이만 추가됨이라 데이터/상태 영향 없음.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
