### PR TITLE
[FEAT#524] Enrich stage Redis ZSET intermediate queue — priority sub-ordering

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -133,6 +133,19 @@ VALIDATE_ZSET_MAX_SIZE=100000
 VALIDATE_ZSET_ENTRY_TTL=24h
 VALIDATE_ZSET_POP_TIMEOUT=1s
 
+# Enrich stage Redis ZSET intermediate queue (이슈 #524, 메타 #515 Phase 2)
+# Parser / Validate 와 동일 패턴 — Kafka TopicValidated 메시지를 Redis ZSET 에 인입 후 priority 정렬 pop.
+# score = priority(1=high/2=normal/3=low) × 1e13 + arrival_ts_ms.
+#
+# 활성화 조건: ENABLED=true + STAGES_ENRICH_ENABLED=true + Redis 가용 + RetryScheduler 설정.
+# 미충족 시 안전 fallback (기존 Kafka 흐름).
+ENRICH_PRIORITY_QUEUE_ENABLED=false
+ENRICH_ZSET_QUEUE_KEY=enrich:zset:queue
+ENRICH_ZSET_ENTRY_PREFIX=enrich:zset:entry:
+ENRICH_ZSET_MAX_SIZE=100000
+ENRICH_ZSET_ENTRY_TTL=24h
+ENRICH_ZSET_POP_TIMEOUT=1s
+
 # Classifier 서비스 연결 설정
 CLASSIFIER_HTTP_ADDR=http://localhost:8000
 CLASSIFIER_GRPC_ADDR=localhost:50051

--- a/cmd/issuetracker/main.go
+++ b/cmd/issuetracker/main.go
@@ -1117,14 +1117,45 @@ func main() {
 	enrichKafkaCfg := queue.DefaultConfig()
 	enrichKafkaCfg.GroupID = queue.GroupEnrichers
 
-	enrichConsumer := queue.NewConsumer(enrichKafkaCfg, queue.TopicValidated)
-	defer enrichConsumer.Close()
+	enrichKafkaConsumer := queue.NewConsumer(enrichKafkaCfg, queue.TopicValidated)
+	defer enrichKafkaConsumer.Close()
 
 	enrichProducer := queue.NewProducer(enrichKafkaCfg)
 	defer enrichProducer.Close()
 
 	// publisher facade — enrich 는 Forward (validated → enriched) 만 사용.
 	enrichPublisher := bus.New(enrichProducer, nil, log)
+
+	// 이슈 #524 — ZSET 인입 모드 (ENRICH_PRIORITY_QUEUE_ENABLED + redisClientShared + stage enabled):
+	//   - Kafka consumer → ZSET intake goroutine 이 ZSET 으로 적재
+	//   - Worker 는 ZSET consumer 로 BZPOPMIN → priority sub-ordering 보장
+	//   - 처리 실패 시 RetryScheduler 경유 + DLQ fallback
+	enrichPriorityQueueEnabled := stagesCfg.EnrichEnabled &&
+		envBoolOrDefault("ENRICH_PRIORITY_QUEUE_ENABLED", false) &&
+		redisClientShared != nil
+	var enrichConsumer bus.Consumer = enrichKafkaConsumer
+	var enrichZSetIntake *enrichWorkerPkg.ZSetIntake
+	if enrichPriorityQueueEnabled {
+		zsetCfg := queue.PriorityZSetConfig{
+			ZSetKey:        envOrDefault("ENRICH_ZSET_QUEUE_KEY", "enrich:zset:queue"),
+			EntryKeyPrefix: envOrDefault("ENRICH_ZSET_ENTRY_PREFIX", "enrich:zset:entry:"),
+			MaxSize:        int64(envIntOrDefault("ENRICH_ZSET_MAX_SIZE", int(queue.PriorityZSetMaxSize))),
+			EntryTTL:       envDurationOrDefault("ENRICH_ZSET_ENTRY_TTL", queue.PriorityZSetEntryTTL),
+		}
+		enrichZSetQueue, qerr := queue.NewPriorityZSetQueue(redisClientShared.Raw(), zsetCfg)
+		if qerr != nil {
+			log.WithError(qerr).Fatal("failed to construct enrich priority zset queue")
+		}
+		zsetConsumer := queue.NewPriorityZSetConsumer(enrichZSetQueue, "enrich:zset", envDurationOrDefault("ENRICH_ZSET_POP_TIMEOUT", time.Second))
+		enrichConsumer = zsetConsumer
+		enrichZSetIntake = enrichWorkerPkg.NewZSetIntake(enrichKafkaConsumer, enrichZSetQueue, log)
+		log.WithFields(map[string]interface{}{
+			"zset_key":     zsetCfg.ZSetKey,
+			"entry_prefix": zsetCfg.EntryKeyPrefix,
+			"max_size":     zsetCfg.MaxSize,
+			"entry_ttl_ms": zsetCfg.EntryTTL.Milliseconds(),
+		}).Info("enrich priority zset queue enabled")
+	}
 
 	enrichCap := runtimecfg.CapPerStage(workerCountsCfg.Enrich, stageGateCfg.EnrichMaxConcurrentPerStage)
 	enrichGate := locks.BuildStageGate(locks.StageEnricher, enrichCap, procLock, log)
@@ -1205,6 +1236,15 @@ func main() {
 
 	enrichW := enrichWorkerPkg.NewWorker(enrichConsumer, enrichPublisher, contentSvc, enrichExtractor, enrichVerifier, enrichContextualizer, enrichScorer, enrichedRepo, enrichGate, workerCountsCfg.Enrich)
 
+	// 이슈 #524 — ZSET 모드 활성 시 RetryScheduler 필수 (메시지 손실 방지 가드).
+	if enrichPriorityQueueEnabled {
+		if retryScheduler == nil {
+			log.Fatal("enrich priority zset queue enabled but retry scheduler not configured — set REDIS_HOST or disable ENRICH_PRIORITY_QUEUE_ENABLED")
+		}
+		enrichW.SetRetryScheduler(retryScheduler)
+		log.Info("enrich worker: retry scheduler injected (zset mode message loss guard)")
+	}
+
 	log.WithFields(map[string]interface{}{
 		"worker_count": workerCountsCfg.Enrich,
 		"input_topic":  queue.TopicValidated,
@@ -1239,6 +1279,9 @@ func main() {
 	enrichStage, err := enrich.NewStage(enrichW)
 	if err != nil {
 		log.WithError(err).Fatal("failed to construct enrich stage")
+	}
+	if enrichZSetIntake != nil {
+		enrichStage.SetZSetIntake(enrichZSetIntake)
 	}
 
 	// 이슈 #443 — stage 별 활성 플래그에 따라 selective Start.

--- a/internal/processor/enrich/enrich.go
+++ b/internal/processor/enrich/enrich.go
@@ -15,6 +15,7 @@ import (
 // Stage 는 enrich worker 를 processor.Stage 인터페이스로 wrapping 합니다.
 type Stage struct {
 	worker *worker.Worker
+	intake *worker.ZSetIntake // nil 허용 — ZSET 인입 모드일 때만 (이슈 #524)
 }
 
 // NewStage 는 wired Worker 를 받아 enrich.Stage 를 반환합니다.
@@ -26,12 +27,26 @@ func NewStage(w *worker.Worker) (*Stage, error) {
 	return &Stage{worker: w}, nil
 }
 
+// SetZSetIntake 는 Kafka → ZSET 인입 단계 컴포넌트를 주입합니다 (이슈 #524 / 메타 #515 Phase 2).
+//
+// nil 주입 시 ZSET 모드 비활성 — Worker 가 일반 Kafka consumer 로 동작하는 경로.
+// Start 호출 전 wiring 단계에서 1회 설정.
+func (s *Stage) SetZSetIntake(intake *worker.ZSetIntake) {
+	s.intake = intake
+}
+
 // Name 은 stage 식별자 ("enricher") 를 반환합니다.
 func (s *Stage) Name() string { return worker.StageName }
 
 // Start 는 enrich worker pool 을 기동합니다.
+//
+// 이슈 #524 — ZSET 인입 모드 활성 시 별도 goroutine 에서 Kafka → ZSET intake 동시 운용.
+// ctx cancel 시 자연 종료 (별도 Stop 메소드 불필요).
 func (s *Stage) Start(ctx context.Context) {
 	s.worker.Start(ctx)
+	if s.intake != nil {
+		go s.intake.Run(ctx)
+	}
 }
 
 // Stop 은 enrich worker 의 graceful shutdown 을 수행합니다.

--- a/internal/processor/enrich/worker/worker.go
+++ b/internal/processor/enrich/worker/worker.go
@@ -239,7 +239,7 @@ func BuildRetryJob(msg *queue.Message) (*core.CrawlJob, error) {
 		return nil, fmt.Errorf("retry unmarshal: empty URL in ContentRef %s", ref.ID)
 	}
 
-	priority := core.Priority(PriorityFromHeader(msg.Headers))
+	priority := core.Priority(queue.PriorityFromHeader(msg.Headers))
 
 	crawlerName := msg.Headers["crawler"]
 	if crawlerName == "" {
@@ -285,21 +285,8 @@ func BuildRetryJob(msg *queue.Message) (*core.CrawlJob, error) {
 // buildRetryDefaultTimeout 은 BuildRetryJob 의 timeout_ms 헤더가 부재할 때 사용하는 기본값입니다.
 const buildRetryDefaultTimeout = 30 * time.Second
 
-// PriorityFromHeader 는 Kafka 메시지 헤더의 "priority" 값을 int 로 파싱합니다 (이슈 #524).
-// 미설정 / 파싱 실패 / 범위 밖 (1~3 외) 은 PriorityNormal (2) 로 보정.
-//
-// 본 함수는 Parser / Validate 의 동일 이름 함수와 1:1 — 향후 공통 helper 로 이관 가능.
-func PriorityFromHeader(headers map[string]string) int {
-	v, ok := headers["priority"]
-	if !ok {
-		return int(core.PriorityNormal)
-	}
-	n, err := strconv.Atoi(v)
-	if err != nil || n < 1 || n > 3 {
-		return int(core.PriorityNormal)
-	}
-	return n
-}
+// 이슈 #524 (gemini #3278202670 DRY) — PriorityFromHeader 는 queue.PriorityFromHeader 로 이관.
+// 본 패키지의 동일 이름 함수는 제거. 단위 테스트는 test/pkg/queue/priority_header_test.go.
 
 // isValidTargetType 은 retry job 에 적용 가능한 TargetType 인지 검증합니다.
 // article / category 만 허용 — 알 수 없는 값은 caller 가 Article default 로 보정.

--- a/internal/processor/enrich/worker/worker.go
+++ b/internal/processor/enrich/worker/worker.go
@@ -13,6 +13,7 @@ import (
 	"errors"
 	"fmt"
 	"net/url"
+	"strconv"
 	"time"
 
 	"issuetracker/internal/bus"
@@ -62,6 +63,13 @@ type Worker struct {
 	workerCount    int
 
 	pool *workerpool.ConsumerPool
+
+	// retryScheduler 는 process 실패 시 재시도 발행 경로 (이슈 #524 / 메타 #515 Phase 2).
+	// nil 허용 — nil 이면 기존 동작 (commit skip → Kafka redeliver).
+	//
+	// ZSET 인입 모드에서는 BZPOPMIN 이 곧 ack 라 commit skip 으로 redeliver 불가 — RetryScheduler
+	// 주입 필수. 주입 시 Handle 이 process error 에 대해 Enqueue 후 commit (메시지 손실 방지).
+	retryScheduler bus.RetryScheduler
 }
 
 // NewWorker 는 새로운 Worker 를 생성합니다.
@@ -116,6 +124,16 @@ func NewWorker(
 	}
 }
 
+// SetRetryScheduler 는 process 실패 시 재시도 발행 경로를 주입합니다 (이슈 #524 / 메타 #515 Phase 2).
+//
+// nil 주입 시 기존 동작 (commit skip → Kafka redeliver) 유지. ZSET 인입 모드에서는 pop 이
+// 곧 ack 이라 commit skip 으로는 redeliver 불가 — 본 setter 로 RetryScheduler 를 반드시 주입.
+//
+// Start 호출 전 wiring 단계에서 1회 설정.
+func (w *Worker) SetRetryScheduler(rs bus.RetryScheduler) {
+	w.retryScheduler = rs
+}
+
 // Start 는 workerpool harness 를 기동합니다. 인스턴스당 1회만 호출 (2회차는 panic).
 func (w *Worker) Start(ctx context.Context) {
 	if w.pool != nil {
@@ -145,14 +163,152 @@ func (w *Worker) Stop(ctx context.Context) error {
 }
 
 // Handle 은 workerpool.Handler 구현 — 각 메시지마다 호출됩니다.
+//
+// process 의 결과에 따른 분기:
+//   - nil → 성공 (process 내부에서 commit 이미 수행)
+//   - context.Canceled → graceful shutdown (DEBUG 강등)
+//   - 그 외 process 실패:
+//   - retryScheduler 주입 시 (이슈 #524): RetryScheduler.Enqueue → commit (메시지 손실 방지)
+//   - enqueue 실패 시 DLQ fallback (영구 손실 방지)
+//   - 미주입 시: commit skip (Kafka redeliver, 기존 동작)
 func (w *Worker) Handle(ctx context.Context, msg *queue.Message) {
 	log := logger.FromContext(ctx)
-	if err := w.process(ctx, msg); err != nil {
-		if errors.Is(err, context.Canceled) {
-			log.WithError(err).Debug("enrich worker canceled during shutdown")
-		} else {
-			log.WithError(err).Error("enrich worker failed to process message")
+	err := w.process(ctx, msg)
+	if err == nil {
+		return
+	}
+	if errors.Is(err, context.Canceled) {
+		log.WithError(err).Debug("enrich worker canceled during shutdown")
+		return
+	}
+	if w.retryScheduler != nil {
+		if enqueueErr := w.enqueueRetry(ctx, msg, err); enqueueErr != nil {
+			// ZSET 모드에서 메시지는 이미 pop 됐으므로 enqueue 실패 시 영구 손실 — fallback 으로
+			// DLQ 발행하여 운영 가시성 + 수동 복구 가능.
+			log.WithError(enqueueErr).Warn("retry enqueue failed, sending to dlq as fallback")
+			if dlqErr := w.sendToDLQ(ctx, msg, fmt.Errorf("retry enqueue failed: %w (original: %v)", enqueueErr, err)); dlqErr != nil {
+				log.WithError(dlqErr).Error("dlq fallback failed, message will be lost in zset mode")
+				return
+			}
+			if commitErr := w.commit(ctx, msg); commitErr != nil && ctx.Err() == nil {
+				log.WithError(commitErr).Warn("commit after dlq fallback failed")
+			}
+			return
 		}
+		if commitErr := w.commit(ctx, msg); commitErr != nil && ctx.Err() == nil {
+			log.WithError(commitErr).Warn("commit after retry enqueue failed")
+		}
+		log.WithError(err).Info("enrich process failed, enqueued for retry")
+		return
+	}
+	log.WithError(err).Error("enrich worker failed to process message")
+}
+
+// enqueueRetry 는 process 실패한 메시지를 RetryScheduler 경유로 재시도 큐에 등록합니다 (이슈 #524).
+//
+// ContentRef → CrawlJob 변환은 BuildRetryJob 으로 분리 (unit test 용이성).
+func (w *Worker) enqueueRetry(ctx context.Context, msg *queue.Message, lastErr error) error {
+	job, err := BuildRetryJob(msg)
+	if err != nil {
+		return err
+	}
+	return w.retryScheduler.Enqueue(ctx, job, lastErr)
+}
+
+// BuildRetryJob 은 process 실패한 Kafka 메시지를 retry 용 CrawlJob 으로 변환합니다 (이슈 #524).
+//
+// ProcessingMessage.Data 에서 ContentRef 를 추출하여 URL + CrawlerName + priority + target_type
+// 을 복원. msg.Headers 가 우선:
+//   - crawler 헤더 우선, 없으면 ContentRef.SourceInfo.Name, 둘 다 빈 값이면 "enrich-retry"
+//   - priority 헤더는 PriorityFromHeader 헬퍼로 통일
+//   - target_type 헤더가 유효 (article/category) 이면 사용, 없으면 Article default
+//
+// retry_reason / original_ref_id 메타로 추적 가시성 제공.
+//
+// 빈 URL 또는 unmarshal 실패 시 error — 호출자가 retry 불가로 분기.
+func BuildRetryJob(msg *queue.Message) (*core.CrawlJob, error) {
+	var pm core.ProcessingMessage
+	if uerr := json.Unmarshal(msg.Value, &pm); uerr != nil {
+		return nil, fmt.Errorf("retry unmarshal processing message: %w", uerr)
+	}
+	var ref core.ContentRef
+	if uerr := json.Unmarshal(pm.Data, &ref); uerr != nil {
+		return nil, fmt.Errorf("retry unmarshal content ref: %w", uerr)
+	}
+	if ref.URL == "" {
+		return nil, fmt.Errorf("retry unmarshal: empty URL in ContentRef %s", ref.ID)
+	}
+
+	priority := core.Priority(PriorityFromHeader(msg.Headers))
+
+	crawlerName := msg.Headers["crawler"]
+	if crawlerName == "" {
+		crawlerName = ref.SourceInfo.Name
+	}
+	if crawlerName == "" {
+		crawlerName = "enrich-retry"
+	}
+
+	targetType := core.TargetTypeArticle
+	if t, ok := msg.Headers["target_type"]; ok {
+		if tt := core.TargetType(t); isValidTargetType(tt) {
+			targetType = tt
+		}
+	}
+
+	// timeout — 원본 timeout_ms 헤더 계승, 부재 시 기본 (gemini PR #527 #3275211693 패턴).
+	jobTimeout := buildRetryDefaultTimeout
+	if raw := msg.Headers[core.HeaderTimeoutMs]; raw != "" {
+		if ms, perr := strconv.Atoi(raw); perr == nil && ms > 0 {
+			jobTimeout = time.Duration(ms) * time.Millisecond
+		}
+	}
+
+	return &core.CrawlJob{
+		ID:          ref.ID,
+		CrawlerName: crawlerName,
+		Target: core.Target{
+			URL:  ref.URL,
+			Type: targetType,
+			Metadata: map[string]interface{}{
+				"retry_reason":    "enrich_process_failed",
+				"original_ref_id": ref.ID,
+			},
+		},
+		Priority:    priority,
+		ScheduledAt: time.Now(),
+		Timeout:     jobTimeout,
+		MaxRetries:  bus.DefaultMaxRetries,
+	}, nil
+}
+
+// buildRetryDefaultTimeout 은 BuildRetryJob 의 timeout_ms 헤더가 부재할 때 사용하는 기본값입니다.
+const buildRetryDefaultTimeout = 30 * time.Second
+
+// PriorityFromHeader 는 Kafka 메시지 헤더의 "priority" 값을 int 로 파싱합니다 (이슈 #524).
+// 미설정 / 파싱 실패 / 범위 밖 (1~3 외) 은 PriorityNormal (2) 로 보정.
+//
+// 본 함수는 Parser / Validate 의 동일 이름 함수와 1:1 — 향후 공통 helper 로 이관 가능.
+func PriorityFromHeader(headers map[string]string) int {
+	v, ok := headers["priority"]
+	if !ok {
+		return int(core.PriorityNormal)
+	}
+	n, err := strconv.Atoi(v)
+	if err != nil || n < 1 || n > 3 {
+		return int(core.PriorityNormal)
+	}
+	return n
+}
+
+// isValidTargetType 은 retry job 에 적용 가능한 TargetType 인지 검증합니다.
+// article / category 만 허용 — 알 수 없는 값은 caller 가 Article default 로 보정.
+func isValidTargetType(t core.TargetType) bool {
+	switch t {
+	case core.TargetTypeArticle, core.TargetTypeCategory:
+		return true
+	default:
+		return false
 	}
 }
 

--- a/internal/processor/enrich/worker/zset_intake.go
+++ b/internal/processor/enrich/worker/zset_intake.go
@@ -128,7 +128,7 @@ func (i *ZSetIntake) handleOne(ctx context.Context, msg *queue.Message) {
 		return
 	}
 
-	priority := PriorityFromHeader(msg.Headers)
+	priority := queue.PriorityFromHeader(msg.Headers)
 
 	if err := i.zsetQueue.Push(ctx, priority, ref.ID, msg.Value); err != nil {
 		log.WithError(err).WithField("ref_id", ref.ID).Warn("intake zset push failed, skipping commit for redeliver")

--- a/internal/processor/enrich/worker/zset_intake.go
+++ b/internal/processor/enrich/worker/zset_intake.go
@@ -1,0 +1,150 @@
+// ZSetIntake — Enrich 의 Kafka → Redis ZSET 인입 단계 (이슈 #524 / 메타 #515 Phase 2).
+//
+// 단일 goroutine 이 TopicValidated Kafka 메시지를 받아 priority + arrival timestamp 로
+// score 를 계산해 ZSET 에 적재 + Kafka commit. Worker pool 은 ZSET 에서 BZPOPMIN 으로
+// pop 하여 처리 — Kafka partition FIFO 제약을 우회한 priority sub-ordering 보장.
+//
+// 흐름:
+//  1. consumer.FetchMessage — Kafka 에서 1건 fetch
+//  2. ProcessingMessage / ContentRef.ID 추출 (ZSET member key)
+//  3. priority header 추출 (1/2/3, 잘못된 값은 normal)
+//  4. zsetQueue.Push(priority, id, payload)
+//  5. consumer.CommitMessages — Kafka commit
+//
+// 실패 정책 (Parser ZSetIntake 와 동일):
+//   - Unmarshal 실패: 메시지 형식 깨짐 — commit (재시도 무의미)
+//   - 빈 ID: commit + skip
+//   - ZSET push 실패: commit skip (Kafka redeliver)
+//   - Kafka commit 실패: ZSET 에 이미 push, redeliver 시 동일 ID 재push (idempotent)
+package worker
+
+import (
+	"context"
+	"encoding/json"
+	"time"
+
+	"issuetracker/internal/bus"
+	"issuetracker/internal/processor/fetcher/core"
+	"issuetracker/pkg/logger"
+	"issuetracker/pkg/queue"
+)
+
+// ZSetIntake 는 Kafka → ZSET 인입 단계의 컴포넌트입니다.
+//
+// zsetQueue 는 queue.PriorityPusher 인터페이스 — *queue.PriorityZSetQueue 가 자동 만족하며,
+// 단위 테스트에서는 in-memory stub 으로 교체 가능.
+type ZSetIntake struct {
+	consumer  bus.Consumer
+	zsetQueue queue.PriorityPusher
+	log       *logger.Logger
+}
+
+// NewZSetIntake 는 ZSetIntake 인스턴스를 생성합니다.
+//
+// 모든 인자 nil 불허 — wiring 단계에서 사전 검증. nil 시 nil 반환.
+func NewZSetIntake(consumer bus.Consumer, zsetQueue queue.PriorityPusher, log *logger.Logger) *ZSetIntake {
+	if consumer == nil || zsetQueue == nil || log == nil {
+		return nil
+	}
+	return &ZSetIntake{
+		consumer:  consumer,
+		zsetQueue: zsetQueue,
+		log:       log,
+	}
+}
+
+// Run 은 ctx 가 cancel 될 때까지 Kafka FetchMessage → ZSET push → Kafka commit 루프를 실행합니다.
+//
+// goroutine 으로 시작 권장 — 본 함수는 blocking. 종료 시 defer consumer.Close() 로 Kafka
+// reader 자원 누수 방지.
+func (i *ZSetIntake) Run(ctx context.Context) {
+	i.log.Info("enrich zset intake started")
+	defer func() {
+		if err := i.consumer.Close(); err != nil {
+			i.log.WithError(err).Warn("intake consumer close failed")
+		}
+		i.log.Info("enrich zset intake stopped")
+	}()
+
+	for {
+		if err := ctx.Err(); err != nil {
+			return
+		}
+		msg, err := i.consumer.FetchMessage(ctx)
+		if err != nil {
+			if ctx.Err() != nil {
+				return
+			}
+			i.log.WithError(err).Error("intake fetch failed")
+			select {
+			case <-ctx.Done():
+				return
+			case <-time.After(100 * time.Millisecond):
+			}
+			continue
+		}
+		i.handleOne(ctx, msg)
+	}
+}
+
+// HandleOneForTest 는 handleOne 의 테스트 전용 export 입니다.
+func (i *ZSetIntake) HandleOneForTest(ctx context.Context, msg *queue.Message) {
+	i.handleOne(ctx, msg)
+}
+
+// handleOne 은 단일 메시지를 ZSET 에 적재 + Kafka commit 합니다.
+//
+// Enrich 는 ProcessingMessage 한 단계 wrap 위에 ContentRef 가 들어 있으므로 인입 시점에는
+// ContentRef.ID 를 ZSET key 로 사용 — Worker.process 가 동일 형식으로 다시 unmarshal 함.
+func (i *ZSetIntake) handleOne(ctx context.Context, msg *queue.Message) {
+	log := i.log.WithFields(map[string]interface{}{
+		"offset":    msg.Offset,
+		"partition": msg.Partition,
+	})
+
+	var pm core.ProcessingMessage
+	if err := json.Unmarshal(msg.Value, &pm); err != nil {
+		log.WithError(err).Warn("intake unmarshal failed, committing to avoid redeliver loop")
+		if cerr := i.consumer.CommitMessages(ctx, msg); cerr != nil && ctx.Err() == nil {
+			log.WithError(cerr).Warn("intake commit (after unmarshal failure) failed")
+		}
+		return
+	}
+
+	// ContentRef.ID 를 ZSET member 로 사용 — 동일 ref 가 재차 도착해도 idempotent.
+	var ref core.ContentRef
+	if err := json.Unmarshal(pm.Data, &ref); err != nil {
+		log.WithError(err).Warn("intake content ref unmarshal failed, committing")
+		if cerr := i.consumer.CommitMessages(ctx, msg); cerr != nil && ctx.Err() == nil {
+			log.WithError(cerr).Warn("intake commit (after ref unmarshal failure) failed")
+		}
+		return
+	}
+	if ref.ID == "" {
+		log.Warn("intake skipping message with empty ContentRef.ID")
+		if cerr := i.consumer.CommitMessages(ctx, msg); cerr != nil && ctx.Err() == nil {
+			log.WithError(cerr).Warn("intake commit (empty id) failed")
+		}
+		return
+	}
+
+	priority := PriorityFromHeader(msg.Headers)
+
+	if err := i.zsetQueue.Push(ctx, priority, ref.ID, msg.Value); err != nil {
+		log.WithError(err).WithField("ref_id", ref.ID).Warn("intake zset push failed, skipping commit for redeliver")
+		return
+	}
+
+	if err := i.consumer.CommitMessages(ctx, msg); err != nil {
+		if ctx.Err() != nil {
+			return
+		}
+		log.WithError(err).WithField("ref_id", ref.ID).Warn("intake commit failed (zset already pushed, idempotent on redeliver)")
+		return
+	}
+
+	log.WithFields(map[string]interface{}{
+		"ref_id":   ref.ID,
+		"priority": priority,
+	}).Debug("intake pushed to zset and committed")
+}

--- a/internal/processor/parser/worker/worker.go
+++ b/internal/processor/parser/worker/worker.go
@@ -386,7 +386,7 @@ func BuildRetryJob(msg *queue.Message) (*core.CrawlJob, error) {
 		return nil, fmt.Errorf("retry unmarshal: empty URL in RawContentRef %s", ref.ID)
 	}
 
-	priority := core.Priority(PriorityFromHeader(msg.Headers))
+	priority := core.Priority(queue.PriorityFromHeader(msg.Headers))
 
 	crawlerName := msg.Headers["crawler"]
 	if crawlerName == "" {

--- a/internal/processor/parser/worker/zset_intake.go
+++ b/internal/processor/parser/worker/zset_intake.go
@@ -23,7 +23,6 @@ package worker
 import (
 	"context"
 	"encoding/json"
-	"strconv"
 	"time"
 
 	"issuetracker/internal/bus"
@@ -123,7 +122,7 @@ func (i *ZSetIntake) handleOne(ctx context.Context, msg *queue.Message) {
 		return
 	}
 
-	priority := PriorityFromHeader(msg.Headers)
+	priority := queue.PriorityFromHeader(msg.Headers)
 
 	if err := i.zsetQueue.Push(ctx, priority, ref.ID, msg.Value); err != nil {
 		// Redis 일시 장애 — commit skip 으로 Kafka 가 redeliver. 다음 polling 에서 자연 retry.
@@ -146,16 +145,5 @@ func (i *ZSetIntake) handleOne(ctx context.Context, msg *queue.Message) {
 	}).Debug("intake pushed to zset and committed")
 }
 
-// PriorityFromHeader 는 Kafka 메시지 헤더의 "priority" 값을 int 로 파싱합니다.
-// 미설정 / 파싱 실패 / 범위 밖 (1~3 외) 은 PriorityNormal (2) 로 보정.
-func PriorityFromHeader(headers map[string]string) int {
-	v, ok := headers["priority"]
-	if !ok {
-		return int(core.PriorityNormal)
-	}
-	n, err := strconv.Atoi(v)
-	if err != nil || n < 1 || n > 3 {
-		return int(core.PriorityNormal)
-	}
-	return n
-}
+// 이슈 #524 (gemini #3278202670 DRY) — PriorityFromHeader 는 queue.PriorityFromHeader 로 이관.
+// 본 패키지의 동일 이름 함수는 제거. 단위 테스트는 test/pkg/queue/priority_header_test.go.

--- a/internal/processor/validate/worker/worker.go
+++ b/internal/processor/validate/worker/worker.go
@@ -225,7 +225,7 @@ func BuildRetryJob(msg *queue.Message) (*core.CrawlJob, error) {
 		return nil, fmt.Errorf("retry unmarshal: empty URL in ContentRef %s", ref.ID)
 	}
 
-	priority := core.Priority(PriorityFromHeader(msg.Headers))
+	priority := core.Priority(queue.PriorityFromHeader(msg.Headers))
 
 	crawlerName := msg.Headers["crawler"]
 	if crawlerName == "" {
@@ -272,21 +272,8 @@ func BuildRetryJob(msg *queue.Message) (*core.CrawlJob, error) {
 // buildRetryDefaultTimeout 은 BuildRetryJob 의 timeout_ms 헤더가 부재할 때 사용하는 기본값입니다.
 const buildRetryDefaultTimeout = 30 * time.Second
 
-// PriorityFromHeader 는 Kafka 메시지 헤더의 "priority" 값을 int 로 파싱합니다 (이슈 #523).
-// 미설정 / 파싱 실패 / 범위 밖 (1~3 외) 은 PriorityNormal (2) 로 보정.
-//
-// 본 함수는 Parser 의 동일 이름 함수와 1:1 — 향후 공통 helper 로 이관 가능.
-func PriorityFromHeader(headers map[string]string) int {
-	v, ok := headers["priority"]
-	if !ok {
-		return int(core.PriorityNormal)
-	}
-	n, err := strconv.Atoi(v)
-	if err != nil || n < 1 || n > 3 {
-		return int(core.PriorityNormal)
-	}
-	return n
-}
+// 이슈 #524 (gemini #3278202670 DRY) — PriorityFromHeader 는 queue.PriorityFromHeader 로 이관.
+// 본 패키지의 동일 이름 함수는 제거. 단위 테스트는 test/pkg/queue/priority_header_test.go.
 
 // isValidTargetType 은 retry job 에 적용 가능한 TargetType 인지 검증합니다.
 // article / category 만 허용 — 알 수 없는 값은 caller 가 Article default 로 보정.

--- a/internal/processor/validate/worker/zset_intake.go
+++ b/internal/processor/validate/worker/zset_intake.go
@@ -128,7 +128,7 @@ func (i *ZSetIntake) handleOne(ctx context.Context, msg *queue.Message) {
 		return
 	}
 
-	priority := PriorityFromHeader(msg.Headers)
+	priority := queue.PriorityFromHeader(msg.Headers)
 
 	if err := i.zsetQueue.Push(ctx, priority, ref.ID, msg.Value); err != nil {
 		log.WithError(err).WithField("ref_id", ref.ID).Warn("intake zset push failed, skipping commit for redeliver")

--- a/pkg/queue/priority_header.go
+++ b/pkg/queue/priority_header.go
@@ -1,0 +1,30 @@
+// Package queue 의 priority 헤더 파싱 유틸 (이슈 #524 — gemini #3278202670 DRY).
+//
+// Parser / Validate / Enrich worker 가 동일 로직 (Kafka 메시지 헤더의 "priority" 값을
+// 1=high/2=normal/3=low int 로 파싱) 을 사용하므로 중복 함수를 공통 패키지로 이관.
+package queue
+
+import "strconv"
+
+// PriorityHeaderKey 는 Kafka 메시지 헤더에 부착되는 priority 값의 키 이름입니다.
+// bus.buildMessage 가 동일 키로 부착 — 본 상수와 일치해야 합니다.
+const PriorityHeaderKey = "priority"
+
+// PriorityFromHeader 는 Kafka 메시지 헤더의 "priority" 값을 int 로 파싱합니다.
+//
+// 매핑: 1=high / 2=normal / 3=low — core.Priority 와 동일.
+// 미설정 / 파싱 실패 / 범위 밖 (1~3 외) 은 2 (PriorityNormal) 로 보정.
+//
+// 본 패키지가 core 의존을 피하기 위해 int 반환 — caller 가 필요시 core.Priority(v) 캐스팅.
+// Parser / Validate / Enrich 의 동일 이름 함수는 본 함수로 이관 후 제거됨 (이슈 #524).
+func PriorityFromHeader(headers map[string]string) int {
+	v, ok := headers[PriorityHeaderKey]
+	if !ok {
+		return 2 // PriorityNormal
+	}
+	n, err := strconv.Atoi(v)
+	if err != nil || n < 1 || n > 3 {
+		return 2
+	}
+	return n
+}

--- a/test/internal/processor/enrich/worker/retry_job_test.go
+++ b/test/internal/processor/enrich/worker/retry_job_test.go
@@ -1,0 +1,184 @@
+// BuildRetryJob 의 ContentRef → CrawlJob 변환 + PriorityFromHeader 검증 (이슈 #523).
+package worker_test
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"issuetracker/internal/processor/enrich/worker"
+	"issuetracker/internal/processor/fetcher/core"
+	"issuetracker/pkg/queue"
+)
+
+func makeRetryMsg(t *testing.T, id, url, sourceName string, headers map[string]string) *queue.Message {
+	t.Helper()
+	ref := core.ContentRef{
+		ID:  id,
+		URL: url,
+		SourceInfo: core.SourceInfo{
+			Name: sourceName,
+		},
+	}
+	refBytes, err := json.Marshal(ref)
+	require.NoError(t, err)
+	pm := core.ProcessingMessage{ID: id, Data: refBytes}
+	b, err := json.Marshal(pm)
+	require.NoError(t, err)
+	return &queue.Message{Value: b, Headers: headers}
+}
+
+func TestBuildRetryJob_ValidRef_ReturnsCrawlJob(t *testing.T) {
+	msg := makeRetryMsg(t, "ref-1", "https://example.com/x", "cnn", map[string]string{"priority": "1"})
+
+	job, err := worker.BuildRetryJob(msg)
+	require.NoError(t, err)
+	require.NotNil(t, job)
+	assert.Equal(t, "ref-1", job.ID)
+	assert.Equal(t, "https://example.com/x", job.Target.URL)
+	assert.Equal(t, "cnn", job.CrawlerName)
+	assert.Equal(t, core.PriorityHigh, job.Priority)
+	assert.Equal(t, core.TargetTypeArticle, job.Target.Type)
+	assert.Equal(t, "enrich_process_failed", job.Target.Metadata["retry_reason"])
+	assert.Equal(t, "ref-1", job.Target.Metadata["original_ref_id"])
+}
+
+func TestBuildRetryJob_NoPriorityHeader_DefaultsToNormal(t *testing.T) {
+	msg := makeRetryMsg(t, "ref-2", "https://example.com/", "src", nil)
+	job, err := worker.BuildRetryJob(msg)
+	require.NoError(t, err)
+	assert.Equal(t, core.PriorityNormal, job.Priority)
+}
+
+func TestBuildRetryJob_InvalidPriorityHeader_DefaultsToNormal(t *testing.T) {
+	cases := []string{"0", "4", "abc", "-1"}
+	for _, p := range cases {
+		t.Run("priority="+p, func(t *testing.T) {
+			msg := makeRetryMsg(t, "ref-x", "https://example.com/", "src", map[string]string{"priority": p})
+			job, err := worker.BuildRetryJob(msg)
+			require.NoError(t, err)
+			assert.Equal(t, core.PriorityNormal, job.Priority)
+		})
+	}
+}
+
+func TestBuildRetryJob_HeaderCrawlerPreferredOverSourceInfo(t *testing.T) {
+	msg := makeRetryMsg(t, "ref-h1", "https://example.com/", "source-info-name", map[string]string{"crawler": "header-crawler"})
+	job, err := worker.BuildRetryJob(msg)
+	require.NoError(t, err)
+	assert.Equal(t, "header-crawler", job.CrawlerName)
+}
+
+func TestBuildRetryJob_NoHeaderCrawler_UsesSourceInfo(t *testing.T) {
+	msg := makeRetryMsg(t, "ref-h2", "https://example.com/", "fallback-source", map[string]string{})
+	job, err := worker.BuildRetryJob(msg)
+	require.NoError(t, err)
+	assert.Equal(t, "fallback-source", job.CrawlerName)
+}
+
+func TestBuildRetryJob_EmptyAllCrawler_UsesFallback(t *testing.T) {
+	msg := makeRetryMsg(t, "ref-h3", "https://example.com/", "", nil)
+	job, err := worker.BuildRetryJob(msg)
+	require.NoError(t, err)
+	assert.Equal(t, "enrich-retry", job.CrawlerName)
+}
+
+func TestBuildRetryJob_TargetTypeHeader_Category(t *testing.T) {
+	msg := makeRetryMsg(t, "ref-tt-1", "https://example.com/", "src", map[string]string{"target_type": "category"})
+	job, err := worker.BuildRetryJob(msg)
+	require.NoError(t, err)
+	assert.Equal(t, core.TargetTypeCategory, job.Target.Type)
+}
+
+func TestBuildRetryJob_TargetTypeHeader_InvalidFallsBackToArticle(t *testing.T) {
+	cases := []string{"unknown", "", "page", "list"}
+	for _, tt := range cases {
+		t.Run("type="+tt, func(t *testing.T) {
+			msg := makeRetryMsg(t, "ref-tt-x", "https://example.com/", "src", map[string]string{"target_type": tt})
+			job, err := worker.BuildRetryJob(msg)
+			require.NoError(t, err)
+			assert.Equal(t, core.TargetTypeArticle, job.Target.Type, "unknown %q → Article fallback", tt)
+		})
+	}
+}
+
+func TestBuildRetryJob_EmptyURL_ReturnsError(t *testing.T) {
+	msg := makeRetryMsg(t, "ref-4", "", "src", nil)
+	_, err := worker.BuildRetryJob(msg)
+	assert.Error(t, err)
+}
+
+func TestBuildRetryJob_TimeoutHeaderHonored(t *testing.T) {
+	// gemini #3275211693 — timeout_ms 헤더가 있으면 그 값 사용 (republishForReparse 와 동일 정책).
+	msg := makeRetryMsg(t, "ref-to-1", "https://example.com/", "src", map[string]string{
+		"timeout_ms": "60000", // 60s
+	})
+	job, err := worker.BuildRetryJob(msg)
+	require.NoError(t, err)
+	assert.Equal(t, 60*time.Second, job.Timeout)
+}
+
+func TestBuildRetryJob_NoTimeoutHeader_UsesDefault(t *testing.T) {
+	msg := makeRetryMsg(t, "ref-to-2", "https://example.com/", "src", nil)
+	job, err := worker.BuildRetryJob(msg)
+	require.NoError(t, err)
+	assert.Equal(t, 30*time.Second, job.Timeout, "헤더 부재 시 default 30s")
+}
+
+func TestBuildRetryJob_InvalidTimeoutHeader_UsesDefault(t *testing.T) {
+	cases := []string{"0", "-1", "not-a-number", ""}
+	for _, v := range cases {
+		t.Run("timeout_ms="+v, func(t *testing.T) {
+			msg := makeRetryMsg(t, "ref-to-x", "https://example.com/", "src", map[string]string{
+				"timeout_ms": v,
+			})
+			job, err := worker.BuildRetryJob(msg)
+			require.NoError(t, err)
+			assert.Equal(t, 30*time.Second, job.Timeout, "잘못된 timeout_ms %q → default", v)
+		})
+	}
+}
+
+func TestBuildRetryJob_MalformedProcessingMessage_ReturnsError(t *testing.T) {
+	msg := &queue.Message{Value: []byte("{not-json")}
+	_, err := worker.BuildRetryJob(msg)
+	assert.Error(t, err)
+}
+
+func TestBuildRetryJob_MalformedContentRef_ReturnsError(t *testing.T) {
+	// ProcessingMessage.Data 는 json.RawMessage 라 marshal 시 valid JSON 여야 함.
+	// 유효 JSON 이지만 ContentRef 스키마 외 형식 (배열) 으로 unmarshal 실패 유도.
+	pm := core.ProcessingMessage{ID: "x", Data: json.RawMessage(`[1,2,3]`)}
+	b, err := json.Marshal(pm)
+	require.NoError(t, err)
+	msg := &queue.Message{Value: b}
+	_, err = worker.BuildRetryJob(msg)
+	assert.Error(t, err)
+}
+
+func TestPriorityFromHeader_Mapping(t *testing.T) {
+	tests := []struct {
+		name    string
+		headers map[string]string
+		want    int
+	}{
+		{"high (1)", map[string]string{"priority": "1"}, 1},
+		{"normal (2)", map[string]string{"priority": "2"}, 2},
+		{"low (3)", map[string]string{"priority": "3"}, 3},
+		{"missing → normal", nil, 2},
+		{"empty → normal", map[string]string{"priority": ""}, 2},
+		{"non-numeric → normal", map[string]string{"priority": "xx"}, 2},
+		{"out of range 0 → normal", map[string]string{"priority": "0"}, 2},
+		{"out of range 4 → normal", map[string]string{"priority": "4"}, 2},
+		{"negative → normal", map[string]string{"priority": "-1"}, 2},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := worker.PriorityFromHeader(tt.headers)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/test/internal/processor/enrich/worker/retry_job_test.go
+++ b/test/internal/processor/enrich/worker/retry_job_test.go
@@ -158,27 +158,3 @@ func TestBuildRetryJob_MalformedContentRef_ReturnsError(t *testing.T) {
 	_, err = worker.BuildRetryJob(msg)
 	assert.Error(t, err)
 }
-
-func TestPriorityFromHeader_Mapping(t *testing.T) {
-	tests := []struct {
-		name    string
-		headers map[string]string
-		want    int
-	}{
-		{"high (1)", map[string]string{"priority": "1"}, 1},
-		{"normal (2)", map[string]string{"priority": "2"}, 2},
-		{"low (3)", map[string]string{"priority": "3"}, 3},
-		{"missing → normal", nil, 2},
-		{"empty → normal", map[string]string{"priority": ""}, 2},
-		{"non-numeric → normal", map[string]string{"priority": "xx"}, 2},
-		{"out of range 0 → normal", map[string]string{"priority": "0"}, 2},
-		{"out of range 4 → normal", map[string]string{"priority": "4"}, 2},
-		{"negative → normal", map[string]string{"priority": "-1"}, 2},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got := worker.PriorityFromHeader(tt.headers)
-			assert.Equal(t, tt.want, got)
-		})
-	}
-}

--- a/test/internal/processor/enrich/worker/zset_intake_test.go
+++ b/test/internal/processor/enrich/worker/zset_intake_test.go
@@ -1,0 +1,161 @@
+// ZSetIntake.handleOne 의 분기 검증 (이슈 #523).
+//
+// PriorityPusher 인터페이스 + bus.Consumer 인터페이스에 의존하므로 Redis / Kafka 없이 단위 검증.
+package worker_test
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"issuetracker/internal/processor/enrich/worker"
+	"issuetracker/internal/processor/fetcher/core"
+	"issuetracker/pkg/logger"
+	"issuetracker/pkg/queue"
+)
+
+type stubPusher struct {
+	mu      sync.Mutex
+	calls   []stubPushCall
+	failErr error
+}
+
+type stubPushCall struct {
+	Priority int
+	ID       string
+	Payload  []byte
+}
+
+func (s *stubPusher) Push(_ context.Context, priority int, id string, payload []byte) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.failErr != nil {
+		return s.failErr
+	}
+	s.calls = append(s.calls, stubPushCall{Priority: priority, ID: id, Payload: append([]byte(nil), payload...)})
+	return nil
+}
+
+func (s *stubPusher) Calls() []stubPushCall {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return append([]stubPushCall(nil), s.calls...)
+}
+
+type stubConsumer struct {
+	commits int32
+	closed  bool
+}
+
+func (c *stubConsumer) FetchMessage(_ context.Context) (*queue.Message, error) {
+	return nil, errors.New("not used in handleOne tests")
+}
+
+func (c *stubConsumer) CommitMessages(_ context.Context, _ ...*queue.Message) error {
+	atomic.AddInt32(&c.commits, 1)
+	return nil
+}
+
+func (c *stubConsumer) Close() error {
+	c.closed = true
+	return nil
+}
+
+func (c *stubConsumer) CommitCount() int32 { return atomic.LoadInt32(&c.commits) }
+
+func newIntake(t *testing.T, pusher queue.PriorityPusher) (*worker.ZSetIntake, *stubConsumer) {
+	t.Helper()
+	log := logger.New(logger.Config{Level: "error"})
+	cons := &stubConsumer{}
+	intake := worker.NewZSetIntake(cons, pusher, log)
+	require.NotNil(t, intake)
+	return intake, cons
+}
+
+func makeIntakeMsg(t *testing.T, ref core.ContentRef, headers map[string]string) *queue.Message {
+	t.Helper()
+	refBytes, err := json.Marshal(ref)
+	require.NoError(t, err)
+	pm := core.ProcessingMessage{ID: ref.ID, Data: refBytes}
+	b, err := json.Marshal(pm)
+	require.NoError(t, err)
+	return &queue.Message{Value: b, Headers: headers}
+}
+
+func TestZSetIntake_HandleOne_Success_PushesAndCommits(t *testing.T) {
+	pusher := &stubPusher{}
+	intake, cons := newIntake(t, pusher)
+
+	msg := makeIntakeMsg(t,
+		core.ContentRef{ID: "ref-1", URL: "https://example.com/", SourceInfo: core.SourceInfo{Name: "src"}},
+		map[string]string{"priority": "1"},
+	)
+	intake.HandleOneForTest(context.Background(), msg)
+
+	calls := pusher.Calls()
+	require.Len(t, calls, 1)
+	assert.Equal(t, "ref-1", calls[0].ID)
+	assert.Equal(t, 1, calls[0].Priority)
+	assert.Equal(t, int32(1), cons.CommitCount())
+}
+
+func TestZSetIntake_HandleOne_ProcessingMessageUnmarshalFailure_Commits(t *testing.T) {
+	pusher := &stubPusher{}
+	intake, cons := newIntake(t, pusher)
+	msg := &queue.Message{Value: []byte("{not-json"), Headers: map[string]string{}}
+	intake.HandleOneForTest(context.Background(), msg)
+	assert.Empty(t, pusher.Calls())
+	assert.Equal(t, int32(1), cons.CommitCount())
+}
+
+func TestZSetIntake_HandleOne_ContentRefUnmarshalFailure_Commits(t *testing.T) {
+	pusher := &stubPusher{}
+	intake, cons := newIntake(t, pusher)
+	// Data 가 유효 JSON 이지만 ContentRef 스키마 외 형식 (배열) — unmarshal 실패.
+	pm := core.ProcessingMessage{ID: "x", Data: json.RawMessage(`[1,2,3]`)}
+	b, err := json.Marshal(pm)
+	require.NoError(t, err)
+	msg := &queue.Message{Value: b, Headers: map[string]string{}}
+	intake.HandleOneForTest(context.Background(), msg)
+	assert.Empty(t, pusher.Calls())
+	assert.Equal(t, int32(1), cons.CommitCount())
+}
+
+func TestZSetIntake_HandleOne_EmptyID_Commits(t *testing.T) {
+	pusher := &stubPusher{}
+	intake, cons := newIntake(t, pusher)
+	msg := makeIntakeMsg(t, core.ContentRef{URL: "https://example.com/"}, nil)
+	intake.HandleOneForTest(context.Background(), msg)
+	assert.Empty(t, pusher.Calls())
+	assert.Equal(t, int32(1), cons.CommitCount())
+}
+
+func TestZSetIntake_HandleOne_PushFailure_SkipsCommit(t *testing.T) {
+	pusher := &stubPusher{failErr: errors.New("push failed")}
+	intake, cons := newIntake(t, pusher)
+	msg := makeIntakeMsg(t,
+		core.ContentRef{ID: "ref-2", URL: "https://example.com/", SourceInfo: core.SourceInfo{Name: "s"}},
+		map[string]string{"priority": "2"},
+	)
+	intake.HandleOneForTest(context.Background(), msg)
+	assert.Equal(t, int32(0), cons.CommitCount(), "push 실패 시 commit skip — Kafka redeliver")
+}
+
+func TestZSetIntake_HandleOne_HeaderMissing_DefaultsNormalPriority(t *testing.T) {
+	pusher := &stubPusher{}
+	intake, _ := newIntake(t, pusher)
+	msg := makeIntakeMsg(t,
+		core.ContentRef{ID: "ref-3", URL: "https://example.com/", SourceInfo: core.SourceInfo{Name: "x"}},
+		nil,
+	)
+	intake.HandleOneForTest(context.Background(), msg)
+	calls := pusher.Calls()
+	require.Len(t, calls, 1)
+	assert.Equal(t, 2, calls[0].Priority)
+}

--- a/test/internal/processor/parser/worker/retry_job_test.go
+++ b/test/internal/processor/parser/worker/retry_job_test.go
@@ -166,27 +166,3 @@ func TestBuildRetryJob_MalformedJSON_ReturnsError(t *testing.T) {
 	_, err := worker.BuildRetryJob(msg)
 	assert.Error(t, err)
 }
-
-func TestPriorityFromHeader_Mapping(t *testing.T) {
-	tests := []struct {
-		name    string
-		headers map[string]string
-		want    int
-	}{
-		{"high (1)", map[string]string{"priority": "1"}, 1},
-		{"normal (2)", map[string]string{"priority": "2"}, 2},
-		{"low (3)", map[string]string{"priority": "3"}, 3},
-		{"missing key → normal", nil, 2},
-		{"empty value → normal", map[string]string{"priority": ""}, 2},
-		{"non-numeric → normal", map[string]string{"priority": "xx"}, 2},
-		{"out of range 0 → normal", map[string]string{"priority": "0"}, 2},
-		{"out of range 4 → normal", map[string]string{"priority": "4"}, 2},
-		{"negative → normal", map[string]string{"priority": "-1"}, 2},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got := worker.PriorityFromHeader(tt.headers)
-			assert.Equal(t, tt.want, got)
-		})
-	}
-}

--- a/test/internal/processor/validate/worker/retry_job_test.go
+++ b/test/internal/processor/validate/worker/retry_job_test.go
@@ -158,27 +158,3 @@ func TestBuildRetryJob_MalformedContentRef_ReturnsError(t *testing.T) {
 	_, err = worker.BuildRetryJob(msg)
 	assert.Error(t, err)
 }
-
-func TestPriorityFromHeader_Mapping(t *testing.T) {
-	tests := []struct {
-		name    string
-		headers map[string]string
-		want    int
-	}{
-		{"high (1)", map[string]string{"priority": "1"}, 1},
-		{"normal (2)", map[string]string{"priority": "2"}, 2},
-		{"low (3)", map[string]string{"priority": "3"}, 3},
-		{"missing → normal", nil, 2},
-		{"empty → normal", map[string]string{"priority": ""}, 2},
-		{"non-numeric → normal", map[string]string{"priority": "xx"}, 2},
-		{"out of range 0 → normal", map[string]string{"priority": "0"}, 2},
-		{"out of range 4 → normal", map[string]string{"priority": "4"}, 2},
-		{"negative → normal", map[string]string{"priority": "-1"}, 2},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got := worker.PriorityFromHeader(tt.headers)
-			assert.Equal(t, tt.want, got)
-		})
-	}
-}

--- a/test/pkg/queue/priority_header_test.go
+++ b/test/pkg/queue/priority_header_test.go
@@ -1,0 +1,37 @@
+// queue.PriorityFromHeader 의 매핑 검증 (이슈 #524 — gemini #3278202670 DRY).
+//
+// 기존 Parser / Validate / Enrich worker package 의 동일 이름 함수가 본 함수로 이관됨.
+// 각 worker package 의 동일 테스트는 본 파일로 통합.
+package queue_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"issuetracker/pkg/queue"
+)
+
+func TestPriorityFromHeader_Mapping(t *testing.T) {
+	tests := []struct {
+		name    string
+		headers map[string]string
+		want    int
+	}{
+		{"high (1)", map[string]string{"priority": "1"}, 1},
+		{"normal (2)", map[string]string{"priority": "2"}, 2},
+		{"low (3)", map[string]string{"priority": "3"}, 3},
+		{"missing key → normal", nil, 2},
+		{"empty value → normal", map[string]string{"priority": ""}, 2},
+		{"non-numeric → normal", map[string]string{"priority": "xx"}, 2},
+		{"out of range 0 → normal", map[string]string{"priority": "0"}, 2},
+		{"out of range 4 → normal", map[string]string{"priority": "4"}, 2},
+		{"negative → normal", map[string]string{"priority": "-1"}, 2},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := queue.PriorityFromHeader(tt.headers)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}


### PR DESCRIPTION
## 연관 이슈
- Closes #524
- Parent: #515 (Phase 2 Sub 6, 마지막)
- 선행: #522 (PR #526), #523 (PR #527)

<br>

## 구현 내용

메타 이슈 #515 의 **Phase 2 마지막 stage** — Validate #527 패턴을 Enrich 에 미러링. Kafka partition FIFO 가 priority sub-ordering 을 제공 못 하는 한계를 Redis ZSET 으로 해소.

흐름 (Validate 동일):
```
Kafka.TopicValidated → [intake goroutine] → Redis ZSET → [worker pool] → process
                                                                  ↓ 실패
                                                           RetryScheduler.Enqueue → Kafka 재발행
                                                                  ↓ Enqueue 실패
                                                           DLQ fallback (메시지 영구 손실 방지)
```

### Sub 1 — Enrich Worker retry hook (7830db9)
- `Worker.retryScheduler` 필드 + `SetRetryScheduler` setter
- `Handle` 분기: process 실패 → enqueueRetry → DLQ fallback → commit
- `BuildRetryJob`: ProcessingMessage → ContentRef → CrawlJob 변환
  - crawler/target_type 헤더 우선, "enrich-retry" fallback
  - `PriorityFromHeader` 헬퍼 / `isValidTargetType` 헬퍼
  - `timeout_ms` 헤더 계승
  - `retry_reason="enrich_process_failed"` + `original_ref_id` metadata

### Sub 2 — Kafka → ZSET intake goroutine (1f4768f)
- `worker.ZSetIntake` — Validate 동일 패턴, 입력 토픽만 `TopicValidated` 로 변경
- 실패 정책 동일 (unmarshal/빈 ID → commit / push 실패 → commit skip)

### Sub 3 — Feature flag + main.go wiring + Stage 통합 (e59474d)
- `ENRICH_PRIORITY_QUEUE_ENABLED=true` + `STAGES_ENRICH_ENABLED=true` + `redisClientShared != nil` 시 ZSET 모드 활성
- ZSET 모드 + retryScheduler nil → **fatal**
- `enrich.Stage.SetZSetIntake` 로 lifecycle 통합
- 환경변수: `ENRICH_ZSET_QUEUE_KEY` / `ENRICH_ZSET_ENTRY_PREFIX` / `ENRICH_ZSET_MAX_SIZE` / `ENRICH_ZSET_ENTRY_TTL` / `ENRICH_ZSET_POP_TIMEOUT`
- `.env.example` 갱신

### Sub 4 — 단위 테스트 (이번 커밋)
- BuildRetryJob 11 cases + ZSetIntake.handleOne 6 cases + PriorityFromHeader 9 cases (총 26건)

<br>

## CI / 머지 게이트 점검

### 변경 영향 범위
- 영향 패키지/모듈: `internal/processor/enrich`, `cmd/issuetracker`, `.env.example`
- 위험도: **Medium** — Enrich stage 핵심 흐름 변경. 단, feature flag default false + 미설정 시 기존 Kafka 흐름 100% 유지 → 안전 fallback.

### Required Status Checks
- 통과 확인 대상 (PR Checks 탭에서 확인):
  - [ ] `Commit Lint`
  - [ ] `PR Title Lint`
  - [ ] `Linked Issue Check`
  - [ ] `Format Check`
  - [ ] `Build`
  - [ ] `Test`
  - [ ] `Lint`

### 롤백 계획
1. `ENRICH_PRIORITY_QUEUE_ENABLED=false` (또는 unset) — 기존 Kafka consume 흐름 복귀
2. ZSET 잔존 항목은 entry TTL 24h 후 자연 정리
3. 영구 롤백: 위 환경변수 + 본 PR revert

<br>

## 메타 이슈 #515 Phase 2 완료

본 PR 머지 시 메타 이슈 #515 의 모든 sub-issue (#521 / #522 / #523 / #524) 완료. Publisher 단계 host/path priority 분기 (Phase 1) + Parser / Validate / Enrich 의 ZSET priority sub-ordering (Phase 2) 인프라가 모두 갖춰집니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added optional Redis-backed priority queue support for the Enrich processing stage, enabling priority-based message routing and retry scheduling.
  * Priority queue automatically falls back to standard Kafka flow when not configured or unavailable.

* **Configuration**
  * New environment variables added for Enrich stage priority queue setup, including enabling the feature, queue sizing, and timeout controls.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/EinSofINTEREST/IssueTracker/pull/528?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->