### PR TITLE
[FIX#519] Notion PR Sync — relative path markdown link 을 GitHub blob URL 로 자동 변환

### DIFF
--- a/.github/workflows/ci-quality.yml
+++ b/.github/workflows/ci-quality.yml
@@ -119,3 +119,27 @@ jobs:
         uses: golangci/golangci-lint-action@v6
         with:
           version: v1.64.8
+
+  python-test:
+    # scripts/ 하위 Python 유틸 (notion_pr_sync.py 등) 회귀 방지용 pytest 실행.
+    # Notion sync 같이 외부 호출이 잦지 않은 스크립트라도 link 정규화 / 본문 변환 로직은
+    # 망가지면 PR 자동화가 조용히 깨지므로 CI 에서 매 PR 검증한다 (이슈 #519 / PR #520).
+    name: Python Test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install pytest
+        run: |
+          python -m pip install --upgrade pip
+          pip install pytest
+
+      - name: Run pytest
+        working-directory: scripts
+        run: python -m pytest -v

--- a/.github/workflows/ci-quality.yml
+++ b/.github/workflows/ci-quality.yml
@@ -119,27 +119,3 @@ jobs:
         uses: golangci/golangci-lint-action@v6
         with:
           version: v1.64.8
-
-  python-test:
-    # scripts/ 하위 Python 유틸 (notion_pr_sync.py 등) 회귀 방지용 pytest 실행.
-    # Notion sync 같이 외부 호출이 잦지 않은 스크립트라도 link 정규화 / 본문 변환 로직은
-    # 망가지면 PR 자동화가 조용히 깨지므로 CI 에서 매 PR 검증한다 (이슈 #519 / PR #520).
-    name: Python Test
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Setup Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.12"
-
-      - name: Install pytest
-        run: |
-          python -m pip install --upgrade pip
-          pip install pytest
-
-      - name: Run pytest
-        working-directory: scripts
-        run: python -m pytest -v

--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,7 @@ debug_*.log
 # Claude scheduler lock (session-local)
 .claude/scheduled_tasks.lock
 .claude/settings.local.json
+
+# python files
+*.pyc
+__pycache__/

--- a/scripts/notion_pr_sync.py
+++ b/scripts/notion_pr_sync.py
@@ -196,7 +196,13 @@ def _normalize_link_url(url: str) -> str | None:
     ref = _link_context.get("ref")
     if not repo_url or not ref:
         return None  # caller 가 plain text fallback
-    cleaned = url.lstrip("./").lstrip("/")
+    # `./` prefix 만 명시적으로 1회 제거, 그 후 단일 `/` 만 제거.
+    # `lstrip("./")` 는 character set 으로 동작해 `.github/`, `.gitignore` 같은 dotfile prefix 가
+    # 깨지므로 사용 불가 (gemini PR #520 피드백).
+    cleaned = url
+    if cleaned.startswith("./"):
+        cleaned = cleaned[2:]
+    cleaned = cleaned.lstrip("/")
     if not cleaned:
         return None
     return f"{repo_url}/blob/{ref}/{cleaned}"

--- a/scripts/notion_pr_sync.py
+++ b/scripts/notion_pr_sync.py
@@ -151,6 +151,57 @@ def _truncate(s: str, n: int = 1900) -> str:
     return s if len(s) <= n else s[: n - 1] + "…"
 
 
+# ---------- link URL normalization (이슈 #519) ----------
+#
+# PR body 안의 markdown link `[text](url)` 에서 url 이 absolute URL 이면 Notion API 가 그대로
+# 받아들이나, **relative path** (예: `internal/foo.go`) 는 "Invalid URL for link" 로 400 reject.
+# 운영자가 PR body 에 relative path link 를 자연스럽게 적는 것을 막지 않도록, sync 측에서
+# GitHub blob URL 로 자동 변환.
+#
+# Context 전파: md_inline 은 호출 체인 깊은 곳이라 매번 인자 전달은 cascading 부담. PR 처리는
+# single-process 단발 호출이므로 module-level dict 사용 + 진입 시 set / 종료 시 clear.
+_link_context: dict[str, str] = {"repo_url": "", "ref": ""}
+
+
+def _set_link_context(repo_url: str, ref: str) -> None:
+    _link_context["repo_url"] = repo_url or ""
+    _link_context["ref"] = ref or ""
+
+
+def _clear_link_context() -> None:
+    _link_context["repo_url"] = ""
+    _link_context["ref"] = ""
+
+
+def _normalize_link_url(url: str) -> str | None:
+    """Convert relative path to GitHub blob URL.
+
+    - absolute URL (http/https/ftp/mailto/tel/...) → return as-is
+    - fragment-only (#section)                     → return as-is (Notion accepts)
+    - empty                                        → return None (caller drops link)
+    - relative path WITH repo context              → return GitHub blob URL
+    - relative path WITHOUT repo context           → return None (caller drops link,
+                                                     keeps text without link)
+    """
+    if not url:
+        return None
+    # absolute scheme detection — "scheme:" 형태 (http: https: mailto: tel: ftp: ...)
+    if "://" in url or url.startswith(("mailto:", "tel:", "data:")):
+        return url
+    # fragment-only — Notion 의 page 내부 anchor 로 처리 가능
+    if url.startswith("#"):
+        return url
+    # relative path — repo context 있을 때만 GitHub blob URL 로 변환
+    repo_url = _link_context.get("repo_url")
+    ref = _link_context.get("ref")
+    if not repo_url or not ref:
+        return None  # caller 가 plain text fallback
+    cleaned = url.lstrip("./").lstrip("/")
+    if not cleaned:
+        return None
+    return f"{repo_url}/blob/{ref}/{cleaned}"
+
+
 def md_inline(text: str) -> list[dict]:
     """Parse inline markdown into a list of rich_text spans."""
     spans: list[dict] = []
@@ -163,7 +214,12 @@ def md_inline(text: str) -> list[dict]:
         elif m.group(2) is not None:
             spans.append(rt(_truncate(m.group(2)), code=True))
         elif m.group(3) is not None and m.group(4) is not None:
-            spans.append(rt(_truncate(m.group(3)), link=m.group(4)))
+            # 이슈 #519 — relative path 는 GitHub blob URL 로 변환, 변환 불가 시 plain text fallback.
+            normalized = _normalize_link_url(m.group(4))
+            if normalized:
+                spans.append(rt(_truncate(m.group(3)), link=normalized))
+            else:
+                spans.append(rt(_truncate(m.group(3))))
         elif m.group(5) is not None:
             spans.append(rt(_truncate(m.group(5)), italic=True))
         elif m.group(6) is not None:
@@ -302,48 +358,63 @@ def files_to_blocks(files: list[dict], max_files: int = 100) -> list[dict]:
 
 
 def pr_to_body_blocks(pr: dict) -> list[dict]:
-    """Compose the full child-block list rendered into a PR row page."""
-    blocks: list[dict] = []
-    # Header / URL
-    blocks.append(_block(
-        "callout",
-        rich_text=[
-            rt(f"#{pr['number']} ", code=True),
-            rt(pr.get("title", ""), bold=True),
-        ],
-        icon={"type": "emoji", "emoji": "🔗"},
-        color="gray_background",
-    ))
-    blocks.append(_block(
-        "paragraph",
-        rich_text=[rt("GitHub: "), rt(pr["url"], link=pr["url"])],
-    ))
+    """Compose the full child-block list rendered into a PR row page.
 
-    # Body
-    body = (pr.get("body") or "").strip()
-    blocks.append(_block("divider"))
-    blocks.append(_block("heading_2", rich_text=[rt("📝 본문")]))
-    if body:
-        blocks.extend(md_to_blocks(body))
-    else:
+    PR body 안의 relative path markdown link 를 GitHub blob URL 로 자동 변환하기 위해
+    link context (repo_url + ref) 를 set/clear (이슈 #519). 함수 진입/종료 시 모두 처리하여
+    재진입 / 예외 발생에도 잔존 state 없음.
+
+    ref 우선순위: headRefOid (commit SHA, 가장 stable) → headRefName (branch) → "main" (fallback).
+    """
+    # link context 설정 — PR URL 에서 repo URL 추출 ("https://github.com/o/r/pull/123" → "https://github.com/o/r").
+    pr_url = pr.get("url") or ""
+    repo_url = pr_url.rsplit("/pull/", 1)[0] if "/pull/" in pr_url else ""
+    ref = pr.get("headRefOid") or pr.get("headRefName") or "main"
+    _set_link_context(repo_url, ref)
+    try:
+        blocks: list[dict] = []
+        # Header / URL
+        blocks.append(_block(
+            "callout",
+            rich_text=[
+                rt(f"#{pr['number']} ", code=True),
+                rt(pr.get("title", ""), bold=True),
+            ],
+            icon={"type": "emoji", "emoji": "🔗"},
+            color="gray_background",
+        ))
         blocks.append(_block(
             "paragraph",
-            rich_text=[rt("(본문 없음)", italic=True)],
+            rich_text=[rt("GitHub: "), rt(pr["url"], link=pr["url"])],
         ))
 
-    # Files
-    files = pr.get("files") or []
-    blocks.append(_block("divider"))
-    blocks.append(_block("heading_2", rich_text=[rt(f"📁 변경 파일 ({len(files)})")]))
-    if files:
-        blocks.extend(files_to_blocks(files))
-    else:
-        blocks.append(_block(
-            "paragraph",
-            rich_text=[rt("(변경 파일 정보 없음)", italic=True)],
-        ))
+        # Body
+        body = (pr.get("body") or "").strip()
+        blocks.append(_block("divider"))
+        blocks.append(_block("heading_2", rich_text=[rt("📝 본문")]))
+        if body:
+            blocks.extend(md_to_blocks(body))
+        else:
+            blocks.append(_block(
+                "paragraph",
+                rich_text=[rt("(본문 없음)", italic=True)],
+            ))
 
-    return blocks
+        # Files
+        files = pr.get("files") or []
+        blocks.append(_block("divider"))
+        blocks.append(_block("heading_2", rich_text=[rt(f"📁 변경 파일 ({len(files)})")]))
+        if files:
+            blocks.extend(files_to_blocks(files))
+        else:
+            blocks.append(_block(
+                "paragraph",
+                rich_text=[rt("(변경 파일 정보 없음)", italic=True)],
+            ))
+
+        return blocks
+    finally:
+        _clear_link_context()
 
 
 def split_prefix(title: str) -> tuple[str | None, int | None, str]:
@@ -464,7 +535,7 @@ def upsert_pr(ds_id: str, pr: dict, body_sync: bool = True) -> str:
 
 # ---------- GitHub fetching ----------
 
-PR_FIELDS = "number,title,state,url,author,createdAt,mergedAt,closedAt,updatedAt,body,files"
+PR_FIELDS = "number,title,state,url,author,createdAt,mergedAt,closedAt,updatedAt,body,files,headRefOid,headRefName"
 PR_FIELDS_LIST = "number,title,state,url,author,createdAt,mergedAt,closedAt,updatedAt"
 
 

--- a/scripts/test_notion_pr_sync.py
+++ b/scripts/test_notion_pr_sync.py
@@ -1,0 +1,218 @@
+"""Unit tests for notion_pr_sync.py (이슈 #519).
+
+`_normalize_link_url` 및 `pr_to_body_blocks` 의 link context 전파를 검증.
+chrome / Notion API 외부 의존성 없는 순수 로직만 테스트.
+
+실행: `cd scripts && python -m pytest test_notion_pr_sync.py -v`
+"""
+from __future__ import annotations
+
+import os
+import sys
+
+import pytest
+
+# 같은 디렉토리의 notion_pr_sync 를 import
+sys.path.insert(0, os.path.dirname(__file__))
+import notion_pr_sync as nps  # noqa: E402
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# _normalize_link_url
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+@pytest.fixture(autouse=True)
+def _reset_context():
+    """매 테스트 전후 link context 초기화 — module-level state 격리."""
+    nps._clear_link_context()
+    yield
+    nps._clear_link_context()
+
+
+def test_normalize_absolute_https_passthrough():
+    assert nps._normalize_link_url("https://example.com/x") == "https://example.com/x"
+
+
+def test_normalize_absolute_http_passthrough():
+    assert nps._normalize_link_url("http://example.com") == "http://example.com"
+
+
+def test_normalize_mailto_passthrough():
+    assert nps._normalize_link_url("mailto:test@example.com") == "mailto:test@example.com"
+
+
+def test_normalize_tel_passthrough():
+    assert nps._normalize_link_url("tel:+1-555-1234") == "tel:+1-555-1234"
+
+
+def test_normalize_fragment_only_passthrough():
+    assert nps._normalize_link_url("#section") == "#section"
+
+
+def test_normalize_empty_returns_none():
+    assert nps._normalize_link_url("") is None
+
+
+def test_normalize_relative_without_context_returns_none():
+    # context 미설정 — relative path 는 link 제거 (caller 가 plain text fallback)
+    nps._clear_link_context()
+    assert nps._normalize_link_url("internal/foo.go") is None
+
+
+def test_normalize_relative_with_context_returns_blob_url():
+    nps._set_link_context("https://github.com/owner/repo", "abc123")
+    got = nps._normalize_link_url("internal/foo.go")
+    assert got == "https://github.com/owner/repo/blob/abc123/internal/foo.go"
+
+
+def test_normalize_relative_dot_prefix_stripped():
+    nps._set_link_context("https://github.com/owner/repo", "main")
+    got = nps._normalize_link_url("./internal/foo.go")
+    assert got == "https://github.com/owner/repo/blob/main/internal/foo.go"
+
+
+def test_normalize_relative_absolute_slash_stripped():
+    nps._set_link_context("https://github.com/owner/repo", "main")
+    got = nps._normalize_link_url("/internal/foo.go")
+    assert got == "https://github.com/owner/repo/blob/main/internal/foo.go"
+
+
+def test_normalize_relative_only_slashes_returns_none():
+    # ".//" 같은 의미 없는 path → 모두 strip 후 빈 문자열 → None (link 제거)
+    nps._set_link_context("https://github.com/owner/repo", "main")
+    assert nps._normalize_link_url("./") is None
+    assert nps._normalize_link_url("/") is None
+
+
+def test_normalize_data_url_passthrough():
+    # data: URL 도 absolute scheme 으로 통과 (Notion 이 받아들이는지는 별개 — 본 함수는 거부 안 함)
+    url = "data:image/png;base64,iVBORw0KGgo="
+    assert nps._normalize_link_url(url) == url
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# md_inline + link context 통합
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def test_md_inline_absolute_link_preserved():
+    spans = nps.md_inline("[GitHub](https://github.com)")
+    # 첫 span 이 [text](link) — link 보존
+    assert len(spans) == 1
+    assert spans[0]["text"]["link"] == {"url": "https://github.com"}
+
+
+def test_md_inline_relative_link_without_context_becomes_plain_text():
+    nps._clear_link_context()
+    spans = nps.md_inline("[graceful_timeout.go](internal/foo.go)")
+    assert len(spans) == 1
+    # link 제거 + plain text 만 잔존
+    assert spans[0]["text"]["link"] is None
+    assert spans[0]["text"]["content"] == "graceful_timeout.go"
+
+
+def test_md_inline_relative_link_with_context_becomes_blob_url():
+    nps._set_link_context("https://github.com/owner/repo", "sha123")
+    spans = nps.md_inline("[graceful_timeout.go](internal/foo.go)")
+    assert spans[0]["text"]["link"] == {
+        "url": "https://github.com/owner/repo/blob/sha123/internal/foo.go"
+    }
+
+
+def test_md_inline_mixed_spans_relative_and_absolute():
+    nps._set_link_context("https://github.com/owner/repo", "main")
+    spans = nps.md_inline(
+        "see [code](internal/foo.go) and [docs](https://example.com/doc)"
+    )
+    # spans 순서: "see " (plain) / "code" (link blob URL) / " and " (plain) / "docs" (link absolute) / trailing
+    link_spans = [s for s in spans if s["text"]["link"] is not None]
+    assert len(link_spans) == 2
+    assert link_spans[0]["text"]["link"]["url"] == "https://github.com/owner/repo/blob/main/internal/foo.go"
+    assert link_spans[1]["text"]["link"]["url"] == "https://example.com/doc"
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# pr_to_body_blocks context set/clear
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def _minimal_pr(*, url="https://github.com/owner/repo/pull/123", body="", head_oid="", head_ref=""):
+    return {
+        "number": 123,
+        "title": "Test PR",
+        "url": url,
+        "body": body,
+        "files": [],
+        "headRefOid": head_oid,
+        "headRefName": head_ref,
+    }
+
+
+def test_pr_to_body_blocks_sets_context_from_pr_url_and_head_sha():
+    pr = _minimal_pr(
+        url="https://github.com/myowner/myrepo/pull/42",
+        body="See [foo](internal/foo.go)",
+        head_oid="deadbeef",
+    )
+    blocks = nps.pr_to_body_blocks(pr)
+    # 본문 paragraph 블록 안에 link 가 blob URL 로 변환됐는지
+    found = False
+    for b in blocks:
+        if b["type"] != "paragraph":
+            continue
+        for span in b["paragraph"]["rich_text"]:
+            link = span["text"].get("link")
+            if link and "/blob/deadbeef/internal/foo.go" in link.get("url", ""):
+                assert link["url"] == "https://github.com/myowner/myrepo/blob/deadbeef/internal/foo.go"
+                found = True
+                break
+    assert found, "relative link 이 blob URL 로 변환되어야 함"
+
+
+def test_pr_to_body_blocks_falls_back_to_head_ref_name():
+    pr = _minimal_pr(
+        url="https://github.com/owner/repo/pull/9",
+        body="[x](path/to/file.go)",
+        head_oid="",
+        head_ref="feature/branch-name",
+    )
+    blocks = nps.pr_to_body_blocks(pr)
+    found = False
+    for b in blocks:
+        if b["type"] != "paragraph":
+            continue
+        for span in b["paragraph"]["rich_text"]:
+            link = span["text"].get("link")
+            if link and "/blob/feature/branch-name/path/to/file.go" in link.get("url", ""):
+                found = True
+                break
+    assert found, "headRefOid 부재 시 headRefName 사용"
+
+
+def test_pr_to_body_blocks_clears_context_after_return():
+    pr = _minimal_pr(
+        url="https://github.com/owner/repo/pull/1",
+        body="[x](rel/path)",
+        head_oid="abc",
+    )
+    _ = nps.pr_to_body_blocks(pr)
+    # 종료 후 context 가 비어있어야 — 다음 PR 처리에 leak 없음
+    assert nps._link_context["repo_url"] == ""
+    assert nps._link_context["ref"] == ""
+
+
+def test_pr_to_body_blocks_clears_context_on_exception():
+    # md_to_blocks 가 어떤 이유로 예외 던져도 context 잔존하지 않음을 검증.
+    # pr["title"] 키 부재 → KeyError 발생 시점에 context clear 확인.
+    pr = {
+        # title 누락 → callout 생성 시 pr['title'] 접근 가능 (default 빈 문자열)
+        # 대신 url 도 부재 → pr["url"] 접근 시 KeyError
+        "number": 1,
+        "body": "[x](rel)",
+        "files": [],
+    }
+    with pytest.raises(KeyError):
+        nps.pr_to_body_blocks(pr)
+    assert nps._link_context["repo_url"] == ""
+    assert nps._link_context["ref"] == ""

--- a/scripts/test_notion_pr_sync.py
+++ b/scripts/test_notion_pr_sync.py
@@ -79,10 +79,31 @@ def test_normalize_relative_absolute_slash_stripped():
 
 
 def test_normalize_relative_only_slashes_returns_none():
-    # ".//" 같은 의미 없는 path → 모두 strip 후 빈 문자열 → None (link 제거)
+    # "./" 또는 "/" 단독은 정리 후 빈 문자열 → None (link 제거)
     nps._set_link_context("https://github.com/owner/repo", "main")
     assert nps._normalize_link_url("./") is None
     assert nps._normalize_link_url("/") is None
+
+
+def test_normalize_relative_dotfile_prefix_preserved():
+    # `.github/`, `.gitignore` 같은 dotfile prefix 가 깨지면 안 됨 (gemini PR #520).
+    # lstrip("./") 가 character set 으로 동작했던 버그 검증.
+    nps._set_link_context("https://github.com/owner/repo", "main")
+    assert nps._normalize_link_url(".github/workflows/ci.yml") == (
+        "https://github.com/owner/repo/blob/main/.github/workflows/ci.yml"
+    )
+    assert nps._normalize_link_url(".gitignore") == (
+        "https://github.com/owner/repo/blob/main/.gitignore"
+    )
+
+
+def test_normalize_relative_parent_path_preserved():
+    # `../../foo` 같은 상위 경로도 의도치 않게 축소되지 않아야 함.
+    # GitHub blob URL 에 그대로 들어가도 OK — 깨진 link 가 되더라도 PR body 원본 의도 보존.
+    nps._set_link_context("https://github.com/owner/repo", "main")
+    assert nps._normalize_link_url("../sibling/file") == (
+        "https://github.com/owner/repo/blob/main/../sibling/file"
+    )
 
 
 def test_normalize_data_url_passthrough():


### PR DESCRIPTION
## 연관 이슈
- Closes #519

<br>

## 구현 내용

PR #518 작업 중 발견된 sync workflow 의 본질적 fix. 이전 PR 들은 운 좋게 relative link 없어 통과했지만, 향후 작업자가 자연스럽게 PR body 에 relative link 작성 시 같은 실패 재발 가능성. 본 PR 으로 근본 해소.

### 변경 사항

#### 1) `_normalize_link_url(url) -> str | None` 신규 헬퍼

- absolute scheme (http/https/mailto/tel/data:) → passthrough
- fragment-only (#section) → passthrough (Notion accept)
- empty → None (caller 가 link 제거 + plain text fallback)
- **relative path + context** → `{repo_url}/blob/{ref}/{path}` 자동 변환
- relative path + context 부재 → None (link 제거)

#### 2) `md_inline` 의 link 분기에 정규화 적용

```python
elif m.group(3) is not None and m.group(4) is not None:
    normalized = _normalize_link_url(m.group(4))
    if normalized:
        spans.append(rt(_truncate(m.group(3)), link=normalized))
    else:
        spans.append(rt(_truncate(m.group(3))))  # plain text fallback
```

#### 3) `pr_to_body_blocks` 에서 link context set/clear

```python
def pr_to_body_blocks(pr):
    repo_url = pr_url.rsplit("/pull/", 1)[0]  # "https://github.com/o/r"
    ref = pr.get("headRefOid") or pr.get("headRefName") or "main"
    _set_link_context(repo_url, ref)
    try:
        # ... existing logic
        return blocks
    finally:
        _clear_link_context()  # 예외에도 leak 없음
```

ref 우선순위: `headRefOid` (commit SHA, 가장 stable — PR 머지 후에도 git 히스토리에 보존) → `headRefName` (branch) → `"main"` (fallback)

#### 4) `PR_FIELDS` 에 `headRefOid` + `headRefName` 추가

`gh pr view --json` 이 head 정보를 fetch 하도록.

### 단위 테스트 (pytest 20 케이스)

[scripts/test_notion_pr_sync.py](scripts/test_notion_pr_sync.py):

- **`_normalize_link_url`** (12): absolute https/http/mailto/tel/data/fragment / empty / relative ±context / dot prefix / slash prefix / slashes-only
- **`md_inline` 통합** (4): absolute link / relative w/o context (plain text) / relative w/ context (blob URL) / mixed batch
- **`pr_to_body_blocks`** (4): context from `headRefOid` / fallback to `headRefName` / context cleared after return / context cleared on exception

실행:
```bash
cd scripts && python3 -m pytest test_notion_pr_sync.py -v
# 20 passed in 0.03s
```

### Backward compatibility

- absolute URL link 동작 동일
- relative path 가 있던 기존 PR 들은 sync 시점에 자동 blob URL 변환 (이전엔 400 실패)
- ref 미존재 (특수 케이스) 시 plain text fallback — 기존 silent 400 보다 안전

<br>

## CI / 머지 게이트 점검

### 변경 영향 범위
- 영향 패키지/모듈:
  - `scripts/notion_pr_sync.py` (sync workflow 실행 스크립트)
  - `scripts/test_notion_pr_sync.py` (신규 pytest)
  - `.gitignore` (python __pycache__ / .pyc 추가)
- 위험도: `Low` — sync workflow 만 영향, 운영 코드 변경 없음. backward compat (absolute URL 동작 동일). 20 pytest 통과 + Go 전체 테스트 통과.

### Required Status Checks
- 통과 확인 대상:
  - [ ] `Commit Lint`
  - [ ] `PR Title Lint`
  - [ ] `Linked Issue Check`
  - [ ] `Format Check`
  - [ ] `Build`
  - [ ] `Test`
  - [ ] `Lint`

### 롤백 계획
- 본 PR revert 만으로 원복 — sync 가 다시 relative URL 그대로 전달하는 이전 동작으로 복귀. 데이터 손상 없음.

🤖 Generated with Claude Code (https://claude.com/claude-code)