### PR TITLE
[FEAT#521] Publisher 단계 host/path 기반 priority 차등 — parser_rules 룰 + Resolver hydrate + Upgrader 하드코딩 제거

### DIFF
--- a/cmd/issuetracker/main.go
+++ b/cmd/issuetracker/main.go
@@ -677,6 +677,7 @@ func main() {
 			rawIDTracker,
 			rawSvc,
 			jobPublisher, // 이슈 #388 — bus.UpgradePublisher (단일 facade)
+			resolver,     // 이슈 #521 — host/path 기반 priority 결정
 			redisRaw,     // nil 허용 — in-flight lock 비활성 (단일 인스턴스)
 			log,
 		)

--- a/cmd/issuetracker/main.go
+++ b/cmd/issuetracker/main.go
@@ -37,6 +37,7 @@ import (
 	validateWorkerPkg "issuetracker/internal/processor/validate/worker"
 	"issuetracker/internal/scheduler"
 	"issuetracker/internal/storage/decorator"
+	"issuetracker/internal/storage/model"
 	pgstore "issuetracker/internal/storage/postgres"
 	"issuetracker/internal/storage/primitive"
 	redisstore "issuetracker/internal/storage/redis"
@@ -210,10 +211,15 @@ func main() {
 	// 이슈 #391 — PriorityResolver chain 이 publisher 측으로 이동 + 모든 PublishX 가
 	// resolver 통과 (메타 #385 Sub 6). ExplicitPriorityResolver 를 chain 1순위 로 등록 —
 	// 발행자가 job.Priority 를 사전 명시한 경우 (seed entry / retry / upgrade) 그 값이 보존됨.
+	//
+	// 이슈 #521 — RuleBasedPriorityResolver 가 parser_rules.crawl_priority 컬럼을 hydrate
+	// 하여 host/path 기반 priority 분기. ruleBased 인스턴스를 변수로 보유해 후속 단계에서
+	// PriorityRulesRefresher 가 hydrate 가능 (pool 생성 이후).
 	resolver := bus.NewCompositeResolver(core.PriorityNormal)
 	resolver.Add(&bus.ExplicitPriorityResolver{})
 	resolver.Add(bus.NewSourcePriorityResolver(core.PriorityNormal))
-	resolver.Add(bus.NewRuleBasedPriorityResolver(core.PriorityNormal))
+	ruleBasedResolver := bus.NewRuleBasedPriorityResolver(core.PriorityNormal)
+	resolver.Add(ruleBasedResolver)
 
 	highConsumer := queue.NewConsumer(crawlerKafkaCfg, queue.TopicCrawlHigh)
 	defer highConsumer.Close()
@@ -254,6 +260,33 @@ func main() {
 		service.WithParserRuleQueryTimeout(dbCfg.QueryTimeout),
 		service.WithParserRuleInvalidator(ruleResolver),
 	)
+
+	// 이슈 #521 — RuleBasedPriorityResolver hydrate. parser_rules 의 enabled 룰에서
+	// (host_pattern, path_pattern, crawl_priority) 추출 후 atomic 으로 resolver 에 주입.
+	// 부팅 직후 1회 + 주기 refresh (default 5분, env PRIORITY_RULES_REFRESH_INTERVAL).
+	priorityRefreshInterval := envDurationOrDefault("PRIORITY_RULES_REFRESH_INTERVAL", 5*time.Minute)
+	priorityLoader := func(loadCtx context.Context) ([]bus.HostPathPriorityRule, error) {
+		// 룰 수가 ~10k 미만 가정 — 한 번에 전부 fetch. 50개 default LIMIT 회피.
+		records, err := parserRuleRepoRaw.List(loadCtx, model.ParserRuleFilter{
+			OnlyEnabled: true,
+			Limit:       10000,
+		})
+		if err != nil {
+			return nil, err
+		}
+		rules := make([]bus.HostPathPriorityRule, 0, len(records))
+		for _, rec := range records {
+			rules = append(rules, bus.HostPathPriorityRule{
+				HostPattern: rec.HostPattern,
+				PathPattern: rec.PathPattern,
+				Priority:    priorityFromInt16(rec.CrawlPriority),
+			})
+		}
+		return rules, nil
+	}
+	priorityRefresher := bus.NewPriorityRulesRefresher(ruleBasedResolver, priorityLoader, priorityRefreshInterval, log)
+	priorityRefresher.Start(ctx)
+	log.WithField("interval_ms", priorityRefreshInterval.Milliseconds()).Info("priority rules refresher started")
 	// page-parse 블랙리스트 — 카테고리 → article job 발행 단계에서 매칭 URL 차단.
 	// Enabled=false 시 Matcher 미주입 → parser_worker 가 모든 링크 그대로 발행 (기능 OFF).
 	//
@@ -1210,6 +1243,33 @@ func main() {
 	}
 
 	log.Info("shutdown completed")
+}
+
+// envDurationOrDefault 는 환경변수에서 time.Duration 을 파싱하여 반환합니다 (이슈 #521).
+// 미설정 / 파싱 실패 시 def 반환. 운영자가 PRIORITY_RULES_REFRESH_INTERVAL 같은 변수 조정 시 사용.
+func envDurationOrDefault(key string, def time.Duration) time.Duration {
+	raw := os.Getenv(key)
+	if raw == "" {
+		return def
+	}
+	d, err := time.ParseDuration(raw)
+	if err != nil {
+		return def
+	}
+	return d
+}
+
+// priorityFromInt16 은 DB 의 crawl_priority (SMALLINT, 1~3) 를 core.Priority 로 변환합니다 (이슈 #521).
+// 매핑: 1=high / 2=normal / 3=low. 잘못된 값은 normal 로 보정 — DB CHECK 제약으로 정상은 미도달.
+func priorityFromInt16(v int16) core.Priority {
+	switch v {
+	case 1:
+		return core.PriorityHigh
+	case 3:
+		return core.PriorityLow
+	default:
+		return core.PriorityNormal
+	}
 }
 
 // buildEnricherROMCPConfig 는 ENRICHER_DB_RO_* 환경변수에서 read-only DSN 을 구성하고

--- a/cmd/issuetracker/main.go
+++ b/cmd/issuetracker/main.go
@@ -10,6 +10,7 @@ import (
 	storagecfg "issuetracker/pkg/config/storage"
 	"os"
 	"os/signal"
+	"strconv"
 	"syscall"
 	"time"
 
@@ -261,18 +262,30 @@ func main() {
 		service.WithParserRuleInvalidator(ruleResolver),
 	)
 
-	// 이슈 #521 — RuleBasedPriorityResolver hydrate. parser_rules 의 enabled 룰에서
-	// (host_pattern, path_pattern, crawl_priority) 추출 후 atomic 으로 resolver 에 주입.
+	// 이슈 #521 — RuleBasedPriorityResolver hydrate. parser_rules 의 enabled 룰 (target_type=page)
+	// 에서 (host_pattern, path_pattern, crawl_priority) 추출 후 atomic 으로 resolver 에 주입.
+	//
+	// target_type=page 만 로드 — Copilot #3274137388 피드백: 같은 host 의 page/list 룰이 priority
+	// 가 다를 경우 모호. URL crawl priority 분기는 page (article body) 단위가 자연스러우므로
+	// 본 단계에서는 page 만 hydrate.
+	//
+	// Limit (default 10000, env PRIORITY_RULES_LOAD_LIMIT) 도달 시 WARN — silent truncation 회피
+	// (gemini #3274133287 / Copilot #3274137421 피드백).
+	//
 	// 부팅 직후 1회 + 주기 refresh (default 5분, env PRIORITY_RULES_REFRESH_INTERVAL).
 	priorityRefreshInterval := envDurationOrDefault("PRIORITY_RULES_REFRESH_INTERVAL", 5*time.Minute)
+	priorityLoadLimit := envIntOrDefault("PRIORITY_RULES_LOAD_LIMIT", 10000)
 	priorityLoader := func(loadCtx context.Context) ([]bus.HostPathPriorityRule, error) {
-		// 룰 수가 ~10k 미만 가정 — 한 번에 전부 fetch. 50개 default LIMIT 회피.
 		records, err := parserRuleRepoRaw.List(loadCtx, model.ParserRuleFilter{
 			OnlyEnabled: true,
-			Limit:       10000,
+			TargetType:  model.TargetTypePage,
+			Limit:       priorityLoadLimit,
 		})
 		if err != nil {
 			return nil, err
+		}
+		if len(records) == priorityLoadLimit {
+			log.WithField("limit", priorityLoadLimit).Warn("priority rules load reached limit, possible truncation — raise PRIORITY_RULES_LOAD_LIMIT")
 		}
 		rules := make([]bus.HostPathPriorityRule, 0, len(records))
 		for _, rec := range records {
@@ -286,7 +299,10 @@ func main() {
 	}
 	priorityRefresher := bus.NewPriorityRulesRefresher(ruleBasedResolver, priorityLoader, priorityRefreshInterval, log)
 	priorityRefresher.Start(ctx)
-	log.WithField("interval_ms", priorityRefreshInterval.Milliseconds()).Info("priority rules refresher started")
+	log.WithFields(map[string]interface{}{
+		"interval_ms": priorityRefreshInterval.Milliseconds(),
+		"load_limit":  priorityLoadLimit,
+	}).Info("priority rules refresher started")
 	// page-parse 블랙리스트 — 카테고리 → article job 발행 단계에서 매칭 URL 차단.
 	// Enabled=false 시 Matcher 미주입 → parser_worker 가 모든 링크 그대로 발행 (기능 OFF).
 	//
@@ -1258,6 +1274,20 @@ func envDurationOrDefault(key string, def time.Duration) time.Duration {
 		return def
 	}
 	return d
+}
+
+// envIntOrDefault 는 환경변수에서 양의 int 를 파싱하여 반환합니다 (이슈 #521).
+// 미설정 / 파싱 실패 / 0 이하 값은 def 반환.
+func envIntOrDefault(key string, def int) int {
+	raw := os.Getenv(key)
+	if raw == "" {
+		return def
+	}
+	v, err := strconv.Atoi(raw)
+	if err != nil || v <= 0 {
+		return def
+	}
+	return v
 }
 
 // priorityFromInt16 은 DB 의 crawl_priority (SMALLINT, 1~3) 를 core.Priority 로 변환합니다 (이슈 #521).

--- a/internal/bus/priority_refresher.go
+++ b/internal/bus/priority_refresher.go
@@ -1,0 +1,89 @@
+package bus
+
+import (
+	"context"
+	"time"
+
+	"issuetracker/pkg/logger"
+)
+
+// PriorityRulesLoader 는 host/path priority 룰을 외부 store (DB 등) 에서 로드하는 콜백입니다.
+//
+// main.go 가 ParserRuleRepository 에 의존하여 본 콜백을 주입합니다 — bus 패키지가 storage
+// 패키지에 직접 의존하지 않도록 layering 보존 (이슈 #521).
+type PriorityRulesLoader func(ctx context.Context) ([]HostPathPriorityRule, error)
+
+// PriorityRulesRefresher 는 RuleBasedPriorityResolver 의 host/path 룰을 주기적으로 hydrate 합니다.
+//
+// 부팅 직후 1회 즉시 로드 + interval 마다 ticker 로 refresh. ctx 취소 시 graceful 종료.
+//
+// 운영자가 parser_rules.crawl_priority 를 변경하면 다음 refresh tick 에 자동 반영 — TTL 5분
+// default 이므로 운영 반영 지연 최대 5분.
+type PriorityRulesRefresher struct {
+	resolver *RuleBasedPriorityResolver
+	loader   PriorityRulesLoader
+	interval time.Duration
+	log      *logger.Logger
+}
+
+// NewPriorityRulesRefresher 는 refresher 인스턴스를 생성합니다.
+// interval <= 0 이면 5분 default.
+func NewPriorityRulesRefresher(
+	resolver *RuleBasedPriorityResolver,
+	loader PriorityRulesLoader,
+	interval time.Duration,
+	log *logger.Logger,
+) *PriorityRulesRefresher {
+	if interval <= 0 {
+		interval = 5 * time.Minute
+	}
+	return &PriorityRulesRefresher{
+		resolver: resolver,
+		loader:   loader,
+		interval: interval,
+		log:      log,
+	}
+}
+
+// Start 는 부팅 직후 1회 즉시 hydrate + ticker goroutine 을 기동합니다.
+//
+// 부팅 시점 hydrate 실패는 WARN 로그 + 기동 진행 — refresher 가 없는 상태로 시스템이 흘러
+// fallback 우선순위 (Normal) 로 동작. 다음 tick 에서 자연 복구.
+//
+// goroutine 은 ctx.Done() 시 즉시 종료. graceful shutdown 신호 그대로 흡수.
+func (r *PriorityRulesRefresher) Start(ctx context.Context) {
+	r.refreshOnce(ctx)
+
+	go func() {
+		ticker := time.NewTicker(r.interval)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				r.refreshOnce(ctx)
+			}
+		}
+	}()
+}
+
+// refreshOnce 는 loader 호출 + resolver 의 host/path 룰 atomic 교체.
+//
+// loader 에러 시 WARN 로그 + 기존 룰 유지 (silent skip) — 다음 tick 에서 자연 복구.
+func (r *PriorityRulesRefresher) refreshOnce(ctx context.Context) {
+	if ctx.Err() != nil {
+		return
+	}
+	rules, err := r.loader(ctx)
+	if err != nil {
+		if r.log != nil {
+			r.log.WithError(err).Warn("priority rules refresh failed, retaining previous rules")
+		}
+		return
+	}
+	r.resolver.SetHostPathRules(rules)
+	if r.log != nil {
+		r.log.WithField("rule_count", len(rules)).Debug("priority rules refreshed")
+	}
+}

--- a/internal/bus/resolver.go
+++ b/internal/bus/resolver.go
@@ -9,6 +9,7 @@ package bus
 import (
 	"net/url"
 	"regexp"
+	"sort"
 	"sync/atomic"
 
 	"issuetracker/internal/processor/fetcher/core"
@@ -132,9 +133,14 @@ type HostPathPriorityRule struct {
 }
 
 // compiledHostPathRule 은 hydrate 시점에 path regex 가 컴파일된 내부 표현입니다.
+//
+// pathLen 은 정렬용 — len(rule.PathPattern). 빈 path (catch-all) 은 길이 0 으로 host 안에서
+// 가장 마지막 평가. coderabbit 피드백 #3274112935 — 같은 host 에서 catch-all 이 specific
+// path 룰을 shadow 하지 않도록 사전 정렬에 사용.
 type compiledHostPathRule struct {
 	host     string
 	path     *regexp.Regexp // nil 이면 모든 path 매칭
+	pathLen  int            // 원본 PathPattern 길이 — 정렬 키
 	priority core.Priority
 }
 
@@ -182,11 +188,18 @@ func (r *RuleBasedPriorityResolver) AddRule(
 //  2. host 정확 매칭 + path regex 매칭 첫 룰의 priority 반환
 //
 // nil 또는 빈 슬라이스 전달 시 host/path 룰이 비활성화되어 fallback 동작 (CanResolve 가 false).
+//
+// 정렬 (coderabbit 피드백 #3274112935):
+//   - 1순위 host ASC (그룹화 — host 평가는 정확 매칭이므로 그룹화만으로 충분)
+//   - 2순위 pathLen DESC (긴 path regex 우선 → 같은 host 에서 catch-all 이 specific 을 shadow 회피)
+//
+// 동일 host + 동일 pathLen 의 경우 입력 순서 보존 (sort.SliceStable).
 func (r *RuleBasedPriorityResolver) SetHostPathRules(rules []HostPathPriorityRule) {
 	compiled := make([]compiledHostPathRule, 0, len(rules))
 	for _, rule := range rules {
 		entry := compiledHostPathRule{
 			host:     rule.HostPattern,
+			pathLen:  len(rule.PathPattern),
 			priority: rule.Priority,
 		}
 		if rule.PathPattern != "" {
@@ -199,6 +212,12 @@ func (r *RuleBasedPriorityResolver) SetHostPathRules(rules []HostPathPriorityRul
 		}
 		compiled = append(compiled, entry)
 	}
+	sort.SliceStable(compiled, func(i, j int) bool {
+		if compiled[i].host != compiled[j].host {
+			return compiled[i].host < compiled[j].host
+		}
+		return compiled[i].pathLen > compiled[j].pathLen
+	})
 	r.hostPathPtr.Store(&compiled)
 }
 

--- a/internal/bus/resolver.go
+++ b/internal/bus/resolver.go
@@ -147,9 +147,9 @@ type compiledHostPathRule struct {
 // SetHostPathRules 는 atomic 교체로 동시 Resolve 호출과 race-safe — periodic refresher
 // goroutine 이 안전하게 새 룰 슬라이스로 교체 가능 (이슈 #521).
 type RuleBasedPriorityResolver struct {
-	rules        []PriorityRule
-	hostPathPtr  atomic.Pointer[[]compiledHostPathRule]
-	fallback     core.Priority
+	rules       []PriorityRule
+	hostPathPtr atomic.Pointer[[]compiledHostPathRule]
+	fallback    core.Priority
 }
 
 // NewRuleBasedPriorityResolver 는 기본 우선순위를 지정하여 빈 resolver 를 생성합니다.

--- a/internal/bus/resolver.go
+++ b/internal/bus/resolver.go
@@ -10,6 +10,7 @@ import (
 	"net/url"
 	"regexp"
 	"sort"
+	"strings"
 	"sync/atomic"
 
 	"issuetracker/internal/processor/fetcher/core"
@@ -197,8 +198,9 @@ func (r *RuleBasedPriorityResolver) AddRule(
 func (r *RuleBasedPriorityResolver) SetHostPathRules(rules []HostPathPriorityRule) {
 	compiled := make([]compiledHostPathRule, 0, len(rules))
 	for _, rule := range rules {
+		// host 정규화 — matchHostPath 의 u.Hostname() lowercase 매칭과 일관 (gemini #3274133274 / Copilot #3274137309).
 		entry := compiledHostPathRule{
-			host:     rule.HostPattern,
+			host:     strings.ToLower(rule.HostPattern),
 			pathLen:  len(rule.PathPattern),
 			priority: rule.Priority,
 		}
@@ -224,6 +226,10 @@ func (r *RuleBasedPriorityResolver) SetHostPathRules(rules []HostPathPriorityRul
 // matchHostPath 는 job 의 URL 에서 host/path 룰 매칭을 시도하여 priority + 매칭 여부를 반환합니다.
 //
 // URL parse 실패 시 (false, _) — 호출자가 fallback 처리.
+//
+// 호스트 정규화 (gemini #3274133274 / Copilot #3274137309):
+//   - u.Hostname() 로 port 제외 (parser_rules.host_pattern 은 보통 port 없는 도메인)
+//   - strings.ToLower 로 대소문자 통일 (parser_rule resolver 와 일관)
 func (r *RuleBasedPriorityResolver) matchHostPath(job *core.CrawlJob) (core.Priority, bool) {
 	rulesPtr := r.hostPathPtr.Load()
 	if rulesPtr == nil || len(*rulesPtr) == 0 {
@@ -233,7 +239,7 @@ func (r *RuleBasedPriorityResolver) matchHostPath(job *core.CrawlJob) (core.Prio
 	if err != nil || u.Host == "" {
 		return 0, false
 	}
-	host := u.Host
+	host := strings.ToLower(u.Hostname())
 	path := u.Path
 	if path == "" {
 		path = "/"

--- a/internal/bus/resolver.go
+++ b/internal/bus/resolver.go
@@ -7,6 +7,10 @@
 package bus
 
 import (
+	"net/url"
+	"regexp"
+	"sync/atomic"
+
 	"issuetracker/internal/processor/fetcher/core"
 )
 
@@ -115,10 +119,37 @@ type PriorityRule struct {
 	Priority core.Priority
 }
 
+// HostPathPriorityRule 은 host_pattern + path_pattern + priority 로 구성된 라우팅 규칙입니다.
+// parser_rules.crawl_priority 컬럼에서 hydrate 되어 RuleBasedPriorityResolver 에 주입됩니다 (이슈 #521).
+type HostPathPriorityRule struct {
+	// HostPattern 은 정확 host 매칭 (예: "n.news.naver.com").
+	// parser_rules.host_pattern 그대로 — RE2 패턴이 아닌 정확 문자열 매칭.
+	HostPattern string
+	// PathPattern 은 RE2 정규식. 빈 문자열이면 모든 path 매칭.
+	PathPattern string
+	// Priority 는 매칭 시 적용할 우선순위 (1=high / 2=normal / 3=low).
+	Priority core.Priority
+}
+
+// compiledHostPathRule 은 hydrate 시점에 path regex 가 컴파일된 내부 표현입니다.
+type compiledHostPathRule struct {
+	host     string
+	path     *regexp.Regexp // nil 이면 모든 path 매칭
+	priority core.Priority
+}
+
 // RuleBasedPriorityResolver 는 등록된 규칙을 순서대로 평가하여 첫 번째 매치의 우선순위를 반환합니다.
+//
+// 두 종류의 룰을 지원합니다:
+//  1. 함수형 PriorityRule (AddRule) — 임의 조건 매칭
+//  2. host/path 룰 (SetHostPathRules) — DB hydrate 대상, atomic.Pointer 로 lock-free 교체
+//
+// SetHostPathRules 는 atomic 교체로 동시 Resolve 호출과 race-safe — periodic refresher
+// goroutine 이 안전하게 새 룰 슬라이스로 교체 가능 (이슈 #521).
 type RuleBasedPriorityResolver struct {
-	rules    []PriorityRule
-	fallback core.Priority
+	rules        []PriorityRule
+	hostPathPtr  atomic.Pointer[[]compiledHostPathRule]
+	fallback     core.Priority
 }
 
 // NewRuleBasedPriorityResolver 는 기본 우선순위를 지정하여 빈 resolver 를 생성합니다.
@@ -137,13 +168,80 @@ func (r *RuleBasedPriorityResolver) AddRule(
 	r.rules = append(r.rules, PriorityRule{Match: match, Priority: priority})
 }
 
+// SetHostPathRules 는 host/path 룰 슬라이스를 atomic 으로 교체합니다 (이슈 #521).
+//
+// hydrate / refresh 시점에 호출됩니다. path_pattern 의 RE2 컴파일 실패한 항목은 silently
+// skip + 결과 슬라이스에 미포함. (이는 INSERT 단계에서 사전 검증되므로 정상 흐름에서는
+// 컴파일 실패가 없어야 합니다 — postgres.Insert 가 RE2 검증).
+//
+// 정렬: 같은 host 내 더 구체적인 (긴) path regex 가 먼저 평가되도록 LENGTH(path) DESC.
+// 빈 path_pattern 은 host catch-all 로 마지막 평가.
+//
+// 매칭 정책 — Resolve 시:
+//  1. job.Target.URL 에서 host + path 추출
+//  2. host 정확 매칭 + path regex 매칭 첫 룰의 priority 반환
+//
+// nil 또는 빈 슬라이스 전달 시 host/path 룰이 비활성화되어 fallback 동작 (CanResolve 가 false).
+func (r *RuleBasedPriorityResolver) SetHostPathRules(rules []HostPathPriorityRule) {
+	compiled := make([]compiledHostPathRule, 0, len(rules))
+	for _, rule := range rules {
+		entry := compiledHostPathRule{
+			host:     rule.HostPattern,
+			priority: rule.Priority,
+		}
+		if rule.PathPattern != "" {
+			re, err := regexp.Compile(rule.PathPattern)
+			if err != nil {
+				// INSERT 시점에 검증되므로 정상 흐름은 도달 불가 — 도달 시 해당 룰만 skip.
+				continue
+			}
+			entry.path = re
+		}
+		compiled = append(compiled, entry)
+	}
+	r.hostPathPtr.Store(&compiled)
+}
+
+// matchHostPath 는 job 의 URL 에서 host/path 룰 매칭을 시도하여 priority + 매칭 여부를 반환합니다.
+//
+// URL parse 실패 시 (false, _) — 호출자가 fallback 처리.
+func (r *RuleBasedPriorityResolver) matchHostPath(job *core.CrawlJob) (core.Priority, bool) {
+	rulesPtr := r.hostPathPtr.Load()
+	if rulesPtr == nil || len(*rulesPtr) == 0 {
+		return 0, false
+	}
+	u, err := url.Parse(job.Target.URL)
+	if err != nil || u.Host == "" {
+		return 0, false
+	}
+	host := u.Host
+	path := u.Path
+	if path == "" {
+		path = "/"
+	}
+	for _, rule := range *rulesPtr {
+		if rule.host != host {
+			continue
+		}
+		if rule.path == nil || rule.path.MatchString(path) {
+			return rule.priority, true
+		}
+	}
+	return 0, false
+}
+
 // Resolve 는 등록된 규칙을 순서대로 평가합니다.
+// 1순위: 함수형 PriorityRule (AddRule 으로 등록).
+// 2순위: host/path 룰 (SetHostPathRules 으로 등록).
 // 매치되는 규칙이 없으면 fallback 우선순위를 반환합니다.
 func (r *RuleBasedPriorityResolver) Resolve(job *core.CrawlJob) core.Priority {
 	for _, rule := range r.rules {
 		if rule.Match(job) {
 			return rule.Priority
 		}
+	}
+	if p, ok := r.matchHostPath(job); ok {
+		return p
 	}
 	return r.fallback
 }
@@ -155,6 +253,9 @@ func (r *RuleBasedPriorityResolver) CanResolve(job *core.CrawlJob) bool {
 		if rule.Match(job) {
 			return true
 		}
+	}
+	if _, ok := r.matchHostPath(job); ok {
+		return true
 	}
 	return false
 }

--- a/internal/processor/fetcher/rule/upgrader.go
+++ b/internal/processor/fetcher/rule/upgrader.go
@@ -61,26 +61,28 @@ const (
 //   - max 20 cap: 단일 사이클 republish 폭주 회피
 //   - 모든 단계 실패는 non-fatal — best-effort. 다음 카운팅 사이클이 자연스러운 retry.
 type Upgrader struct {
-	repo       repository.FetcherRuleRepository
-	resolver   Resolver
-	tracker    primitive.RawIDTracker
-	rawSvc     service.RawContentService
-	upgradePub bus.UpgradePublisher // gemini PR #398 — `publisher` package import 와 shadow 회피.
-	redis      *goredis.Client      // SETNX in-flight lock 용. nil 이면 lock 비활성 (단일 인스턴스 환경).
-	log        *logger.Logger
+	repo             repository.FetcherRuleRepository
+	resolver         Resolver
+	tracker          primitive.RawIDTracker
+	rawSvc           service.RawContentService
+	upgradePub       bus.UpgradePublisher // gemini PR #398 — `publisher` package import 와 shadow 회피.
+	priorityResolver bus.PriorityResolver // 이슈 #521 — host/path 기반 priority 결정. nil 이면 PriorityNormal fallback.
+	redis            *goredis.Client      // SETNX in-flight lock 용. nil 이면 lock 비활성 (단일 인스턴스 환경).
+	log              *logger.Logger
 }
 
 // NewUpgrader 는 Upgrader 를 생성합니다 (이슈 #388 — producer queue.Producer →
 // bus.UpgradePublisher 의존 교체).
 //
-// 모든 인자는 nil 허용 안 함 (redis 만 nil 허용 — 단일 인스턴스 환경에서 lock 비활성).
-// nil 인자 발견 시 error.
+// 모든 인자는 nil 허용 안 함 (redis / priorityResolver 만 nil 허용).
+// priorityResolver 가 nil 이면 republish job 의 priority 가 항상 PriorityNormal (기존 동작 호환).
 func NewUpgrader(
 	repo repository.FetcherRuleRepository,
 	resolver Resolver,
 	tracker primitive.RawIDTracker,
 	rawSvc service.RawContentService,
 	pub bus.UpgradePublisher,
+	priorityResolver bus.PriorityResolver,
 	redisClient *goredis.Client,
 	log *logger.Logger,
 ) (*Upgrader, error) {
@@ -103,13 +105,14 @@ func NewUpgrader(
 		return nil, errors.New("rule: NewUpgrader requires non-nil Logger")
 	}
 	return &Upgrader{
-		repo:       repo,
-		resolver:   resolver,
-		tracker:    tracker,
-		rawSvc:     rawSvc,
-		upgradePub: pub,
-		redis:      redisClient,
-		log:        log,
+		repo:             repo,
+		resolver:         resolver,
+		tracker:          tracker,
+		rawSvc:           rawSvc,
+		upgradePub:       pub,
+		priorityResolver: priorityResolver,
+		redis:            redisClient,
+		log:              log,
 	}, nil
 }
 
@@ -220,10 +223,16 @@ func (u *Upgrader) republishRaws(ctx context.Context, host string, rawIDs []stri
 					"original_raw_id":            rawID,
 				},
 			},
-			Priority:    core.PriorityNormal,
 			ScheduledAt: time.Now(),
 			Timeout:     republishedJobTimeout,
 			MaxRetries:  3,
+		}
+		// 이슈 #521 — priorityResolver 가 host/path 기반 priority 결정.
+		// nil 이면 PriorityNormal fallback (기존 동작 호환).
+		if u.priorityResolver != nil {
+			job.Priority = u.priorityResolver.Resolve(job)
+		} else {
+			job.Priority = core.PriorityNormal
 		}
 		data, err := job.Marshal()
 		if err != nil {
@@ -232,7 +241,7 @@ func (u *Upgrader) republishRaws(ctx context.Context, host string, rawIDs []stri
 			continue
 		}
 		msgs = append(msgs, queue.Message{
-			Topic: queue.TopicCrawlNormal,
+			Topic: bus.CrawlTopic(job.Priority),
 			Key:   []byte(job.ID),
 			Value: data,
 			Headers: map[string]string{

--- a/internal/storage/model/parser_rule.go
+++ b/internal/storage/model/parser_rule.go
@@ -85,6 +85,9 @@ type ParserRuleRecord struct {
 	PageType    string
 	// Article 은 룰이 적용되는 페이지가 뉴스 기사 본문인지 표시합니다 (이슈 #421).
 	Article bool
+	// CrawlPriority 는 host/path 매칭된 URL 의 crawl 우선순위입니다 (이슈 #521).
+	// 1=high / 2=normal / 3=low — core.Priority 매핑 동일. DEFAULT 2.
+	CrawlPriority int16
 
 	CreatedAt time.Time
 	UpdatedAt time.Time

--- a/internal/storage/postgres/parser_rule.go
+++ b/internal/storage/postgres/parser_rule.go
@@ -36,9 +36,9 @@ func NewParserRuleRepository(pool *pgxpool.Pool, log *logger.Logger) repository.
 
 const sqlInsertParserRule = `
 INSERT INTO parser_rules (
-  source_name, host_pattern, path_pattern, target_type, version, enabled, selectors, confidence, description, page_type, article
+  source_name, host_pattern, path_pattern, target_type, version, enabled, selectors, confidence, description, page_type, article, crawl_priority
 ) VALUES (
-  $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11
+  $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12
 )
 RETURNING id, created_at, updated_at
 `
@@ -68,9 +68,14 @@ func (r *pgParserRuleRepository) Insert(ctx context.Context, rec *model.ParserRu
 	if rec.Version == 0 {
 		rec.Version = 1
 	}
+	// crawl_priority 미설정 (0) 은 normal (2) 로 보정 — DB DEFAULT 와 일치 (이슈 #521).
+	priority := rec.CrawlPriority
+	if priority < 1 || priority > 3 {
+		priority = 2
+	}
 	row := r.pool.QueryRow(ctx, sqlInsertParserRule,
 		rec.SourceName, rec.HostPattern, rec.PathPattern, string(rec.TargetType), rec.Version,
-		rec.Enabled, selectors, confidence, rec.Description, rec.PageType, rec.Article,
+		rec.Enabled, selectors, confidence, rec.Description, rec.PageType, rec.Article, priority,
 	)
 	if err := row.Scan(&rec.ID, &rec.CreatedAt, &rec.UpdatedAt); err != nil {
 		var pgErr *pgconn.PgError
@@ -155,7 +160,7 @@ func (r *pgParserRuleRepository) UpdatePathPattern(ctx context.Context, id int64
 }
 
 const sqlGetParserRuleByID = `
-SELECT id, source_name, host_pattern, path_pattern, target_type, version, enabled, selectors, confidence, description, page_type, article, created_at, updated_at
+SELECT id, source_name, host_pattern, path_pattern, target_type, version, enabled, selectors, confidence, description, page_type, article, crawl_priority, created_at, updated_at
 FROM parser_rules
 WHERE id = $1
 `
@@ -174,7 +179,7 @@ func (r *pgParserRuleRepository) GetByID(ctx context.Context, id int64) (*model.
 }
 
 const sqlFindParserRuleByNaturalKey = `
-SELECT id, source_name, host_pattern, path_pattern, target_type, version, enabled, selectors, confidence, description, page_type, article, created_at, updated_at
+SELECT id, source_name, host_pattern, path_pattern, target_type, version, enabled, selectors, confidence, description, page_type, article, crawl_priority, created_at, updated_at
 FROM parser_rules
 WHERE source_name  = $1
   AND host_pattern = $2
@@ -265,7 +270,7 @@ func (r *pgParserRuleRepository) HasAnyRule(ctx context.Context, hostPattern str
 //   - LENGTH(path_pattern) DESC : 더 구체적인 (긴) regex 패턴 우선 (path_pattern=” 은 길이 0 으로 마지막)
 //   - version DESC             : 같은 패턴 안에서 최신 버전 우선
 const sqlFindActiveCandidates = `
-SELECT id, source_name, host_pattern, path_pattern, target_type, version, enabled, selectors, confidence, description, page_type, article, created_at, updated_at
+SELECT id, source_name, host_pattern, path_pattern, target_type, version, enabled, selectors, confidence, description, page_type, article, crawl_priority, created_at, updated_at
 FROM parser_rules
 WHERE host_pattern = $1
   AND target_type  = $2
@@ -322,7 +327,7 @@ func (r *pgParserRuleRepository) List(ctx context.Context, f model.ParserRuleFil
 	}
 
 	query := `
-SELECT id, source_name, host_pattern, path_pattern, target_type, version, enabled, selectors, confidence, description, page_type, article, created_at, updated_at
+SELECT id, source_name, host_pattern, path_pattern, target_type, version, enabled, selectors, confidence, description, page_type, article, crawl_priority, created_at, updated_at
 FROM parser_rules
 WHERE 1=1`
 	args := make([]any, 0, 4)
@@ -394,7 +399,7 @@ func scanParserRule(s scanner) (*model.ParserRuleRecord, error) {
 	if err := s.Scan(
 		&rec.ID, &rec.SourceName, &rec.HostPattern, &rec.PathPattern, &targetType, &rec.Version,
 		&rec.Enabled, &selectorsRaw, &confidenceRaw, &rec.Description, &rec.PageType, &rec.Article,
-		&rec.CreatedAt, &rec.UpdatedAt,
+		&rec.CrawlPriority, &rec.CreatedAt, &rec.UpdatedAt,
 	); err != nil {
 		return nil, err
 	}

--- a/internal/storage/postgres/parser_rule.go
+++ b/internal/storage/postgres/parser_rule.go
@@ -69,10 +69,13 @@ func (r *pgParserRuleRepository) Insert(ctx context.Context, rec *model.ParserRu
 		rec.Version = 1
 	}
 	// crawl_priority 미설정 (0) 은 normal (2) 로 보정 — DB DEFAULT 와 일치 (이슈 #521).
+	// 보정된 값을 rec.CrawlPriority 에 다시 반영해 in-memory 와 DB row 의 값을 일치시킴
+	// (coderabbit 피드백 #3274112959 — caller 가 Insert 후 rec 의 priority 를 참조해도 정합).
 	priority := rec.CrawlPriority
 	if priority < 1 || priority > 3 {
 		priority = 2
 	}
+	rec.CrawlPriority = priority
 	row := r.pool.QueryRow(ctx, sqlInsertParserRule,
 		rec.SourceName, rec.HostPattern, rec.PathPattern, string(rec.TargetType), rec.Version,
 		rec.Enabled, selectors, confidence, rec.Description, rec.PageType, rec.Article, priority,

--- a/migrations/down/032_parser_rules_crawl_priority.sql
+++ b/migrations/down/032_parser_rules_crawl_priority.sql
@@ -1,0 +1,7 @@
+-- 032_parser_rules_crawl_priority (down): crawl_priority 컬럼 + CHECK 제약 제거
+
+ALTER TABLE parser_rules
+  DROP CONSTRAINT IF EXISTS parser_rules_crawl_priority_range;
+
+ALTER TABLE parser_rules
+  DROP COLUMN IF EXISTS crawl_priority;

--- a/migrations/up/032_parser_rules_crawl_priority.sql
+++ b/migrations/up/032_parser_rules_crawl_priority.sql
@@ -1,0 +1,36 @@
+-- 032_parser_rules_crawl_priority: parser_rules 에 crawl_priority 컬럼 추가 (이슈 #521, 메타 #515 Sub 1)
+--
+-- 배경:
+--   현 운영에서 95%+ 트래픽이 Normal 토픽 단일 경로로 흐름 (이슈 #515 분석).
+--   bus.RuleBasedPriorityResolver 가 wiring 만 됐고 룰 0건이라 dead wiring 상태.
+--   host_pattern + path_pattern 이 이미 parser_rules 에 존재하므로 같은 row 에
+--   crawl_priority 를 함께 두면 RuleBasedPriorityResolver 가 자연스럽게 host/path 기반
+--   priority 분기를 수행 가능.
+--
+-- 스키마:
+--   - crawl_priority SMALLINT NOT NULL DEFAULT 2
+--   - 매핑: 1=high / 2=normal / 3=low — core.Priority 와 동일 (scheduler_entries.priority 와 정렬)
+--   - CHECK 제약: 1~3 만 허용 — 잘못된 값 진입 차단
+--
+-- 호환성:
+--   - DEFAULT 2 (normal) — 기존 모든 룰의 라우팅 동작 100% 보존
+--   - 운영자가 명시적으로 1 (high) / 3 (low) 로 지정한 룰만 분기 효과
+--
+-- 적용 흐름:
+--   1. 본 migration 으로 컬럼 추가 (모든 row 가 2 로 초기화)
+--   2. 운영자가 breaking-news / archive 등의 host/path 룰에 1 또는 3 명시
+--   3. RuleBasedPriorityResolver 가 parser_rules 를 lookup 하여 host/path → priority 결정
+--   4. 매칭 룰 없으면 DefaultPriorityResolver fallback (Normal)
+
+ALTER TABLE parser_rules
+  ADD COLUMN IF NOT EXISTS crawl_priority SMALLINT NOT NULL DEFAULT 2;
+
+ALTER TABLE parser_rules
+  DROP CONSTRAINT IF EXISTS parser_rules_crawl_priority_range;
+
+ALTER TABLE parser_rules
+  ADD CONSTRAINT parser_rules_crawl_priority_range
+    CHECK (crawl_priority BETWEEN 1 AND 3);
+
+COMMENT ON COLUMN parser_rules.crawl_priority IS
+  'host/path 매칭된 URL 의 crawl 우선순위. 1=high / 2=normal / 3=low (core.Priority 매핑). RuleBasedPriorityResolver 가 lookup 하여 chained / upgrade URL 발행 시 토픽 라우팅 결정. 이슈 #521 / 메타 #515.';

--- a/test/internal/bus/priority_refresher_test.go
+++ b/test/internal/bus/priority_refresher_test.go
@@ -1,0 +1,125 @@
+// PriorityRulesRefresher 의 부팅 hydrate + 주기 refresh + loader 에러 처리 검증 (이슈 #521).
+package bus_test
+
+import (
+	"context"
+	"errors"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"issuetracker/internal/bus"
+	"issuetracker/internal/processor/fetcher/core"
+)
+
+func TestPriorityRulesRefresher_BootHydrate_AppliesImmediately(t *testing.T) {
+	resolver := bus.NewRuleBasedPriorityResolver(core.PriorityNormal)
+
+	loader := func(_ context.Context) ([]bus.HostPathPriorityRule, error) {
+		return []bus.HostPathPriorityRule{
+			{HostPattern: "boot.example.com", PathPattern: "", Priority: core.PriorityHigh},
+		}, nil
+	}
+
+	// interval 을 길게 설정 — 부팅 hydrate 만 검증.
+	refresher := bus.NewPriorityRulesRefresher(resolver, loader, time.Hour, nil)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	refresher.Start(ctx)
+
+	// Start 가 즉시 refreshOnce 호출 — 룰이 적용되어 있어야 함.
+	job := &core.CrawlJob{Target: core.Target{URL: "https://boot.example.com/"}}
+	assert.Equal(t, core.PriorityHigh, resolver.Resolve(job))
+}
+
+func TestPriorityRulesRefresher_LoaderError_RetainsPreviousRules(t *testing.T) {
+	resolver := bus.NewRuleBasedPriorityResolver(core.PriorityNormal)
+	// 초기 룰 직접 주입.
+	resolver.SetHostPathRules([]bus.HostPathPriorityRule{
+		{HostPattern: "prev.example.com", PathPattern: "", Priority: core.PriorityLow},
+	})
+
+	loader := func(_ context.Context) ([]bus.HostPathPriorityRule, error) {
+		return nil, errors.New("db connection lost")
+	}
+
+	refresher := bus.NewPriorityRulesRefresher(resolver, loader, time.Hour, nil)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	refresher.Start(ctx)
+
+	// 에러 시 기존 룰 유지 — prev.example.com 가 여전히 Low 로 매칭.
+	job := &core.CrawlJob{Target: core.Target{URL: "https://prev.example.com/x"}}
+	assert.Equal(t, core.PriorityLow, resolver.Resolve(job))
+}
+
+func TestPriorityRulesRefresher_PeriodicRefresh_PicksUpChanges(t *testing.T) {
+	resolver := bus.NewRuleBasedPriorityResolver(core.PriorityNormal)
+
+	var callCount int32
+	loader := func(_ context.Context) ([]bus.HostPathPriorityRule, error) {
+		n := atomic.AddInt32(&callCount, 1)
+		if n == 1 {
+			return []bus.HostPathPriorityRule{
+				{HostPattern: "first.example.com", PathPattern: "", Priority: core.PriorityHigh},
+			}, nil
+		}
+		return []bus.HostPathPriorityRule{
+			{HostPattern: "second.example.com", PathPattern: "", Priority: core.PriorityLow},
+		}, nil
+	}
+
+	// 짧은 interval — ticker 가 한 번은 발화하도록.
+	refresher := bus.NewPriorityRulesRefresher(resolver, loader, 50*time.Millisecond, nil)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	refresher.Start(ctx)
+
+	// 부팅 호출 1번 — first 룰.
+	firstJob := &core.CrawlJob{Target: core.Target{URL: "https://first.example.com/"}}
+	assert.Equal(t, core.PriorityHigh, resolver.Resolve(firstJob))
+
+	// ticker 발화 대기 (50ms × 3 = 150ms 안에 최소 2번 더 호출).
+	time.Sleep(200 * time.Millisecond)
+
+	// 이제 second 룰 적용 — first 미매칭.
+	assert.Equal(t, core.PriorityNormal, resolver.Resolve(firstJob))
+	secondJob := &core.CrawlJob{Target: core.Target{URL: "https://second.example.com/x"}}
+	assert.Equal(t, core.PriorityLow, resolver.Resolve(secondJob))
+}
+
+func TestPriorityRulesRefresher_CtxCancel_StopsTicker(t *testing.T) {
+	resolver := bus.NewRuleBasedPriorityResolver(core.PriorityNormal)
+
+	var callCount int32
+	loader := func(_ context.Context) ([]bus.HostPathPriorityRule, error) {
+		atomic.AddInt32(&callCount, 1)
+		return nil, nil
+	}
+
+	refresher := bus.NewPriorityRulesRefresher(resolver, loader, 30*time.Millisecond, nil)
+	ctx, cancel := context.WithCancel(context.Background())
+	refresher.Start(ctx)
+
+	// 부팅 호출 1번 발생 후 즉시 cancel.
+	cancel()
+
+	// cancel 후 ticker 가 종료되어 추가 호출 없음 — 짧은 sleep 후 카운트 안정.
+	time.Sleep(100 * time.Millisecond)
+	stableCount := atomic.LoadInt32(&callCount)
+	time.Sleep(100 * time.Millisecond)
+	finalCount := atomic.LoadInt32(&callCount)
+	assert.Equal(t, stableCount, finalCount, "ticker should not fire after ctx cancel")
+}
+
+func TestNewPriorityRulesRefresher_ZeroInterval_UsesDefault(t *testing.T) {
+	// interval <= 0 → 5분 default — 사이드이펙트 없는 정합성 검증 (panic 안 함).
+	resolver := bus.NewRuleBasedPriorityResolver(core.PriorityNormal)
+	loader := func(_ context.Context) ([]bus.HostPathPriorityRule, error) { return nil, nil }
+
+	refresher := bus.NewPriorityRulesRefresher(resolver, loader, 0, nil)
+	assert.NotNil(t, refresher)
+}

--- a/test/internal/bus/priority_refresher_test.go
+++ b/test/internal/bus/priority_refresher_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"issuetracker/internal/bus"
 	"issuetracker/internal/processor/fetcher/core"
@@ -91,7 +92,10 @@ func TestPriorityRulesRefresher_PeriodicRefresh_PicksUpChanges(t *testing.T) {
 	assert.Equal(t, core.PriorityLow, resolver.Resolve(secondJob))
 }
 
-func TestPriorityRulesRefresher_CtxCancel_StopsTicker(t *testing.T) {
+func TestPriorityRulesRefresher_CtxCancel_EventuallyStopsTicker(t *testing.T) {
+	// select 가 ctx.Done() 과 ticker.C 동시 ready 시 ticker 분기를 우연히 선택할 수 있어
+	// "cancel 직후 카운트 동결" 검증은 flaky (Copilot 피드백 #3274137500).
+	// 대신 "어느 시점부터는 카운트가 더 이상 증가하지 않음" 을 require.Eventually 로 검증.
 	resolver := bus.NewRuleBasedPriorityResolver(core.PriorityNormal)
 
 	var callCount int32
@@ -104,15 +108,15 @@ func TestPriorityRulesRefresher_CtxCancel_StopsTicker(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	refresher.Start(ctx)
 
-	// 부팅 호출 1번 발생 후 즉시 cancel.
 	cancel()
 
-	// cancel 후 ticker 가 종료되어 추가 호출 없음 — 짧은 sleep 후 카운트 안정.
-	time.Sleep(100 * time.Millisecond)
-	stableCount := atomic.LoadInt32(&callCount)
-	time.Sleep(100 * time.Millisecond)
-	finalCount := atomic.LoadInt32(&callCount)
-	assert.Equal(t, stableCount, finalCount, "ticker should not fire after ctx cancel")
+	// 500ms 안에 카운트가 정지해야 함 — 50ms 마다 200ms 윈도우에서 동일 카운트면 정지로 판정.
+	require.Eventually(t, func() bool {
+		c1 := atomic.LoadInt32(&callCount)
+		time.Sleep(200 * time.Millisecond)
+		c2 := atomic.LoadInt32(&callCount)
+		return c1 == c2
+	}, 1500*time.Millisecond, 50*time.Millisecond, "ticker should eventually stop firing after ctx cancel")
 }
 
 func TestNewPriorityRulesRefresher_ZeroInterval_UsesDefault(t *testing.T) {

--- a/test/internal/bus/resolver_test.go
+++ b/test/internal/bus/resolver_test.go
@@ -1,0 +1,166 @@
+// RuleBasedPriorityResolver 의 host/path 룰 라우팅 검증 (이슈 #521).
+//
+// 기존 PriorityRule (함수형) 은 기존 흐름 보존을 위해 별도 테스트 — 본 파일은 신규 host/path
+// hydrate 경로 + matchHostPath 위주.
+package bus_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"issuetracker/internal/bus"
+	"issuetracker/internal/processor/fetcher/core"
+)
+
+func makeJobWithURL(url string) *core.CrawlJob {
+	return &core.CrawlJob{
+		Target: core.Target{
+			URL: url,
+		},
+	}
+}
+
+func TestRuleBasedPriorityResolver_HostPathRule_ExactHostAndPathMatch_ReturnsPriority(t *testing.T) {
+	r := bus.NewRuleBasedPriorityResolver(core.PriorityNormal)
+	r.SetHostPathRules([]bus.HostPathPriorityRule{
+		{HostPattern: "breaking.example.com", PathPattern: "^/news/", Priority: core.PriorityHigh},
+	})
+
+	job := makeJobWithURL("https://breaking.example.com/news/headline-123")
+
+	assert.True(t, r.CanResolve(job))
+	assert.Equal(t, core.PriorityHigh, r.Resolve(job))
+}
+
+func TestRuleBasedPriorityResolver_HostPathRule_HostMatchPathMismatch_FallsThrough(t *testing.T) {
+	// path regex 가 매칭 안 되면 룰 미적용 → CanResolve=false (다음 chain 으로 위임).
+	r := bus.NewRuleBasedPriorityResolver(core.PriorityNormal)
+	r.SetHostPathRules([]bus.HostPathPriorityRule{
+		{HostPattern: "breaking.example.com", PathPattern: "^/news/", Priority: core.PriorityHigh},
+	})
+
+	job := makeJobWithURL("https://breaking.example.com/sports/different")
+
+	assert.False(t, r.CanResolve(job))
+	// fallback (PriorityNormal) 반환 — CanResolve=false 임에도 Resolve 가 fallback 보장.
+	assert.Equal(t, core.PriorityNormal, r.Resolve(job))
+}
+
+func TestRuleBasedPriorityResolver_HostPathRule_EmptyPath_MatchesAllPaths(t *testing.T) {
+	// path_pattern 이 빈 문자열이면 host catch-all 룰 — 모든 path 매칭.
+	r := bus.NewRuleBasedPriorityResolver(core.PriorityNormal)
+	r.SetHostPathRules([]bus.HostPathPriorityRule{
+		{HostPattern: "archive.example.com", PathPattern: "", Priority: core.PriorityLow},
+	})
+
+	cases := []string{
+		"https://archive.example.com/",
+		"https://archive.example.com/old/article",
+		"https://archive.example.com/anything",
+	}
+	for _, url := range cases {
+		job := makeJobWithURL(url)
+		assert.True(t, r.CanResolve(job), "URL %s should match host catch-all", url)
+		assert.Equal(t, core.PriorityLow, r.Resolve(job), "URL %s should resolve to Low", url)
+	}
+}
+
+func TestRuleBasedPriorityResolver_HostPathRule_HostMismatch_FallsThrough(t *testing.T) {
+	r := bus.NewRuleBasedPriorityResolver(core.PriorityNormal)
+	r.SetHostPathRules([]bus.HostPathPriorityRule{
+		{HostPattern: "breaking.example.com", PathPattern: "", Priority: core.PriorityHigh},
+	})
+
+	job := makeJobWithURL("https://other.example.com/news/abc")
+
+	assert.False(t, r.CanResolve(job))
+	assert.Equal(t, core.PriorityNormal, r.Resolve(job))
+}
+
+func TestRuleBasedPriorityResolver_HostPathRule_InvalidRegex_SilentlySkipped(t *testing.T) {
+	// path_pattern 이 RE2 컴파일 실패하면 해당 룰만 제외하고 나머지는 유지.
+	r := bus.NewRuleBasedPriorityResolver(core.PriorityNormal)
+	r.SetHostPathRules([]bus.HostPathPriorityRule{
+		{HostPattern: "bad.example.com", PathPattern: "[invalid(", Priority: core.PriorityHigh},
+		{HostPattern: "good.example.com", PathPattern: "^/x/", Priority: core.PriorityHigh},
+	})
+
+	// bad rule 은 skip — host 만 매칭으로는 fallback.
+	badJob := makeJobWithURL("https://bad.example.com/anywhere")
+	assert.False(t, r.CanResolve(badJob))
+
+	// good rule 은 정상 동작.
+	goodJob := makeJobWithURL("https://good.example.com/x/y")
+	assert.True(t, r.CanResolve(goodJob))
+	assert.Equal(t, core.PriorityHigh, r.Resolve(goodJob))
+}
+
+func TestRuleBasedPriorityResolver_HostPathRule_MalformedURL_FallsThrough(t *testing.T) {
+	r := bus.NewRuleBasedPriorityResolver(core.PriorityNormal)
+	r.SetHostPathRules([]bus.HostPathPriorityRule{
+		{HostPattern: "x", PathPattern: "", Priority: core.PriorityHigh},
+	})
+
+	// 빈 URL — url.Parse 가 host 빈 문자열 반환 → matchHostPath false.
+	job := makeJobWithURL("")
+	assert.False(t, r.CanResolve(job))
+	assert.Equal(t, core.PriorityNormal, r.Resolve(job))
+}
+
+func TestRuleBasedPriorityResolver_HostPathRule_AtomicReplace(t *testing.T) {
+	// SetHostPathRules 가 atomic 교체 — 두 번째 호출이 첫 번째 룰을 완전히 대체.
+	r := bus.NewRuleBasedPriorityResolver(core.PriorityNormal)
+	r.SetHostPathRules([]bus.HostPathPriorityRule{
+		{HostPattern: "first.example.com", PathPattern: "", Priority: core.PriorityHigh},
+	})
+
+	firstJob := makeJobWithURL("https://first.example.com/")
+	assert.True(t, r.CanResolve(firstJob))
+
+	// 두 번째 호출 — first 룰 제거.
+	r.SetHostPathRules([]bus.HostPathPriorityRule{
+		{HostPattern: "second.example.com", PathPattern: "", Priority: core.PriorityLow},
+	})
+
+	// first 는 더 이상 매칭 안 됨.
+	assert.False(t, r.CanResolve(firstJob))
+
+	// second 는 매칭.
+	secondJob := makeJobWithURL("https://second.example.com/x")
+	assert.True(t, r.CanResolve(secondJob))
+	assert.Equal(t, core.PriorityLow, r.Resolve(secondJob))
+}
+
+func TestRuleBasedPriorityResolver_HostPathRule_NilOrEmpty_NoOp(t *testing.T) {
+	r := bus.NewRuleBasedPriorityResolver(core.PriorityNormal)
+	// hostPathPtr 미초기화 상태.
+	job := makeJobWithURL("https://any.example.com/")
+	assert.False(t, r.CanResolve(job))
+	assert.Equal(t, core.PriorityNormal, r.Resolve(job))
+
+	// 빈 슬라이스로 SetHostPathRules — 동일하게 매칭 없음.
+	r.SetHostPathRules(nil)
+	assert.False(t, r.CanResolve(job))
+
+	r.SetHostPathRules([]bus.HostPathPriorityRule{})
+	assert.False(t, r.CanResolve(job))
+}
+
+func TestRuleBasedPriorityResolver_FunctionalRulesEvaluatedBeforeHostPath(t *testing.T) {
+	// AddRule (함수형) 이 SetHostPathRules (host/path) 보다 먼저 평가됨 — 정합 일관.
+	r := bus.NewRuleBasedPriorityResolver(core.PriorityNormal)
+	r.AddRule(func(job *core.CrawlJob) bool {
+		return job.CrawlerName == "vip"
+	}, core.PriorityHigh)
+	r.SetHostPathRules([]bus.HostPathPriorityRule{
+		{HostPattern: "any.example.com", PathPattern: "", Priority: core.PriorityLow},
+	})
+
+	// CrawlerName=vip + host=any.example.com — 함수형 룰 우선.
+	job := &core.CrawlJob{
+		CrawlerName: "vip",
+		Target:      core.Target{URL: "https://any.example.com/"},
+	}
+	assert.Equal(t, core.PriorityHigh, r.Resolve(job))
+}

--- a/test/internal/bus/resolver_test.go
+++ b/test/internal/bus/resolver_test.go
@@ -147,6 +147,40 @@ func TestRuleBasedPriorityResolver_HostPathRule_NilOrEmpty_NoOp(t *testing.T) {
 	assert.False(t, r.CanResolve(job))
 }
 
+func TestRuleBasedPriorityResolver_HostPathRule_PortInURL_MatchesHostname(t *testing.T) {
+	// URL 에 port 가 포함되어도 u.Hostname() 으로 정규화되어 host_pattern 매칭 성공
+	// (gemini #3274133274 / Copilot #3274137309).
+	r := bus.NewRuleBasedPriorityResolver(core.PriorityNormal)
+	r.SetHostPathRules([]bus.HostPathPriorityRule{
+		{HostPattern: "api.example.com", PathPattern: "", Priority: core.PriorityHigh},
+	})
+
+	cases := []string{
+		"https://api.example.com/v1/x",
+		"https://api.example.com:443/v1/x",
+		"https://api.example.com:8080/v1/x",
+		"http://api.example.com:80/v1/x",
+	}
+	for _, url := range cases {
+		job := makeJobWithURL(url)
+		assert.True(t, r.CanResolve(job), "URL %s should match hostname (port stripped)", url)
+		assert.Equal(t, core.PriorityHigh, r.Resolve(job))
+	}
+}
+
+func TestRuleBasedPriorityResolver_HostPathRule_HostCaseInsensitive(t *testing.T) {
+	// URL 의 host 대소문자가 달라도 lowercase 정규화로 매칭 (Copilot #3274137309).
+	r := bus.NewRuleBasedPriorityResolver(core.PriorityNormal)
+	r.SetHostPathRules([]bus.HostPathPriorityRule{
+		// 룰 host 도 대문자 포함 — SetHostPathRules 가 lowercase 정규화.
+		{HostPattern: "API.Example.com", PathPattern: "", Priority: core.PriorityHigh},
+	})
+
+	job := makeJobWithURL("https://api.example.COM/")
+	assert.True(t, r.CanResolve(job))
+	assert.Equal(t, core.PriorityHigh, r.Resolve(job))
+}
+
 func TestRuleBasedPriorityResolver_HostPathRule_SpecificPathBeatsCatchAll(t *testing.T) {
 	// 같은 host 안에서 catch-all (path="") 룰이 specific path 룰을 shadow 하면 안 됨
 	// (coderabbit 피드백 #3274112935). SetHostPathRules 가 LENGTH(path) DESC 정렬 수행.

--- a/test/internal/bus/resolver_test.go
+++ b/test/internal/bus/resolver_test.go
@@ -147,6 +147,24 @@ func TestRuleBasedPriorityResolver_HostPathRule_NilOrEmpty_NoOp(t *testing.T) {
 	assert.False(t, r.CanResolve(job))
 }
 
+func TestRuleBasedPriorityResolver_HostPathRule_SpecificPathBeatsCatchAll(t *testing.T) {
+	// 같은 host 안에서 catch-all (path="") 룰이 specific path 룰을 shadow 하면 안 됨
+	// (coderabbit 피드백 #3274112935). SetHostPathRules 가 LENGTH(path) DESC 정렬 수행.
+	r := bus.NewRuleBasedPriorityResolver(core.PriorityNormal)
+	r.SetHostPathRules([]bus.HostPathPriorityRule{
+		// catch-all 을 specific 앞에 명시적으로 배치 — 정렬이 동작해야 specific 가 먼저 평가됨.
+		{HostPattern: "mixed.example.com", PathPattern: "", Priority: core.PriorityLow},
+		{HostPattern: "mixed.example.com", PathPattern: "^/breaking/", Priority: core.PriorityHigh},
+	})
+
+	breakingJob := makeJobWithURL("https://mixed.example.com/breaking/headline")
+	assert.Equal(t, core.PriorityHigh, r.Resolve(breakingJob), "specific path 가 catch-all 보다 우선")
+
+	// catch-all 은 specific 미매칭 시 정상 fallback.
+	otherJob := makeJobWithURL("https://mixed.example.com/other/path")
+	assert.Equal(t, core.PriorityLow, r.Resolve(otherJob), "specific 미매칭 시 catch-all 적용")
+}
+
 func TestRuleBasedPriorityResolver_FunctionalRulesEvaluatedBeforeHostPath(t *testing.T) {
 	// AddRule (함수형) 이 SetHostPathRules (host/path) 보다 먼저 평가됨 — 정합 일관.
 	r := bus.NewRuleBasedPriorityResolver(core.PriorityNormal)

--- a/test/internal/processor/fetcher/rule/upgrader_test.go
+++ b/test/internal/processor/fetcher/rule/upgrader_test.go
@@ -17,7 +17,7 @@ import (
 // 전체 흐름 검증은 통합 테스트 영역.
 func TestNewUpgrader_NilDependencies_ReturnsError(t *testing.T) {
 	// 모두 nil
-	_, err := fetcherRule.NewUpgrader(nil, nil, nil, nil, nil, nil, nil)
+	_, err := fetcherRule.NewUpgrader(nil, nil, nil, nil, nil, nil, nil, nil)
 	assert.Error(t, err)
 }
 


### PR DESCRIPTION
## 연관 이슈
- Closes #521
- Parent: #515 (Phase 1)

<br>

## 구현 내용

메타 이슈 #515 의 **Phase 1** — Publisher 단계 sub 1~3 통합. 머지 직후 즉시 효과: chained article URL + upgrade URL 이 host/path 기반 priority 로 분기되어 `crawl.high / normal / low` 토픽으로 라우팅됩니다.

### Sub 1 — Migration 032 (parser_rules.crawl_priority)

- 신규 컬럼: `SMALLINT NOT NULL DEFAULT 2` (1=high / 2=normal / 3=low)
- `CHECK (crawl_priority BETWEEN 1 AND 3)` 제약
- DEFAULT 2 로 기존 룰의 라우팅 동작 100% 보존
- up/down migration 모두 작성

### Sub 2 — RuleBasedPriorityResolver DB-backed hydrate

- `model.ParserRuleRecord` 에 `CrawlPriority int16` 필드 추가
- `postgres/parser_rule.go` 의 INSERT/SELECT/scan 에 `crawl_priority` 컬럼 포함
- `bus/resolver.go`:
  - `HostPathPriorityRule` 타입 신설 (host_pattern + path_pattern + priority)
  - `RuleBasedPriorityResolver.SetHostPathRules(rules)` 추가 — `atomic.Pointer` 로 lock-free 교체
  - `Resolve` / `CanResolve` 가 함수형 룰 평가 후 host/path 룰 평가, 둘 다 미매칭 시 fallback
- `bus/priority_refresher.go` (신규) — `PriorityRulesRefresher`
  - `PriorityRulesLoader` 콜백으로 layering 분리 (bus → storage 직접 의존 회피)
  - 부팅 직후 1회 hydrate + ticker 주기 refresh (env `PRIORITY_RULES_REFRESH_INTERVAL`, default 5분)
  - loader 에러 시 기존 룰 유지 + WARN 로그
- `cmd/issuetracker/main.go`: pool 생성 후 `PriorityRulesRefresher.Start(ctx)` 호출

### Sub 3 — Upgrader 하드코딩 제거

- `Upgrader` 에 `priorityResolver bus.PriorityResolver` 필드 추가 (nil 허용 — PriorityNormal fallback)
- `republishRaws`: `job.Priority = resolver.Resolve(job)` → `msg.Topic = bus.CrawlTopic(priority)`
- 기존 `core.PriorityNormal` / `queue.TopicCrawlNormal` 하드코딩 제거

### 단위 테스트 (14 cases)

- `test/internal/bus/resolver_test.go` (9 cases) — host/path 매칭 / 잘못된 regex skip / atomic 교체 / 함수형 룰 우선 등
- `test/internal/bus/priority_refresher_test.go` (5 cases) — 부팅 hydrate / loader 에러 / 주기 refresh / ctx cancel / default interval

<br>

## CI / 머지 게이트 점검

### 변경 영향 범위
- 영향 패키지/모듈: `internal/bus`, `internal/storage/model`, `internal/storage/postgres`, `internal/processor/fetcher/rule`, `cmd/issuetracker`, `migrations/`
- 위험도: `Medium` — DB schema 변경 + resolver 핫패스 변경. 단, `crawl_priority` DEFAULT 2 + resolver nil fallback 으로 기존 동작 100% 호환.

### Required Status Checks
- 통과 확인 대상 (PR Checks 탭에서 확인):
  - [ ] `Commit Lint`
  - [ ] `PR Title Lint`
  - [ ] `Linked Issue Check`
  - [ ] `Format Check`
  - [ ] `Build`
  - [ ] `Test`
  - [ ] `Lint`

### 롤백 계획

1. `migrations/down/032_parser_rules_crawl_priority.sql` 적용 (컬럼 + CHECK 제거)
2. `main.go` 의 `PriorityRulesRefresher.Start(ctx)` 라인 + import 롤백
3. `Upgrader` 의 `priorityResolver` 인자 제거

기존 룰 0건 상태에서 머지된 경우: 운영자가 `UPDATE parser_rules SET crawl_priority = 2 WHERE crawl_priority != 2` 한 줄로 모든 우선순위 분기 즉시 무효화 가능 (resolver fallback 으로 Normal).

<br>

## 후속 작업

Phase 2 (메타 #515) — Stage priority-aware 처리 (Redis ZSET intermediate queue):
- #522 Parser stage
- #523 Validate stage (선행: #522)
- #524 Enrich stage (선행: #522)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced host and path pattern-based crawl priority rules (high/normal/low).
  * Added automatic periodic refresh of priority rules from the system configuration.
  * Enhanced job processing to respect defined URL pattern priorities during republishing.

* **Tests**
  * Comprehensive test coverage for priority rule resolution and periodic refresh behavior.

* **Database**
  * Added migration to support crawl priority storage and validation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/EinSofINTEREST/IssueTracker/pull/525?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->