### PR TITLE
[FEAT#522] Parser stage Redis ZSET intermediate queue — priority sub-ordering

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -105,6 +105,22 @@ PUBLISHER_REDIS_BUFFER_DRAIN_BATCH=100
 PUBLISHER_REDIS_BUFFER_MAX_LEN=100000
 PUBLISHER_REDIS_BUFFER_CHECK_TIMEOUT=5s
 
+# Parser stage Redis ZSET intermediate queue (이슈 #522, 메타 #515 Phase 2)
+# Kafka TopicFetched 의 partition FIFO 가 priority sub-ordering 제공 못 하는 한계 해소.
+# Kafka 메시지를 Redis ZSET 에 인입 (intake goroutine) → Worker pool 이 BZPOPMIN 으로 pop.
+# score = priority(1=high/2=normal/3=low) × 1e13 + arrival_ts_ms — priority dominant 정렬.
+#
+# 활성화 조건: 본 ENABLED=true + Redis 가용 + RetryScheduler 설정. 셋 중 하나라도 미충족 시
+# 안전 fallback (기존 Kafka consume 흐름).
+#
+# 처리 실패 시 RetryScheduler 경유로 Kafka 재발행 → 다음 intake 가 ZSET 으로 흡수 (Redis 잔존 X).
+PARSER_PRIORITY_QUEUE_ENABLED=false
+PARSER_ZSET_QUEUE_KEY=parser:zset:queue
+PARSER_ZSET_ENTRY_PREFIX=parser:zset:entry:
+PARSER_ZSET_MAX_SIZE=100000
+PARSER_ZSET_ENTRY_TTL=24h
+PARSER_ZSET_POP_TIMEOUT=1s
+
 # Classifier 서비스 연결 설정
 CLASSIFIER_HTTP_ADDR=http://localhost:8000
 CLASSIFIER_GRPC_ADDR=localhost:50051

--- a/cmd/issuetracker/main.go
+++ b/cmd/issuetracker/main.go
@@ -709,9 +709,43 @@ func main() {
 	// fetcher 와 분리된 별도 consumer group (issuetracker-parsers) 으로 동작 — 인스턴스 수 독립 스케일.
 	// TopicFetched 의 RawContentRef 를 consume 하여 raw 로드 + 파싱 + content 저장 + raw 삭제.
 	// 파싱 실패 (rule.Error) 시 raw 잔존 → LLM 재처리 윈도우.
+	//
+	// 이슈 #522 — ZSET 인입 모드 (PARSER_PRIORITY_QUEUE_ENABLED=true + redisClientShared) :
+	//   - Kafka consumer → ZSET intake goroutine (별도) 가 ZSET 으로 적재
+	//   - Worker 는 ZSET consumer 로 BZPOPMIN → priority sub-ordering 보장
+	//   - 처리 실패 시 RetryScheduler 경유로 Kafka 재발행 (Redis 잔존 X)
 	parserKafkaCfg := queue.DefaultConfig()
 	parserKafkaCfg.GroupID = queue.GroupParsers
-	parserConsumer := queue.NewConsumer(parserKafkaCfg, queue.TopicFetched)
+	parserKafkaConsumer := queue.NewConsumer(parserKafkaCfg, queue.TopicFetched)
+
+	// priorityQueueEnabled 가 true 면 Worker 는 ZSET consumer 를, intake 가 kafka consumer 를 사용.
+	// false 면 Worker 가 kafka consumer 를 직접 사용 (기존 동작).
+	parserPriorityQueueEnabled := envBoolOrDefault("PARSER_PRIORITY_QUEUE_ENABLED", false) && redisClientShared != nil
+	var parserConsumer bus.Consumer = parserKafkaConsumer
+	var parserZSetIntake *parserWorker.ZSetIntake
+	var parserZSetQueue *queue.PriorityZSetQueue
+	if parserPriorityQueueEnabled {
+		zsetCfg := queue.PriorityZSetConfig{
+			ZSetKey:        envOrDefault("PARSER_ZSET_QUEUE_KEY", "parser:zset:queue"),
+			EntryKeyPrefix: envOrDefault("PARSER_ZSET_ENTRY_PREFIX", "parser:zset:entry:"),
+			MaxSize:        int64(envIntOrDefault("PARSER_ZSET_MAX_SIZE", int(queue.PriorityZSetMaxSize))),
+			EntryTTL:       envDurationOrDefault("PARSER_ZSET_ENTRY_TTL", queue.PriorityZSetEntryTTL),
+		}
+		var qerr error
+		parserZSetQueue, qerr = queue.NewPriorityZSetQueue(redisClientShared.Raw(), zsetCfg)
+		if qerr != nil {
+			log.WithError(qerr).Fatal("failed to construct parser priority zset queue")
+		}
+		zsetConsumer := queue.NewPriorityZSetConsumer(parserZSetQueue, "parser:zset", envDurationOrDefault("PARSER_ZSET_POP_TIMEOUT", time.Second))
+		parserConsumer = zsetConsumer
+		parserZSetIntake = parserWorker.NewZSetIntake(parserKafkaConsumer, parserZSetQueue, log)
+		log.WithFields(map[string]interface{}{
+			"zset_key":     zsetCfg.ZSetKey,
+			"entry_prefix": zsetCfg.EntryKeyPrefix,
+			"max_size":     zsetCfg.MaxSize,
+			"entry_ttl_ms": zsetCfg.EntryTTL.Milliseconds(),
+		}).Info("parser priority zset queue enabled")
+	}
 	// sample URL 누적 — parser_worker 가 정상 파싱 후 누적, 단계 4-2 의 정밀화 트리거 입력.
 	sampleRepo := decorator.WrapSampleURLWithTimeout(pgstore.NewSampleURLRepository(pool, log), dbCfg.QueryTimeout)
 
@@ -731,8 +765,8 @@ func main() {
 	}
 
 	w := parserWorker.NewWorker(
-		parserConsumer,
-		jobPublisher, // 이슈 #392 — 구 producer + JobPublisher 두 인자 통합 (bus.Publisher 가 Forward + PublishChained 모두 제공)
+		parserConsumer, // ZSET 모드면 zsetConsumer, 아니면 kafka consumer (이슈 #522)
+		jobPublisher,   // 이슈 #392 — 구 producer + JobPublisher 두 인자 통합 (bus.Publisher 가 Forward + PublishChained 모두 제공)
 		rawSvc,
 		contentSvc,
 		ruleParser,
@@ -753,6 +787,19 @@ func main() {
 	// Category cycle 종료 시 marker release — scheduler 다음 주기에 즉시 진입 가능.
 	if pipelineGuard != nil {
 		w.SetPipelineGuard(pipelineGuard)
+	}
+
+	// ── RetryScheduler 주입 (이슈 #522) ────────────────────────────
+	// ZSET 인입 모드에서는 BZPOPMIN 이 곧 ack 라 commit skip 으로 redeliver 가 불가.
+	// RetryScheduler 가 주입되어야 ProcessMessage 실패 시 Kafka 재발행 → 다음 intake → ZSET 재진입
+	// 패턴으로 메시지 손실 방지. retryScheduler 가 nil 인 환경에서 ZSET 모드 활성화하면 처리 실패가
+	// 메시지 손실로 이어지므로 fatal.
+	if parserPriorityQueueEnabled {
+		if retryScheduler == nil {
+			log.Fatal("parser priority zset queue enabled but retry scheduler not configured — set REDIS_HOST or disable PARSER_PRIORITY_QUEUE_ENABLED")
+		}
+		w.SetRetryScheduler(retryScheduler)
+		log.Info("parser worker: retry scheduler injected (zset mode message loss guard)")
 	}
 
 	// ── Precheck 게이트 (이슈 #425) ───────────────────────────────────
@@ -1132,6 +1179,11 @@ func main() {
 	if err != nil {
 		log.WithError(err).Fatal("failed to construct parser stage")
 	}
+	// 이슈 #522 — ZSET 인입 모드일 때 intake goroutine 을 parser Stage 의 lifecycle 에 묶음.
+	// Stage.Start 가 go intake.Run(ctx), ctx cancel 시 자연 종료.
+	if parserZSetIntake != nil {
+		parserStg.SetZSetIntake(parserZSetIntake)
+	}
 	validateStage, err := validate.NewStage(validateWorker)
 	if err != nil {
 		log.WithError(err).Fatal("failed to construct validate stage")
@@ -1274,6 +1326,29 @@ func envDurationOrDefault(key string, def time.Duration) time.Duration {
 		return def
 	}
 	return d
+}
+
+// envBoolOrDefault 는 환경변수에서 bool 을 파싱하여 반환합니다 (이슈 #522).
+// 미설정 시 def. "true"/"1" → true / "false"/"0" → false. 기타는 def.
+func envBoolOrDefault(key string, def bool) bool {
+	raw := os.Getenv(key)
+	if raw == "" {
+		return def
+	}
+	v, err := strconv.ParseBool(raw)
+	if err != nil {
+		return def
+	}
+	return v
+}
+
+// envOrDefault 는 환경변수에서 string 을 파싱하여 반환합니다 (이슈 #522).
+// 미설정 / 빈 값 시 def.
+func envOrDefault(key, def string) string {
+	if raw := os.Getenv(key); raw != "" {
+		return raw
+	}
+	return def
 }
 
 // envIntOrDefault 는 환경변수에서 양의 int 를 파싱하여 반환합니다 (이슈 #521).

--- a/internal/processor/parser/stage.go
+++ b/internal/processor/parser/stage.go
@@ -43,9 +43,9 @@ const stageName = "parser"
 type Stage struct {
 	worker  *worker.Worker
 	cleaner *worker.RawContentCleaner
-	llmGen  *llmgen.Generator   // nil 허용
-	refiner *refiner.Refiner    // nil 허용
-	intake  *worker.ZSetIntake  // nil 허용 — ZSET 인입 모드일 때만 (이슈 #522)
+	llmGen  *llmgen.Generator  // nil 허용
+	refiner *refiner.Refiner   // nil 허용
+	intake  *worker.ZSetIntake // nil 허용 — ZSET 인입 모드일 때만 (이슈 #522)
 	log     *logger.Logger
 }
 

--- a/internal/processor/parser/stage.go
+++ b/internal/processor/parser/stage.go
@@ -38,11 +38,14 @@ const stageName = "parser"
 //  3. llmgen.Generator (선택) — ErrNoRule async LLM 호출. Worker 가 유일 Enqueue source 이므로
 //     Worker.Stop 후에 Stop 해야 in-flight LLM 호출 완료 보장.
 //  4. refiner.Refiner (선택) — interval polling. ctx cancel 시 cycle 즉시 종료.
+//  5. ZSetIntake (선택, 이슈 #522) — Kafka → Redis ZSET 인입. Worker 가 ZSET consumer 모드로
+//     동작하는 환경에서만 활성. ctx cancel 시 종료.
 type Stage struct {
 	worker  *worker.Worker
 	cleaner *worker.RawContentCleaner
-	llmGen  *llmgen.Generator // nil 허용
-	refiner *refiner.Refiner  // nil 허용
+	llmGen  *llmgen.Generator   // nil 허용
+	refiner *refiner.Refiner    // nil 허용
+	intake  *worker.ZSetIntake  // nil 허용 — ZSET 인입 모드일 때만 (이슈 #522)
 	log     *logger.Logger
 }
 
@@ -73,6 +76,14 @@ func NewStage(
 	}, nil
 }
 
+// SetZSetIntake 는 Kafka → ZSET 인입 단계 컴포넌트를 주입합니다 (이슈 #522 / 메타 #515 Phase 2).
+//
+// nil 주입 시 ZSET 모드 비활성 — Worker 가 일반 Kafka consumer 로 동작하는 경로.
+// Start 호출 전 wiring 단계에서 1회 설정.
+func (s *Stage) SetZSetIntake(intake *worker.ZSetIntake) {
+	s.intake = intake
+}
+
 // Name 은 stage 식별자 ("parser") 를 반환합니다.
 func (s *Stage) Name() string { return stageName }
 
@@ -88,6 +99,11 @@ func (s *Stage) Start(ctx context.Context) {
 	s.cleaner.Start(ctx)
 	if s.refiner != nil {
 		s.refiner.Start(ctx)
+	}
+	// 이슈 #522 — ZSET 인입 모드. Worker 가 ZSET consumer 로 동작하므로 별도 goroutine 에서
+	// Kafka → ZSET intake 를 동시 운용. ctx cancel 시 자연 종료 (별도 Stop 메소드 불필요).
+	if s.intake != nil {
+		go s.intake.Run(ctx)
 	}
 }
 

--- a/internal/processor/parser/worker/worker.go
+++ b/internal/processor/parser/worker/worker.go
@@ -311,8 +311,8 @@ func (w *Worker) Stop(ctx context.Context) error {
 //   - ProcessMessage 성공 → commit
 //   - ErrStageGateNotAcquired → commit skip (Debug — 다른 worker 가 처리 중인 정상 dedup)
 //   - 기타 transient 에러:
-//     - retryScheduler 주입 시 (이슈 #522): RetryScheduler.Enqueue → commit (메시지 손실 방지)
-//     - retryScheduler 미주입 시: commit skip (Warn — Kafka 가 redeliver, 기존 동작)
+//   - retryScheduler 주입 시 (이슈 #522): RetryScheduler.Enqueue → commit (메시지 손실 방지)
+//   - retryScheduler 미주입 시: commit skip (Warn — Kafka 가 redeliver, 기존 동작)
 //
 // commit 실패는 ctx cancel 인 경우 강등하지 않으면 셧다운 시점에 noise. Warn 으로 가시성 유지.
 func (w *Worker) Handle(ctx context.Context, msg *queue.Message) {
@@ -355,16 +355,29 @@ func (w *Worker) Handle(ctx context.Context, msg *queue.Message) {
 
 // enqueueRetry 는 ProcessMessage 실패한 메시지를 RetryScheduler 경유로 재시도 큐에 등록합니다 (이슈 #522).
 //
-// RawContentRef → CrawlJob 변환 — URL + CrawlerName 보존. priority 는 메시지 header 에서 추출
-// (1=high / 2=normal / 3=low, 잘못된 값은 normal). Target.Type=Article (parse 단계 메시지는
-// raw 1건의 article 처리 의미). retry_reason / original_raw_id 헤더로 추적 가시성 제공.
+// RawContentRef → CrawlJob 변환은 BuildRetryJob 으로 분리 (unit test 용이성).
 func (w *Worker) enqueueRetry(ctx context.Context, msg *queue.Message, lastErr error) error {
+	job, err := BuildRetryJob(msg)
+	if err != nil {
+		return err
+	}
+	return w.retryScheduler.Enqueue(ctx, job, lastErr)
+}
+
+// BuildRetryJob 은 parse 실패한 Kafka 메시지를 retry 용 CrawlJob 으로 변환합니다 (이슈 #522).
+//
+// RawContentRef.URL + CrawlerName 보존 + priority header 추출 (1=high / 2=normal / 3=low,
+// 잘못된 값은 normal). Target.Type=Article (parse 단계 메시지는 raw 1건의 article 처리 의미).
+// retry_reason / original_raw_id 헤더로 추적 가시성 제공.
+//
+// 빈 URL 또는 unmarshal 실패 시 error — 호출자가 retry 불가로 분기.
+func BuildRetryJob(msg *queue.Message) (*core.CrawlJob, error) {
 	var ref core.RawContentRef
 	if uerr := json.Unmarshal(msg.Value, &ref); uerr != nil {
-		return fmt.Errorf("retry unmarshal: %w", uerr)
+		return nil, fmt.Errorf("retry unmarshal: %w", uerr)
 	}
 	if ref.URL == "" {
-		return fmt.Errorf("retry unmarshal: empty URL in RawContentRef %s", ref.ID)
+		return nil, fmt.Errorf("retry unmarshal: empty URL in RawContentRef %s", ref.ID)
 	}
 
 	priority := core.PriorityNormal
@@ -382,7 +395,7 @@ func (w *Worker) enqueueRetry(ctx context.Context, msg *queue.Message, lastErr e
 		crawlerName = "parser-retry"
 	}
 
-	job := &core.CrawlJob{
+	return &core.CrawlJob{
 		ID:          ref.ID,
 		CrawlerName: crawlerName,
 		Target: core.Target{
@@ -397,8 +410,7 @@ func (w *Worker) enqueueRetry(ctx context.Context, msg *queue.Message, lastErr e
 		ScheduledAt: time.Now(),
 		Timeout:     defaultJobTimeout,
 		MaxRetries:  3,
-	}
-	return w.retryScheduler.Enqueue(ctx, job, lastErr)
+	}, nil
 }
 
 // ErrStageGateNotAcquired 는 parser stage 의 ProcessingLock 이 다른 worker 에 점유 중이라

--- a/internal/processor/parser/worker/worker.go
+++ b/internal/processor/parser/worker/worker.go
@@ -119,6 +119,13 @@ type Worker struct {
 	// pool 은 workerpool harness — Start 에서 lazy 생성. lifecycle (poll / dispatch / shutdown /
 	// commit-with-drain) 을 위임 (이슈 #406 — 메타 #403 Sub 3).
 	pool *workerpool.ConsumerPool
+
+	// retryScheduler 는 ProcessMessage 실패 시 재시도 발행 경로 (이슈 #522 / 메타 #515 Phase 2).
+	// nil 허용 — nil 이면 기존 동작 (commit skip → Kafka redeliver).
+	//
+	// ZSET 인입 모드에서는 pop 이 곧 ack 이라 commit skip 으로 redeliver 불가 — RetryScheduler
+	// 주입 필수. 주입 시 Handle 이 ProcessMessage 실패에 대해 Enqueue 후 commit (메시지 손실 방지).
+	retryScheduler bus.RetryScheduler
 }
 
 // PipelineGuard 는 Category cycle 종료 시 marker 를 release 하기 위한 최소 인터페이스입니다.
@@ -226,6 +233,16 @@ func (w *Worker) SetPrecheck(d precheck.Decider) {
 	w.precheck = d
 }
 
+// SetRetryScheduler 는 ProcessMessage 실패 시 재시도 발행 경로를 주입합니다 (이슈 #522 / 메타 #515 Phase 2).
+//
+// nil 주입 시 기존 동작 (commit skip → Kafka redeliver) 유지. ZSET 인입 모드에서는 pop 이
+// 곧 ack 이라 commit skip 으로는 redeliver 불가 — 본 setter 로 RetryScheduler 를 반드시 주입.
+//
+// Start 호출 전 wiring 단계에서 1회 설정.
+func (w *Worker) SetRetryScheduler(rs bus.RetryScheduler) {
+	w.retryScheduler = rs
+}
+
 // SetStaleCounter 는 stale rule 재학습 트리거 카운터 + 임계값을 주입합니다.
 //
 // nil counter 주입 시 stale 재학습 비활성 (기존 chromedp 자동 전환만 동작).
@@ -293,7 +310,9 @@ func (w *Worker) Stop(ctx context.Context) error {
 // 흐름:
 //   - ProcessMessage 성공 → commit
 //   - ErrStageGateNotAcquired → commit skip (Debug — 다른 worker 가 처리 중인 정상 dedup)
-//   - 기타 transient 에러 → commit skip (Warn — Kafka 가 redeliver)
+//   - 기타 transient 에러:
+//     - retryScheduler 주입 시 (이슈 #522): RetryScheduler.Enqueue → commit (메시지 손실 방지)
+//     - retryScheduler 미주입 시: commit skip (Warn — Kafka 가 redeliver, 기존 동작)
 //
 // commit 실패는 ctx cancel 인 경우 강등하지 않으면 셧다운 시점에 noise. Warn 으로 가시성 유지.
 func (w *Worker) Handle(ctx context.Context, msg *queue.Message) {
@@ -306,7 +325,23 @@ func (w *Worker) Handle(ctx context.Context, msg *queue.Message) {
 			log.WithField("offset", msg.Offset).Debug("stage gate not acquired by this worker, uncommitted")
 			return
 		}
-		// ProcessMessage 가 commit 하지 않은 경우 — 재시도 위해 commit skip (Kafka 가 redeliver).
+		// retryScheduler 주입 시 — Enqueue 후 commit. ZSET 인입 모드 (pop=ack) 에서는 commit skip
+		// 으로 redeliver 가 불가능하므로 RetryScheduler 경유 (Kafka 재발행) 만이 메시지 손실 방지책.
+		if w.retryScheduler != nil {
+			if enqueueErr := w.enqueueRetry(ctx, msg, err); enqueueErr != nil {
+				log.WithError(enqueueErr).WithField("offset", msg.Offset).Warn("retry enqueue failed, message will be lost in zset mode")
+				return
+			}
+			// Enqueue 성공 — commit (메시지 손실 방지). ZSETConsumer 의 Commit 은 no-op.
+			if commitErr := w.pool.Commit(ctx, msg); commitErr != nil {
+				if ctx.Err() == nil {
+					log.WithError(commitErr).Warn("commit after retry enqueue failed")
+				}
+			}
+			log.WithError(err).WithField("offset", msg.Offset).Info("process message failed, enqueued for retry")
+			return
+		}
+		// retryScheduler 미주입 — commit skip (Kafka 가 redeliver, 기존 동작).
 		log.WithError(err).WithField("offset", msg.Offset).Warn("process message failed, will be redelivered")
 		return
 	}
@@ -316,6 +351,54 @@ func (w *Worker) Handle(ctx context.Context, msg *queue.Message) {
 			log.WithError(commitErr).Warn("commit failed after success")
 		}
 	}
+}
+
+// enqueueRetry 는 ProcessMessage 실패한 메시지를 RetryScheduler 경유로 재시도 큐에 등록합니다 (이슈 #522).
+//
+// RawContentRef → CrawlJob 변환 — URL + CrawlerName 보존. priority 는 메시지 header 에서 추출
+// (1=high / 2=normal / 3=low, 잘못된 값은 normal). Target.Type=Article (parse 단계 메시지는
+// raw 1건의 article 처리 의미). retry_reason / original_raw_id 헤더로 추적 가시성 제공.
+func (w *Worker) enqueueRetry(ctx context.Context, msg *queue.Message, lastErr error) error {
+	var ref core.RawContentRef
+	if uerr := json.Unmarshal(msg.Value, &ref); uerr != nil {
+		return fmt.Errorf("retry unmarshal: %w", uerr)
+	}
+	if ref.URL == "" {
+		return fmt.Errorf("retry unmarshal: empty URL in RawContentRef %s", ref.ID)
+	}
+
+	priority := core.PriorityNormal
+	if p, ok := msg.Headers["priority"]; ok {
+		if v, err := strconv.Atoi(p); err == nil {
+			switch core.Priority(v) {
+			case core.PriorityHigh, core.PriorityNormal, core.PriorityLow:
+				priority = core.Priority(v)
+			}
+		}
+	}
+
+	crawlerName := ref.SourceInfo.Name
+	if crawlerName == "" {
+		crawlerName = "parser-retry"
+	}
+
+	job := &core.CrawlJob{
+		ID:          ref.ID,
+		CrawlerName: crawlerName,
+		Target: core.Target{
+			URL:  ref.URL,
+			Type: core.TargetTypeArticle,
+			Metadata: map[string]interface{}{
+				"retry_reason":    "parser_process_failed",
+				"original_raw_id": ref.ID,
+			},
+		},
+		Priority:    priority,
+		ScheduledAt: time.Now(),
+		Timeout:     defaultJobTimeout,
+		MaxRetries:  3,
+	}
+	return w.retryScheduler.Enqueue(ctx, job, lastErr)
 }
 
 // ErrStageGateNotAcquired 는 parser stage 의 ProcessingLock 이 다른 worker 에 점유 중이라

--- a/internal/processor/parser/worker/worker.go
+++ b/internal/processor/parser/worker/worker.go
@@ -417,7 +417,9 @@ func BuildRetryJob(msg *queue.Message) (*core.CrawlJob, error) {
 		Priority:    priority,
 		ScheduledAt: time.Now(),
 		Timeout:     defaultJobTimeout,
-		MaxRetries:  3,
+		// MaxRetries 는 bus.DefaultMaxRetries 단일 출처 — chain.go buildJobMessages 와 일관
+		// (Copilot #3274731364 — 매직 넘버 제거).
+		MaxRetries: bus.DefaultMaxRetries,
 	}, nil
 }
 

--- a/internal/processor/parser/worker/worker.go
+++ b/internal/processor/parser/worker/worker.go
@@ -366,9 +366,15 @@ func (w *Worker) enqueueRetry(ctx context.Context, msg *queue.Message, lastErr e
 
 // BuildRetryJob 은 parse 실패한 Kafka 메시지를 retry 용 CrawlJob 으로 변환합니다 (이슈 #522).
 //
-// RawContentRef.URL + CrawlerName 보존 + priority header 추출 (1=high / 2=normal / 3=low,
-// 잘못된 값은 normal). Target.Type=Article (parse 단계 메시지는 raw 1건의 article 처리 의미).
-// retry_reason / original_raw_id 헤더로 추적 가시성 제공.
+// RawContentRef.URL + CrawlerName + priority + target_type 을 보존하며, 일부 필드는 msg.Headers
+// 가 우선:
+//   - crawler 헤더 우선, 없으면 RawContentRef.SourceInfo.Name, 둘 다 빈 값이면 "parser-retry"
+//     (gemini #3274689308 — ProcessMessage 의 헤더 우선 정책과 일관)
+//   - priority 헤더는 PriorityFromHeader 헬퍼로 통일 (gemini #3274689296)
+//   - target_type 헤더가 유효 (article/category) 이면 사용, 없거나 잘못되면 Article default
+//     (gemini #3274689285 — Category 페이지 retry 시 Article 로 오인 차단)
+//
+// retry_reason / original_raw_id 메타로 추적 가시성 제공.
 //
 // 빈 URL 또는 unmarshal 실패 시 error — 호출자가 retry 불가로 분기.
 func BuildRetryJob(msg *queue.Message) (*core.CrawlJob, error) {
@@ -380,19 +386,21 @@ func BuildRetryJob(msg *queue.Message) (*core.CrawlJob, error) {
 		return nil, fmt.Errorf("retry unmarshal: empty URL in RawContentRef %s", ref.ID)
 	}
 
-	priority := core.PriorityNormal
-	if p, ok := msg.Headers["priority"]; ok {
-		if v, err := strconv.Atoi(p); err == nil {
-			switch core.Priority(v) {
-			case core.PriorityHigh, core.PriorityNormal, core.PriorityLow:
-				priority = core.Priority(v)
-			}
-		}
-	}
+	priority := core.Priority(PriorityFromHeader(msg.Headers))
 
-	crawlerName := ref.SourceInfo.Name
+	crawlerName := msg.Headers["crawler"]
+	if crawlerName == "" {
+		crawlerName = ref.SourceInfo.Name
+	}
 	if crawlerName == "" {
 		crawlerName = "parser-retry"
+	}
+
+	targetType := core.TargetTypeArticle
+	if t, ok := msg.Headers["target_type"]; ok {
+		if tt := core.TargetType(t); isValidTargetType(tt) {
+			targetType = tt
+		}
 	}
 
 	return &core.CrawlJob{
@@ -400,7 +408,7 @@ func BuildRetryJob(msg *queue.Message) (*core.CrawlJob, error) {
 		CrawlerName: crawlerName,
 		Target: core.Target{
 			URL:  ref.URL,
-			Type: core.TargetTypeArticle,
+			Type: targetType,
 			Metadata: map[string]interface{}{
 				"retry_reason":    "parser_process_failed",
 				"original_raw_id": ref.ID,
@@ -411,6 +419,17 @@ func BuildRetryJob(msg *queue.Message) (*core.CrawlJob, error) {
 		Timeout:     defaultJobTimeout,
 		MaxRetries:  3,
 	}, nil
+}
+
+// isValidTargetType 은 retry job 에 적용 가능한 TargetType 인지 검증합니다.
+// article / category 만 허용 — 알 수 없는 값은 caller 가 Article default 로 보정.
+func isValidTargetType(t core.TargetType) bool {
+	switch t {
+	case core.TargetTypeArticle, core.TargetTypeCategory:
+		return true
+	default:
+		return false
+	}
 }
 
 // ErrStageGateNotAcquired 는 parser stage 의 ProcessingLock 이 다른 worker 에 점유 중이라

--- a/internal/processor/parser/worker/zset_intake.go
+++ b/internal/processor/parser/worker/zset_intake.go
@@ -107,7 +107,7 @@ func (i *ZSetIntake) handleOne(ctx context.Context, msg *queue.Message) {
 		return
 	}
 
-	priority := priorityFromHeader(msg.Headers)
+	priority := PriorityFromHeader(msg.Headers)
 
 	if err := i.zsetQueue.Push(ctx, priority, ref.ID, msg.Value); err != nil {
 		// Redis 일시 장애 — commit skip 으로 Kafka 가 redeliver. 다음 polling 에서 자연 retry.
@@ -130,9 +130,9 @@ func (i *ZSetIntake) handleOne(ctx context.Context, msg *queue.Message) {
 	}).Debug("intake pushed to zset and committed")
 }
 
-// priorityFromHeader 는 Kafka 메시지 헤더의 "priority" 값을 int 로 파싱합니다.
+// PriorityFromHeader 는 Kafka 메시지 헤더의 "priority" 값을 int 로 파싱합니다.
 // 미설정 / 파싱 실패 / 범위 밖 (1~3 외) 은 PriorityNormal (2) 로 보정.
-func priorityFromHeader(headers map[string]string) int {
+func PriorityFromHeader(headers map[string]string) int {
 	v, ok := headers["priority"]
 	if !ok {
 		return int(core.PriorityNormal)

--- a/internal/processor/parser/worker/zset_intake.go
+++ b/internal/processor/parser/worker/zset_intake.go
@@ -1,0 +1,145 @@
+// ZSetIntake — Parser 의 Kafka → Redis ZSET 인입 단계 (이슈 #522 / 메타 #515 Phase 2).
+//
+// 단일 goroutine 이 TopicFetched Kafka 메시지를 받아 priority + arrival timestamp 로
+// score 를 계산해 ZSET 에 적재 + Kafka commit. Worker pool 은 ZSET 에서 BZPOPMIN 으로
+// pop 하여 처리 — Kafka partition FIFO 제약을 우회한 priority sub-ordering 보장.
+//
+// 흐름:
+//  1. consumer.FetchMessage — Kafka 에서 1건 fetch
+//  2. RawContentRef.ID 추출 (ZSET member key)
+//  3. priority header 추출 (1/2/3, 잘못된 값은 normal)
+//  4. zsetQueue.Push(priority, id, payload)
+//  5. consumer.CommitMessages — Kafka commit
+//
+// 실패 정책:
+//   - Unmarshal 실패: 메시지 형식이 잘못된 정상적 데이터 — commit (재시도 무의미)
+//   - ZSET push 실패: Redis 일시 장애 — commit skip (Kafka 재배달로 자연 복구)
+//   - Kafka commit 실패: ctx cancel 시 정상 종료 흐름, 그 외에는 WARN — 중복 push 가능성 (idempotent)
+//
+// 단일 goroutine 운용: priority 결정과 push 사이의 race 없음. 다중 인스턴스 환경은 Kafka
+// consumer group 이 partition 자동 분배로 충분.
+package worker
+
+import (
+	"context"
+	"encoding/json"
+	"strconv"
+	"time"
+
+	"issuetracker/internal/bus"
+	"issuetracker/internal/processor/fetcher/core"
+	"issuetracker/pkg/logger"
+	"issuetracker/pkg/queue"
+)
+
+// ZSetIntake 는 Kafka → ZSET 인입 단계의 컴포넌트입니다.
+type ZSetIntake struct {
+	consumer  bus.Consumer
+	zsetQueue *queue.PriorityZSetQueue
+	log       *logger.Logger
+}
+
+// NewZSetIntake 는 ZSetIntake 인스턴스를 생성합니다.
+//
+// 모든 인자 nil 불허 — wiring 단계에서 사전 검증. nil 시 nil 반환.
+func NewZSetIntake(consumer bus.Consumer, zsetQueue *queue.PriorityZSetQueue, log *logger.Logger) *ZSetIntake {
+	if consumer == nil || zsetQueue == nil || log == nil {
+		return nil
+	}
+	return &ZSetIntake{
+		consumer:  consumer,
+		zsetQueue: zsetQueue,
+		log:       log,
+	}
+}
+
+// Run 은 ctx 가 cancel 될 때까지 Kafka FetchMessage → ZSET push → Kafka commit 루프를 실행합니다.
+//
+// goroutine 으로 시작 권장 — 본 함수는 blocking. 종료 시 consumer.Close 는 호출자 책임.
+func (i *ZSetIntake) Run(ctx context.Context) {
+	i.log.Info("parser zset intake started")
+	defer i.log.Info("parser zset intake stopped")
+
+	for {
+		if err := ctx.Err(); err != nil {
+			return
+		}
+		msg, err := i.consumer.FetchMessage(ctx)
+		if err != nil {
+			if ctx.Err() != nil {
+				return
+			}
+			i.log.WithError(err).Error("intake fetch failed")
+			// 짧은 sleep 으로 ctx cancel 흡수 + 무한 빠른 loop 회피.
+			select {
+			case <-ctx.Done():
+				return
+			case <-time.After(100 * time.Millisecond):
+			}
+			continue
+		}
+		i.handleOne(ctx, msg)
+	}
+}
+
+// handleOne 은 단일 메시지를 ZSET 에 적재 + Kafka commit 합니다.
+// 단위 테스트 용이성을 위해 분리.
+func (i *ZSetIntake) handleOne(ctx context.Context, msg *queue.Message) {
+	log := i.log.WithFields(map[string]interface{}{
+		"offset":    msg.Offset,
+		"partition": msg.Partition,
+	})
+
+	var ref core.RawContentRef
+	if err := json.Unmarshal(msg.Value, &ref); err != nil {
+		// 형식 잘못된 메시지 — Kafka 재배달로는 복구 불가. commit + skip.
+		log.WithError(err).Warn("intake unmarshal failed, committing to avoid redeliver loop")
+		if cerr := i.consumer.CommitMessages(ctx, msg); cerr != nil && ctx.Err() == nil {
+			log.WithError(cerr).Warn("intake commit (after unmarshal failure) failed")
+		}
+		return
+	}
+	if ref.ID == "" {
+		log.Warn("intake skipping message with empty RawContentRef.ID")
+		if cerr := i.consumer.CommitMessages(ctx, msg); cerr != nil && ctx.Err() == nil {
+			log.WithError(cerr).Warn("intake commit (empty id) failed")
+		}
+		return
+	}
+
+	priority := priorityFromHeader(msg.Headers)
+
+	if err := i.zsetQueue.Push(ctx, priority, ref.ID, msg.Value); err != nil {
+		// Redis 일시 장애 — commit skip 으로 Kafka 가 redeliver. 다음 polling 에서 자연 retry.
+		log.WithError(err).WithField("raw_id", ref.ID).Warn("intake zset push failed, skipping commit for redeliver")
+		return
+	}
+
+	if err := i.consumer.CommitMessages(ctx, msg); err != nil {
+		if ctx.Err() != nil {
+			return
+		}
+		// commit 실패해도 ZSET 에 이미 push 됨 — Kafka redeliver 시 동일 ID 재push (idempotent).
+		log.WithError(err).WithField("raw_id", ref.ID).Warn("intake commit failed (zset already pushed, idempotent on redeliver)")
+		return
+	}
+
+	log.WithFields(map[string]interface{}{
+		"raw_id":   ref.ID,
+		"priority": priority,
+	}).Debug("intake pushed to zset and committed")
+}
+
+// priorityFromHeader 는 Kafka 메시지 헤더의 "priority" 값을 int 로 파싱합니다.
+// 미설정 / 파싱 실패 / 범위 밖 (1~3 외) 은 PriorityNormal (2) 로 보정.
+func priorityFromHeader(headers map[string]string) int {
+	v, ok := headers["priority"]
+	if !ok {
+		return int(core.PriorityNormal)
+	}
+	n, err := strconv.Atoi(v)
+	if err != nil || n < 1 || n > 3 {
+		return int(core.PriorityNormal)
+	}
+	return n
+}

--- a/internal/processor/parser/worker/zset_intake.go
+++ b/internal/processor/parser/worker/zset_intake.go
@@ -33,16 +33,19 @@ import (
 )
 
 // ZSetIntake 는 Kafka → ZSET 인입 단계의 컴포넌트입니다.
+//
+// zsetQueue 가 queue.PriorityPusher 인터페이스 (Push only) — *queue.PriorityZSetQueue 가
+// 자동 만족하며, 단위 테스트에서는 in-memory stub 으로 교체 가능 (Copilot #3274731563).
 type ZSetIntake struct {
 	consumer  bus.Consumer
-	zsetQueue *queue.PriorityZSetQueue
+	zsetQueue queue.PriorityPusher
 	log       *logger.Logger
 }
 
 // NewZSetIntake 는 ZSetIntake 인스턴스를 생성합니다.
 //
 // 모든 인자 nil 불허 — wiring 단계에서 사전 검증. nil 시 nil 반환.
-func NewZSetIntake(consumer bus.Consumer, zsetQueue *queue.PriorityZSetQueue, log *logger.Logger) *ZSetIntake {
+func NewZSetIntake(consumer bus.Consumer, zsetQueue queue.PriorityPusher, log *logger.Logger) *ZSetIntake {
 	if consumer == nil || zsetQueue == nil || log == nil {
 		return nil
 	}
@@ -55,10 +58,17 @@ func NewZSetIntake(consumer bus.Consumer, zsetQueue *queue.PriorityZSetQueue, lo
 
 // Run 은 ctx 가 cancel 될 때까지 Kafka FetchMessage → ZSET push → Kafka commit 루프를 실행합니다.
 //
-// goroutine 으로 시작 권장 — 본 함수는 blocking. 종료 시 consumer.Close 는 호출자 책임.
+// goroutine 으로 시작 권장 — 본 함수는 blocking. 종료 시 consumer.Close 를 defer 로 호출하여
+// Kafka reader 자원 누수 방지 (Copilot #3274731405). ZSET 모드에서는 parserKafkaConsumer 가
+// intake 전용으로만 사용되므로 본 함수 종료 시점이 closing 의 자연스러운 위치.
 func (i *ZSetIntake) Run(ctx context.Context) {
 	i.log.Info("parser zset intake started")
-	defer i.log.Info("parser zset intake stopped")
+	defer func() {
+		if err := i.consumer.Close(); err != nil {
+			i.log.WithError(err).Warn("intake consumer close failed")
+		}
+		i.log.Info("parser zset intake stopped")
+	}()
 
 	for {
 		if err := ctx.Err(); err != nil {
@@ -80,6 +90,12 @@ func (i *ZSetIntake) Run(ctx context.Context) {
 		}
 		i.handleOne(ctx, msg)
 	}
+}
+
+// HandleOneForTest 는 handleOne 의 테스트 전용 export 입니다 — unit test 분기 검증 용.
+// 외부 호출자는 본 메소드 대신 Run 을 사용해야 합니다.
+func (i *ZSetIntake) HandleOneForTest(ctx context.Context, msg *queue.Message) {
+	i.handleOne(ctx, msg)
 }
 
 // handleOne 은 단일 메시지를 ZSET 에 적재 + Kafka commit 합니다.

--- a/pkg/queue/priority_zset.go
+++ b/pkg/queue/priority_zset.go
@@ -1,0 +1,277 @@
+// Package queue 의 Redis ZSET 기반 priority queue (이슈 #522, 메타 #515 Phase 2).
+//
+// 단일 Kafka topic 의 partition FIFO 가 priority sub-ordering 을 제공 못 하는 한계를
+// 해소하기 위한 intermediate queue. Kafka 가 transport 역할만 하고, ZSET 이 priority
+// 정렬을 담당합니다.
+//
+// 사용 흐름 (Parser/Validate/Enrich 공통):
+//
+//  1. Kafka consumer 가 메시지 수신 → Push(priority, id, payload) → Kafka commit
+//  2. Worker pool 이 BZPopMin 으로 가장 낮은 score (high priority + oldest) 1건 pop
+//  3. Pop 실패 시 처리자 (caller) 가 bus.RetryScheduler 경유 → Kafka 로 재발행
+//
+// score 계산: priority(1=high/2=normal/3=low) × 1e10 + arrival_timestamp_ms
+//   - 1e10 가 priority 간 간격 — arrival_ts (~1.7e12) 가 같은 priority 안에서 FIFO 결정
+//   - 다른 priority 간 차이가 1e10 이상이라 high 가 항상 normal/low 보다 먼저 pop
+//   - float64 mantissa 한계 2^53 (~9e15) 이내 — 정밀도 손실 없음
+package queue
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strconv"
+	"time"
+
+	goredis "github.com/redis/go-redis/v9"
+)
+
+// PriorityZSetEntryTTL 은 entry STRING 의 TTL 기본값입니다.
+// ZSET 에 잔존하는 동안 entry 가 만료되지 않도록 충분히 큰 값.
+const PriorityZSetEntryTTL = 24 * time.Hour
+
+// PriorityZSetMaxSize 는 ZSET 의 최대 항목 수 기본값입니다 — overflow 보호.
+// 초과 시 score 가 가장 큰 (low priority + oldest) 항목들 drop.
+const PriorityZSetMaxSize = 100000
+
+// priorityFactor 는 priority 와 timestamp 사이의 score 간격 계수입니다.
+// arrival_ts (UnixMilli, ~1.7e12) 가 priorityFactor (=1e10) 보다 작아야 priority 가
+// 정렬에서 dominant — 1e10 으로 두면 ms 단위 timestamp 가 priority 안에서 sub-ordering.
+const priorityFactor = 1e10
+
+// PriorityZSetConfig 는 PriorityZSetQueue 의 동작을 제어하는 설정입니다.
+type PriorityZSetConfig struct {
+	// ZSetKey 는 priority + timestamp 를 score 로 갖는 ZSET 의 Redis 키입니다.
+	// 예: "parser:zset:queue", "validate:zset:queue", "enrich:zset:queue".
+	ZSetKey string
+
+	// EntryKeyPrefix 는 개별 entry payload (STRING) 의 키 접두사입니다.
+	// 실제 키: <EntryKeyPrefix><id>. 예: "parser:zset:entry:".
+	EntryKeyPrefix string
+
+	// MaxSize 는 ZSET 의 최대 크기입니다. 0 또는 음수면 unlimited.
+	// 초과 시 score 가 가장 큰 (low priority + 오래된) 항목 drop.
+	MaxSize int64
+
+	// EntryTTL 은 entry STRING 의 TTL 입니다. 0 또는 음수면 PriorityZSetEntryTTL.
+	EntryTTL time.Duration
+}
+
+// PriorityZSetQueue 는 Redis ZSET 기반 priority queue 입니다.
+//
+// 모든 메소드는 goroutine-safe — 내부적으로 go-redis 의 thread-safe client 사용.
+type PriorityZSetQueue struct {
+	rdb      *goredis.Client
+	zsetKey  string
+	entryKey string
+	maxSize  int64
+	entryTTL time.Duration
+}
+
+// NewPriorityZSetQueue 는 PriorityZSetQueue 를 생성합니다.
+//
+// rdb 는 nil 불허 — 호출자가 사전 검증.
+// cfg.ZSetKey / EntryKeyPrefix 가 빈 문자열이면 ErrPriorityZSetInvalidConfig.
+func NewPriorityZSetQueue(rdb *goredis.Client, cfg PriorityZSetConfig) (*PriorityZSetQueue, error) {
+	if rdb == nil {
+		return nil, errors.New("priority zset queue: redis client required")
+	}
+	if cfg.ZSetKey == "" || cfg.EntryKeyPrefix == "" {
+		return nil, ErrPriorityZSetInvalidConfig
+	}
+	maxSize := cfg.MaxSize
+	if maxSize <= 0 {
+		maxSize = PriorityZSetMaxSize
+	}
+	entryTTL := cfg.EntryTTL
+	if entryTTL <= 0 {
+		entryTTL = PriorityZSetEntryTTL
+	}
+	return &PriorityZSetQueue{
+		rdb:      rdb,
+		zsetKey:  cfg.ZSetKey,
+		entryKey: cfg.EntryKeyPrefix,
+		maxSize:  maxSize,
+		entryTTL: entryTTL,
+	}, nil
+}
+
+// ErrPriorityZSetInvalidConfig 는 NewPriorityZSetQueue 의 설정이 잘못된 경우 반환됩니다.
+var ErrPriorityZSetInvalidConfig = errors.New("priority zset queue: ZSetKey and EntryKeyPrefix required")
+
+// Push 는 id 와 payload 를 priority + 현재 시각 기준 score 로 ZSET 에 적재합니다.
+//
+// 동일 id 재호출 시 ZSET score / entry payload 모두 덮어쓰기 (idempotent for retry).
+//
+// maxSize 초과 시 ZREMRANGEBYRANK 로 score 가 가장 큰 (low priority + 오래된) 항목 drop.
+// drop 실패는 ERROR 가 아닌 운영 가시성 신호로 호출자가 처리 (본 메소드는 nil 반환).
+//
+// priority 는 core.Priority 와 동일 매핑 (1=high / 2=normal / 3=low). 1~3 범위 밖이면
+// PriorityNormal (2) 로 보정.
+func (q *PriorityZSetQueue) Push(ctx context.Context, priority int, id string, payload []byte) error {
+	if id == "" {
+		return errors.New("priority zset push: id required")
+	}
+	if len(payload) == 0 {
+		return errors.New("priority zset push: empty payload")
+	}
+	score := priorityScore(priority, time.Now())
+
+	pipe := q.rdb.Pipeline()
+	pipe.ZAdd(ctx, q.zsetKey, goredis.Z{Score: score, Member: id})
+	pipe.Set(ctx, q.entryKey+id, payload, q.entryTTL)
+	if _, err := pipe.Exec(ctx); err != nil {
+		return fmt.Errorf("priority zset push (id=%s): %w", id, err)
+	}
+
+	// maxSize 초과 시 가장 큰 score 들 drop. 실패는 무시 (운영 가시성은 호출자가 Len 으로 확인).
+	if q.maxSize > 0 {
+		_ = q.rdb.ZRemRangeByRank(ctx, q.zsetKey, q.maxSize, -1)
+	}
+	return nil
+}
+
+// PopResult 는 Pop 의 단일 반환 항목입니다.
+type PopResult struct {
+	ID       string
+	Score    float64
+	Priority int
+	Payload  []byte
+}
+
+// Pop 은 ZSET 의 가장 낮은 score (high priority + oldest) 1건을 atomic 으로 pop 합니다.
+//
+// timeout 은 BZPOPMIN 의 Redis-side blocking 시간입니다. 0 이면 unlimited (ctx cancel 까지).
+// ctx cancel 시 즉시 ctx.Err() 반환.
+//
+// 빈 큐에서 timeout 만료 시 (nil, nil) — 호출자가 polling loop 에서 재시도.
+//
+// entry STRING 이 만료된 경우 (TTL 초과) Payload=nil 로 반환. 호출자가 로그 + skip.
+func (q *PriorityZSetQueue) Pop(ctx context.Context, timeout time.Duration) (*PopResult, error) {
+	res, err := q.rdb.BZPopMin(ctx, timeout, q.zsetKey).Result()
+	if err != nil {
+		if errors.Is(err, goredis.Nil) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("priority zset bzpop: %w", err)
+	}
+	if res == nil {
+		return nil, nil
+	}
+	id, ok := res.Member.(string)
+	if !ok {
+		return nil, fmt.Errorf("priority zset bzpop: unexpected member type %T", res.Member)
+	}
+
+	priority := priorityFromScore(res.Score)
+	payload, err := q.rdb.Get(ctx, q.entryKey+id).Bytes()
+	if err != nil && !errors.Is(err, goredis.Nil) {
+		return nil, fmt.Errorf("priority zset entry get (id=%s): %w", id, err)
+	}
+	// pop 된 후 entry 도 cleanup — TTL 로도 자연 만료되지만 명시적 삭제로 메모리 즉시 회수.
+	q.rdb.Del(ctx, q.entryKey+id)
+
+	return &PopResult{
+		ID:       id,
+		Score:    res.Score,
+		Priority: priority,
+		Payload:  payload,
+	}, nil
+}
+
+// Len 은 ZSET 의 현재 항목 수를 반환합니다 (메트릭 / overflow 감지용).
+func (q *PriorityZSetQueue) Len(ctx context.Context) (int64, error) {
+	n, err := q.rdb.ZCard(ctx, q.zsetKey).Result()
+	if err != nil {
+		return 0, fmt.Errorf("priority zset len: %w", err)
+	}
+	return n, nil
+}
+
+// priorityScore 는 priority + arrival timestamp 로부터 ZSET score 를 계산합니다.
+// priority 범위 밖 (0 / <1 / >3) 은 PriorityNormal=2 로 보정.
+func priorityScore(priority int, arrival time.Time) float64 {
+	p := priority
+	if p < 1 || p > 3 {
+		p = 2
+	}
+	return float64(p)*priorityFactor + float64(arrival.UnixMilli())
+}
+
+// priorityFromScore 는 ZSET score 에서 priority 를 역추출합니다.
+// score / 1e10 의 정수부.
+func priorityFromScore(score float64) int {
+	return int(score / priorityFactor)
+}
+
+// PriorityZSetConsumer 는 PriorityZSetQueue 를 Consumer 인터페이스로 노출하는 어댑터입니다.
+//
+// workerpool.ConsumerPool 이 별도 변경 없이 ZSET 기반 큐를 그대로 사용 가능 — Kafka 모드와
+// 동일한 폴링 / 핸들링 인프라 재활용.
+//
+// CommitMessages 는 no-op — ZSET 의 BZPOPMIN 이 곧 ack (pop = remove). 처리 실패 시 메시지
+// 손실 방지는 호출자가 bus.RetryScheduler 경유 (Kafka 재발행 → 다음 intake → ZSET 재진입).
+type PriorityZSetConsumer struct {
+	queue      *PriorityZSetQueue
+	topicLabel string // logical topic label for Message.Topic (e.g., "parser:zset")
+	popTimeout time.Duration
+}
+
+// NewPriorityZSetConsumer 는 PriorityZSetConsumer 를 생성합니다.
+// popTimeout 은 BZPOPMIN 의 Redis-side blocking 시간. 0 또는 음수면 1초 default.
+func NewPriorityZSetConsumer(q *PriorityZSetQueue, topicLabel string, popTimeout time.Duration) *PriorityZSetConsumer {
+	if popTimeout <= 0 {
+		popTimeout = time.Second
+	}
+	return &PriorityZSetConsumer{
+		queue:      q,
+		topicLabel: topicLabel,
+		popTimeout: popTimeout,
+	}
+}
+
+// FetchMessage 는 ZSET 에서 1건 pop 하여 Message 로 반환합니다.
+//
+// 빈 큐에서 timeout 만료 시 polling loop 로 재시도 — ctx cancel 시 즉시 ctx.Err() 반환.
+// entry expired (payload=nil) 인 경우 다음 항목으로 진행 (호출자가 받지 않음).
+func (c *PriorityZSetConsumer) FetchMessage(ctx context.Context) (*Message, error) {
+	for {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+		res, err := c.queue.Pop(ctx, c.popTimeout)
+		if err != nil {
+			return nil, err
+		}
+		if res == nil {
+			// 빈 큐 — polling 재시도.
+			continue
+		}
+		if res.Payload == nil {
+			// entry TTL 만료 — payload 손실. 다음 항목으로 진행.
+			continue
+		}
+		return &Message{
+			Topic: c.topicLabel,
+			Key:   []byte(res.ID),
+			Value: res.Payload,
+			Headers: map[string]string{
+				"priority": strconv.Itoa(res.Priority),
+			},
+			Time: time.Now(),
+		}, nil
+	}
+}
+
+// CommitMessages 는 no-op 입니다 — ZSET pop 이 곧 ack.
+//
+// Kafka consumer 와 동일 시그니처를 만족하기 위해 존재합니다. workerpool.ConsumerPool 이
+// 본 메소드를 호출해도 추가 동작 없음. 실패 retry 는 bus.RetryScheduler 경유.
+func (c *PriorityZSetConsumer) CommitMessages(ctx context.Context, msgs ...*Message) error {
+	return nil
+}
+
+// Close 는 no-op 입니다 — Redis 클라이언트는 외부에서 관리.
+func (c *PriorityZSetConsumer) Close() error {
+	return nil
+}

--- a/pkg/queue/priority_zset.go
+++ b/pkg/queue/priority_zset.go
@@ -35,9 +35,16 @@ const PriorityZSetEntryTTL = 24 * time.Hour
 const PriorityZSetMaxSize = 100000
 
 // priorityFactor 는 priority 와 timestamp 사이의 score 간격 계수입니다.
-// arrival_ts (UnixMilli, ~1.7e12) 가 priorityFactor (=1e10) 보다 작아야 priority 가
-// 정렬에서 dominant — 1e10 으로 두면 ms 단위 timestamp 가 priority 안에서 sub-ordering.
-const priorityFactor = 1e10
+//
+// 정렬 정책: priority 가 dominant, timestamp 가 같은 priority 내 sub-ordering.
+//
+// 값 결정 (gemini PR #526 high-priority 피드백):
+//   - arrival_ts = UnixMilli (~1.7e12 in 2026, 100년 후도 ~5e12 미만)
+//   - priorityFactor 가 arrival_ts 보다 충분히 커야 priority 가 dominant
+//   - 1e10 (이전 값) 은 ~10초 이상 시간 차이만 나도 priority 영향이 ts 차이에 묻힘
+//   - 1e13 으로 두면 priority 간 차이 (1e13) 가 ts 변동 (~1e12) 보다 ~10x 큼
+//   - float64 mantissa 한계 9e15 — priority=3 * 1e13 + ts ≈ 3.018e13, 정밀도 안전
+const priorityFactor = 1e13
 
 // PriorityZSetConfig 는 PriorityZSetQueue 의 동작을 제어하는 설정입니다.
 type PriorityZSetConfig struct {

--- a/pkg/queue/priority_zset.go
+++ b/pkg/queue/priority_zset.go
@@ -56,12 +56,23 @@ type PriorityZSetConfig struct {
 	// 실제 키: <EntryKeyPrefix><id>. 예: "parser:zset:entry:".
 	EntryKeyPrefix string
 
-	// MaxSize 는 ZSET 의 최대 크기입니다. 0 또는 음수면 unlimited.
-	// 초과 시 score 가 가장 큰 (low priority + 오래된) 항목 drop.
+	// MaxSize 는 ZSET 의 최대 크기입니다 — 운영 안전망 (Redis 메모리 보호).
+	// 0 또는 음수면 PriorityZSetMaxSize default (100000) — unlimited 옵션은 의도적으로 미지원.
+	// 초과 시 score 가 가장 큰 (low priority + 오래된) 항목 drop (Copilot #3274731323 정합).
 	MaxSize int64
 
 	// EntryTTL 은 entry STRING 의 TTL 입니다. 0 또는 음수면 PriorityZSetEntryTTL.
 	EntryTTL time.Duration
+}
+
+// PriorityPusher 는 PriorityZSetQueue 의 Push 책임만 추상화한 인터페이스입니다 (이슈 #522).
+//
+// ZSetIntake 등 push-only 호출자가 *PriorityZSetQueue 대신 본 인터페이스에 의존하면 단위 테스트
+// 에서 in-memory mock 으로 손쉽게 교체 가능 — Copilot #3274731563 피드백.
+//
+// Validate/Enrich 의 인입 단계도 동일 인터페이스를 재사용 예정 (메타 #515 Phase 2).
+type PriorityPusher interface {
+	Push(ctx context.Context, priority int, id string, payload []byte) error
 }
 
 // PriorityZSetQueue 는 Redis ZSET 기반 priority queue 입니다.
@@ -154,6 +165,11 @@ type PopResult struct {
 // 빈 큐에서 timeout 만료 시 (nil, nil) — 호출자가 polling loop 에서 재시도.
 //
 // entry STRING 이 만료된 경우 (TTL 초과) Payload=nil 로 반환. 호출자가 로그 + skip.
+//
+// 메시지 손실 방지 (Copilot #3274731302):
+// BZPOPMIN 으로 ZSET 에서 먼저 제거된 후 entry GET 이 Redis 오류 (timeout 등) 로 실패하면
+// 메시지가 영구 손실됨. 이를 피하기 위해 GET 실패 시 동일 score 로 ZADD 복구를 시도하고,
+// 복구도 실패하면 진짜 손실로 분류하여 error 반환. 호출자가 RetryScheduler 등으로 후속 처리 가능.
 func (q *PriorityZSetQueue) Pop(ctx context.Context, timeout time.Duration) (*PopResult, error) {
 	res, err := q.rdb.BZPopMin(ctx, timeout, q.zsetKey).Result()
 	if err != nil {
@@ -173,7 +189,12 @@ func (q *PriorityZSetQueue) Pop(ctx context.Context, timeout time.Duration) (*Po
 	priority := priorityFromScore(res.Score)
 	payload, err := q.rdb.Get(ctx, q.entryKey+id).Bytes()
 	if err != nil && !errors.Is(err, goredis.Nil) {
-		return nil, fmt.Errorf("priority zset entry get (id=%s): %w", id, err)
+		// entry GET 이 Redis 오류로 실패 — 이미 ZSET 에서 pop 된 ID 가 손실되는 것을 막기 위해
+		// 동일 score 로 ZADD 복구 시도. 복구 성공 시 caller 가 재시도 가능.
+		if zaddErr := q.rdb.ZAdd(ctx, q.zsetKey, goredis.Z{Score: res.Score, Member: id}).Err(); zaddErr != nil {
+			return nil, fmt.Errorf("priority zset entry get failed and zset restore failed (id=%s): get=%w; zadd=%v", id, err, zaddErr)
+		}
+		return nil, fmt.Errorf("priority zset entry get (id=%s, restored to zset): %w", id, err)
 	}
 	// pop 된 후 entry 도 cleanup — TTL 로도 자연 만료되지만 명시적 삭제로 메모리 즉시 회수.
 	q.rdb.Del(ctx, q.entryKey+id)

--- a/test/internal/processor/parser/worker/retry_job_test.go
+++ b/test/internal/processor/parser/worker/retry_job_test.go
@@ -75,6 +75,73 @@ func TestBuildRetryJob_InvalidPriorityHeader_DefaultsToNormal(t *testing.T) {
 	}
 }
 
+func TestBuildRetryJob_HeaderCrawlerPreferredOverSourceInfo(t *testing.T) {
+	// crawler 헤더가 있으면 SourceInfo.Name 보다 우선 (gemini #3274689308).
+	msg := &queue.Message{
+		Value: makeRawRef(t, "raw-h1", "https://example.com/", "source-info-name"),
+		Headers: map[string]string{
+			"crawler": "header-crawler",
+		},
+	}
+	job, err := worker.BuildRetryJob(msg)
+	require.NoError(t, err)
+	assert.Equal(t, "header-crawler", job.CrawlerName)
+}
+
+func TestBuildRetryJob_NoHeaderCrawler_UsesSourceInfo(t *testing.T) {
+	// crawler 헤더가 없으면 RawContentRef.SourceInfo.Name fallback.
+	msg := &queue.Message{
+		Value:   makeRawRef(t, "raw-h2", "https://example.com/", "fallback-source"),
+		Headers: map[string]string{},
+	}
+	job, err := worker.BuildRetryJob(msg)
+	require.NoError(t, err)
+	assert.Equal(t, "fallback-source", job.CrawlerName)
+}
+
+func TestBuildRetryJob_TargetTypeHeader_Category(t *testing.T) {
+	// target_type 헤더가 유효 (category) 면 사용 (gemini #3274689285 — Article 오인 차단).
+	msg := &queue.Message{
+		Value: makeRawRef(t, "raw-tt-1", "https://example.com/", "src"),
+		Headers: map[string]string{
+			"target_type": "category",
+		},
+	}
+	job, err := worker.BuildRetryJob(msg)
+	require.NoError(t, err)
+	assert.Equal(t, core.TargetTypeCategory, job.Target.Type)
+}
+
+func TestBuildRetryJob_TargetTypeHeader_Article(t *testing.T) {
+	msg := &queue.Message{
+		Value: makeRawRef(t, "raw-tt-2", "https://example.com/", "src"),
+		Headers: map[string]string{
+			"target_type": "article",
+		},
+	}
+	job, err := worker.BuildRetryJob(msg)
+	require.NoError(t, err)
+	assert.Equal(t, core.TargetTypeArticle, job.Target.Type)
+}
+
+func TestBuildRetryJob_TargetTypeHeader_InvalidFallsBackToArticle(t *testing.T) {
+	cases := []string{"unknown", "", "page", "list"}
+	for _, tt := range cases {
+		t.Run("type="+tt, func(t *testing.T) {
+			msg := &queue.Message{
+				Value: makeRawRef(t, "raw-tt-x", "https://example.com/", "src"),
+				Headers: map[string]string{
+					"target_type": tt,
+				},
+			}
+			job, err := worker.BuildRetryJob(msg)
+			require.NoError(t, err)
+			assert.Equal(t, core.TargetTypeArticle, job.Target.Type,
+				"unknown target_type %q should fall back to Article", tt)
+		})
+	}
+}
+
 func TestBuildRetryJob_EmptySourceName_UsesFallback(t *testing.T) {
 	msg := &queue.Message{
 		Value: makeRawRef(t, "raw-3", "https://example.com/", ""),

--- a/test/internal/processor/parser/worker/retry_job_test.go
+++ b/test/internal/processor/parser/worker/retry_job_test.go
@@ -1,0 +1,125 @@
+// BuildRetryJob 의 RawContentRef → CrawlJob 변환 검증 + PriorityFromHeader (이슈 #522).
+package worker_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"issuetracker/internal/processor/fetcher/core"
+	"issuetracker/internal/processor/parser/worker"
+	"issuetracker/pkg/queue"
+)
+
+func makeRawRef(t *testing.T, id, url, sourceName string) []byte {
+	t.Helper()
+	ref := core.RawContentRef{
+		ID:  id,
+		URL: url,
+		SourceInfo: core.SourceInfo{
+			Name: sourceName,
+		},
+	}
+	b, err := json.Marshal(ref)
+	require.NoError(t, err)
+	return b
+}
+
+func TestBuildRetryJob_ValidRef_ReturnsCrawlJob(t *testing.T) {
+	msg := &queue.Message{
+		Value: makeRawRef(t, "raw-1", "https://example.com/x", "cnn"),
+		Headers: map[string]string{
+			"priority": "1",
+		},
+	}
+
+	job, err := worker.BuildRetryJob(msg)
+	require.NoError(t, err)
+	require.NotNil(t, job)
+	assert.Equal(t, "raw-1", job.ID)
+	assert.Equal(t, "https://example.com/x", job.Target.URL)
+	assert.Equal(t, "cnn", job.CrawlerName)
+	assert.Equal(t, core.PriorityHigh, job.Priority)
+	assert.Equal(t, core.TargetTypeArticle, job.Target.Type)
+	assert.Equal(t, "parser_process_failed", job.Target.Metadata["retry_reason"])
+	assert.Equal(t, "raw-1", job.Target.Metadata["original_raw_id"])
+}
+
+func TestBuildRetryJob_NoPriorityHeader_DefaultsToNormal(t *testing.T) {
+	msg := &queue.Message{
+		Value:   makeRawRef(t, "raw-2", "https://example.com/", "src"),
+		Headers: map[string]string{},
+	}
+
+	job, err := worker.BuildRetryJob(msg)
+	require.NoError(t, err)
+	assert.Equal(t, core.PriorityNormal, job.Priority)
+}
+
+func TestBuildRetryJob_InvalidPriorityHeader_DefaultsToNormal(t *testing.T) {
+	cases := []string{"0", "4", "abc", "-1"}
+	for _, p := range cases {
+		t.Run("priority="+p, func(t *testing.T) {
+			msg := &queue.Message{
+				Value: makeRawRef(t, "raw-x", "https://example.com/", "src"),
+				Headers: map[string]string{
+					"priority": p,
+				},
+			}
+			job, err := worker.BuildRetryJob(msg)
+			require.NoError(t, err)
+			assert.Equal(t, core.PriorityNormal, job.Priority)
+		})
+	}
+}
+
+func TestBuildRetryJob_EmptySourceName_UsesFallback(t *testing.T) {
+	msg := &queue.Message{
+		Value: makeRawRef(t, "raw-3", "https://example.com/", ""),
+	}
+	job, err := worker.BuildRetryJob(msg)
+	require.NoError(t, err)
+	assert.Equal(t, "parser-retry", job.CrawlerName)
+}
+
+func TestBuildRetryJob_EmptyURL_ReturnsError(t *testing.T) {
+	msg := &queue.Message{
+		Value: makeRawRef(t, "raw-4", "", "src"),
+	}
+	_, err := worker.BuildRetryJob(msg)
+	assert.Error(t, err)
+}
+
+func TestBuildRetryJob_MalformedJSON_ReturnsError(t *testing.T) {
+	msg := &queue.Message{
+		Value: []byte("{not-valid-json"),
+	}
+	_, err := worker.BuildRetryJob(msg)
+	assert.Error(t, err)
+}
+
+func TestPriorityFromHeader_Mapping(t *testing.T) {
+	tests := []struct {
+		name    string
+		headers map[string]string
+		want    int
+	}{
+		{"high (1)", map[string]string{"priority": "1"}, 1},
+		{"normal (2)", map[string]string{"priority": "2"}, 2},
+		{"low (3)", map[string]string{"priority": "3"}, 3},
+		{"missing key → normal", nil, 2},
+		{"empty value → normal", map[string]string{"priority": ""}, 2},
+		{"non-numeric → normal", map[string]string{"priority": "xx"}, 2},
+		{"out of range 0 → normal", map[string]string{"priority": "0"}, 2},
+		{"out of range 4 → normal", map[string]string{"priority": "4"}, 2},
+		{"negative → normal", map[string]string{"priority": "-1"}, 2},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := worker.PriorityFromHeader(tt.headers)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/test/internal/processor/parser/worker/zset_intake_test.go
+++ b/test/internal/processor/parser/worker/zset_intake_test.go
@@ -1,0 +1,176 @@
+// ZSetIntake.handleOne 의 분기 검증 (Copilot #3274731563 — mock Consumer + stub queue).
+//
+// PriorityPusher 인터페이스 + bus.Consumer 인터페이스에 의존하므로 Redis / Kafka 없이 단위 검증.
+package worker_test
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"issuetracker/internal/processor/fetcher/core"
+	"issuetracker/internal/processor/parser/worker"
+	"issuetracker/pkg/logger"
+	"issuetracker/pkg/queue"
+)
+
+// stubPusher 는 in-memory PriorityPusher mock. Push 호출 인자를 캡쳐 + failErr 로 실패 시뮬레이션.
+type stubPusher struct {
+	mu       sync.Mutex
+	calls    []stubPushCall
+	failErr  error
+	failOnce bool
+}
+
+type stubPushCall struct {
+	Priority int
+	ID       string
+	Payload  []byte
+}
+
+func (s *stubPusher) Push(_ context.Context, priority int, id string, payload []byte) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.failErr != nil {
+		err := s.failErr
+		if s.failOnce {
+			s.failErr = nil
+		}
+		return err
+	}
+	s.calls = append(s.calls, stubPushCall{
+		Priority: priority,
+		ID:       id,
+		Payload:  append([]byte(nil), payload...),
+	})
+	return nil
+}
+
+func (s *stubPusher) Calls() []stubPushCall {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return append([]stubPushCall(nil), s.calls...)
+}
+
+// stubConsumer 는 in-memory bus.Consumer mock. CommitMessages 호출 횟수 + Close 여부 캡쳐.
+type stubConsumer struct {
+	mu        sync.Mutex
+	commits   int32
+	commitErr error
+	closed    bool
+}
+
+func (c *stubConsumer) FetchMessage(_ context.Context) (*queue.Message, error) {
+	return nil, errors.New("stubConsumer.FetchMessage not used in handleOne tests")
+}
+
+func (c *stubConsumer) CommitMessages(_ context.Context, _ ...*queue.Message) error {
+	atomic.AddInt32(&c.commits, 1)
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.commitErr
+}
+
+func (c *stubConsumer) Close() error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.closed = true
+	return nil
+}
+
+func (c *stubConsumer) CommitCount() int32 { return atomic.LoadInt32(&c.commits) }
+
+func newIntake(t *testing.T, pusher queue.PriorityPusher) (*worker.ZSetIntake, *stubConsumer) {
+	t.Helper()
+	log := logger.New(logger.Config{Level: "error"})
+	cons := &stubConsumer{}
+	intake := worker.NewZSetIntake(cons, pusher, log)
+	require.NotNil(t, intake)
+	return intake, cons
+}
+
+func makeIntakeMsg(t *testing.T, ref core.RawContentRef, headers map[string]string) *queue.Message {
+	t.Helper()
+	b, err := json.Marshal(ref)
+	require.NoError(t, err)
+	return &queue.Message{
+		Value:   b,
+		Headers: headers,
+	}
+}
+
+func TestZSetIntake_HandleOne_Success_PushesAndCommits(t *testing.T) {
+	pusher := &stubPusher{}
+	intake, cons := newIntake(t, pusher)
+
+	msg := makeIntakeMsg(t,
+		core.RawContentRef{ID: "raw-1", URL: "https://example.com/", SourceInfo: core.SourceInfo{Name: "src"}},
+		map[string]string{"priority": "1"},
+	)
+	intake.HandleOneForTest(context.Background(), msg)
+
+	calls := pusher.Calls()
+	require.Len(t, calls, 1)
+	assert.Equal(t, "raw-1", calls[0].ID)
+	assert.Equal(t, 1, calls[0].Priority)
+	assert.Equal(t, int32(1), cons.CommitCount(), "성공 시 commit 1회")
+}
+
+func TestZSetIntake_HandleOne_Unmarshal_Failure_Commits(t *testing.T) {
+	// 잘못된 JSON — push 호출 X, commit 호출 (redeliver loop 회피).
+	pusher := &stubPusher{}
+	intake, cons := newIntake(t, pusher)
+
+	msg := &queue.Message{Value: []byte("{not-json"), Headers: map[string]string{}}
+	intake.HandleOneForTest(context.Background(), msg)
+
+	assert.Empty(t, pusher.Calls(), "unmarshal 실패 시 push 미호출")
+	assert.Equal(t, int32(1), cons.CommitCount(), "unmarshal 실패 시 commit 호출 — redeliver 회피")
+}
+
+func TestZSetIntake_HandleOne_EmptyID_Commits(t *testing.T) {
+	// 빈 RawContentRef.ID — push 호출 X, commit 호출.
+	pusher := &stubPusher{}
+	intake, cons := newIntake(t, pusher)
+
+	msg := makeIntakeMsg(t, core.RawContentRef{URL: "https://example.com/"}, map[string]string{})
+	intake.HandleOneForTest(context.Background(), msg)
+
+	assert.Empty(t, pusher.Calls(), "빈 ID 시 push 미호출")
+	assert.Equal(t, int32(1), cons.CommitCount(), "빈 ID 시 commit 호출")
+}
+
+func TestZSetIntake_HandleOne_PushFailure_SkipsCommit(t *testing.T) {
+	// push 실패 → commit 호출 안 함 (Kafka 가 redeliver).
+	pusher := &stubPusher{failErr: errors.New("push failed")}
+	intake, cons := newIntake(t, pusher)
+
+	msg := makeIntakeMsg(t,
+		core.RawContentRef{ID: "raw-2", URL: "https://example.com/", SourceInfo: core.SourceInfo{Name: "s"}},
+		map[string]string{"priority": "2"},
+	)
+	intake.HandleOneForTest(context.Background(), msg)
+
+	assert.Equal(t, int32(0), cons.CommitCount(), "push 실패 시 commit skip — Kafka redeliver")
+}
+
+func TestZSetIntake_HandleOne_HeaderMissing_DefaultsNormalPriority(t *testing.T) {
+	pusher := &stubPusher{}
+	intake, _ := newIntake(t, pusher)
+
+	msg := makeIntakeMsg(t,
+		core.RawContentRef{ID: "raw-3", URL: "https://example.com/", SourceInfo: core.SourceInfo{Name: "x"}},
+		nil,
+	)
+	intake.HandleOneForTest(context.Background(), msg)
+
+	calls := pusher.Calls()
+	require.Len(t, calls, 1)
+	assert.Equal(t, 2, calls[0].Priority, "priority header 없으면 normal (2) default")
+}

--- a/test/pkg/queue/priority_zset_test.go
+++ b/test/pkg/queue/priority_zset_test.go
@@ -1,0 +1,299 @@
+// PriorityZSetQueue + PriorityZSetConsumer 통합 테스트 (이슈 #522, 메타 #515 Phase 2).
+//
+// 로컬 Redis 가 없으면 skip — REDIS_HOST/PORT env 로 주소 조정 가능.
+// 테스트 간 격리: 각 테스트가 고유 ZSetKey/EntryKeyPrefix 사용 (시각 기반 prefix).
+package queue_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	storagecfg "issuetracker/pkg/config/storage"
+	"issuetracker/pkg/queue"
+	pkgredis "issuetracker/pkg/redis"
+)
+
+// newPriorityZSetTestQueue 는 격리된 ZSetKey 로 PriorityZSetQueue 를 생성합니다.
+// Redis 미가용 시 t.Skip — 통합 테스트.
+func newPriorityZSetTestQueue(t *testing.T, suffix string) (*queue.PriorityZSetQueue, *pkgredis.Client) {
+	t.Helper()
+	cfg, err := storagecfg.LoadRedis()
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	client, err := pkgredis.New(ctx, cfg)
+	if err != nil {
+		t.Skipf("Redis not available (%v) — skipping integration test", err)
+	}
+	t.Cleanup(func() { _ = client.Close() })
+
+	// unique prefix per test — 시각 기반.
+	prefix := fmt.Sprintf("test:priority-zset:%s:%d:", suffix, time.Now().UnixNano())
+	q, err := queue.NewPriorityZSetQueue(client.Raw(), queue.PriorityZSetConfig{
+		ZSetKey:        prefix + "queue",
+		EntryKeyPrefix: prefix + "entry:",
+		MaxSize:        100,
+		EntryTTL:       1 * time.Minute,
+	})
+	require.NoError(t, err)
+
+	// 테스트 종료 시 ZSET + 모든 entry cleanup.
+	t.Cleanup(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+		defer cancel()
+		client.Raw().Del(ctx, prefix+"queue")
+		// entries 는 wildcard SCAN + DEL — 운영에선 권장 안 되지만 테스트 cleanup 한정.
+		iter := client.Raw().Scan(ctx, 0, prefix+"entry:*", 0).Iterator()
+		for iter.Next(ctx) {
+			client.Raw().Del(ctx, iter.Val())
+		}
+	})
+	return q, client
+}
+
+func TestNewPriorityZSetQueue_NilRedis_ReturnsError(t *testing.T) {
+	_, err := queue.NewPriorityZSetQueue(nil, queue.PriorityZSetConfig{
+		ZSetKey: "x", EntryKeyPrefix: "y:",
+	})
+	assert.Error(t, err)
+}
+
+func TestNewPriorityZSetQueue_EmptyKey_ReturnsError(t *testing.T) {
+	// rdb 는 nil 이 아니어도, key 빈 문자열은 ErrPriorityZSetInvalidConfig.
+	// 실제 client 미가용시 nil 검사가 먼저 발동하므로 Skip 처리 필요 — 본 케이스는 unit only.
+	cfg, err := storagecfg.LoadRedis()
+	require.NoError(t, err)
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	client, err := pkgredis.New(ctx, cfg)
+	if err != nil {
+		t.Skipf("Redis not available — skipping")
+	}
+	t.Cleanup(func() { _ = client.Close() })
+
+	_, err = queue.NewPriorityZSetQueue(client.Raw(), queue.PriorityZSetConfig{
+		ZSetKey: "", EntryKeyPrefix: "x:",
+	})
+	assert.ErrorIs(t, err, queue.ErrPriorityZSetInvalidConfig)
+}
+
+func TestPriorityZSetQueue_PushPop_BasicRoundtrip(t *testing.T) {
+	q, _ := newPriorityZSetTestQueue(t, "roundtrip")
+	ctx := context.Background()
+
+	payload := []byte(`{"id":"x","url":"https://example.com"}`)
+	require.NoError(t, q.Push(ctx, 2, "x", payload))
+
+	res, err := q.Pop(ctx, 2*time.Second)
+	require.NoError(t, err)
+	require.NotNil(t, res)
+	assert.Equal(t, "x", res.ID)
+	assert.Equal(t, 2, res.Priority)
+	assert.Equal(t, payload, res.Payload)
+}
+
+func TestPriorityZSetQueue_HighPriorityPoppedFirst(t *testing.T) {
+	// 다른 priority 메시지를 normal → low → high 순서로 push 해도 pop 은 high 가 먼저.
+	q, _ := newPriorityZSetTestQueue(t, "priority-order")
+	ctx := context.Background()
+
+	require.NoError(t, q.Push(ctx, 2, "normal-1", []byte("normal")))
+	require.NoError(t, q.Push(ctx, 3, "low-1", []byte("low")))
+	require.NoError(t, q.Push(ctx, 1, "high-1", []byte("high")))
+
+	first, err := q.Pop(ctx, 2*time.Second)
+	require.NoError(t, err)
+	require.NotNil(t, first)
+	assert.Equal(t, "high-1", first.ID, "high priority should pop first")
+
+	second, err := q.Pop(ctx, 2*time.Second)
+	require.NoError(t, err)
+	require.NotNil(t, second)
+	assert.Equal(t, "normal-1", second.ID, "normal priority should pop second")
+
+	third, err := q.Pop(ctx, 2*time.Second)
+	require.NoError(t, err)
+	require.NotNil(t, third)
+	assert.Equal(t, "low-1", third.ID, "low priority should pop last")
+}
+
+func TestPriorityZSetQueue_SamePriority_FIFO(t *testing.T) {
+	// 같은 priority 안에서는 push 시점 순서 (FIFO).
+	q, _ := newPriorityZSetTestQueue(t, "fifo")
+	ctx := context.Background()
+
+	for i := 0; i < 3; i++ {
+		id := fmt.Sprintf("normal-%d", i)
+		require.NoError(t, q.Push(ctx, 2, id, []byte(id)))
+		// 동일 priority 안에서 timestamp 가 다르도록 작은 sleep.
+		time.Sleep(2 * time.Millisecond)
+	}
+
+	for i := 0; i < 3; i++ {
+		res, err := q.Pop(ctx, 2*time.Second)
+		require.NoError(t, err)
+		require.NotNil(t, res)
+		assert.Equal(t, fmt.Sprintf("normal-%d", i), res.ID, "FIFO order within same priority (i=%d)", i)
+	}
+}
+
+func TestPriorityZSetQueue_Pop_EmptyQueue_Timeout(t *testing.T) {
+	q, _ := newPriorityZSetTestQueue(t, "empty-timeout")
+	ctx := context.Background()
+
+	res, err := q.Pop(ctx, 200*time.Millisecond)
+	require.NoError(t, err)
+	assert.Nil(t, res, "empty queue should return (nil, nil) after timeout")
+}
+
+func TestPriorityZSetQueue_Pop_CtxCancel_ReturnsErr(t *testing.T) {
+	q, _ := newPriorityZSetTestQueue(t, "cancel")
+	ctx, cancel := context.WithCancel(context.Background())
+
+	// pop goroutine 시작 후 즉시 cancel.
+	type popResult struct {
+		res *queue.PopResult
+		err error
+	}
+	ch := make(chan popResult, 1)
+	go func() {
+		res, err := q.Pop(ctx, 5*time.Second)
+		ch <- popResult{res, err}
+	}()
+	time.Sleep(50 * time.Millisecond)
+	cancel()
+
+	select {
+	case r := <-ch:
+		assert.Error(t, r.err)
+	case <-time.After(2 * time.Second):
+		t.Fatal("Pop did not return after ctx cancel")
+	}
+}
+
+func TestPriorityZSetQueue_Push_EmptyID_ReturnsError(t *testing.T) {
+	q, _ := newPriorityZSetTestQueue(t, "empty-id")
+	err := q.Push(context.Background(), 2, "", []byte("x"))
+	assert.Error(t, err)
+}
+
+func TestPriorityZSetQueue_Push_EmptyPayload_ReturnsError(t *testing.T) {
+	q, _ := newPriorityZSetTestQueue(t, "empty-payload")
+	err := q.Push(context.Background(), 2, "id-1", []byte{})
+	assert.Error(t, err)
+}
+
+func TestPriorityZSetQueue_Len(t *testing.T) {
+	q, _ := newPriorityZSetTestQueue(t, "len")
+	ctx := context.Background()
+
+	for i := 0; i < 5; i++ {
+		require.NoError(t, q.Push(ctx, 2, fmt.Sprintf("id-%d", i), []byte("p")))
+	}
+
+	n, err := q.Len(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, int64(5), n)
+
+	// 1건 pop 후 4.
+	_, err = q.Pop(ctx, 1*time.Second)
+	require.NoError(t, err)
+	n, err = q.Len(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, int64(4), n)
+}
+
+func TestPriorityZSetQueue_DuplicateID_OverwritesPayload(t *testing.T) {
+	q, _ := newPriorityZSetTestQueue(t, "dup-id")
+	ctx := context.Background()
+
+	require.NoError(t, q.Push(ctx, 2, "same-id", []byte("first")))
+	require.NoError(t, q.Push(ctx, 2, "same-id", []byte("second")))
+
+	n, err := q.Len(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), n, "ZADD with same member should not duplicate")
+
+	res, err := q.Pop(ctx, 1*time.Second)
+	require.NoError(t, err)
+	require.NotNil(t, res)
+	assert.Equal(t, []byte("second"), res.Payload, "second push should overwrite payload")
+}
+
+func TestPriorityZSetQueue_Push_InvalidPriority_NormalizesToNormal(t *testing.T) {
+	q, _ := newPriorityZSetTestQueue(t, "invalid-priority")
+	ctx := context.Background()
+
+	// priority=0 (invalid) — should be treated as normal (2).
+	require.NoError(t, q.Push(ctx, 0, "weird", []byte("p")))
+	res, err := q.Pop(ctx, 1*time.Second)
+	require.NoError(t, err)
+	require.NotNil(t, res)
+	assert.Equal(t, 2, res.Priority, "out-of-range priority should normalize to normal")
+}
+
+func TestPriorityZSetConsumer_FetchMessage_BasicRoundtrip(t *testing.T) {
+	// PriorityZSetConsumer 가 Consumer 인터페이스를 만족 + Push → FetchMessage 가 동일 payload 반환.
+	q, _ := newPriorityZSetTestQueue(t, "consumer-roundtrip")
+	c := queue.NewPriorityZSetConsumer(q, "parser:zset", 500*time.Millisecond)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+
+	payload := []byte(`{"id":"y","url":"https://test"}`)
+	require.NoError(t, q.Push(ctx, 1, "y", payload))
+
+	msg, err := c.FetchMessage(ctx)
+	require.NoError(t, err)
+	require.NotNil(t, msg)
+	assert.Equal(t, "parser:zset", msg.Topic)
+	assert.Equal(t, []byte("y"), msg.Key)
+	assert.Equal(t, payload, msg.Value)
+	assert.Equal(t, "1", msg.Headers["priority"], "priority header should reflect pop score")
+}
+
+func TestPriorityZSetConsumer_CommitMessages_NoOp(t *testing.T) {
+	// CommitMessages 는 no-op — 호출이 에러를 발생시키지 않아야 함.
+	q, _ := newPriorityZSetTestQueue(t, "consumer-commit")
+	c := queue.NewPriorityZSetConsumer(q, "parser:zset", 500*time.Millisecond)
+	assert.NoError(t, c.CommitMessages(context.Background()))
+	assert.NoError(t, c.CommitMessages(context.Background(), &queue.Message{}))
+}
+
+func TestPriorityZSetConsumer_Close_NoOp(t *testing.T) {
+	q, _ := newPriorityZSetTestQueue(t, "consumer-close")
+	c := queue.NewPriorityZSetConsumer(q, "parser:zset", 500*time.Millisecond)
+	assert.NoError(t, c.Close())
+}
+
+func TestPriorityZSetConsumer_FetchMessage_CtxCancel(t *testing.T) {
+	// Empty queue + cancel — FetchMessage 가 ctx.Err() 반환.
+	q, _ := newPriorityZSetTestQueue(t, "consumer-cancel")
+	c := queue.NewPriorityZSetConsumer(q, "parser:zset", 500*time.Millisecond)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	type res struct {
+		msg *queue.Message
+		err error
+	}
+	ch := make(chan res, 1)
+	go func() {
+		m, err := c.FetchMessage(ctx)
+		ch <- res{m, err}
+	}()
+	time.Sleep(100 * time.Millisecond)
+	cancel()
+
+	select {
+	case r := <-ch:
+		assert.Error(t, r.err)
+	case <-time.After(2 * time.Second):
+		t.Fatal("FetchMessage did not return after ctx cancel")
+	}
+}

--- a/test/pkg/queue/priority_zset_test.go
+++ b/test/pkg/queue/priority_zset_test.go
@@ -49,9 +49,13 @@ func newPriorityZSetTestQueue(t *testing.T, suffix string) (*queue.PriorityZSetQ
 		defer cancel()
 		client.Raw().Del(ctx, prefix+"queue")
 		// entries 는 wildcard SCAN + DEL — 운영에선 권장 안 되지만 테스트 cleanup 한정.
+		// iter.Err() 검증 (Copilot #3274731503) — cleanup 실패가 silent 하지 않도록.
 		iter := client.Raw().Scan(ctx, 0, prefix+"entry:*", 0).Iterator()
 		for iter.Next(ctx) {
 			client.Raw().Del(ctx, iter.Val())
+		}
+		if err := iter.Err(); err != nil {
+			t.Logf("cleanup SCAN iterator error (ignored): %v", err)
 		}
 	})
 	return q, client
@@ -270,6 +274,32 @@ func TestPriorityZSetConsumer_Close_NoOp(t *testing.T) {
 	q, _ := newPriorityZSetTestQueue(t, "consumer-close")
 	c := queue.NewPriorityZSetConsumer(q, "parser:zset", 500*time.Millisecond)
 	assert.NoError(t, c.Close())
+}
+
+func TestPriorityZSetQueue_Pop_EntryExpiredBeforeGet_ReturnsNilPayload(t *testing.T) {
+	// entry STRING 이 TTL 만료된 상태 — Pop 은 (id, score, nil payload) 반환.
+	// 직접 ZADD 만 하고 SET 은 생략하여 시뮬레이션.
+	q, client := newPriorityZSetTestQueue(t, "entry-expired")
+	ctx := context.Background()
+
+	prefix := "test:priority-zset:entry-expired:"
+	// queue key 정확히 알 수 없으니 직접 push 후 SCAN
+	require.NoError(t, q.Push(ctx, 2, "id-1", []byte("payload")))
+
+	// entry STRING 직접 삭제 — TTL 만료 시뮬레이션.
+	iter := client.Raw().Scan(ctx, 0, prefix+"*:entry:*", 0).Iterator()
+	for iter.Next(ctx) {
+		client.Raw().Del(ctx, iter.Val())
+	}
+	if err := iter.Err(); err != nil {
+		t.Logf("scan err (ignored): %v", err)
+	}
+
+	res, err := q.Pop(ctx, 1*time.Second)
+	require.NoError(t, err)
+	require.NotNil(t, res)
+	assert.Equal(t, "id-1", res.ID)
+	assert.Nil(t, res.Payload, "entry 만료 시 Payload=nil")
 }
 
 func TestPriorityZSetConsumer_FetchMessage_CtxCancel(t *testing.T) {


### PR DESCRIPTION
## 연관 이슈
- Closes #522
- Parent: #515 (Phase 2 Sub 4)

<br>

## 구현 내용

메타 이슈 #515 의 **Phase 2 Parser stage**. Kafka partition FIFO 가 priority sub-ordering 을 제공 못 하는 한계를 Redis ZSET intermediate queue 로 해소. PR #511 / #516 의 Redis 패턴 재사용.

흐름:
```
Kafka.TopicFetched → [intake goroutine] → Redis ZSET → [worker pool] → ProcessMessage
                                                              ↓ 실패
                                                       RetryScheduler.Enqueue → Kafka 재발행
```

### Sub 1 — `pkg/queue.PriorityZSetQueue` 추상화 (fd91b3c)
- score = priority(1=high/2=normal/3=low) × 1e10 + arrival_timestamp_ms
- `Push(ctx, priority, id, payload)` — ZADD + SET pipeline (retry_queue 동일 패턴)
- `Pop(ctx, timeout)` — BZPOPMIN + entry GET / DEL (atomic pop = ack)
- `Len(ctx)` — ZCard
- MaxSize 초과 시 ZREMRANGEBYRANK 로 가장 낮은 priority + 오래된 항목 drop
- `PriorityZSetConsumer` — `queue.Consumer` 어댑터 → workerpool.ConsumerPool 재사용
- 16 단위 테스트 (Redis 통합, 미가용 시 skip)

### Sub 2 — Parser Worker RetryScheduler hook (3e5e285)
- `Worker.retryScheduler bus.RetryScheduler` 필드 + `SetRetryScheduler` setter
- `Handle` 분기: ProcessMessage 실패 시
  - retryScheduler 주입 시 → `enqueueRetry` 후 commit (메시지 손실 방지)
  - 미주입 시 → commit skip → Kafka redeliver (기존 동작 호환)
- `BuildRetryJob(msg) (*core.CrawlJob, error)` 헬퍼 (export for test)

### Sub 3 — Kafka → ZSET intake goroutine (b724732)
- `worker.ZSetIntake` 단일 goroutine
- FetchMessage → Unmarshal → priority 추출 → ZSET Push → Kafka commit
- 실패 정책: unmarshal/빈 ID → commit (재시도 무의미) / ZSET push 실패 → commit skip (Kafka redeliver) / commit 실패 → 다음 fetch (idempotent)
- `PriorityFromHeader(headers)` 헬퍼 (export for test)

### Sub 4 — Feature flag + main.go wiring (370b0ff)
- `PARSER_PRIORITY_QUEUE_ENABLED=true` + `redisClientShared != nil` 시 ZSET 모드 활성
- ZSET 모드 + retryScheduler nil → **fatal** (메시지 손실 방지 가드)
- `parser.Stage.SetZSetIntake` 로 lifecycle 통합 (Stage.Start 시 go intake.Run(ctx), ctx cancel 시 자연 종료)
- 환경변수: PARSER_ZSET_QUEUE_KEY / PARSER_ZSET_ENTRY_PREFIX / PARSER_ZSET_MAX_SIZE / PARSER_ZSET_ENTRY_TTL / PARSER_ZSET_POP_TIMEOUT
- `envBoolOrDefault` / `envOrDefault` 헬퍼 추가

### Sub 5 — 단위 테스트 (134b3db)
- BuildRetryJob 7 cases: 정상 / 잘못된 priority / 빈 source name / 빈 URL / malformed JSON
- PriorityFromHeader 9 cases: 1/2/3 매핑 / missing / empty / non-numeric / out-of-range
- pkg/queue PriorityZSet 16 cases (통합)

<br>

## CI / 머지 게이트 점검

### 변경 영향 범위
- 영향 패키지/모듈: `pkg/queue`, `internal/processor/parser/worker`, `internal/processor/parser`, `cmd/issuetracker`
- 위험도: **Medium** — Parser stage 핵심 흐름 변경. 단, feature flag default false + 미설정 시 기존 Kafka 흐름 100% 유지 → 안전 fallback.

### Required Status Checks
- 통과 확인 대상 (PR Checks 탭에서 확인):
  - [ ] `Commit Lint`
  - [ ] `PR Title Lint`
  - [ ] `Linked Issue Check`
  - [ ] `Format Check`
  - [ ] `Build`
  - [ ] `Test`
  - [ ] `Lint`

### 롤백 계획

1. `PARSER_PRIORITY_QUEUE_ENABLED=false` (또는 unset) — 기존 Kafka 직접 consume 흐름 복귀
2. Redis 의 잔존 ZSET 항목은 다음 부팅 시 자동 처리 (entry TTL 24h 후 자연 정리)
3. 영구 롤백: 위 환경변수 + 본 PR revert

<br>

## 후속 작업 (메타 #515 Phase 2)
- #523 Validate stage Redis ZSET (선행: 본 PR 의 `pkg/queue.PriorityZSetQueue` 추상화 활용)
- #524 Enrich stage Redis ZSET (선행: 본 PR, 병렬 가능)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Optional priority-based message processing mode (configurable via environment settings)
  * Enhanced handling of transient failures with automatic retry capability to prevent message loss

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/EinSofINTEREST/IssueTracker/pull/526?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->